### PR TITLE
Added Keychain key picker

### DIFF
--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -935,6 +935,14 @@ impl App {
         self.wallet_registry.spark().cloned()
     }
 
+    /// Returns a clone of the authenticated coincube-api client (with JWT set),
+    /// or `None` if the user has not logged in yet.
+    pub fn authenticated_coincube_client(
+        &self,
+    ) -> Option<crate::services::coincube::CoincubeClient> {
+        self.panels.connect.account.authenticated_client()
+    }
+
     pub fn wallet(&self) -> Option<&Wallet> {
         self.wallet.as_ref().map(|w| w.as_ref())
     }

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -72,7 +72,7 @@ fn backup_master_seed_card<'a>(backed_up: bool) -> Element<'a, Message> {
             "Start Backup",
         )
     };
-        card::simple(
+    card::simple(
         Row::new()
             .spacing(20)
             .align_y(Alignment::Center)

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -185,8 +185,9 @@ impl Tab {
                             );
                         }
                     }
-                    let (install, command) =
-                        Installer::new(datadir, network, None, init, false, None, None, None, false);
+                    let (install, command) = Installer::new(
+                        datadir, network, None, init, false, None, None, None, false, None,
+                    );
                     self.state = State::Installer(install);
                     command.map(Message::Install)
                 }
@@ -272,6 +273,7 @@ impl Tab {
                         None, // No breez_client from login screen
                         None, // No spark_backend from login screen
                         false,
+                        None, // No coincube_client from login screen
                     );
                     self.state = State::Installer(install);
                     command.map(Message::Install)
@@ -452,6 +454,7 @@ impl Tab {
                         GlobalSettings::load_developer_mode(&GlobalSettings::path(
                             &loader.datadir_path,
                         )),
+                        None, // No coincube_client from loader path
                     );
                     self.state = State::Installer(install);
                     command.map(Message::Install)
@@ -594,6 +597,7 @@ impl Tab {
                             GlobalSettings::load_developer_mode(&GlobalSettings::path(
                                 app.datadir(),
                             )),
+                            app.authenticated_coincube_client(), // authenticated API client for Keychain keys
                         );
                         self.state = State::Installer(install);
                         command.map(Message::Install)
@@ -631,8 +635,7 @@ impl Tab {
                                 async move {
                                     // Both Breez SDKs (Liquid + Spark) load
                                     // from the same master seed fingerprint.
-                                    let breez_signer_fingerprint =
-                                        cube.master_signer_fingerprint;
+                                    let breez_signer_fingerprint = cube.master_signer_fingerprint;
 
                                     let breez_result =
                                         if let Some(fingerprint) = breez_signer_fingerprint {

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -187,6 +187,7 @@ impl Tab {
                     }
                     let (install, command) = Installer::new(
                         datadir, network, None, init, false, None, None, None, false,
+                        None, // No coincube_client from launcher
                     );
                     self.state = State::Installer(install);
                     command.map(Message::Install)

--- a/coincube-gui/src/installer/context.rs
+++ b/coincube-gui/src/installer/context.rs
@@ -7,7 +7,10 @@ use crate::{
     backup::Backup,
     dir::CoincubeDirectory,
     node::bitcoind::{Bitcoind, InternalBitcoindConfig},
-    services::connect::client::backend::{BackendClient, BackendWalletClient},
+    services::{
+        coincube::CoincubeClient,
+        connect::client::backend::{BackendClient, BackendWalletClient},
+    },
     signer::Signer,
 };
 use async_hwi::DeviceKind;
@@ -78,6 +81,16 @@ pub struct Context {
     pub remote_backend: RemoteBackend,
     pub backup: Option<Backup>,
     pub wallet_alias: String,
+    /// Cube UUID (from CubeSettings.id) — present when the Vault installer
+    /// is launched from inside a Cube.  Used by the key picker to fetch
+    /// Cube-scoped Keychain keys from the API.
+    pub cube_id: Option<String>,
+    /// Human-readable Cube name for display in the key-picker modal.
+    pub cube_name: Option<String>,
+    /// Authenticated coincube-api client, used by the key picker to
+    /// fetch Cube-scoped Keychain keys.  `None` when launched from
+    /// the Loader (user hasn't done coincube-api auth yet).
+    pub coincube_client: Option<CoincubeClient>,
 }
 
 impl Context {
@@ -85,6 +98,8 @@ impl Context {
         network: bitcoin::Network,
         coincube_directory: CoincubeDirectory,
         remote_backend: RemoteBackend,
+        cube_settings: Option<&crate::app::settings::CubeSettings>,
+        coincube_client: Option<CoincubeClient>,
     ) -> Self {
         Self {
             descriptor_template: DescriptorTemplate::default(),
@@ -110,6 +125,9 @@ impl Context {
             remote_backend,
             wallet_alias: String::new(),
             backup: None,
+            cube_id: cube_settings.map(|cs| cs.id.clone()),
+            cube_name: cube_settings.map(|cs| cs.name.clone()),
+            coincube_client,
         }
     }
 }

--- a/coincube-gui/src/installer/context.rs
+++ b/coincube-gui/src/installer/context.rs
@@ -85,8 +85,6 @@ pub struct Context {
     /// is launched from inside a Cube.  Used by the key picker to fetch
     /// Cube-scoped Keychain keys from the API.
     pub cube_id: Option<String>,
-    /// Human-readable Cube name for display in the key-picker modal.
-    pub cube_name: Option<String>,
     /// Authenticated coincube-api client, used by the key picker to
     /// fetch Cube-scoped Keychain keys.  `None` when launched from
     /// the Loader (user hasn't done coincube-api auth yet).
@@ -126,7 +124,6 @@ impl Context {
             wallet_alias: String::new(),
             backup: None,
             cube_id: cube_settings.map(|cs| cs.id.clone()),
-            cube_name: cube_settings.map(|cs| cs.name.clone()),
             coincube_client,
         }
     }

--- a/coincube-gui/src/installer/descriptor.rs
+++ b/coincube-gui/src/installer/descriptor.rs
@@ -11,6 +11,17 @@ use crate::{
 /// Whether to enable cosigner keys on all paths (excluding safety net paths).
 const ENABLE_COSIGNER_KEYS: bool = false;
 
+/// Identifies the owner of a Keychain key — either the current user
+/// or one of their contacts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeychainKeyOwner {
+    SelfUser,
+    Contact {
+        contact_id: u64,
+        contact_email: String,
+    },
+}
+
 /// The source of a descriptor public key.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KeySource {
@@ -24,6 +35,15 @@ pub enum KeySource {
     Token(KeyKind, ProviderKey),
     /// A Border Wallet key (derived transiently from grid pattern).
     BorderWallet,
+    /// A key from the COINCUBE Keychain, attached to a Cube.
+    /// At sign time the Vault sends a PSBT signing request to the
+    /// Keychain app via gRPC; the signer accepts/rejects and signs
+    /// locally on their device.
+    KeychainKey {
+        owner: KeychainKeyOwner,
+        key_id: u64,
+        name: String,
+    },
 }
 
 impl KeySource {
@@ -66,6 +86,7 @@ impl KeySource {
             Self::Manual => KeySourceKind::Manual,
             Self::Token(kind, _) => KeySourceKind::Token(*kind),
             Self::BorderWallet => KeySourceKind::BorderWallet,
+            Self::KeychainKey { .. } => KeySourceKind::KeychainKey,
         }
     }
 
@@ -107,6 +128,8 @@ pub enum KeySourceKind {
     Token(KeyKind),
     /// A Border Wallet key.
     BorderWallet,
+    /// A key from the COINCUBE Keychain.
+    KeychainKey,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/coincube-gui/src/installer/descriptor.rs
+++ b/coincube-gui/src/installer/descriptor.rs
@@ -12,14 +12,30 @@ use crate::{
 const ENABLE_COSIGNER_KEYS: bool = false;
 
 /// Identifies the owner of a Keychain key — either the current user
-/// or one of their contacts.
+/// or one of their contacts.  Carries `primary_owner_id` on every
+/// variant so duplicate-owner checks are self-contained and don't
+/// depend on the fetched key lists.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KeychainKeyOwner {
-    SelfUser,
+    SelfUser {
+        primary_owner_id: u64,
+    },
     Contact {
+        primary_owner_id: u64,
         contact_id: u64,
         contact_email: String,
     },
+}
+
+impl KeychainKeyOwner {
+    pub fn primary_owner_id(&self) -> u64 {
+        match self {
+            Self::SelfUser { primary_owner_id } => *primary_owner_id,
+            Self::Contact {
+                primary_owner_id, ..
+            } => *primary_owner_id,
+        }
+    }
 }
 
 /// The source of a descriptor public key.

--- a/coincube-gui/src/installer/mod.rs
+++ b/coincube-gui/src/installer/mod.rs
@@ -58,7 +58,7 @@ use crate::{
     signer::Signer,
 };
 
-pub use descriptor::{KeySource, KeySourceKind, PathKind, PathSequence};
+pub use descriptor::{KeySource, KeySourceKind, KeychainKeyOwner, PathKind, PathSequence};
 pub use message::Message;
 use step::{
     BackupDescriptor, BackupMnemonic, ChooseBackend, ChooseDescriptorTemplate, CoincubeConnectStep,
@@ -144,6 +144,7 @@ impl Installer {
         breez_client: Option<std::sync::Arc<crate::app::breez_liquid::BreezClient>>,
         spark_backend: Option<std::sync::Arc<crate::app::wallets::SparkBackend>>,
         mut developer_mode: bool,
+        coincube_client: Option<crate::services::coincube::CoincubeClient>,
     ) -> (Installer, Task<Message>) {
         let signer = if developer_mode {
             let master_signer = breez_client
@@ -184,6 +185,8 @@ impl Installer {
                         _ => RemoteBackend::None,
                     }
                 }),
+            cube_settings.as_ref(),
+            coincube_client,
         );
         let mut installer = Installer {
             network,

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -1577,10 +1577,14 @@ impl super::DescriptorEditModal for SelectKeySource {
         self.processing
     }
     fn update(&mut self, hws: &mut HardwareWallets, message: Message) -> Task<Message> {
-        // Trigger initial Keychain keys fetch on first update
-        if !self.keychain_keys_fetched && self.keychain_available() {
-            return self.on_fetch_cube_keys();
-        }
+        // Trigger initial Keychain keys fetch on first update.
+        // Batched with the normal message handling so the incoming
+        // message is not dropped.
+        let fetch_task = if !self.keychain_keys_fetched && self.keychain_available() {
+            Some(self.on_fetch_cube_keys())
+        } else {
+            None
+        };
         // step back if selected device disconnected
         if self.step == Step::Details {
             if let Focus::Device(fg) = self.focus {
@@ -1591,7 +1595,7 @@ impl super::DescriptorEditModal for SelectKeySource {
                 }
             }
         }
-        match message {
+        let msg_task = match message {
             Message::ImportExport(ImportExportMessage::Close) => {
                 self.modal = None;
                 if self.step == Step::Select {
@@ -1666,6 +1670,11 @@ impl super::DescriptorEditModal for SelectKeySource {
                 }
             },
             _ => Task::none(),
+        };
+        // Batch the one-shot fetch alongside the normal message result.
+        match fetch_task {
+            Some(ft) => Task::batch([ft, msg_task]),
+            None => msg_task,
         }
     }
     fn subscription(&self, hws: &HardwareWallets) -> Subscription<Message> {

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -1039,19 +1039,22 @@ impl SelectKeySource {
             return Task::none();
         }
 
-        let key = Key {
-            source: KeySource::KeychainKey {
-                owner: resolved.owner,
-                key_id: resolved.raw.id,
+        if self.keys.contains_key(&fingerprint) {
+            self.selected_key = SelectedKey::Existing(fingerprint);
+        } else {
+            let key = Key {
+                source: KeySource::KeychainKey {
+                    owner: resolved.owner,
+                    key_id: resolved.raw.id,
+                    name: resolved.raw.name.clone(),
+                },
                 name: resolved.raw.name.clone(),
-            },
-            name: resolved.raw.name.clone(),
-            fingerprint,
-            key: descriptor_key,
-            account: None,
-        };
-
-        self.selected_key = SelectedKey::New(Box::new(key));
+                fingerprint,
+                key: descriptor_key,
+                account: None,
+            };
+            self.selected_key = SelectedKey::New(Box::new(key));
+        }
         self.form_alias.value = resolved.raw.name;
         self.form_alias.valid = true;
         self.focus = Focus::None;
@@ -1142,15 +1145,16 @@ impl SelectKeySource {
             return col.into();
         }
 
-        // Group keys by owner
-        let mut seen_contacts: HashMap<u64, Vec<&ResolvedCubeKey>> = HashMap::new();
+        // Group keys by owner (BTreeMap for stable render order)
+        let mut seen_contacts: std::collections::BTreeMap<u64, Vec<&ResolvedCubeKey>> =
+            std::collections::BTreeMap::new();
         for rk in &self.contact_keychain_keys {
             seen_contacts
                 .entry(rk.raw.primary_owner_id)
                 .or_default()
                 .push(rk);
         }
-        for (_, keys) in &seen_contacts {
+        for keys in seen_contacts.values() {
             if let Some(first) = keys.first() {
                 let contact_label = match &first.owner {
                     KeychainKeyOwner::Contact { contact_email, .. } => {

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -954,7 +954,7 @@ impl SelectKeySource {
                     .map_err(|e| e.to_string())?;
                 let contacts = client.get_contacts().await.map_err(|e| e.to_string())?;
                 let user = client.get_user().await.map_err(|e| e.to_string())?;
-                let current_user_id = user.id as u64;
+                let current_user_id: u64 = user.id.into();
 
                 let mut my_keys = Vec::new();
                 let mut contact_keys = Vec::new();

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -38,12 +38,13 @@ use crate::{
     export::{ImportExportMessage, ImportExportType},
     hw::{is_compatible_with_tapminiscript, HardwareWallet, HardwareWallets, UnsupportedReason},
     installer::{
-        descriptor::{Key, KeySource},
+        descriptor::{Key, KeySource, KeychainKeyOwner},
         message::{self, Message},
         Error, PathKind,
     },
     services::{
         self,
+        coincube::CubeKeyRaw,
         keys::{self, api::KeyKind},
     },
     signer::Signer,
@@ -51,6 +52,20 @@ use crate::{
 
 const MAX_ALIAS_LEN: usize = 24;
 pub type FnMsg = fn() -> Message;
+
+/// A `CubeKeyRaw` enriched with resolved owner identity (self vs. contact).
+#[derive(Debug, Clone)]
+pub struct ResolvedCubeKey {
+    pub raw: CubeKeyRaw,
+    pub owner: KeychainKeyOwner,
+}
+
+/// Result of fetching and resolving Cube keys.
+#[derive(Debug, Clone)]
+pub struct ResolvedCubeKeys {
+    pub my_keys: Vec<ResolvedCubeKey>,
+    pub contact_keys: Vec<ResolvedCubeKey>,
+}
 
 pub fn new_multixkey_from_xpub(
     xpub: DescriptorXKey<Xpub>,
@@ -132,6 +147,10 @@ pub enum SelectKeySourceMessage {
     Collapse(bool),
     Retry,
     None,
+    // Keychain key messages
+    FetchCubeKeys,
+    CubeKeysLoaded(Result<ResolvedCubeKeys, String>),
+    SelectKeychainKey(ResolvedCubeKey),
 }
 
 /// This struct represent metadata about a spending path, including whether it's
@@ -183,6 +202,20 @@ pub struct SelectKeySource {
     actual_path: PathData,
     master_signer: Arc<Mutex<Signer>>,
     developer_mode: bool,
+    /// Cube UUID for fetching Keychain keys from the API.
+    cube_id: Option<String>,
+    /// Authenticated coincube-api client for fetching Keychain keys.
+    coincube_client: Option<crate::services::coincube::CoincubeClient>,
+    /// Resolved Keychain keys owned by the current user.
+    my_keychain_keys: Vec<ResolvedCubeKey>,
+    /// Resolved Keychain keys owned by contacts (Keyholder role only).
+    contact_keychain_keys: Vec<ResolvedCubeKey>,
+    /// Whether we are currently loading Keychain keys from the API.
+    keychain_keys_loading: bool,
+    /// Error from the last Keychain keys fetch attempt.
+    keychain_keys_error: Option<String>,
+    /// Whether the initial fetch has been triggered.
+    keychain_keys_fetched: bool,
     /// The currently selected key.
     selected_key: SelectedKey,
     step: Step,
@@ -213,6 +246,8 @@ impl SelectKeySource {
         accounts: HashMap<Fingerprint, ChildNumber>,
         master_signer: Arc<Mutex<Signer>>,
         developer_mode: bool,
+        cube_id: Option<String>,
+        coincube_client: Option<crate::services::coincube::CoincubeClient>,
     ) -> Self {
         Self {
             network,
@@ -222,6 +257,13 @@ impl SelectKeySource {
             actual_path,
             master_signer,
             developer_mode,
+            cube_id,
+            coincube_client,
+            my_keychain_keys: Vec::new(),
+            contact_keychain_keys: Vec::new(),
+            keychain_keys_loading: false,
+            keychain_keys_error: None,
+            keychain_keys_fetched: false,
             selected_key: SelectedKey::None,
             step: Step::Select,
             focus: Focus::None,
@@ -893,6 +935,273 @@ impl SelectKeySource {
             _ => Task::none(),
         }
     }
+    // ── Keychain key handlers ─────────────────────────────────────────
+
+    fn on_fetch_cube_keys(&mut self) -> Task<Message> {
+        let (Some(cube_id), Some(client)) = (self.cube_id.clone(), self.coincube_client.clone())
+        else {
+            return Task::none();
+        };
+        self.keychain_keys_loading = true;
+        self.keychain_keys_error = None;
+        self.keychain_keys_fetched = true;
+
+        Task::perform(
+            async move {
+                let raw_keys = client
+                    .get_cube_keys(&cube_id)
+                    .await
+                    .map_err(|e| e.to_string())?;
+                let contacts = client.get_contacts().await.map_err(|e| e.to_string())?;
+                let user = client.get_user().await.map_err(|e| e.to_string())?;
+                let current_user_id = user.id as u64;
+
+                let mut my_keys = Vec::new();
+                let mut contact_keys = Vec::new();
+
+                for key in raw_keys {
+                    if key.primary_owner_id == current_user_id {
+                        my_keys.push(ResolvedCubeKey {
+                            raw: key,
+                            owner: KeychainKeyOwner::SelfUser,
+                        });
+                    } else if let Some(contact) = contacts.iter().find(|c| {
+                        c.contact_user_id == key.primary_owner_id
+                            && c.role == crate::services::coincube::ContactRole::Keyholder
+                    }) {
+                        contact_keys.push(ResolvedCubeKey {
+                            raw: key,
+                            owner: KeychainKeyOwner::Contact {
+                                contact_id: contact.id,
+                                contact_email: contact.contact_user.email.clone(),
+                            },
+                        });
+                    }
+                    // Keys from non-Keyholder contacts are silently discarded.
+                }
+
+                Ok(ResolvedCubeKeys {
+                    my_keys,
+                    contact_keys,
+                })
+            },
+            |result| Self::route(SelectKeySourceMessage::CubeKeysLoaded(result)),
+        )
+    }
+
+    fn on_cube_keys_loaded(&mut self, result: Result<ResolvedCubeKeys, String>) -> Task<Message> {
+        self.keychain_keys_loading = false;
+        match result {
+            Ok(resolved) => {
+                self.my_keychain_keys = resolved.my_keys;
+                self.contact_keychain_keys = resolved.contact_keys;
+                self.keychain_keys_error = None;
+            }
+            Err(e) => {
+                tracing::warn!("Failed to fetch Cube keys: {}", e);
+                self.keychain_keys_error = Some(e);
+            }
+        }
+        Task::none()
+    }
+
+    fn on_select_keychain_key(&mut self, resolved: ResolvedCubeKey) -> Task<Message> {
+        let fingerprint_str = &resolved.raw.fingerprint;
+        let xpub_str = &resolved.raw.xpub;
+        let derivation_str = &resolved.raw.derivation_path;
+
+        let Ok(fingerprint) = Fingerprint::from_str(fingerprint_str) else {
+            self.error = Some(format!("Invalid fingerprint: {}", fingerprint_str));
+            return Task::none();
+        };
+        let Ok(xpub) = xpub_str.parse::<Xpub>() else {
+            self.error = Some(format!("Invalid xpub: {}", xpub_str));
+            return Task::none();
+        };
+        let Ok(derivation_path) = DerivationPath::from_str(derivation_str) else {
+            self.error = Some(format!("Invalid derivation path: {}", derivation_str));
+            return Task::none();
+        };
+
+        let descriptor_key = DescriptorPublicKey::XPub(DescriptorXKey {
+            origin: Some((fingerprint, derivation_path)),
+            xkey: xpub,
+            derivation_path: DerivationPath::master(),
+            wildcard: Wildcard::Unhardened,
+        });
+
+        if !check_key_network(&descriptor_key, self.network) {
+            self.error = Some("Key network does not match".to_string());
+            return Task::none();
+        }
+
+        let key = Key {
+            source: KeySource::KeychainKey {
+                owner: resolved.owner,
+                key_id: resolved.raw.id,
+                name: resolved.raw.name.clone(),
+            },
+            name: resolved.raw.name.clone(),
+            fingerprint,
+            key: descriptor_key,
+            account: None,
+        };
+
+        self.selected_key = SelectedKey::New(Box::new(key));
+        self.form_alias.value = resolved.raw.name;
+        self.form_alias.valid = true;
+        self.focus = Focus::None;
+        self.step = Step::Details;
+        Task::none()
+    }
+
+    /// Whether the Keychain key sections should be shown.
+    fn keychain_available(&self) -> bool {
+        self.cube_id.is_some() && self.coincube_client.is_some()
+    }
+
+    /// Check if a key's owner already has a key placed in this vault.
+    fn is_owner_already_placed(&self, primary_owner_id: u64) -> bool {
+        self.keys.values().any(|(_, k)| {
+            if let KeySource::KeychainKey { owner, .. } = &k.source {
+                match owner {
+                    KeychainKeyOwner::SelfUser => {
+                        // Check if any placed key is owned by self and the
+                        // incoming key is also self
+                        // We need the current user's ID — compare via the
+                        // my_keychain_keys list
+                        self.my_keychain_keys
+                            .iter()
+                            .any(|mk| mk.raw.primary_owner_id == primary_owner_id)
+                    }
+                    KeychainKeyOwner::Contact { contact_id, .. } => {
+                        // Check if any contact key is from the same contact
+                        self.contact_keychain_keys.iter().any(|ck| {
+                            ck.raw.primary_owner_id == primary_owner_id
+                                && matches!(
+                                    &ck.owner,
+                                    KeychainKeyOwner::Contact {
+                                        contact_id: cid, ..
+                                    } if *cid == *contact_id
+                                )
+                        })
+                    }
+                }
+            } else {
+                false
+            }
+        })
+    }
+
+    // ── Keychain key views ──────────────────────────────────────────
+
+    fn view_my_keychain_keys(&self) -> Element<Message> {
+        let mut col = Column::new().spacing(modal::V_SPACING).width(modal::BTN_W);
+        col = col.push(p1_bold("My Keychain Keys"));
+
+        if self.keychain_keys_loading && self.my_keychain_keys.is_empty() {
+            col = col.push(p1_regular("Fetching Keychain keys…"));
+            return col.into();
+        }
+        if let Some(err) = &self.keychain_keys_error {
+            col = col.push(p1_regular(format!("Failed to load keys: {}", err)));
+            col = col.push(
+                button::secondary(Some(icon::reload_icon()), "Retry")
+                    .on_press(Self::route(SelectKeySourceMessage::FetchCubeKeys)),
+            );
+            return col.into();
+        }
+        if self.my_keychain_keys.is_empty() {
+            col = col.push(p1_regular(
+                "No Keychain keys. Add one in the COINCUBE mobile app.",
+            ));
+            return col.into();
+        }
+
+        for rk in &self.my_keychain_keys {
+            let disabled = self.is_owner_already_placed(rk.raw.primary_owner_id);
+            let fp = &rk.raw.fingerprint;
+            let fingerprint = Some(format!("#{}", &fp[..fp.len().min(8)]));
+            let msg = if disabled {
+                None
+            } else {
+                let rk_clone = rk.clone();
+                Some(move || {
+                    Self::route(SelectKeySourceMessage::SelectKeychainKey(rk_clone.clone()))
+                })
+            };
+            let warning = disabled.then(|| "Already selected".to_string());
+            col = col.push(modal::key_entry(
+                Some(icon::round_key_icon()),
+                rk.raw.name.clone(),
+                fingerprint,
+                None,
+                None,
+                warning,
+                msg,
+            ));
+        }
+        col.into()
+    }
+
+    fn view_contact_keychain_keys(&self) -> Element<Message> {
+        let mut col = Column::new().spacing(modal::V_SPACING).width(modal::BTN_W);
+        col = col.push(p1_bold("Contact Keychain Keys"));
+
+        if self.keychain_keys_loading && self.contact_keychain_keys.is_empty() {
+            col = col.push(p1_regular("Fetching contact keys…"));
+            return col.into();
+        }
+        if self.contact_keychain_keys.is_empty() {
+            col = col.push(p1_regular("None of your contacts have shared keys yet."));
+            return col.into();
+        }
+
+        // Group keys by owner
+        let mut seen_contacts: HashMap<u64, Vec<&ResolvedCubeKey>> = HashMap::new();
+        for rk in &self.contact_keychain_keys {
+            seen_contacts
+                .entry(rk.raw.primary_owner_id)
+                .or_default()
+                .push(rk);
+        }
+        for (_, keys) in &seen_contacts {
+            if let Some(first) = keys.first() {
+                let contact_label = match &first.owner {
+                    KeychainKeyOwner::Contact { contact_email, .. } => {
+                        format!("{} [Keyholder]", contact_email)
+                    }
+                    _ => "Contact".to_string(),
+                };
+                col = col.push(p1_bold(contact_label));
+                for rk in keys {
+                    let disabled = self.is_owner_already_placed(rk.raw.primary_owner_id);
+                    let fp = &rk.raw.fingerprint;
+                    let fingerprint = Some(format!("#{}", &fp[..fp.len().min(8)]));
+                    let msg = if disabled {
+                        None
+                    } else {
+                        let rk_clone = (*rk).clone();
+                        Some(move || {
+                            Self::route(SelectKeySourceMessage::SelectKeychainKey(rk_clone.clone()))
+                        })
+                    };
+                    let warning = disabled.then(|| "Already selected".to_string());
+                    col = col.push(modal::key_entry(
+                        Some(icon::round_key_icon()),
+                        rk.raw.name.clone(),
+                        fingerprint,
+                        None,
+                        None,
+                        warning,
+                        msg,
+                    ));
+                }
+            }
+        }
+        col.into()
+    }
+
     fn main_view(
         &self,
         hws: Vec<(
@@ -919,12 +1228,19 @@ impl SelectKeySource {
             Some(|| Message::Close),
         );
 
+        let my_keychain =
+            (self.keychain_available() && !only_safety_net).then(|| self.view_my_keychain_keys());
+        let contact_keychain = (self.keychain_available() && !only_safety_net)
+            .then(|| self.view_contact_keychain_keys());
+
         let column = Column::new()
             .spacing(10)
             .push(header)
             .push(no_devices)
             .push(devices)
             .push(keys)
+            .push(my_keychain)
+            .push(contact_keychain)
             .push(self.view_other_options())
             .align_x(Horizontal::Center)
             .width(modal::MODAL_WIDTH);
@@ -1161,6 +1477,7 @@ impl SelectKeySource {
             KeySource::Manual => icon::round_key_icon(),
             KeySource::Token(..) => icon::hdd_icon(),
             KeySource::BorderWallet => icon::round_key_icon(),
+            KeySource::KeychainKey { .. } => icon::round_key_icon(),
         };
         let message = if let KeySource::Token(kind, _) = source {
             if !self.actual_path.token_kind.contains(&kind) {
@@ -1260,6 +1577,10 @@ impl super::DescriptorEditModal for SelectKeySource {
         self.processing
     }
     fn update(&mut self, hws: &mut HardwareWallets, message: Message) -> Task<Message> {
+        // Trigger initial Keychain keys fetch on first update
+        if !self.keychain_keys_fetched && self.keychain_available() {
+            return self.on_fetch_cube_keys();
+        }
         // step back if selected device disconnected
         if self.step == Step::Details {
             if let Focus::Device(fg) = self.focus {
@@ -1338,6 +1659,11 @@ impl super::DescriptorEditModal for SelectKeySource {
                 SelectKeySourceMessage::Collapse(collapse) => self.on_collapse(collapse),
                 SelectKeySourceMessage::Retry => self.on_retry(),
                 SelectKeySourceMessage::None => Task::none(),
+                SelectKeySourceMessage::FetchCubeKeys => self.on_fetch_cube_keys(),
+                SelectKeySourceMessage::CubeKeysLoaded(result) => self.on_cube_keys_loaded(result),
+                SelectKeySourceMessage::SelectKeychainKey(resolved) => {
+                    self.on_select_keychain_key(resolved)
+                }
             },
             _ => Task::none(),
         }

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -960,18 +960,22 @@ impl SelectKeySource {
                 let mut contact_keys = Vec::new();
 
                 for key in raw_keys {
-                    if key.primary_owner_id == current_user_id {
+                    let owner_id = key.primary_owner_id;
+                    if owner_id == current_user_id {
                         my_keys.push(ResolvedCubeKey {
                             raw: key,
-                            owner: KeychainKeyOwner::SelfUser,
+                            owner: KeychainKeyOwner::SelfUser {
+                                primary_owner_id: owner_id,
+                            },
                         });
                     } else if let Some(contact) = contacts.iter().find(|c| {
-                        c.contact_user_id == key.primary_owner_id
+                        c.contact_user_id == owner_id
                             && c.role == crate::services::coincube::ContactRole::Keyholder
                     }) {
                         contact_keys.push(ResolvedCubeKey {
                             raw: key,
                             owner: KeychainKeyOwner::Contact {
+                                primary_owner_id: owner_id,
                                 contact_id: contact.id,
                                 contact_email: contact.contact_user.email.clone(),
                             },
@@ -1061,32 +1065,13 @@ impl SelectKeySource {
     }
 
     /// Check if a key's owner already has a key placed in this vault.
+    /// Self-contained: reads `primary_owner_id` directly from the
+    /// `KeychainKeyOwner` stored on each placed key, so it works
+    /// regardless of the fetched key list state.
     fn is_owner_already_placed(&self, primary_owner_id: u64) -> bool {
         self.keys.values().any(|(_, k)| {
             if let KeySource::KeychainKey { owner, .. } = &k.source {
-                match owner {
-                    KeychainKeyOwner::SelfUser => {
-                        // Check if any placed key is owned by self and the
-                        // incoming key is also self
-                        // We need the current user's ID — compare via the
-                        // my_keychain_keys list
-                        self.my_keychain_keys
-                            .iter()
-                            .any(|mk| mk.raw.primary_owner_id == primary_owner_id)
-                    }
-                    KeychainKeyOwner::Contact { contact_id, .. } => {
-                        // Check if any contact key is from the same contact
-                        self.contact_keychain_keys.iter().any(|ck| {
-                            ck.raw.primary_owner_id == primary_owner_id
-                                && matches!(
-                                    &ck.owner,
-                                    KeychainKeyOwner::Contact {
-                                        contact_id: cid, ..
-                                    } if *cid == *contact_id
-                                )
-                        })
-                    }
-                }
+                owner.primary_owner_id() == primary_owner_id
             } else {
                 false
             }

--- a/coincube-gui/src/installer/step/descriptor/editor/mod.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/mod.rs
@@ -64,6 +64,12 @@ pub struct DefineDescriptor {
     accounts: HashMap<Fingerprint, ChildNumber>,
     descriptor_template: DescriptorTemplate,
 
+    /// Cube UUID for fetching Keychain keys from the API.
+    /// Present when the Vault installer was launched from inside a Cube.
+    cube_id: Option<String>,
+    /// Authenticated coincube-api client for fetching Keychain keys.
+    coincube_client: Option<crate::services::coincube::CoincubeClient>,
+
     error: Option<String>,
 }
 
@@ -81,6 +87,8 @@ impl DefineDescriptor {
             descriptor_template: DescriptorTemplate::default(),
             paths: Vec::new(),
             accounts: Default::default(),
+            cube_id: None,
+            coincube_client: None,
         }
     }
 
@@ -216,13 +224,17 @@ impl DefineDescriptor {
             self.accounts.clone(),
             self.signer.clone(),
             self.developer_mode,
+            self.cube_id.clone(),
+            self.coincube_client.clone(),
         )
     }
 }
 
 impl Step for DefineDescriptor {
     fn load_context(&mut self, ctx: &Context) {
-        self.load_template(ctx.descriptor_template)
+        self.load_template(ctx.descriptor_template);
+        self.cube_id = ctx.cube_id.clone();
+        self.coincube_client = ctx.coincube_client.clone();
     }
     // form value is set as valid each time it is edited.
     // Verification of the values is happening when the user click on Next button.
@@ -829,6 +841,8 @@ mod tests {
             Network::Signet,
             CoincubeDirectory::new(PathBuf::from_str("/").unwrap()),
             crate::installer::context::RemoteBackend::None,
+            None,
+            None,
         );
         let sandbox: Sandbox<DefineDescriptor> = Sandbox::new(DefineDescriptor::new(
             Network::Signet,
@@ -912,6 +926,8 @@ mod tests {
             Network::Testnet,
             CoincubeDirectory::new(PathBuf::from_str("/").unwrap()),
             crate::installer::context::RemoteBackend::None,
+            None,
+            None,
         );
         let sandbox: Sandbox<DefineDescriptor> = Sandbox::new(DefineDescriptor::new(
             Network::Testnet,

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -2,7 +2,7 @@ use super::{
     get_countries, ApiErrorResponse, ApiResponse, AvatarGenerateData, AvatarGenerateRequest,
     AvatarSelectData, AvatarSelectRequest, BillingHistoryEntry, ChargeStatusResponse,
     CheckUsernameResponse, CheckoutRequest, CheckoutResponse, ClaimLightningAddressRequest,
-    CoincubeError, ConnectPlan, Contact, ContactCube, Country, CreateInviteRequest,
+    CoincubeError, ConnectPlan, Contact, ContactCube, Country, CreateInviteRequest, CubeKeyRaw,
     CubeLimitsResponse, CubeResponse, DownloadStats, FeaturesResponse, GetAvatarData, Invite,
     LightningAddress, LoginActivity, LoginResponse, OtpRequest, OtpVerifyRequest, PublicAvatarData,
     RefreshTokenRequest, RegenerationData, RegisterCubeRequest, SaveQuoteRequest,
@@ -564,6 +564,17 @@ impl CoincubeClient {
         let res = self.client.get(&url).send().await?;
         let res = res.check_success().await?;
         let resp: ApiResponse<Vec<Contact>> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// GET /api/v1/connect/cubes/{cubeUuid}/keys — retrieve Keychain keys
+    /// attached to a Cube.  Returns a flat array of keys; owner resolution
+    /// (self vs. contact) is done client-side.
+    pub async fn get_cube_keys(&self, cube_uuid: &str) -> Result<Vec<CubeKeyRaw>, CoincubeError> {
+        let url = format!("{}/api/v1/connect/cubes/{}/keys", self.base_url, cube_uuid);
+        let res = self.client.get(&url).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<Vec<CubeKeyRaw>> = res.json().await?;
         Ok(resp.data)
     }
 

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -380,6 +380,29 @@ pub struct CubeResponse {
     pub status: String,
 }
 
+/// A key returned by `GET /api/v1/connect/cubes/{cubeUuid}/keys`.
+/// The response is a flat array — owner resolution (self vs. contact)
+/// is done client-side by comparing `primary_owner_id` against the
+/// authenticated user's ID.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CubeKeyRaw {
+    pub id: u64,
+    pub primary_owner_id: u64,
+    pub keychain_id: Option<u64>,
+    pub name: String,
+    pub curve: String,
+    pub taproot: bool,
+    pub xpub: String,
+    pub fingerprint: String,
+    pub derivation_path: String,
+    pub network: String,
+    pub cube_id: u64,
+    pub status: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
 /// Response from GET /api/v1/connect/cubes/limits
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new authenticated coincube-api calls and integrates them into descriptor key selection, which can impact vault configuration and relies on correct owner/key parsing and filtering. Risk is moderate due to new network/API dependencies and new key-source variant in core key-selection flow.
> 
> **Overview**
> Adds a new **COINCUBE Keychain** key source to the vault descriptor editor, letting users pick keys attached to the current Cube (including *Keyholder* contact keys) and preventing duplicate selection per key owner.
> 
> Plumbs `cube_id` and an authenticated `CoincubeClient` from the running app into the installer context, adds `GET /api/v1/connect/cubes/{cubeUuid}/keys` support (with `CubeKeyRaw`), and updates installer launch paths to pass `None` when unauthenticated so the Keychain sections are hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1a71c177c17e28a60bead22e2a4041231cd915e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing cryptocurrency keys from your Coincube Keychain during vault descriptor setup. You can now select from existing personal and contact keys when configuring your security settings, streamlining the key management process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->