### PR TITLE
Feature/cleanup billing

### DIFF
--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -351,6 +351,7 @@ impl ConnectAccountPanel {
                 self.checkout = None;
                 self.billing_history = None;
                 self.show_billing_history = false;
+                self.selected_billing_cycle = BillingCycle::Monthly;
                 self.contacts_state.clear();
                 self.clear_keyring_session();
                 self.client = CoincubeClient::new();

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -333,6 +333,9 @@ impl ConnectAccountPanel {
 
             ConnectAccountMessage::PlanLoaded(plan, gen) => {
                 if gen == self.session_generation && plan.is_some() {
+                    if let Some(cycle) = plan.as_ref().and_then(|p| p.billing_cycle) {
+                        self.selected_billing_cycle = cycle;
+                    }
                     self.plan = plan;
                 }
             }

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -625,8 +625,7 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
                 card_col = card_col
                     .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
                     .push(
-                        text::p2_regular(format!("Expires on {}", date_short))
-                            .color(color::GREY_3),
+                        text::p2_regular(format!("Expires on {}", date_short)).color(color::GREY_3),
                     );
             }
         }

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -614,6 +614,23 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
                 card_col.push(text::p2_regular(format!("• {}", feature)).color(color::GREY_3));
         }
 
+        // Expiry line on the user's current paid plan card.
+        if is_current && card.tier != PlanTier::Free {
+            if let Some(renewal) = state.plan.as_ref().and_then(|p| p.renewal_at.as_deref()) {
+                let date_short = if renewal.len() >= 10 {
+                    &renewal[..10]
+                } else {
+                    renewal
+                };
+                card_col = card_col
+                    .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+                    .push(
+                        text::p2_regular(format!("Expires on {}", date_short))
+                            .color(color::GREY_3),
+                    );
+            }
+        }
+
         card_col = card_col
             .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
             .push(if is_current {

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -470,6 +470,7 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
         .as_ref()
         .map(|p| p.tier())
         .unwrap_or(&PlanTier::Free);
+    let current_cycle = state.plan.as_ref().and_then(|p| p.billing_cycle);
 
     let cycle = state.selected_billing_cycle;
 
@@ -589,7 +590,13 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
         .push(iced::widget::Space::new().height(Length::Fixed(15.0)));
 
     for card in cards {
-        let is_current = card.tier == *current_tier;
+        // Paid tiers are "current" only when both tier *and* cycle match the
+        // user's actual plan. Free tier has no cycle, so tier alone suffices.
+        let is_current = card.tier == *current_tier
+            && match current_cycle {
+                Some(cc) => cc == cycle,
+                None => true,
+            };
         let is_upgrade = tier_rank(&card.tier) > tier_rank(current_tier);
         let badge_color = plan_tier_color(&card.tier);
 
@@ -846,17 +853,21 @@ fn checkout_ux<'a>(
 // ── Billing history view ────────────────────────────────────────────────────
 
 fn billing_history_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMessage> {
+    let back_button = iced::widget::button(
+        Row::new()
+            .push(previous_icon().color(color::GREY_2))
+            .push(iced::widget::Space::new().width(Length::Fixed(5.0)))
+            .push(text::p1_medium("Back").style(theme::text::secondary))
+            .spacing(5)
+            .align_y(Alignment::Center),
+    )
+    .style(theme::button::transparent)
+    .on_press(ConnectAccountMessage::ToggleBillingHistory);
+
     let mut col = Column::new()
-        .push(
-            Row::new()
-                .push(
-                    button::secondary(None, "← Back")
-                        .on_press(ConnectAccountMessage::ToggleBillingHistory),
-                )
-                .push(iced::widget::Space::new().width(Length::Fixed(10.0)))
-                .push(text::h4_bold("Billing History").style(theme::text::primary))
-                .align_y(Alignment::Center),
-        )
+        .push(back_button)
+        .push(iced::widget::Space::new().height(Length::Fixed(10.0)))
+        .push(text::h4_bold("Billing History").style(theme::text::primary))
         .push(iced::widget::Space::new().height(Length::Fixed(15.0)));
 
     match &state.billing_history {

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -214,7 +214,8 @@ impl CoincubeClient {
         let url = format!("{}/api/v1/connect/plan", self.base_url);
         let res = self.client.get(&url).send().await?;
         let res = res.check_success().await?;
-        Ok(res.json().await?)
+        let resp: ApiResponse<ConnectPlan> = res.json().await?;
+        Ok(resp.data)
     }
 
     /// GET /api/v1/connect/features (public — no auth required)
@@ -222,7 +223,8 @@ impl CoincubeClient {
         let url = format!("{}/api/v1/connect/features", self.base_url);
         let res = self.client.get(&url).send().await?;
         let res = res.check_success().await?;
-        Ok(res.json().await?)
+        let resp: ApiResponse<FeaturesResponse> = res.json().await?;
+        Ok(resp.data)
     }
 
     /// POST /api/v1/connect/checkout (authenticated)
@@ -233,7 +235,8 @@ impl CoincubeClient {
         let url = format!("{}/api/v1/connect/checkout", self.base_url);
         let res = self.client.post(&url).json(&req).send().await?;
         let res = res.check_success().await?;
-        Ok(res.json().await?)
+        let resp: ApiResponse<CheckoutResponse> = res.json().await?;
+        Ok(resp.data)
     }
 
     /// GET /api/v1/connect/checkout/{chargeId} (authenticated)
@@ -244,7 +247,8 @@ impl CoincubeClient {
         let url = format!("{}/api/v1/connect/checkout/{}", self.base_url, charge_id);
         let res = self.client.get(&url).send().await?;
         let res = res.check_success().await?;
-        Ok(res.json().await?)
+        let resp: ApiResponse<ChargeStatusResponse> = res.json().await?;
+        Ok(resp.data)
     }
 
     /// GET /api/v1/connect/billing/history (authenticated)
@@ -252,7 +256,8 @@ impl CoincubeClient {
         let url = format!("{}/api/v1/connect/billing/history", self.base_url);
         let res = self.client.get(&url).send().await?;
         let res = res.check_success().await?;
-        Ok(res.json().await?)
+        let resp: ApiResponse<Vec<BillingHistoryEntry>> = res.json().await?;
+        Ok(resp.data)
     }
 
     pub async fn get_verified_devices(&self) -> Result<Vec<VerifiedDevice>, CoincubeError> {

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -243,6 +243,9 @@ pub struct ConnectPlan {
     pub status: PlanStatus,
     pub renewal_at: Option<String>,
     pub entitlements: PlanEntitlements,
+    /// Billing cycle of the current plan. `None` for free tier (no charge).
+    #[serde(default)]
+    pub billing_cycle: Option<BillingCycle>,
 }
 
 impl ConnectPlan {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches plan/billing UI state and API response deserialization; incorrect parsing or cycle-matching logic could mislabel the user’s current plan or break plan/checkout/billing history loads if backend response shapes differ.
> 
> **Overview**
> Improves the Connect *Plan & Billing* experience by deriving the selected billing cycle from the loaded plan (and resetting it on logout), and by only marking a paid plan card as **current** when both tier and billing cycle match.
> 
> Adds an *Expires on* line to the current paid plan card using `renewal_at`, and refreshes the billing history view header/back button styling.
> 
> Updates several Connect API calls (`/connect/plan`, `/connect/features`, `/connect/checkout`, `/connect/checkout/{id}`, `/connect/billing/history`) to deserialize the `{success,data}` envelope and return `data`, and extends `ConnectPlan` with optional `billing_cycle` (defaulting to `None` for free tier).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3768d5222017dba51e5bf2767887f0427be6a7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plan expiration dates are now displayed for active paid subscriptions.
  * Enhanced billing cycle handling during plan selection for improved accuracy.

* **Bug Fixes**
  * Improved API response parsing for billing and plan data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->