### PR TITLE
Implemented cube and membership features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,15 +381,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
 ]
 
 [[package]]
@@ -436,6 +476,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "async-hwi"
 version = "0.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,7 +539,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -501,19 +556,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
 name = "async-process"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-lite",
  "rustix 1.1.4",
 ]
@@ -545,6 +609,34 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -782,6 +874,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
 name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,7 +966,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes 0.14.1",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
@@ -872,12 +975,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -1159,7 +1277,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -1609,6 +1727,7 @@ dependencies = [
  "flate2",
  "fs4",
  "hex",
+ "httpmock",
  "iced",
  "iced_anim",
  "iced_aw",
@@ -2252,6 +2371,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,8 +2388,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -2347,7 +2487,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "cssparser",
  "foldhash 0.2.0",
  "html5ever",
@@ -2527,6 +2667,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,6 +2829,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -2695,7 +2850,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -3882,6 +4037,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4107,7 +4290,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4663,6 +4846,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -4903,6 +5095,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set 0.5.3",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph 0.6.5",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache 0.8.9",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4961,6 +5193,12 @@ dependencies = [
  "bitcoin 0.32.8",
  "miniscript",
 ]
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
@@ -5230,6 +5468,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -5628,7 +5869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.8.0",
  "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
@@ -6716,7 +6957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.13.1",
  "serde",
 ]
 
@@ -6727,7 +6968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -6737,7 +6978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -6747,10 +6988,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -7471,6 +7721,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8382,6 +8643,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8586,6 +8857,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simplecss"
@@ -8873,13 +9150,25 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.13.1",
  "precomputed-hash",
 ]
 
@@ -8890,7 +9179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -9130,6 +9419,17 @@ checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
  "new_debug_unreachable",
  "utf-8",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -10133,6 +10433,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10489,7 +10795,7 @@ checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
 dependencies = [
  "phf",
  "phf_codegen",
- "string_cache",
+ "string_cache 0.9.0",
  "string_cache_codegen",
 ]
 
@@ -10658,8 +10964,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
 dependencies = [
  "arrayvec",
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.11.0",
  "bytemuck",
  "cfg_aliases",
@@ -10719,7 +11025,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
+ "bit-set 0.8.0",
  "bitflags 2.11.0",
  "block",
  "bytemuck",
@@ -10813,7 +11119,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11838,7 +12144,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-core",
  "futures-lite",
  "hex",

--- a/coincube-gui/Cargo.toml
+++ b/coincube-gui/Cargo.toml
@@ -165,6 +165,7 @@ iced = { version = "0.14.0", features = ["x11", "wayland"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
+httpmock = "0.7"
 
 [build-dependencies]
 dotenvy = "0.15.7"

--- a/coincube-gui/src/app/menu.rs
+++ b/coincube-gui/src/app/menu.rs
@@ -30,6 +30,10 @@ pub enum ConnectSubMenu {
     Duress,
     Contacts,
     Invites,
+    /// Cube-scoped members + pending-invites management. Feature-flagged by
+    /// `feature_flags::CUBE_MEMBERS_UI_ENABLED`; sidebar entry is hidden
+    /// otherwise.
+    CubeMembers,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1142,6 +1142,21 @@ impl App {
                     self.panels.current = menu;
                     return contacts_task;
                 }
+                // Load Cube Members on demand (W8 — gated by
+                // CUBE_MEMBERS_UI_ENABLED at the sidebar, but defensive here
+                // in case a deep-link message sneaks through).
+                if matches!(submenu, menu::ConnectSubMenu::CubeMembers)
+                    && self.panels.connect.account.is_authenticated()
+                {
+                    self.panels.current = menu;
+                    return iced::Task::done(Message::View(
+                        crate::app::view::Message::ConnectCube(
+                            crate::app::view::ConnectCubeMessage::Members(
+                                crate::app::view::ConnectCubeMembersMessage::Enter,
+                            ),
+                        ),
+                    ));
+                }
             }
             menu::Menu::Liquid(_submenu) => {
                 // Liquid transaction preselection is handled via PreselectPayment message

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -50,6 +50,16 @@ pub enum ContactsStep {
     Detail(u64),
 }
 
+/// One cube option shown in the invite-form's "Also add to Cube(s)"
+/// multi-select. Kept lightweight — we only need `{id, label}` for the
+/// checkbox row.
+#[derive(Debug, Clone)]
+pub struct InviteCubeOption {
+    pub id: u64,
+    pub name: String,
+    pub network: String,
+}
+
 /// State for the Contacts section within ConnectAccountPanel.
 pub struct ContactsState {
     pub step: ContactsStep,
@@ -62,6 +72,17 @@ pub struct ContactsState {
     pub detail_cubes_error: Option<String>,
     pub loading: bool,
     pub error: Option<String>,
+    // --- W12: cube multi-select on the invite form ---
+    /// Cubes the authenticated user owns or is a member of. Populated
+    /// on `ShowInviteForm`. Empty (or `None` pending load) hides the
+    /// section entirely per the plan.
+    pub invite_available_cubes: Option<Vec<InviteCubeOption>>,
+    /// Cube ids the user has ticked on the invite form. Cleared when
+    /// the user navigates away from the form.
+    pub invite_cube_selections: Vec<u64>,
+    /// Non-`None` when the last submit 403'd on a cube id — drives the
+    /// "one or more selected cubes is no longer available" dialog.
+    pub invite_cube_error: Option<String>,
 }
 
 impl ContactsState {
@@ -77,6 +98,9 @@ impl ContactsState {
             detail_cubes_error: None,
             loading: false,
             error: None,
+            invite_available_cubes: None,
+            invite_cube_selections: Vec::new(),
+            invite_cube_error: None,
         }
     }
 
@@ -857,11 +881,77 @@ impl ConnectAccountPanel {
                 self.contacts_state.invite_role = ContactRole::Keyholder;
                 self.contacts_state.invite_sending = false;
                 self.contacts_state.error = None;
+                self.contacts_state.invite_cube_selections.clear();
+                self.contacts_state.invite_cube_error = None;
+                // Load the user's cubes for the "Also add to Cube(s)"
+                // multi-select (W12). Hidden in the view until this
+                // resolves; empty Vec renders as "no cubes section".
+                let client = self.client.clone();
+                let gen = self.session_generation;
+                return iced::Task::perform(
+                    async move { client.list_cubes().await },
+                    move |res| match res {
+                        Ok(cubes) => {
+                            let options = cubes
+                                .into_iter()
+                                .map(|c| InviteCubeOption {
+                                    id: c.id,
+                                    name: c.name,
+                                    network: c.network,
+                                })
+                                .collect::<Vec<_>>();
+                            Message::View(view::Message::ConnectAccount(
+                                ConnectAccountMessage::Contacts(
+                                    ContactsMessage::InviteCubesAvailable(options, gen),
+                                ),
+                            ))
+                        }
+                        Err(e) => {
+                            // Leave the section hidden on load failure —
+                            // the user can still send a plain invite.
+                            log::warn!("[CONTACTS] Failed to list cubes for invite form: {}", e);
+                            Message::View(view::Message::ConnectAccount(
+                                ConnectAccountMessage::Contacts(
+                                    ContactsMessage::InviteCubesAvailable(Vec::new(), gen),
+                                ),
+                            ))
+                        }
+                    },
+                );
+            }
+
+            ContactsMessage::InviteCubesAvailable(cubes, gen) => {
+                if gen == self.session_generation {
+                    // Drop any prior selection that's no longer in the
+                    // authoritative list (e.g. after a 403 reload where
+                    // the user lost access to a cube mid-form).
+                    let valid_ids: std::collections::HashSet<u64> =
+                        cubes.iter().map(|c| c.id).collect();
+                    self.contacts_state
+                        .invite_cube_selections
+                        .retain(|id| valid_ids.contains(id));
+                    self.contacts_state.invite_available_cubes = Some(cubes);
+                }
+            }
+
+            ContactsMessage::ToggleInviteCube(cube_id) => {
+                let selections = &mut self.contacts_state.invite_cube_selections;
+                if let Some(pos) = selections.iter().position(|id| *id == cube_id) {
+                    selections.remove(pos);
+                } else {
+                    selections.push(cube_id);
+                }
+                // Clear the "cube unavailable" dialog on any edit so a
+                // stale message doesn't linger after the user adjusts
+                // their picks.
+                self.contacts_state.invite_cube_error = None;
             }
 
             ContactsMessage::BackToList => {
                 self.contacts_state.step = ContactsStep::List;
                 self.contacts_state.error = None;
+                self.contacts_state.invite_cube_selections.clear();
+                self.contacts_state.invite_cube_error = None;
             }
 
             ContactsMessage::ShowDetail(contact_id) => {
@@ -914,21 +1004,73 @@ impl ConnectAccountPanel {
                 }
                 self.contacts_state.invite_sending = true;
                 self.contacts_state.error = None;
+                self.contacts_state.invite_cube_error = None;
                 let client = self.client.clone();
                 let role = self.contacts_state.invite_role;
+                let cube_ids = self.contacts_state.invite_cube_selections.clone();
+                let had_cubes = !cube_ids.is_empty();
                 return iced::Task::perform(
                     async move {
                         client
-                            .create_invite(CreateInviteRequest { email, role })
+                            .create_invite(CreateInviteRequest {
+                                email,
+                                role,
+                                cube_ids,
+                            })
                             .await
                     },
-                    |res| match res {
+                    move |res| match res {
                         Ok(()) => Message::View(view::Message::ConnectAccount(
                             ConnectAccountMessage::Contacts(ContactsMessage::InviteCreated),
+                        )),
+                        // A 403 when cubes were attached almost always means
+                        // the caller is no longer a member of one of them
+                        // (the per-cube membership check failed). Route to
+                        // the dedicated handler so the form stays open with
+                        // a clear "some cubes are no longer available" msg.
+                        Err(e) if had_cubes && matches!(
+                            &e,
+                            crate::services::coincube::CoincubeError::Unsuccessful(info)
+                                if info.status_code == 403
+                        ) => Message::View(view::Message::ConnectAccount(
+                            ConnectAccountMessage::Contacts(
+                                ContactsMessage::InviteCubeForbidden(e.to_string()),
+                            ),
                         )),
                         Err(e) => Message::View(view::Message::ConnectAccount(
                             ConnectAccountMessage::Contacts(ContactsMessage::Error(e.to_string())),
                         )),
+                    },
+                );
+            }
+
+            ContactsMessage::InviteCubeForbidden(msg) => {
+                self.contacts_state.invite_sending = false;
+                self.contacts_state.invite_cube_error = Some(msg);
+                // Refresh the cube list so the checkboxes reflect the
+                // user's current memberships. We stay on the form so
+                // the user can adjust and retry.
+                let client = self.client.clone();
+                let gen = self.session_generation;
+                return iced::Task::perform(
+                    async move { client.list_cubes().await },
+                    move |res| {
+                        let options = match res {
+                            Ok(cubes) => cubes
+                                .into_iter()
+                                .map(|c| InviteCubeOption {
+                                    id: c.id,
+                                    name: c.name,
+                                    network: c.network,
+                                })
+                                .collect(),
+                            Err(_) => Vec::new(),
+                        };
+                        Message::View(view::Message::ConnectAccount(
+                            ConnectAccountMessage::Contacts(
+                                ContactsMessage::InviteCubesAvailable(options, gen),
+                            ),
+                        ))
                     },
                 );
             }
@@ -1060,6 +1202,128 @@ pub fn load_contacts_data(client: &CoincubeClient, generation: u64) -> iced::Tas
             },
         ),
     ])
+}
+
+#[cfg(test)]
+mod invite_form_tests {
+    //! State-layer tests for the W12 cube multi-select invite form.
+    //! Exercises the `ContactsMessage` dispatch path via the public
+    //! `update_message` entrypoint; we don't inspect returned `Task`s
+    //! (those are opaque futures) — only the resulting `ContactsState`.
+    use super::*;
+
+    fn option(id: u64, name: &str) -> InviteCubeOption {
+        InviteCubeOption {
+            id,
+            name: name.to_string(),
+            network: "bitcoin".to_string(),
+        }
+    }
+
+    fn dispatch(panel: &mut ConnectAccountPanel, msg: ContactsMessage) {
+        let _ = panel.update_message(ConnectAccountMessage::Contacts(msg));
+    }
+
+    #[test]
+    fn available_cubes_sets_state_and_becomes_renderable() {
+        let mut panel = ConnectAccountPanel::new();
+        let gen = panel.session_generation();
+        dispatch(
+            &mut panel,
+            ContactsMessage::InviteCubesAvailable(
+                vec![option(1, "Alpha"), option(7, "Bravo")],
+                gen,
+            ),
+        );
+        let cubes = panel
+            .contacts_state
+            .invite_available_cubes
+            .as_ref()
+            .expect("available cubes should be Some");
+        assert_eq!(cubes.len(), 2);
+        assert_eq!(cubes[0].name, "Alpha");
+    }
+
+    #[test]
+    fn available_cubes_empty_hides_section() {
+        let mut panel = ConnectAccountPanel::new();
+        let gen = panel.session_generation();
+        dispatch(
+            &mut panel,
+            ContactsMessage::InviteCubesAvailable(Vec::new(), gen),
+        );
+        // `Some(empty)` means "loaded, but nothing to show" — the view
+        // layer's `if !cubes.is_empty()` guard hides the section.
+        assert!(matches!(
+            panel.contacts_state.invite_available_cubes,
+            Some(ref v) if v.is_empty()
+        ));
+    }
+
+    #[test]
+    fn stale_available_cubes_ignored() {
+        let mut panel = ConnectAccountPanel::new();
+        let stale_gen = panel.session_generation().wrapping_add(1);
+        dispatch(
+            &mut panel,
+            ContactsMessage::InviteCubesAvailable(vec![option(1, "Alpha")], stale_gen),
+        );
+        assert!(panel.contacts_state.invite_available_cubes.is_none());
+    }
+
+    #[test]
+    fn toggle_cube_adds_and_removes_from_selection() {
+        let mut panel = ConnectAccountPanel::new();
+        dispatch(&mut panel, ContactsMessage::ToggleInviteCube(7));
+        assert_eq!(panel.contacts_state.invite_cube_selections, vec![7]);
+
+        dispatch(&mut panel, ContactsMessage::ToggleInviteCube(3));
+        assert_eq!(panel.contacts_state.invite_cube_selections, vec![7, 3]);
+
+        dispatch(&mut panel, ContactsMessage::ToggleInviteCube(7));
+        assert_eq!(panel.contacts_state.invite_cube_selections, vec![3]);
+    }
+
+    #[test]
+    fn toggle_cube_clears_stale_conflict_banner() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.contacts_state.invite_cube_error = Some("old".to_string());
+        dispatch(&mut panel, ContactsMessage::ToggleInviteCube(7));
+        assert!(panel.contacts_state.invite_cube_error.is_none());
+    }
+
+    #[test]
+    fn invite_cube_forbidden_clears_sending_and_stores_message() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.contacts_state.invite_sending = true;
+        dispatch(
+            &mut panel,
+            ContactsMessage::InviteCubeForbidden("Cube 7 unavailable".to_string()),
+        );
+        assert!(!panel.contacts_state.invite_sending);
+        assert_eq!(
+            panel.contacts_state.invite_cube_error.as_deref(),
+            Some("Cube 7 unavailable"),
+        );
+    }
+
+    #[test]
+    fn reload_prunes_stale_selections() {
+        // User selected cubes [1, 7, 42], then the cube list reloads
+        // without 7 (user lost access). Selection should drop 7 but
+        // keep the others.
+        let mut panel = ConnectAccountPanel::new();
+        panel.contacts_state.invite_cube_selections = vec![1, 7, 42];
+        let gen = panel.session_generation();
+        dispatch(
+            &mut panel,
+            ContactsMessage::InviteCubesAvailable(
+                vec![option(1, "Alpha"), option(42, "Gamma")],
+                gen,
+            ),
+        );
+        assert_eq!(panel.contacts_state.invite_cube_selections, vec![1, 42]);
+    }
 }
 
 /// Load Security tab data (verified devices + login activity).

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -883,6 +883,12 @@ impl ConnectAccountPanel {
                 self.contacts_state.error = None;
                 self.contacts_state.invite_cube_selections.clear();
                 self.contacts_state.invite_cube_error = None;
+                // Drop the prior cube list so re-opens don't briefly
+                // render stale checkboxes from a previous session while
+                // the fresh `list_cubes()` call is in flight. The view
+                // hides the "Also add to Cube(s)" section entirely when
+                // this is `None`.
+                self.contacts_state.invite_available_cubes = None;
                 // Load the user's cubes for the "Also add to Cube(s)"
                 // multi-select (W12). Hidden in the view until this
                 // resolves; empty Vec renders as "no cubes section".

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -297,6 +297,32 @@ impl ConnectAccountPanel {
         self.contacts_state.active_cube_server_id = cube_id;
     }
 
+    /// Kick off a `get_cubes_by_contact(contact_id)` fetch and wire
+    /// the result into `ContactCubesLoaded` / `ContactCubesFailed`.
+    /// Shared by `ShowDetail` (initial load) and by post-mutation
+    /// handlers that need to refresh the Associated Cubes section
+    /// after a successful add.
+    fn fetch_contact_cubes(&self, contact_id: u64) -> iced::Task<Message> {
+        let client = self.client.clone();
+        let gen = self.session_generation;
+        iced::Task::perform(
+            async move { client.get_cubes_by_contact(contact_id).await },
+            move |res| match res {
+                Ok(cubes) => Message::View(view::Message::ConnectAccount(
+                    ConnectAccountMessage::Contacts(ContactsMessage::ContactCubesLoaded(
+                        contact_id, cubes, gen,
+                    )),
+                )),
+                Err(e) => Message::View(view::Message::ConnectAccount(
+                    ConnectAccountMessage::Contacts(ContactsMessage::ContactCubesFailed(
+                        contact_id,
+                        e.to_string(),
+                    )),
+                )),
+            },
+        )
+    }
+
     /// Reset contacts state to list view and reload data from the API.
     pub fn reload_contacts(&mut self) -> iced::Task<Message> {
         self.contacts_state.step = ContactsStep::List;
@@ -1026,24 +1052,7 @@ impl ConnectAccountPanel {
                 self.contacts_state.detail_cubes = None;
                 self.contacts_state.detail_cubes_error = None;
                 self.contacts_state.error = None;
-                let client = self.client.clone();
-                let gen = self.session_generation;
-                return iced::Task::perform(
-                    async move { client.get_cubes_by_contact(contact_id).await },
-                    move |res| match res {
-                        Ok(cubes) => Message::View(view::Message::ConnectAccount(
-                            ConnectAccountMessage::Contacts(ContactsMessage::ContactCubesLoaded(
-                                contact_id, cubes, gen,
-                            )),
-                        )),
-                        Err(e) => Message::View(view::Message::ConnectAccount(
-                            ConnectAccountMessage::Contacts(ContactsMessage::ContactCubesFailed(
-                                contact_id,
-                                e.to_string(),
-                            )),
-                        )),
-                    },
-                );
+                return self.fetch_contact_cubes(contact_id);
             }
 
             ContactsMessage::InviteEmailChanged(email) => {
@@ -1310,28 +1319,7 @@ impl ConnectAccountPanel {
                         self.contacts_state.step,
                         ContactsStep::Detail(id) if id == contact_id
                     ) {
-                        let client = self.client.clone();
-                        let gen = self.session_generation;
-                        return iced::Task::perform(
-                            async move { client.get_cubes_by_contact(contact_id).await },
-                            move |res| match res {
-                                Ok(cubes) => Message::View(view::Message::ConnectAccount(
-                                    ConnectAccountMessage::Contacts(
-                                        ContactsMessage::ContactCubesLoaded(
-                                            contact_id, cubes, gen,
-                                        ),
-                                    ),
-                                )),
-                                Err(e) => Message::View(view::Message::ConnectAccount(
-                                    ConnectAccountMessage::Contacts(
-                                        ContactsMessage::ContactCubesFailed(
-                                            contact_id,
-                                            e.to_string(),
-                                        ),
-                                    ),
-                                )),
-                            },
-                        );
+                        return self.fetch_contact_cubes(contact_id);
                     }
                     return iced::Task::none();
                 }
@@ -1378,8 +1366,7 @@ impl ConnectAccountPanel {
                 let Some(cube_id) = self.contacts_state.active_cube_server_id else {
                     self.contacts_state.add_to_current_cube_errors.insert(
                         contact_id,
-                        "Current cube isn't registered yet — please retry in a moment."
-                            .to_string(),
+                        "Current cube isn't registered yet — please retry in a moment.".to_string(),
                     );
                     return iced::Task::none();
                 };
@@ -1418,28 +1405,7 @@ impl ConnectAccountPanel {
                         self.contacts_state.step,
                         ContactsStep::Detail(id) if id == contact_id
                     ) {
-                        let client = self.client.clone();
-                        let gen = self.session_generation;
-                        return iced::Task::perform(
-                            async move { client.get_cubes_by_contact(contact_id).await },
-                            move |res| match res {
-                                Ok(cubes) => Message::View(view::Message::ConnectAccount(
-                                    ConnectAccountMessage::Contacts(
-                                        ContactsMessage::ContactCubesLoaded(
-                                            contact_id, cubes, gen,
-                                        ),
-                                    ),
-                                )),
-                                Err(e) => Message::View(view::Message::ConnectAccount(
-                                    ConnectAccountMessage::Contacts(
-                                        ContactsMessage::ContactCubesFailed(
-                                            contact_id,
-                                            e.to_string(),
-                                        ),
-                                    ),
-                                )),
-                            },
-                        );
+                        return self.fetch_contact_cubes(contact_id);
                     }
                 }
                 Err(msg) => {
@@ -1925,10 +1891,7 @@ mod add_to_cube_tests {
             &mut panel,
             ContactsMessage::AddToCubeCandidatesLoaded(
                 7,
-                vec![
-                    option(1, "Alpha", "bitcoin"),
-                    option(2, "Bravo", "bitcoin"),
-                ],
+                vec![option(1, "Alpha", "bitcoin"), option(2, "Bravo", "bitcoin")],
                 gen,
             ),
         );
@@ -2168,10 +2131,7 @@ mod add_to_cube_tests {
         let mut panel = panel_with_contact(contact, Some("bitcoin"));
         dispatch(
             &mut panel,
-            ContactsMessage::AddContactToCurrentCubeResult(
-                7,
-                Err("backend 500".to_string()),
-            ),
+            ContactsMessage::AddContactToCurrentCubeResult(7, Err("backend 500".to_string())),
         );
         assert_eq!(
             panel
@@ -2181,5 +2141,88 @@ mod add_to_cube_tests {
                 .map(String::as_str),
             Some("backend 500")
         );
+    }
+
+    // ── `contact_is_in_active_cube` helper ────────────────────────
+    // The contact-detail view uses this to hide the "Add to Current
+    // Cube" button when clicking it would no-op / 409.
+    use crate::services::coincube::ContactCube;
+
+    fn sample_contact_cube(id: u64, network: &str) -> ContactCube {
+        ContactCube {
+            id,
+            uuid: format!("cube-{id}"),
+            name: format!("Cube {id}"),
+            network: network.to_string(),
+            has_recovery_kit: false,
+        }
+    }
+
+    #[test]
+    fn contact_is_in_active_cube_false_when_no_active_cube() {
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        panel.contacts_state.step = ContactsStep::Detail(7);
+        panel.contacts_state.detail_cubes = Some(vec![sample_contact_cube(42, "bitcoin")]);
+        // No active_cube_server_id → helper returns false (we can't say
+        // the contact is in "the active cube" when there isn't one).
+        panel.contacts_state.active_cube_server_id = None;
+        assert!(!panel.contacts_state.contact_is_in_active_cube(7));
+    }
+
+    #[test]
+    fn contact_is_in_active_cube_false_while_detail_cubes_loading() {
+        // Optimistic: show the button until the associated-cubes fetch
+        // completes, rather than flashing it in once data arrives.
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        panel.contacts_state.step = ContactsStep::Detail(7);
+        panel.contacts_state.active_cube_server_id = Some(42);
+        panel.contacts_state.detail_cubes = None;
+        assert!(!panel.contacts_state.contact_is_in_active_cube(7));
+    }
+
+    #[test]
+    fn contact_is_in_active_cube_false_when_not_on_detail_step() {
+        // Defensive: only the Detail(contact_id) step has `detail_cubes`
+        // scoped to this contact. Returning true on any other step
+        // would mis-gate the button on the list view.
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        panel.contacts_state.active_cube_server_id = Some(42);
+        panel.contacts_state.detail_cubes = Some(vec![sample_contact_cube(42, "bitcoin")]);
+        panel.contacts_state.step = ContactsStep::List;
+        assert!(!panel.contacts_state.contact_is_in_active_cube(7));
+    }
+
+    #[test]
+    fn contact_is_in_active_cube_false_when_active_cube_not_in_associated_list() {
+        // Contact is a member of cubes 1 and 2, but the user is loaded
+        // into cube 42 — the contact is NOT in the active cube, so the
+        // button should remain visible.
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        panel.contacts_state.step = ContactsStep::Detail(7);
+        panel.contacts_state.active_cube_server_id = Some(42);
+        panel.contacts_state.detail_cubes = Some(vec![
+            sample_contact_cube(1, "bitcoin"),
+            sample_contact_cube(2, "bitcoin"),
+        ]);
+        assert!(!panel.contacts_state.contact_is_in_active_cube(7));
+    }
+
+    #[test]
+    fn contact_is_in_active_cube_true_when_active_cube_in_associated_list() {
+        // The core regression target: contact is already a member of
+        // the active cube, so the button should hide.
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        panel.contacts_state.step = ContactsStep::Detail(7);
+        panel.contacts_state.active_cube_server_id = Some(42);
+        panel.contacts_state.detail_cubes = Some(vec![
+            sample_contact_cube(1, "bitcoin"),
+            sample_contact_cube(42, "bitcoin"),
+        ]);
+        assert!(panel.contacts_state.contact_is_in_active_cube(7));
     }
 }

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1205,6 +1205,36 @@ pub fn load_contacts_data(client: &CoincubeClient, generation: u64) -> iced::Tas
     ])
 }
 
+/// Load Security tab data (verified devices + login activity).
+pub fn load_security_data(client: &CoincubeClient, generation: u64) -> iced::Task<Message> {
+    let c1 = client.clone();
+    let c2 = client.clone();
+    iced::Task::batch([
+        iced::Task::perform(
+            async move { c1.get_verified_devices().await },
+            move |res| match res {
+                Ok(devices) => Message::View(view::Message::ConnectAccount(
+                    ConnectAccountMessage::VerifiedDevicesLoaded(devices, generation),
+                )),
+                Err(e) => Message::View(view::Message::ConnectAccount(
+                    ConnectAccountMessage::Error(e.to_string()),
+                )),
+            },
+        ),
+        iced::Task::perform(
+            async move { c2.get_login_activity().await },
+            move |res| match res {
+                Ok(activity) => Message::View(view::Message::ConnectAccount(
+                    ConnectAccountMessage::LoginActivityLoaded(activity, generation),
+                )),
+                Err(e) => Message::View(view::Message::ConnectAccount(
+                    ConnectAccountMessage::Error(e.to_string()),
+                )),
+            },
+        ),
+    ])
+}
+
 #[cfg(test)]
 mod invite_form_tests {
     //! State-layer tests for the W12 cube multi-select invite form.
@@ -1325,34 +1355,4 @@ mod invite_form_tests {
         );
         assert_eq!(panel.contacts_state.invite_cube_selections, vec![1, 42]);
     }
-}
-
-/// Load Security tab data (verified devices + login activity).
-pub fn load_security_data(client: &CoincubeClient, generation: u64) -> iced::Task<Message> {
-    let c1 = client.clone();
-    let c2 = client.clone();
-    iced::Task::batch([
-        iced::Task::perform(
-            async move { c1.get_verified_devices().await },
-            move |res| match res {
-                Ok(devices) => Message::View(view::Message::ConnectAccount(
-                    ConnectAccountMessage::VerifiedDevicesLoaded(devices, generation),
-                )),
-                Err(e) => Message::View(view::Message::ConnectAccount(
-                    ConnectAccountMessage::Error(e.to_string()),
-                )),
-            },
-        ),
-        iced::Task::perform(
-            async move { c2.get_login_activity().await },
-            move |res| match res {
-                Ok(activity) => Message::View(view::Message::ConnectAccount(
-                    ConnectAccountMessage::LoginActivityLoaded(activity, generation),
-                )),
-                Err(e) => Message::View(view::Message::ConnectAccount(
-                    ConnectAccountMessage::Error(e.to_string()),
-                )),
-            },
-        ),
-    ])
 }

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -886,37 +886,7 @@ impl ConnectAccountPanel {
                 // Load the user's cubes for the "Also add to Cube(s)"
                 // multi-select (W12). Hidden in the view until this
                 // resolves; empty Vec renders as "no cubes section".
-                let client = self.client.clone();
-                let gen = self.session_generation;
-                return iced::Task::perform(async move { client.list_cubes().await }, move |res| {
-                    match res {
-                        Ok(cubes) => {
-                            let options = cubes
-                                .into_iter()
-                                .map(|c| InviteCubeOption {
-                                    id: c.id,
-                                    name: c.name,
-                                    network: c.network,
-                                })
-                                .collect::<Vec<_>>();
-                            Message::View(view::Message::ConnectAccount(
-                                ConnectAccountMessage::Contacts(
-                                    ContactsMessage::InviteCubesAvailable(options, gen),
-                                ),
-                            ))
-                        }
-                        Err(e) => {
-                            // Leave the section hidden on load failure —
-                            // the user can still send a plain invite.
-                            log::warn!("[CONTACTS] Failed to list cubes for invite form: {}", e);
-                            Message::View(view::Message::ConnectAccount(
-                                ConnectAccountMessage::Contacts(
-                                    ContactsMessage::InviteCubesAvailable(Vec::new(), gen),
-                                ),
-                            ))
-                        }
-                    }
-                });
+                return load_invite_cubes(&self.client, self.session_generation);
             }
 
             ContactsMessage::InviteCubesAvailable(cubes, gen) => {
@@ -1054,26 +1024,7 @@ impl ConnectAccountPanel {
                 // Refresh the cube list so the checkboxes reflect the
                 // user's current memberships. We stay on the form so
                 // the user can adjust and retry.
-                let client = self.client.clone();
-                let gen = self.session_generation;
-                return iced::Task::perform(async move { client.list_cubes().await }, move |res| {
-                    let options = match res {
-                        Ok(cubes) => cubes
-                            .into_iter()
-                            .map(|c| InviteCubeOption {
-                                id: c.id,
-                                name: c.name,
-                                network: c.network,
-                            })
-                            .collect(),
-                        Err(_) => Vec::new(),
-                    };
-                    Message::View(view::Message::ConnectAccount(
-                        ConnectAccountMessage::Contacts(ContactsMessage::InviteCubesAvailable(
-                            options, gen,
-                        )),
-                    ))
-                });
+                return load_invite_cubes(&self.client, self.session_generation);
             }
 
             ContactsMessage::InviteCreated => {
@@ -1203,6 +1154,36 @@ pub fn load_contacts_data(client: &CoincubeClient, generation: u64) -> iced::Tas
             },
         ),
     ])
+}
+
+/// Load the user's cubes for the W12 invite-form multi-select, mapping
+/// the raw `CubeResponse`s into lightweight `InviteCubeOption`s. Used by
+/// both the initial `ShowInviteForm` load and the `InviteCubeForbidden`
+/// reload after a 403 — any backend error silently resolves to an empty
+/// list so the invite form degrades to the plain (cube-less) path.
+fn load_invite_cubes(client: &CoincubeClient, generation: u64) -> iced::Task<Message> {
+    let client = client.clone();
+    iced::Task::perform(async move { client.list_cubes().await }, move |res| {
+        let options = match res {
+            Ok(cubes) => cubes
+                .into_iter()
+                .map(|c| InviteCubeOption {
+                    id: c.id,
+                    name: c.name,
+                    network: c.network,
+                })
+                .collect(),
+            Err(e) => {
+                log::warn!("[CONTACTS] Failed to list cubes for invite form: {}", e);
+                Vec::new()
+            }
+        };
+        Message::View(view::Message::ConnectAccount(
+            ConnectAccountMessage::Contacts(ContactsMessage::InviteCubesAvailable(
+                options, generation,
+            )),
+        ))
+    })
 }
 
 /// Load Security tab data (verified devices + login activity).

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1379,8 +1379,8 @@ impl ConnectAccountPanel {
                     return iced::Task::none();
                 };
                 let email = match contact.contact_user.as_ref() {
-                    Some(u) => u.email.clone(),
-                    None => {
+                    Some(u) if !u.email.is_empty() => u.email.clone(),
+                    _ => {
                         self.contacts_state
                             .add_to_current_cube_errors
                             .insert(contact_id, "Contact has no linked user".to_string());

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -888,9 +888,8 @@ impl ConnectAccountPanel {
                 // resolves; empty Vec renders as "no cubes section".
                 let client = self.client.clone();
                 let gen = self.session_generation;
-                return iced::Task::perform(
-                    async move { client.list_cubes().await },
-                    move |res| match res {
+                return iced::Task::perform(async move { client.list_cubes().await }, move |res| {
+                    match res {
                         Ok(cubes) => {
                             let options = cubes
                                 .into_iter()
@@ -916,8 +915,8 @@ impl ConnectAccountPanel {
                                 ),
                             ))
                         }
-                    },
-                );
+                    }
+                });
             }
 
             ContactsMessage::InviteCubesAvailable(cubes, gen) => {
@@ -1028,15 +1027,20 @@ impl ConnectAccountPanel {
                         // (the per-cube membership check failed). Route to
                         // the dedicated handler so the form stays open with
                         // a clear "some cubes are no longer available" msg.
-                        Err(e) if had_cubes && matches!(
-                            &e,
-                            crate::services::coincube::CoincubeError::Unsuccessful(info)
-                                if info.status_code == 403
-                        ) => Message::View(view::Message::ConnectAccount(
-                            ConnectAccountMessage::Contacts(
-                                ContactsMessage::InviteCubeForbidden(e.to_string()),
-                            ),
-                        )),
+                        Err(e)
+                            if had_cubes
+                                && matches!(
+                                    &e,
+                                    crate::services::coincube::CoincubeError::Unsuccessful(info)
+                                        if info.status_code == 403
+                                ) =>
+                        {
+                            Message::View(view::Message::ConnectAccount(
+                                ConnectAccountMessage::Contacts(
+                                    ContactsMessage::InviteCubeForbidden(e.to_string()),
+                                ),
+                            ))
+                        }
                         Err(e) => Message::View(view::Message::ConnectAccount(
                             ConnectAccountMessage::Contacts(ContactsMessage::Error(e.to_string())),
                         )),
@@ -1052,27 +1056,24 @@ impl ConnectAccountPanel {
                 // the user can adjust and retry.
                 let client = self.client.clone();
                 let gen = self.session_generation;
-                return iced::Task::perform(
-                    async move { client.list_cubes().await },
-                    move |res| {
-                        let options = match res {
-                            Ok(cubes) => cubes
-                                .into_iter()
-                                .map(|c| InviteCubeOption {
-                                    id: c.id,
-                                    name: c.name,
-                                    network: c.network,
-                                })
-                                .collect(),
-                            Err(_) => Vec::new(),
-                        };
-                        Message::View(view::Message::ConnectAccount(
-                            ConnectAccountMessage::Contacts(
-                                ContactsMessage::InviteCubesAvailable(options, gen),
-                            ),
-                        ))
-                    },
-                );
+                return iced::Task::perform(async move { client.list_cubes().await }, move |res| {
+                    let options = match res {
+                        Ok(cubes) => cubes
+                            .into_iter()
+                            .map(|c| InviteCubeOption {
+                                id: c.id,
+                                name: c.name,
+                                network: c.network,
+                            })
+                            .collect(),
+                        Err(_) => Vec::new(),
+                    };
+                    Message::View(view::Message::ConnectAccount(
+                        ConnectAccountMessage::Contacts(ContactsMessage::InviteCubesAvailable(
+                            options, gen,
+                        )),
+                    ))
+                });
             }
 
             ContactsMessage::InviteCreated => {

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -106,6 +106,12 @@ pub struct ContactsState {
     /// overwrite each other). `Ok(())` = in-flight or complete,
     /// `Err(msg)` = last attempt failed.
     pub add_to_current_cube_errors: std::collections::HashMap<u64, String>,
+    /// Contact ids whose one-click "Add to Current Cube" task is
+    /// currently in flight. Prevents a double-click from firing two
+    /// `create_cube_invite` requests (the second would 409, but it
+    /// still wastes a round-trip and would briefly flash the duplicate
+    /// error in the UI).
+    pub add_to_current_cube_pending: std::collections::HashSet<u64>,
 }
 
 /// State for the W14 "Add to Cube(s)…" multi-select dialog. Opened via
@@ -148,6 +154,7 @@ impl ContactsState {
             active_cube_server_id: None,
             add_to_cube_target: None,
             add_to_current_cube_errors: std::collections::HashMap::new(),
+            add_to_current_cube_pending: std::collections::HashSet::new(),
         }
     }
 
@@ -1214,11 +1221,18 @@ impl ConnectAccountPanel {
                     log::warn!("[CONTACTS] OpenAddToCubeDialog: contact {contact_id} not found");
                     return iced::Task::none();
                 };
-                let email = contact
-                    .contact_user
-                    .as_ref()
-                    .map(|u| u.email.clone())
-                    .unwrap_or_default();
+                let email = match contact.contact_user.as_ref() {
+                    Some(u) if !u.email.is_empty() => u.email.clone(),
+                    _ => {
+                        self.contacts_state
+                            .add_to_current_cube_errors
+                            .insert(contact_id, "Contact has no linked user".to_string());
+                        return iced::Task::none();
+                    }
+                };
+                self.contacts_state
+                    .add_to_current_cube_errors
+                    .remove(&contact_id);
                 self.contacts_state.add_to_cube_target = Some(AddToCubeDialog {
                     contact_id,
                     contact_email: email,
@@ -1271,6 +1285,8 @@ impl ConnectAccountPanel {
                 dialog.failures.clear();
                 let email = dialog.contact_email.clone();
                 let cube_ids = dialog.selections.clone();
+                let contact_id = dialog.contact_id;
+                let gen = self.session_generation;
                 let client = self.client.clone();
                 return iced::Task::perform(
                     async move {
@@ -1284,20 +1300,26 @@ impl ConnectAccountPanel {
                         }
                         results
                     },
-                    |results| {
+                    move |results| {
                         Message::View(view::Message::ConnectAccount(
                             ConnectAccountMessage::Contacts(ContactsMessage::AddToCubeResult(
-                                results,
+                                contact_id, gen, results,
                             )),
                         ))
                     },
                 );
             }
 
-            ContactsMessage::AddToCubeResult(results) => {
+            ContactsMessage::AddToCubeResult(contact_id, gen, results) => {
+                if gen != self.session_generation {
+                    return iced::Task::none();
+                }
                 let Some(dialog) = self.contacts_state.add_to_cube_target.as_mut() else {
                     return iced::Task::none();
                 };
+                if dialog.contact_id != contact_id {
+                    return iced::Task::none();
+                }
                 dialog.submitting = false;
                 let mut failures = std::collections::HashMap::new();
                 let mut succeeded_ids: Vec<u64> = Vec::new();
@@ -1335,6 +1357,13 @@ impl ConnectAccountPanel {
             }
 
             ContactsMessage::AddContactToCurrentCube(contact_id) => {
+                if self
+                    .contacts_state
+                    .add_to_current_cube_pending
+                    .contains(&contact_id)
+                {
+                    return iced::Task::none();
+                }
                 let Some(contact) = self
                     .contacts_state
                     .contacts
@@ -1375,6 +1404,9 @@ impl ConnectAccountPanel {
                 self.contacts_state
                     .add_to_current_cube_errors
                     .remove(&contact_id);
+                self.contacts_state
+                    .add_to_current_cube_pending
+                    .insert(contact_id);
                 let client = self.client.clone();
                 return iced::Task::perform(
                     async move {
@@ -1394,26 +1426,31 @@ impl ConnectAccountPanel {
                 );
             }
 
-            ContactsMessage::AddContactToCurrentCubeResult(contact_id, res) => match res {
-                Ok(_cube_id) => {
-                    self.contacts_state
-                        .add_to_current_cube_errors
-                        .remove(&contact_id);
-                    // Refresh the Associated Cubes section if we're on
-                    // that contact's detail view.
-                    if matches!(
-                        self.contacts_state.step,
-                        ContactsStep::Detail(id) if id == contact_id
-                    ) {
-                        return self.fetch_contact_cubes(contact_id);
+            ContactsMessage::AddContactToCurrentCubeResult(contact_id, res) => {
+                self.contacts_state
+                    .add_to_current_cube_pending
+                    .remove(&contact_id);
+                match res {
+                    Ok(_cube_id) => {
+                        self.contacts_state
+                            .add_to_current_cube_errors
+                            .remove(&contact_id);
+                        // Refresh the Associated Cubes section if we're on
+                        // that contact's detail view.
+                        if matches!(
+                            self.contacts_state.step,
+                            ContactsStep::Detail(id) if id == contact_id
+                        ) {
+                            return self.fetch_contact_cubes(contact_id);
+                        }
+                    }
+                    Err(msg) => {
+                        self.contacts_state
+                            .add_to_current_cube_errors
+                            .insert(contact_id, msg);
                     }
                 }
-                Err(msg) => {
-                    self.contacts_state
-                        .add_to_current_cube_errors
-                        .insert(contact_id, msg);
-                }
-            },
+            }
 
             ContactsMessage::Error(e) => {
                 log::error!("[CONTACTS] Error: {}", e);
@@ -1997,7 +2034,7 @@ mod add_to_cube_tests {
         }
         dispatch(
             &mut panel,
-            ContactsMessage::AddToCubeResult(vec![(1, Ok(())), (2, Ok(()))]),
+            ContactsMessage::AddToCubeResult(7, 0, vec![(1, Ok(())), (2, Ok(()))]),
         );
         assert!(
             panel.contacts_state.add_to_cube_target.is_none(),
@@ -2016,11 +2053,15 @@ mod add_to_cube_tests {
         }
         dispatch(
             &mut panel,
-            ContactsMessage::AddToCubeResult(vec![
-                (1, Ok(())),
-                (2, Err("already a member".to_string())),
-                (3, Err("forbidden".to_string())),
-            ]),
+            ContactsMessage::AddToCubeResult(
+                7,
+                0,
+                vec![
+                    (1, Ok(())),
+                    (2, Err("already a member".to_string())),
+                    (3, Err("forbidden".to_string())),
+                ],
+            ),
         );
         let dialog = panel
             .contacts_state

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -83,6 +83,49 @@ pub struct ContactsState {
     /// Non-`None` when the last submit 403'd on a cube id — drives the
     /// "one or more selected cubes is no longer available" dialog.
     pub invite_cube_error: Option<String>,
+    /// Network of the currently-active Cube, synced from
+    /// `ConnectCubePanel` by the parent `ConnectPanel`. Drives the
+    /// network filter on the W12 cube multi-select and the W14
+    /// "Add to Cube(s)…" dialog. `None` when the user is on a
+    /// Connect-only surface with no active cube — in that case callers
+    /// fall back to "all cubes" so the form doesn't render empty.
+    pub active_network: Option<String>,
+    /// Server-side numeric id of the currently-loaded Cube, synced
+    /// from `ConnectCubePanel` once the cube has registered with the
+    /// backend. Drives the W14 "Add to Current Cube" one-click path:
+    /// the action targets this exact cube rather than guessing from a
+    /// network-matching list (which breaks when the user has several
+    /// cubes on the same network).
+    pub active_cube_server_id: Option<u64>,
+    // --- W14: add-existing-contact-to-cube dialog ---
+    /// Active multi-select dialog for the "Add to Cube(s)…" flow.
+    /// `None` when closed. See `AddToCubeDialog`.
+    pub add_to_cube_target: Option<AddToCubeDialog>,
+    /// Transient status for the W14 one-click "Add to Current Cube"
+    /// action (keyed by contact id so concurrent row-clicks don't
+    /// overwrite each other). `Ok(())` = in-flight or complete,
+    /// `Err(msg)` = last attempt failed.
+    pub add_to_current_cube_errors: std::collections::HashMap<u64, String>,
+}
+
+/// State for the W14 "Add to Cube(s)…" multi-select dialog. Opened via
+/// `ContactsMessage::OpenAddToCubeDialog(contact_id)` from the contact
+/// detail view; closed via `CloseAddToCubeDialog` or on successful
+/// `ConfirmAddToCube`.
+#[derive(Debug, Clone)]
+pub struct AddToCubeDialog {
+    pub contact_id: u64,
+    pub contact_email: String,
+    /// Candidate cubes: network-filtered, unjoined-only, callable by
+    /// the current user. `None` while the candidate fetch is in
+    /// flight; `Some(vec)` once loaded (possibly empty).
+    pub candidate_cubes: Option<Vec<InviteCubeOption>>,
+    pub selections: Vec<u64>,
+    pub submitting: bool,
+    /// Per-cube errors from the last submit (keyed by cube id).
+    /// Populated when some of the parallel `create_cube_invite` calls
+    /// fail; the dialog stays open so the user can retry.
+    pub failures: std::collections::HashMap<u64, String>,
 }
 
 impl ContactsState {
@@ -101,11 +144,40 @@ impl ContactsState {
             invite_available_cubes: None,
             invite_cube_selections: Vec::new(),
             invite_cube_error: None,
+            active_network: None,
+            active_cube_server_id: None,
+            add_to_cube_target: None,
+            add_to_current_cube_errors: std::collections::HashMap::new(),
         }
     }
 
     pub fn clear(&mut self) {
         *self = Self::new();
+    }
+
+    /// True when the detail view's Associated-Cubes list includes the
+    /// currently-active cube, i.e. the contact is already a member.
+    /// Used by the contact detail view to hide the "Add to Current
+    /// Cube" button when the action would be a no-op.
+    ///
+    /// Returns `false` when:
+    ///   * the user isn't viewing this contact's detail (no
+    ///     `detail_cubes` loaded for them),
+    ///   * there's no active cube (`active_cube_server_id` is `None`),
+    ///   * the `detail_cubes` fetch hasn't completed yet (optimistic —
+    ///     better to show the button and let the backend 409 than to
+    ///     blink it in once data arrives).
+    pub fn contact_is_in_active_cube(&self, contact_id: u64) -> bool {
+        let Some(active_id) = self.active_cube_server_id else {
+            return false;
+        };
+        if !matches!(self.step, ContactsStep::Detail(id) if id == contact_id) {
+            return false;
+        }
+        self.detail_cubes
+            .as_deref()
+            .map(|cubes| cubes.iter().any(|c| c.id == active_id))
+            .unwrap_or(false)
     }
 }
 
@@ -207,6 +279,22 @@ impl ConnectAccountPanel {
 
     pub fn session_generation(&self) -> u64 {
         self.session_generation
+    }
+
+    /// Set the active Cube's network, used by the invite-form and
+    /// add-to-cube flows to filter candidate cubes to network-matching
+    /// ones. Called by the parent `ConnectPanel` when it wires up or
+    /// updates the cube side.
+    pub fn set_active_network(&mut self, network: Option<String>) {
+        self.contacts_state.active_network = network;
+    }
+
+    /// Set the active Cube's server-side numeric id. Populated by the
+    /// parent `ConnectPanel` once `ConnectCubePanel::server_cube_id`
+    /// resolves (post-registration). Drives the W14 "Add to Current
+    /// Cube" one-click action.
+    pub fn set_active_cube_server_id(&mut self, cube_id: Option<u64>) {
+        self.contacts_state.active_cube_server_id = cube_id;
     }
 
     /// Reset contacts state to list view and reload data from the API.
@@ -892,7 +980,11 @@ impl ConnectAccountPanel {
                 // Load the user's cubes for the "Also add to Cube(s)"
                 // multi-select (W12). Hidden in the view until this
                 // resolves; empty Vec renders as "no cubes section".
-                return load_invite_cubes(&self.client, self.session_generation);
+                return load_invite_cubes(
+                    &self.client,
+                    self.session_generation,
+                    self.contacts_state.active_network.clone(),
+                );
             }
 
             ContactsMessage::InviteCubesAvailable(cubes, gen) => {
@@ -957,10 +1049,6 @@ impl ConnectAccountPanel {
             ContactsMessage::InviteEmailChanged(email) => {
                 self.contacts_state.invite_email = email;
                 self.contacts_state.error = None;
-            }
-
-            ContactsMessage::InviteRoleChanged(role) => {
-                self.contacts_state.invite_role = role;
             }
 
             ContactsMessage::SubmitInvite => {
@@ -1030,7 +1118,11 @@ impl ConnectAccountPanel {
                 // Refresh the cube list so the checkboxes reflect the
                 // user's current memberships. We stay on the form so
                 // the user can adjust and retry.
-                return load_invite_cubes(&self.client, self.session_generation);
+                return load_invite_cubes(
+                    &self.client,
+                    self.session_generation,
+                    self.contacts_state.active_network.clone(),
+                );
             }
 
             ContactsMessage::InviteCreated => {
@@ -1098,6 +1190,264 @@ impl ConnectAccountPanel {
                     self.contacts_state.detail_cubes_error = Some(e);
                 }
             }
+
+            // ── W14: Add-existing-contact-to-Cube ─────────────────────
+            ContactsMessage::OpenAddToCubeDialog(contact_id) => {
+                let Some(contact) = self
+                    .contacts_state
+                    .contacts
+                    .as_deref()
+                    .unwrap_or_default()
+                    .iter()
+                    .find(|c| c.id == contact_id)
+                    .cloned()
+                else {
+                    log::warn!("[CONTACTS] OpenAddToCubeDialog: contact {contact_id} not found");
+                    return iced::Task::none();
+                };
+                let email = contact
+                    .contact_user
+                    .as_ref()
+                    .map(|u| u.email.clone())
+                    .unwrap_or_default();
+                self.contacts_state.add_to_cube_target = Some(AddToCubeDialog {
+                    contact_id,
+                    contact_email: email,
+                    candidate_cubes: None,
+                    selections: Vec::new(),
+                    submitting: false,
+                    failures: std::collections::HashMap::new(),
+                });
+                return load_add_to_cube_candidates(
+                    &self.client,
+                    contact_id,
+                    contact.effective_contact_user_id(),
+                    self.session_generation,
+                    self.contacts_state.active_network.clone(),
+                );
+            }
+
+            ContactsMessage::AddToCubeCandidatesLoaded(contact_id, cubes, gen) => {
+                // Stale-guard: session turnover OR a different contact's
+                // dialog opened in the meantime.
+                if gen != self.session_generation {
+                    return iced::Task::none();
+                }
+                if let Some(dialog) = self.contacts_state.add_to_cube_target.as_mut() {
+                    if dialog.contact_id == contact_id {
+                        dialog.candidate_cubes = Some(cubes);
+                    }
+                }
+            }
+
+            ContactsMessage::ToggleAddToCubeSelection(cube_id) => {
+                if let Some(dialog) = self.contacts_state.add_to_cube_target.as_mut() {
+                    if let Some(pos) = dialog.selections.iter().position(|id| *id == cube_id) {
+                        dialog.selections.remove(pos);
+                    } else {
+                        dialog.selections.push(cube_id);
+                    }
+                    dialog.failures.clear();
+                }
+            }
+
+            ContactsMessage::ConfirmAddToCube => {
+                let Some(dialog) = self.contacts_state.add_to_cube_target.as_mut() else {
+                    return iced::Task::none();
+                };
+                if dialog.submitting || dialog.selections.is_empty() {
+                    return iced::Task::none();
+                }
+                dialog.submitting = true;
+                dialog.failures.clear();
+                let email = dialog.contact_email.clone();
+                let cube_ids = dialog.selections.clone();
+                let client = self.client.clone();
+                return iced::Task::perform(
+                    async move {
+                        // Sequential per-cube calls — N is small and
+                        // sequential keeps the result order deterministic
+                        // for the failures map.
+                        let mut results = Vec::with_capacity(cube_ids.len());
+                        for cube_id in cube_ids {
+                            let r = client.create_cube_invite(cube_id, &email).await;
+                            results.push((cube_id, r.map(|_| ()).map_err(|e| e.to_string())));
+                        }
+                        results
+                    },
+                    |results| {
+                        Message::View(view::Message::ConnectAccount(
+                            ConnectAccountMessage::Contacts(ContactsMessage::AddToCubeResult(
+                                results,
+                            )),
+                        ))
+                    },
+                );
+            }
+
+            ContactsMessage::AddToCubeResult(results) => {
+                let Some(dialog) = self.contacts_state.add_to_cube_target.as_mut() else {
+                    return iced::Task::none();
+                };
+                dialog.submitting = false;
+                let mut failures = std::collections::HashMap::new();
+                let mut succeeded_ids: Vec<u64> = Vec::new();
+                for (cube_id, r) in results {
+                    match r {
+                        Ok(()) => succeeded_ids.push(cube_id),
+                        Err(msg) => {
+                            failures.insert(cube_id, msg);
+                        }
+                    }
+                }
+                if failures.is_empty() {
+                    // Full success: close the dialog and refresh the
+                    // Associated-Cubes section so the UI reflects the
+                    // new memberships.
+                    let contact_id = dialog.contact_id;
+                    self.contacts_state.add_to_cube_target = None;
+                    if matches!(
+                        self.contacts_state.step,
+                        ContactsStep::Detail(id) if id == contact_id
+                    ) {
+                        let client = self.client.clone();
+                        let gen = self.session_generation;
+                        return iced::Task::perform(
+                            async move { client.get_cubes_by_contact(contact_id).await },
+                            move |res| match res {
+                                Ok(cubes) => Message::View(view::Message::ConnectAccount(
+                                    ConnectAccountMessage::Contacts(
+                                        ContactsMessage::ContactCubesLoaded(
+                                            contact_id, cubes, gen,
+                                        ),
+                                    ),
+                                )),
+                                Err(e) => Message::View(view::Message::ConnectAccount(
+                                    ConnectAccountMessage::Contacts(
+                                        ContactsMessage::ContactCubesFailed(
+                                            contact_id,
+                                            e.to_string(),
+                                        ),
+                                    ),
+                                )),
+                            },
+                        );
+                    }
+                    return iced::Task::none();
+                }
+                // Partial / full failure: keep the dialog open and surface
+                // per-cube messages. Drop succeeded selections so the user
+                // can't re-submit them (re-submit would 409 on duplicate).
+                dialog.selections.retain(|id| !succeeded_ids.contains(id));
+                dialog.failures = failures;
+            }
+
+            ContactsMessage::CloseAddToCubeDialog => {
+                self.contacts_state.add_to_cube_target = None;
+            }
+
+            ContactsMessage::AddContactToCurrentCube(contact_id) => {
+                let Some(contact) = self
+                    .contacts_state
+                    .contacts
+                    .as_deref()
+                    .unwrap_or_default()
+                    .iter()
+                    .find(|c| c.id == contact_id)
+                    .cloned()
+                else {
+                    log::warn!(
+                        "[CONTACTS] AddContactToCurrentCube: contact {contact_id} not found"
+                    );
+                    return iced::Task::none();
+                };
+                let email = match contact.contact_user.as_ref() {
+                    Some(u) => u.email.clone(),
+                    None => {
+                        self.contacts_state
+                            .add_to_current_cube_errors
+                            .insert(contact_id, "Contact has no linked user".to_string());
+                        return iced::Task::none();
+                    }
+                };
+                // Target the server-side id of the cube the user is
+                // actually loaded into. This works regardless of how
+                // many other cubes the user owns on the same network —
+                // the prior "match-by-network" heuristic broke when
+                // there were multiple mainnet cubes.
+                let Some(cube_id) = self.contacts_state.active_cube_server_id else {
+                    self.contacts_state.add_to_current_cube_errors.insert(
+                        contact_id,
+                        "Current cube isn't registered yet — please retry in a moment."
+                            .to_string(),
+                    );
+                    return iced::Task::none();
+                };
+                // Clear any prior error for this contact so retries show
+                // fresh state.
+                self.contacts_state
+                    .add_to_current_cube_errors
+                    .remove(&contact_id);
+                let client = self.client.clone();
+                return iced::Task::perform(
+                    async move {
+                        client
+                            .create_cube_invite(cube_id, &email)
+                            .await
+                            .map(|_| cube_id)
+                            .map_err(|e| e.to_string())
+                    },
+                    move |res| {
+                        Message::View(view::Message::ConnectAccount(
+                            ConnectAccountMessage::Contacts(
+                                ContactsMessage::AddContactToCurrentCubeResult(contact_id, res),
+                            ),
+                        ))
+                    },
+                );
+            }
+
+            ContactsMessage::AddContactToCurrentCubeResult(contact_id, res) => match res {
+                Ok(_cube_id) => {
+                    self.contacts_state
+                        .add_to_current_cube_errors
+                        .remove(&contact_id);
+                    // Refresh the Associated Cubes section if we're on
+                    // that contact's detail view.
+                    if matches!(
+                        self.contacts_state.step,
+                        ContactsStep::Detail(id) if id == contact_id
+                    ) {
+                        let client = self.client.clone();
+                        let gen = self.session_generation;
+                        return iced::Task::perform(
+                            async move { client.get_cubes_by_contact(contact_id).await },
+                            move |res| match res {
+                                Ok(cubes) => Message::View(view::Message::ConnectAccount(
+                                    ConnectAccountMessage::Contacts(
+                                        ContactsMessage::ContactCubesLoaded(
+                                            contact_id, cubes, gen,
+                                        ),
+                                    ),
+                                )),
+                                Err(e) => Message::View(view::Message::ConnectAccount(
+                                    ConnectAccountMessage::Contacts(
+                                        ContactsMessage::ContactCubesFailed(
+                                            contact_id,
+                                            e.to_string(),
+                                        ),
+                                    ),
+                                )),
+                            },
+                        );
+                    }
+                }
+                Err(msg) => {
+                    self.contacts_state
+                        .add_to_current_cube_errors
+                        .insert(contact_id, msg);
+                }
+            },
 
             ContactsMessage::Error(e) => {
                 log::error!("[CONTACTS] Error: {}", e);
@@ -1167,12 +1517,28 @@ pub fn load_contacts_data(client: &CoincubeClient, generation: u64) -> iced::Tas
 /// both the initial `ShowInviteForm` load and the `InviteCubeForbidden`
 /// reload after a 403 — any backend error silently resolves to an empty
 /// list so the invite form degrades to the plain (cube-less) path.
-fn load_invite_cubes(client: &CoincubeClient, generation: u64) -> iced::Task<Message> {
+///
+/// When `active_network` is `Some`, only cubes on that network are
+/// returned (PR 5 §2.7 tweak #1 — prevents cross-network invites).
+/// When it's `None` (e.g. the user is on a Connect-only surface with no
+/// active cube selected), no filter is applied so the form doesn't
+/// render empty.
+fn load_invite_cubes(
+    client: &CoincubeClient,
+    generation: u64,
+    active_network: Option<String>,
+) -> iced::Task<Message> {
     let client = client.clone();
     iced::Task::perform(async move { client.list_cubes().await }, move |res| {
         let options = match res {
             Ok(cubes) => cubes
                 .into_iter()
+                .filter(|c| {
+                    active_network
+                        .as_deref()
+                        .map(|net| c.network == net)
+                        .unwrap_or(true)
+                })
                 .map(|c| InviteCubeOption {
                     id: c.id,
                     name: c.name,
@@ -1190,6 +1556,84 @@ fn load_invite_cubes(client: &CoincubeClient, generation: u64) -> iced::Task<Mes
             )),
         ))
     })
+}
+
+/// Load candidate cubes for the W14 "Add to Cube(s)…" dialog.
+///
+/// Applies three filters (in order):
+///   1. **Network filter**: when `active_network` is `Some`, keep only
+///      cubes on that network. When `None`, keep all (same fallback rule
+///      as `load_invite_cubes`).
+///   2. **Owner-or-member filter**: the list is returned by
+///      `list_cubes()` which the backend scopes to cubes the caller
+///      can administer, so this is effectively a noop today —
+///      documented here so the invariant is obvious if backend scope
+///      ever changes.
+///   3. **Unjoined filter**: iterate each candidate, fetch `get_cube(id)`
+///      to populate its `members`, and drop cubes where the contact's
+///      user id already appears in the member list.
+///
+/// On any backend error, the candidate list silently resolves to
+/// empty so the dialog just shows "no eligible cubes" rather than a
+/// scary error. Individual `get_cube` failures drop that single cube.
+fn load_add_to_cube_candidates(
+    client: &CoincubeClient,
+    contact_id: u64,
+    contact_user_id: Option<u64>,
+    generation: u64,
+    active_network: Option<String>,
+) -> iced::Task<Message> {
+    let client = client.clone();
+    iced::Task::perform(
+        async move {
+            let Ok(cubes) = client.list_cubes().await else {
+                return Vec::new();
+            };
+            let mut out: Vec<InviteCubeOption> = Vec::new();
+            for cube in cubes {
+                // (1) network filter
+                if let Some(net) = active_network.as_deref() {
+                    if cube.network != net {
+                        continue;
+                    }
+                }
+                // (3) unjoined filter: per-cube fetch to resolve members.
+                // Skip when we don't know the contact's user id (e.g.
+                // contact has no linked user) — we can't tell if they're
+                // already a member, so be permissive.
+                if let Some(contact_uid) = contact_user_id {
+                    match client.get_cube(cube.id).await {
+                        Ok(full) => {
+                            if full.members.iter().any(|m| m.user_id == contact_uid) {
+                                continue;
+                            }
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "[CONTACTS] get_cube({}) failed while filtering candidates: {}",
+                                cube.id,
+                                e
+                            );
+                            continue;
+                        }
+                    }
+                }
+                out.push(InviteCubeOption {
+                    id: cube.id,
+                    name: cube.name,
+                    network: cube.network,
+                });
+            }
+            out
+        },
+        move |options| {
+            Message::View(view::Message::ConnectAccount(
+                ConnectAccountMessage::Contacts(ContactsMessage::AddToCubeCandidatesLoaded(
+                    contact_id, options, generation,
+                )),
+            ))
+        },
+    )
 }
 
 /// Load Security tab data (verified devices + login activity).
@@ -1341,5 +1785,401 @@ mod invite_form_tests {
             ),
         );
         assert_eq!(panel.contacts_state.invite_cube_selections, vec![1, 42]);
+    }
+
+    // ── PR 5 §2.7 tweak #2 — role selector removal ────────────────
+    #[test]
+    fn invite_role_defaults_to_keyholder_and_stays_keyholder() {
+        // After dropping the role selector the state's `invite_role`
+        // must initialise to — and stay at — Keyholder across a
+        // typical invite form lifecycle.
+        let mut panel = ConnectAccountPanel::new();
+        assert_eq!(
+            panel.contacts_state.invite_role,
+            crate::services::coincube::ContactRole::Keyholder
+        );
+        dispatch(&mut panel, ContactsMessage::ShowInviteForm);
+        assert_eq!(
+            panel.contacts_state.invite_role,
+            crate::services::coincube::ContactRole::Keyholder
+        );
+        dispatch(
+            &mut panel,
+            ContactsMessage::InviteEmailChanged("friend@example.com".to_string()),
+        );
+        assert_eq!(
+            panel.contacts_state.invite_role,
+            crate::services::coincube::ContactRole::Keyholder
+        );
+    }
+
+    // ── PR 5 §2.7 tweak #1 — network filter plumbing ──────────────
+    #[test]
+    fn set_active_network_writes_to_contacts_state() {
+        // The parent `ConnectPanel` calls `set_active_network` on
+        // construction to propagate the cube's network down. Without
+        // it, `load_invite_cubes` has no filter anchor and the dialog
+        // would mix mainnet/regtest cubes.
+        let mut panel = ConnectAccountPanel::new();
+        assert!(panel.contacts_state.active_network.is_none());
+        panel.set_active_network(Some("bitcoin".to_string()));
+        assert_eq!(
+            panel.contacts_state.active_network.as_deref(),
+            Some("bitcoin")
+        );
+        panel.set_active_network(None);
+        assert!(panel.contacts_state.active_network.is_none());
+    }
+}
+
+// =============================================================================
+// W14 state tests — "Add to Cube(s)…" dialog (PR 5 §2.8)
+// =============================================================================
+//
+// Exercises the `ContactsMessage` dispatch path via the public
+// `update_message` entrypoint, same pattern as `invite_form_tests` above.
+// Tests never touch the network — `OpenAddToCubeDialog` also triggers an
+// async `list_cubes()` fetch whose returned `Task` is discarded; we feed
+// the follow-up `AddToCubeCandidatesLoaded` message manually to drive
+// the state machine through its useful transitions.
+#[cfg(test)]
+mod add_to_cube_tests {
+    use super::*;
+    use crate::services::coincube::{ContactRole, ContactUser};
+
+    fn dispatch(panel: &mut ConnectAccountPanel, msg: ContactsMessage) {
+        let _ = panel.update_message(ConnectAccountMessage::Contacts(msg));
+    }
+
+    fn option(id: u64, name: &str, network: &str) -> InviteCubeOption {
+        InviteCubeOption {
+            id,
+            name: name.to_string(),
+            network: network.to_string(),
+        }
+    }
+
+    fn sample_contact(contact_id: u64, user_id: u64, email: &str) -> Contact {
+        Contact {
+            id: contact_id,
+            user_id: 0,
+            contact_user_id: 0,
+            invite_id: None,
+            role: ContactRole::Keyholder,
+            contact_user: Some(ContactUser {
+                id: user_id,
+                email: email.to_string(),
+                email_verified: Some(true),
+            }),
+            created_at: "2026-04-20T00:00:00Z".to_string(),
+        }
+    }
+
+    fn panel_with_contact(contact: Contact, network: Option<&str>) -> ConnectAccountPanel {
+        let mut panel = ConnectAccountPanel::new();
+        panel.contacts_state.contacts = Some(vec![contact]);
+        panel.contacts_state.active_network = network.map(|s| s.to_string());
+        panel
+    }
+
+    #[test]
+    fn open_add_to_cube_dialog_initialises_target_and_loads_candidates() {
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+
+        // `OpenAddToCubeDialog` should install the dialog struct
+        // synchronously and kick off the async candidate fetch (whose
+        // result we ignore in this test — covered separately below).
+        dispatch(&mut panel, ContactsMessage::OpenAddToCubeDialog(7));
+
+        let dialog = panel
+            .contacts_state
+            .add_to_cube_target
+            .as_ref()
+            .expect("dialog should be open");
+        assert_eq!(dialog.contact_id, 7);
+        assert_eq!(dialog.contact_email, "alice@example.com");
+        assert!(dialog.candidate_cubes.is_none(), "candidates pending load");
+        assert!(dialog.selections.is_empty());
+        assert!(!dialog.submitting);
+    }
+
+    #[test]
+    fn open_add_to_cube_dialog_noop_when_contact_missing() {
+        // No contact with id 99 in the panel — the handler should log
+        // and bail without installing a dialog.
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        dispatch(&mut panel, ContactsMessage::OpenAddToCubeDialog(99));
+        assert!(panel.contacts_state.add_to_cube_target.is_none());
+    }
+
+    #[test]
+    fn add_to_cube_candidates_loaded_populates_dialog() {
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        dispatch(&mut panel, ContactsMessage::OpenAddToCubeDialog(7));
+
+        let gen = panel.session_generation();
+        dispatch(
+            &mut panel,
+            ContactsMessage::AddToCubeCandidatesLoaded(
+                7,
+                vec![
+                    option(1, "Alpha", "bitcoin"),
+                    option(2, "Bravo", "bitcoin"),
+                ],
+                gen,
+            ),
+        );
+        let cubes = panel
+            .contacts_state
+            .add_to_cube_target
+            .as_ref()
+            .unwrap()
+            .candidate_cubes
+            .as_ref()
+            .expect("candidates should be populated");
+        assert_eq!(cubes.len(), 2);
+        assert_eq!(cubes[0].name, "Alpha");
+    }
+
+    #[test]
+    fn add_to_cube_candidates_loaded_stale_gen_ignored() {
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        dispatch(&mut panel, ContactsMessage::OpenAddToCubeDialog(7));
+        let stale_gen = panel.session_generation().wrapping_add(1);
+        dispatch(
+            &mut panel,
+            ContactsMessage::AddToCubeCandidatesLoaded(
+                7,
+                vec![option(1, "Alpha", "bitcoin")],
+                stale_gen,
+            ),
+        );
+        assert!(panel
+            .contacts_state
+            .add_to_cube_target
+            .as_ref()
+            .unwrap()
+            .candidate_cubes
+            .is_none());
+    }
+
+    #[test]
+    fn add_to_cube_candidates_loaded_wrong_contact_ignored() {
+        // Dialog opened for contact 7, but the load result arrives for
+        // contact 99 (race with a concurrent Open). Should be dropped.
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        dispatch(&mut panel, ContactsMessage::OpenAddToCubeDialog(7));
+        let gen = panel.session_generation();
+        dispatch(
+            &mut panel,
+            ContactsMessage::AddToCubeCandidatesLoaded(
+                99,
+                vec![option(1, "Alpha", "bitcoin")],
+                gen,
+            ),
+        );
+        assert!(panel
+            .contacts_state
+            .add_to_cube_target
+            .as_ref()
+            .unwrap()
+            .candidate_cubes
+            .is_none());
+    }
+
+    #[test]
+    fn toggle_add_to_cube_selection_adds_and_removes() {
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        dispatch(&mut panel, ContactsMessage::OpenAddToCubeDialog(7));
+        dispatch(&mut panel, ContactsMessage::ToggleAddToCubeSelection(1));
+        dispatch(&mut panel, ContactsMessage::ToggleAddToCubeSelection(3));
+        assert_eq!(
+            panel
+                .contacts_state
+                .add_to_cube_target
+                .as_ref()
+                .unwrap()
+                .selections,
+            vec![1, 3]
+        );
+        dispatch(&mut panel, ContactsMessage::ToggleAddToCubeSelection(1));
+        assert_eq!(
+            panel
+                .contacts_state
+                .add_to_cube_target
+                .as_ref()
+                .unwrap()
+                .selections,
+            vec![3]
+        );
+    }
+
+    #[test]
+    fn add_to_cube_result_full_success_closes_dialog() {
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        dispatch(&mut panel, ContactsMessage::OpenAddToCubeDialog(7));
+        // Stand in for the async branch: pretend the user picked cubes
+        // 1 and 2 and the parallel `create_cube_invite` calls all
+        // succeeded.
+        if let Some(d) = panel.contacts_state.add_to_cube_target.as_mut() {
+            d.selections = vec![1, 2];
+            d.submitting = true;
+        }
+        dispatch(
+            &mut panel,
+            ContactsMessage::AddToCubeResult(vec![(1, Ok(())), (2, Ok(()))]),
+        );
+        assert!(
+            panel.contacts_state.add_to_cube_target.is_none(),
+            "full-success should close the dialog"
+        );
+    }
+
+    #[test]
+    fn add_to_cube_result_partial_failure_keeps_dialog_open_with_error_summary() {
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        dispatch(&mut panel, ContactsMessage::OpenAddToCubeDialog(7));
+        if let Some(d) = panel.contacts_state.add_to_cube_target.as_mut() {
+            d.selections = vec![1, 2, 3];
+            d.submitting = true;
+        }
+        dispatch(
+            &mut panel,
+            ContactsMessage::AddToCubeResult(vec![
+                (1, Ok(())),
+                (2, Err("already a member".to_string())),
+                (3, Err("forbidden".to_string())),
+            ]),
+        );
+        let dialog = panel
+            .contacts_state
+            .add_to_cube_target
+            .as_ref()
+            .expect("partial failure must keep the dialog open");
+        assert!(!dialog.submitting);
+        assert_eq!(
+            dialog.failures.get(&2).map(String::as_str),
+            Some("already a member")
+        );
+        assert_eq!(
+            dialog.failures.get(&3).map(String::as_str),
+            Some("forbidden")
+        );
+        // Succeeded cube (id 1) dropped from selections so it isn't
+        // resubmitted on a retry.
+        assert_eq!(dialog.selections, vec![2, 3]);
+    }
+
+    #[test]
+    fn close_add_to_cube_dialog_clears_target() {
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        dispatch(&mut panel, ContactsMessage::OpenAddToCubeDialog(7));
+        dispatch(&mut panel, ContactsMessage::CloseAddToCubeDialog);
+        assert!(panel.contacts_state.add_to_cube_target.is_none());
+    }
+
+    #[test]
+    fn add_contact_to_current_cube_proceeds_when_server_id_is_set() {
+        // Regression: the prior implementation refused the one-click
+        // action when the user had multiple cubes on the same network.
+        // After routing to the specific `active_cube_server_id`, the
+        // handler must proceed (no per-contact error set) regardless
+        // of how many other cubes exist.
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        panel.contacts_state.active_cube_server_id = Some(42);
+        dispatch(&mut panel, ContactsMessage::AddContactToCurrentCube(7));
+        // The async `create_cube_invite` Task fires but we don't drive
+        // it; assert on what the synchronous handler setup did:
+        // — no error inserted in the per-contact map
+        // — any prior error cleared
+        assert!(!panel
+            .contacts_state
+            .add_to_current_cube_errors
+            .contains_key(&7));
+    }
+
+    #[test]
+    fn add_contact_to_current_cube_without_server_id_surfaces_not_ready_error() {
+        // If the cube hasn't registered with the backend yet
+        // (`active_cube_server_id` is still None), fail fast with a
+        // human-readable message rather than firing a speculative
+        // network request that would also fail.
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        panel.contacts_state.active_cube_server_id = None;
+        dispatch(&mut panel, ContactsMessage::AddContactToCurrentCube(7));
+        let msg = panel
+            .contacts_state
+            .add_to_current_cube_errors
+            .get(&7)
+            .map(String::as_str);
+        assert_eq!(
+            msg,
+            Some("Current cube isn't registered yet — please retry in a moment.")
+        );
+    }
+
+    #[test]
+    fn add_contact_to_current_cube_without_linked_user_surfaces_error() {
+        // Contact has no `contact_user` (backend omitempty'd it) —
+        // there's no email to invite with, so the handler must drop an
+        // inline error keyed by contact id and skip the network call.
+        let mut contact = sample_contact(7, 99, "alice@example.com");
+        contact.contact_user = None;
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        dispatch(&mut panel, ContactsMessage::AddContactToCurrentCube(7));
+        assert!(panel
+            .contacts_state
+            .add_to_current_cube_errors
+            .contains_key(&7));
+    }
+
+    #[test]
+    fn add_contact_to_current_cube_result_ok_clears_any_prior_error() {
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        panel
+            .contacts_state
+            .add_to_current_cube_errors
+            .insert(7, "earlier failure".to_string());
+        dispatch(
+            &mut panel,
+            ContactsMessage::AddContactToCurrentCubeResult(7, Ok(42)),
+        );
+        assert!(!panel
+            .contacts_state
+            .add_to_current_cube_errors
+            .contains_key(&7));
+    }
+
+    #[test]
+    fn add_contact_to_current_cube_result_err_stores_message() {
+        let contact = sample_contact(7, 99, "alice@example.com");
+        let mut panel = panel_with_contact(contact, Some("bitcoin"));
+        dispatch(
+            &mut panel,
+            ContactsMessage::AddContactToCurrentCubeResult(
+                7,
+                Err("backend 500".to_string()),
+            ),
+        );
+        assert_eq!(
+            panel
+                .contacts_state
+                .add_to_current_cube_errors
+                .get(&7)
+                .map(String::as_str),
+            Some("backend 500")
+        );
     }
 }

--- a/coincube-gui/src/app/state/connect/cube.rs
+++ b/coincube-gui/src/app/state/connect/cube.rs
@@ -15,7 +15,7 @@ use crate::{
     },
 };
 
-use super::AvatarFlowStep;
+use super::{cube_members, AvatarFlowStep, ConnectCubeMembersState};
 
 /// Per-Cube Connect panel handling Lightning Address and Avatar.
 /// These features are tied to the Cube's Breez wallet (BOLT12 offer).
@@ -51,6 +51,8 @@ pub struct ConnectCubePanel {
     pub avatar_error: Option<String>,
     pub avatar_image_cache: HashMap<u64, (Vec<u8>, iced::widget::image::Handle)>,
     pub avatar_draft: AvatarUserTraits,
+    // Members (W8)
+    pub members: ConnectCubeMembersState,
 }
 
 impl ConnectCubePanel {
@@ -83,6 +85,7 @@ impl ConnectCubePanel {
             avatar_error: None,
             avatar_image_cache: HashMap::new(),
             avatar_draft: AvatarUserTraits::default(),
+            members: ConnectCubeMembersState::new(),
         }
     }
 
@@ -113,6 +116,7 @@ impl ConnectCubePanel {
         self.avatar_error = None;
         self.avatar_image_cache.clear();
         self.avatar_draft = AvatarUserTraits::default();
+        self.members.clear();
     }
 
     /// Returns the server-side cube ID as a string for API paths.
@@ -332,6 +336,15 @@ impl ConnectCubePanel {
 
             ConnectCubeMessage::Avatar(avatar_msg) => {
                 return self.update_avatar(avatar_msg);
+            }
+
+            ConnectCubeMessage::Members(msg) => {
+                return cube_members::update(
+                    &mut self.members,
+                    msg,
+                    self.client.clone(),
+                    self.server_cube_id,
+                );
             }
         }
 

--- a/coincube-gui/src/app/state/connect/cube_members.rs
+++ b/coincube-gui/src/app/state/connect/cube_members.rs
@@ -63,7 +63,18 @@ pub fn update(
 ) -> iced::Task<Message> {
     match msg {
         ConnectCubeMembersMessage::Enter => {
-            if state.members.is_empty() && state.pending_invites.is_empty() && !state.loading {
+            // Skip if a load is already in flight — avoid piling duplicates
+            // on top of each other when the user taps quickly.
+            if state.loading {
+                return iced::Task::none();
+            }
+            // Retry when (a) we have no data yet, or (b) the previous load
+            // failed and the panel is showing stale/empty data plus an
+            // error banner. Successful cached data is left alone — the
+            // Reload button is the explicit "force refresh" path.
+            let needs_load = state.error.is_some()
+                || (state.members.is_empty() && state.pending_invites.is_empty());
+            if needs_load {
                 return spawn_load(state, client, cube_id);
             }
             iced::Task::none()
@@ -274,8 +285,9 @@ fn spawn_load_silent(
 /// for PR 3. The string match is defensive so a false-negative just routes
 /// to the generic error banner rather than the dedicated dialog.
 fn is_stranded_vault_conflict(err: &str) -> bool {
-    let lower = err.to_ascii_lowercase();
-    lower.contains("active vault") || lower.contains("active vaults")
+    // Matches both "active vault" and "active vaults" (plural contains
+    // singular as a substring).
+    err.to_ascii_lowercase().contains("active vault")
 }
 
 #[cfg(test)]
@@ -525,6 +537,62 @@ mod tests {
         );
         assert_eq!(state.members.len(), 1);
         assert_eq!(state.members[0].id, 2);
+    }
+
+    #[test]
+    fn enter_retries_when_prior_load_errored_even_with_stale_data() {
+        // Regression: successful load populated members, then a later
+        // Reload failed — Enter used to skip the retry because members
+        // wasn't empty, leaving the panel wedged on stale data + an
+        // error banner.
+        let mut state = ConnectCubeMembersState::new();
+        state.members = vec![sample_member(7, "alice@example.com")];
+        state.error = Some("previous load failed".to_string());
+        // generation starts at 0
+        assert_eq!(state.load_generation, 0);
+
+        // None/None for client/cube_id — we assert on the load-generation
+        // bump as a proxy for "spawn_load was invoked". spawn_load's
+        // guarded branch sets state.error and returns Task::none when the
+        // client is missing, so we expect the error message to be
+        // replaced with the "not ready" copy.
+        run(&mut state, ConnectCubeMembersMessage::Enter);
+        // `spawn_load` short-circuits on missing client, which in turn
+        // replaces `state.error` with the "Not ready" message. The stale
+        // error from the prior failed load is cleared as a side effect —
+        // proving the retry path fired.
+        assert_ne!(
+            state.error.as_deref(),
+            Some("previous load failed"),
+            "Enter should have attempted a fresh load, clearing the stale error"
+        );
+    }
+
+    #[test]
+    fn enter_skips_when_loaded_successfully_and_no_error() {
+        // Happy cached state: members present, no error, not loading.
+        // Enter should be a no-op — the explicit Reload button is the
+        // "force refresh" path.
+        let mut state = ConnectCubeMembersState::new();
+        state.members = vec![sample_member(7, "alice@example.com")];
+        state.error = None;
+        // Need a client for spawn_load to fire the network task; we
+        // assert the generation DOESN'T bump instead.
+        let gen_before = state.load_generation;
+        let loading_before = state.loading;
+        run(&mut state, ConnectCubeMembersMessage::Enter);
+        assert_eq!(state.load_generation, gen_before);
+        assert_eq!(state.loading, loading_before);
+    }
+
+    #[test]
+    fn enter_skips_when_load_is_in_flight() {
+        let mut state = ConnectCubeMembersState::new();
+        state.loading = true; // simulate in-flight load
+        let gen_before = state.load_generation;
+        run(&mut state, ConnectCubeMembersMessage::Enter);
+        assert_eq!(state.load_generation, gen_before);
+        assert!(state.loading);
     }
 
     #[test]

--- a/coincube-gui/src/app/state/connect/cube_members.rs
+++ b/coincube-gui/src/app/state/connect/cube_members.rs
@@ -1,0 +1,552 @@
+//! Cube-scoped members panel state (W8).
+//!
+//! Held as a sub-state on [`ConnectCubePanel`](super::cube::ConnectCubePanel)
+//! so it inherits the authenticated `CoincubeClient` and the server cube id
+//! from its parent. See `plans/PLAN-cube-membership-desktop.md` §2.2.
+
+use crate::{
+    app::{
+        message::Message,
+        view::{self, ConnectCubeMembersMessage, ConnectCubeMessage},
+    },
+    services::coincube::{
+        CoincubeClient, CubeInviteOrAddResult, CubeInviteSummary, CubeMember, CubeResponse,
+    },
+};
+
+/// In-memory state for the Members panel.
+///
+/// Mirrors the `ContactsState` shape on the account panel so the view code can
+/// render from plain fields — no task orchestration lives in here.
+#[derive(Debug, Default)]
+pub struct ConnectCubeMembersState {
+    pub members: Vec<CubeMember>,
+    pub pending_invites: Vec<CubeInviteSummary>,
+    pub invite_email: String,
+    pub loading: bool,
+    pub invite_sending: bool,
+    /// Last surfaced error string. Cleared by `DismissError`.
+    pub error: Option<String>,
+    /// Non-`None` when a `RemoveMember` 409'd with stranded-vault details.
+    /// The payload is the raw server message — W4's structured conflict body
+    /// is parsed in PR 3, for now we surface the text verbatim.
+    pub remove_conflict: Option<String>,
+    /// Monotonic counter used to discard stale `Loaded` responses when the
+    /// user issues multiple `Reload`s in quick succession.
+    load_generation: u32,
+}
+
+impl ConnectCubeMembersState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn clear(&mut self) {
+        *self = Self::default();
+    }
+
+    /// True once a successful load has populated state. The view uses this to
+    /// decide whether to render the empty-state placeholder vs. a spinner.
+    pub fn has_loaded(&self) -> bool {
+        !self.loading && self.error.is_none()
+            || !self.members.is_empty()
+            || !self.pending_invites.is_empty()
+    }
+
+    fn bump_generation(&mut self) -> u32 {
+        self.load_generation = self.load_generation.wrapping_add(1);
+        self.load_generation
+    }
+}
+
+/// Handles a [`ConnectCubeMembersMessage`]. Returns an iced `Task` for any
+/// spawned async work. `client` / `cube_id` are passed in rather than held on
+/// the state so the parent panel decides when the panel is "ready" (both
+/// authenticated and registered with the backend).
+pub fn update(
+    state: &mut ConnectCubeMembersState,
+    msg: ConnectCubeMembersMessage,
+    client: Option<CoincubeClient>,
+    cube_id: Option<u64>,
+) -> iced::Task<Message> {
+    match msg {
+        ConnectCubeMembersMessage::Enter => {
+            if state.members.is_empty() && state.pending_invites.is_empty() && !state.loading {
+                return spawn_load(state, client, cube_id);
+            }
+            iced::Task::none()
+        }
+
+        ConnectCubeMembersMessage::Reload => spawn_load(state, client, cube_id),
+
+        ConnectCubeMembersMessage::Loaded(result, gen) => {
+            if gen != state.load_generation {
+                return iced::Task::none();
+            }
+            state.loading = false;
+            match result {
+                Ok(cube) => {
+                    state.members = cube.members;
+                    state.pending_invites = cube.pending_invites;
+                    state.error = None;
+                }
+                Err(e) => {
+                    state.error = Some(e);
+                }
+            }
+            iced::Task::none()
+        }
+
+        ConnectCubeMembersMessage::InviteEmailChanged(email) => {
+            state.invite_email = email;
+            state.error = None;
+            iced::Task::none()
+        }
+
+        ConnectCubeMembersMessage::SubmitInvite => {
+            if state.invite_sending {
+                return iced::Task::none();
+            }
+            let email = state.invite_email.trim().to_string();
+            let valid = email_address::EmailAddress::parse_with_options(
+                &email,
+                email_address::Options::default().with_required_tld(),
+            )
+            .is_ok();
+            if !valid {
+                state.error = Some("Please enter a valid email address".to_string());
+                return iced::Task::none();
+            }
+            let (Some(client), Some(cube_id)) = (client, cube_id) else {
+                state.error = Some("Not ready — the cube is still registering.".to_string());
+                return iced::Task::none();
+            };
+            state.invite_sending = true;
+            state.error = None;
+            iced::Task::perform(
+                async move { client.create_cube_invite(cube_id, &email).await },
+                |res| {
+                    Message::View(view::Message::ConnectCube(ConnectCubeMessage::Members(
+                        ConnectCubeMembersMessage::InviteResult(res.map_err(|e| e.to_string())),
+                    )))
+                },
+            )
+        }
+
+        ConnectCubeMembersMessage::InviteResult(result) => {
+            state.invite_sending = false;
+            match result {
+                Ok(CubeInviteOrAddResult::Added(member)) => {
+                    state.invite_email.clear();
+                    state.error = None;
+                    if !state.members.iter().any(|m| m.id == member.id) {
+                        state.members.push(member);
+                    }
+                    spawn_load_silent(state, client, cube_id)
+                }
+                Ok(CubeInviteOrAddResult::Invited(invite)) => {
+                    state.invite_email.clear();
+                    state.error = None;
+                    if !state.pending_invites.iter().any(|i| i.id == invite.id) {
+                        state.pending_invites.push(invite);
+                    }
+                    iced::Task::none()
+                }
+                Err(e) => {
+                    state.error = Some(e);
+                    iced::Task::none()
+                }
+            }
+        }
+
+        ConnectCubeMembersMessage::RevokeInvite(invite_id) => {
+            let (Some(client), Some(cube_id)) = (client, cube_id) else {
+                return iced::Task::none();
+            };
+            iced::Task::perform(
+                async move { client.revoke_cube_invite(cube_id, invite_id).await },
+                move |res| {
+                    Message::View(view::Message::ConnectCube(ConnectCubeMessage::Members(
+                        ConnectCubeMembersMessage::RevokeInviteResult(
+                            invite_id,
+                            res.map_err(|e| e.to_string()),
+                        ),
+                    )))
+                },
+            )
+        }
+
+        ConnectCubeMembersMessage::RevokeInviteResult(invite_id, result) => {
+            match result {
+                Ok(()) => {
+                    state.pending_invites.retain(|i| i.id != invite_id);
+                    state.error = None;
+                }
+                Err(e) => state.error = Some(e),
+            }
+            iced::Task::none()
+        }
+
+        ConnectCubeMembersMessage::RemoveMember(member_id) => {
+            let (Some(client), Some(cube_id)) = (client, cube_id) else {
+                return iced::Task::none();
+            };
+            iced::Task::perform(
+                async move { client.remove_cube_member(cube_id, member_id).await },
+                move |res| {
+                    Message::View(view::Message::ConnectCube(ConnectCubeMessage::Members(
+                        ConnectCubeMembersMessage::RemoveMemberResult(
+                            member_id,
+                            res.map_err(|e| e.to_string()),
+                        ),
+                    )))
+                },
+            )
+        }
+
+        ConnectCubeMembersMessage::RemoveMemberResult(member_id, result) => {
+            match result {
+                Ok(()) => {
+                    state.members.retain(|m| m.id != member_id);
+                    state.error = None;
+                    state.remove_conflict = None;
+                }
+                Err(e) => {
+                    // W4: stranded-vault 409 — surface it on the dedicated
+                    // conflict slot so the view can render a prominent
+                    // dialog. The backend's error envelope carries the
+                    // conflicting-vaults list; parsing that structured body
+                    // lands in a follow-up once W4 stabilises.
+                    if is_stranded_vault_conflict(&e) {
+                        state.remove_conflict = Some(e);
+                    } else {
+                        state.error = Some(e);
+                    }
+                }
+            }
+            iced::Task::none()
+        }
+
+        ConnectCubeMembersMessage::DismissError => {
+            state.error = None;
+            iced::Task::none()
+        }
+
+        ConnectCubeMembersMessage::DismissRemoveConflict => {
+            state.remove_conflict = None;
+            iced::Task::none()
+        }
+    }
+}
+
+/// User-initiated load (Enter/Reload). Surfaces an error if the cube isn't
+/// registered yet, so the panel explains itself.
+fn spawn_load(
+    state: &mut ConnectCubeMembersState,
+    client: Option<CoincubeClient>,
+    cube_id: Option<u64>,
+) -> iced::Task<Message> {
+    if client.is_none() || cube_id.is_none() {
+        state.error = Some("Not ready — the cube is still registering.".to_string());
+        return iced::Task::none();
+    }
+    spawn_load_silent(state, client, cube_id)
+}
+
+/// Follow-on refresh after a successful mutation. If the client was torn
+/// down mid-flight (logout, etc.), silently skip — the mutation already
+/// updated local state optimistically.
+fn spawn_load_silent(
+    state: &mut ConnectCubeMembersState,
+    client: Option<CoincubeClient>,
+    cube_id: Option<u64>,
+) -> iced::Task<Message> {
+    let (Some(client), Some(cube_id)) = (client, cube_id) else {
+        return iced::Task::none();
+    };
+    let gen = state.bump_generation();
+    state.loading = true;
+    iced::Task::perform(
+        async move { client.get_cube(cube_id).await },
+        move |res: Result<CubeResponse, _>| {
+            Message::View(view::Message::ConnectCube(ConnectCubeMessage::Members(
+                ConnectCubeMembersMessage::Loaded(res.map_err(|e| e.to_string()), gen),
+            )))
+        },
+    )
+}
+
+/// Heuristic: the backend's W4 error message mentions "active Vault" /
+/// "active vault". We could match on the error envelope's `code` field
+/// instead, but that requires plumbing the structured shape through — left
+/// for PR 3. The string match is defensive so a false-negative just routes
+/// to the generic error banner rather than the dedicated dialog.
+fn is_stranded_vault_conflict(err: &str) -> bool {
+    let lower = err.to_ascii_lowercase();
+    lower.contains("active vault") || lower.contains("active vaults")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::coincube::{CubeInviteSummary, CubeMember, CubeMemberUser};
+
+    fn sample_member(id: u64, email: &str) -> CubeMember {
+        CubeMember {
+            id,
+            user_id: id + 100,
+            user: CubeMemberUser {
+                email: email.to_string(),
+            },
+            joined_at: "2026-04-18T00:00:00Z".to_string(),
+        }
+    }
+
+    fn sample_invite(id: u64, email: &str) -> CubeInviteSummary {
+        CubeInviteSummary {
+            id,
+            cube_id: 42,
+            email: email.to_string(),
+            status: "pending".to_string(),
+            expires_at: "2026-05-18T00:00:00Z".to_string(),
+            created_at: "2026-04-18T00:00:00Z".to_string(),
+        }
+    }
+
+    fn run(
+        state: &mut ConnectCubeMembersState,
+        msg: ConnectCubeMembersMessage,
+    ) {
+        // None/None for client/cube_id — every test here exercises the pure
+        // state transitions, not the async branches. Tasks returned when the
+        // client is missing are `Task::none()`.
+        let _ = update(state, msg, None, None);
+    }
+
+    #[test]
+    fn loaded_ok_populates_members_and_invites() {
+        let mut state = ConnectCubeMembersState::new();
+        // Simulate an in-flight load.
+        let gen = state.bump_generation();
+        state.loading = true;
+
+        let cube = CubeResponse {
+            id: 42,
+            uuid: "abc".to_string(),
+            name: "My Cube".to_string(),
+            network: "bitcoin".to_string(),
+            lightning_address: None,
+            bolt12_offer: None,
+            status: "active".to_string(),
+            members: vec![sample_member(7, "alice@example.com")],
+            pending_invites: vec![sample_invite(9, "bob@example.com")],
+        };
+        run(&mut state, ConnectCubeMembersMessage::Loaded(Ok(cube), gen));
+
+        assert!(!state.loading);
+        assert_eq!(state.members.len(), 1);
+        assert_eq!(state.members[0].user.email, "alice@example.com");
+        assert_eq!(state.pending_invites.len(), 1);
+        assert_eq!(state.pending_invites[0].email, "bob@example.com");
+        assert!(state.error.is_none());
+    }
+
+    #[test]
+    fn loaded_discards_stale_generation() {
+        let mut state = ConnectCubeMembersState::new();
+        // Two in-flight loads: only the second's response should land.
+        state.bump_generation(); // gen = 1 (stale)
+        let gen2 = state.bump_generation(); // gen = 2 (current)
+        state.loading = true;
+
+        let stale_cube = CubeResponse {
+            id: 42,
+            uuid: "abc".to_string(),
+            name: "Stale".to_string(),
+            network: "bitcoin".to_string(),
+            lightning_address: None,
+            bolt12_offer: None,
+            status: "active".to_string(),
+            members: vec![sample_member(1, "stale@example.com")],
+            pending_invites: vec![],
+        };
+        run(
+            &mut state,
+            ConnectCubeMembersMessage::Loaded(Ok(stale_cube), 1),
+        );
+        assert!(state.members.is_empty());
+        assert!(state.loading, "stale response should not clear loading");
+
+        let current_cube = CubeResponse {
+            id: 42,
+            uuid: "abc".to_string(),
+            name: "Current".to_string(),
+            network: "bitcoin".to_string(),
+            lightning_address: None,
+            bolt12_offer: None,
+            status: "active".to_string(),
+            members: vec![sample_member(2, "current@example.com")],
+            pending_invites: vec![],
+        };
+        run(
+            &mut state,
+            ConnectCubeMembersMessage::Loaded(Ok(current_cube), gen2),
+        );
+        assert!(!state.loading);
+        assert_eq!(state.members.len(), 1);
+        assert_eq!(state.members[0].user.email, "current@example.com");
+    }
+
+    #[test]
+    fn loaded_err_surfaces_error() {
+        let mut state = ConnectCubeMembersState::new();
+        let gen = state.bump_generation();
+        state.loading = true;
+
+        run(
+            &mut state,
+            ConnectCubeMembersMessage::Loaded(Err("boom".to_string()), gen),
+        );
+        assert!(!state.loading);
+        assert_eq!(state.error.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn invite_email_changed_clears_error() {
+        let mut state = ConnectCubeMembersState::new();
+        state.error = Some("previous".to_string());
+        run(
+            &mut state,
+            ConnectCubeMembersMessage::InviteEmailChanged("new@example.com".to_string()),
+        );
+        assert_eq!(state.invite_email, "new@example.com");
+        assert!(state.error.is_none());
+    }
+
+    #[test]
+    fn invite_result_added_appends_member() {
+        let mut state = ConnectCubeMembersState::new();
+        state.invite_sending = true;
+        state.invite_email = "alice@example.com".to_string();
+        run(
+            &mut state,
+            ConnectCubeMembersMessage::InviteResult(Ok(CubeInviteOrAddResult::Added(
+                sample_member(7, "alice@example.com"),
+            ))),
+        );
+        assert!(!state.invite_sending);
+        assert!(state.invite_email.is_empty());
+        assert_eq!(state.members.len(), 1);
+        assert!(state.error.is_none());
+    }
+
+    #[test]
+    fn invite_result_invited_appends_pending() {
+        let mut state = ConnectCubeMembersState::new();
+        state.invite_sending = true;
+        state.invite_email = "bob@example.com".to_string();
+        run(
+            &mut state,
+            ConnectCubeMembersMessage::InviteResult(Ok(CubeInviteOrAddResult::Invited(
+                sample_invite(9, "bob@example.com"),
+            ))),
+        );
+        assert!(!state.invite_sending);
+        assert!(state.invite_email.is_empty());
+        assert_eq!(state.pending_invites.len(), 1);
+        assert_eq!(state.pending_invites[0].email, "bob@example.com");
+    }
+
+    #[test]
+    fn invite_result_err_surfaces_error_and_keeps_email() {
+        let mut state = ConnectCubeMembersState::new();
+        state.invite_sending = true;
+        state.invite_email = "bob@example.com".to_string();
+        run(
+            &mut state,
+            ConnectCubeMembersMessage::InviteResult(Err("duplicate".to_string())),
+        );
+        assert!(!state.invite_sending);
+        assert_eq!(state.invite_email, "bob@example.com");
+        assert_eq!(state.error.as_deref(), Some("duplicate"));
+    }
+
+    #[test]
+    fn revoke_invite_result_ok_removes_pending() {
+        let mut state = ConnectCubeMembersState::new();
+        state.pending_invites = vec![
+            sample_invite(1, "a@example.com"),
+            sample_invite(2, "b@example.com"),
+        ];
+        run(
+            &mut state,
+            ConnectCubeMembersMessage::RevokeInviteResult(1, Ok(())),
+        );
+        assert_eq!(state.pending_invites.len(), 1);
+        assert_eq!(state.pending_invites[0].id, 2);
+    }
+
+    #[test]
+    fn remove_member_result_err_with_stranded_vault_routes_to_conflict_slot() {
+        let mut state = ConnectCubeMembersState::new();
+        state.members = vec![sample_member(7, "alice@example.com")];
+        run(
+            &mut state,
+            ConnectCubeMembersMessage::RemoveMemberResult(
+                7,
+                Err("Cannot remove member — keys are signing an active Vault".to_string()),
+            ),
+        );
+        assert_eq!(state.members.len(), 1, "member should stay on error");
+        assert!(state.error.is_none());
+        assert!(state.remove_conflict.is_some());
+        assert!(state
+            .remove_conflict
+            .as_deref()
+            .unwrap()
+            .contains("active Vault"));
+    }
+
+    #[test]
+    fn remove_member_result_err_generic_routes_to_error_slot() {
+        let mut state = ConnectCubeMembersState::new();
+        state.members = vec![sample_member(7, "alice@example.com")];
+        run(
+            &mut state,
+            ConnectCubeMembersMessage::RemoveMemberResult(
+                7,
+                Err("Network unreachable".to_string()),
+            ),
+        );
+        assert_eq!(state.members.len(), 1);
+        assert!(state.remove_conflict.is_none());
+        assert_eq!(state.error.as_deref(), Some("Network unreachable"));
+    }
+
+    #[test]
+    fn remove_member_result_ok_removes_member() {
+        let mut state = ConnectCubeMembersState::new();
+        state.members = vec![
+            sample_member(1, "a@example.com"),
+            sample_member(2, "b@example.com"),
+        ];
+        run(
+            &mut state,
+            ConnectCubeMembersMessage::RemoveMemberResult(1, Ok(())),
+        );
+        assert_eq!(state.members.len(), 1);
+        assert_eq!(state.members[0].id, 2);
+    }
+
+    #[test]
+    fn dismiss_error_clears_slots() {
+        let mut state = ConnectCubeMembersState::new();
+        state.error = Some("oops".to_string());
+        run(&mut state, ConnectCubeMembersMessage::DismissError);
+        assert!(state.error.is_none());
+
+        state.remove_conflict = Some("vault conflict".to_string());
+        run(&mut state, ConnectCubeMembersMessage::DismissRemoveConflict);
+        assert!(state.remove_conflict.is_none());
+    }
+}

--- a/coincube-gui/src/app/state/connect/cube_members.rs
+++ b/coincube-gui/src/app/state/connect/cube_members.rs
@@ -25,8 +25,17 @@ pub struct ConnectCubeMembersState {
     pub invite_email: String,
     pub loading: bool,
     pub invite_sending: bool,
-    /// Last surfaced error string. Cleared by `DismissError`.
+    /// User-action errors (invite validation, submit failure, revoke,
+    /// remove). Cleared by `InviteEmailChanged`, `DismissError`, or a
+    /// successful follow-up action.
     pub error: Option<String>,
+    /// Fetch-specific errors from `GET /connect/cubes/{id}`. Kept
+    /// separate from `error` so:
+    ///   * `Enter`'s auto-retry only fires on a prior load failure, not
+    ///     on a validation hiccup the user hasn't dismissed yet.
+    ///   * Editing the invite-email field doesn't silently clear a
+    ///     standing load error.
+    pub load_error: Option<String>,
     /// Non-`None` when a `RemoveMember` 409'd with stranded-vault details.
     /// The payload is the raw server message — W4's structured conflict body
     /// is parsed in PR 3, for now we surface the text verbatim.
@@ -75,11 +84,13 @@ pub fn update(
                 return iced::Task::none();
             }
             // Retry when (a) no successful load has happened yet, or
-            // (b) the previous load failed (error is set). Once a
-            // successful load has landed — even for an empty cube —
-            // `loaded_once` is true and the Reload button is the
-            // explicit "force refresh" path.
-            let needs_load = state.error.is_some() || !state.loaded_once;
+            // (b) the previous load failed. Gate on `load_error`
+            // specifically, not the generic `error` slot — a pending
+            // invite-validation message shouldn't trigger a reload.
+            // Once a successful load has landed — even for an empty
+            // cube — `loaded_once` is true and the Reload button is
+            // the explicit "force refresh" path.
+            let needs_load = state.load_error.is_some() || !state.loaded_once;
             if needs_load {
                 return spawn_load(state, client, cube_id);
             }
@@ -97,13 +108,15 @@ pub fn update(
                 Ok(cube) => {
                     state.members = cube.members;
                     state.pending_invites = cube.pending_invites;
-                    state.error = None;
+                    state.load_error = None;
                     state.loaded_once = true;
                 }
                 Err(e) => {
                     // Leave `loaded_once` alone — a failed load doesn't
                     // count as loaded; the next `Enter` will retry.
-                    state.error = Some(e);
+                    // Route to `load_error` so a standing validation
+                    // message in `error` isn't overwritten.
+                    state.load_error = Some(e);
                 }
             }
             iced::Task::none()
@@ -130,7 +143,11 @@ pub fn update(
                 return iced::Task::none();
             }
             let (Some(client), Some(cube_id)) = (client, cube_id) else {
-                state.error = Some("Not ready — the cube is still registering.".to_string());
+                // Precondition failure on the load path (cube not yet
+                // registered) — route to `load_error` so the next
+                // `Enter` retries the fetch instead of silently sitting
+                // on an action-level error.
+                state.load_error = Some("Not ready — the cube is still registering.".to_string());
                 return iced::Task::none();
             };
             state.invite_sending = true;
@@ -240,7 +257,12 @@ pub fn update(
         }
 
         ConnectCubeMembersMessage::DismissError => {
+            // Dismiss whichever banner is visible. Note: a load error
+            // will simply come back on the next `Enter` / `Reload` if
+            // the underlying cause (network, auth, etc.) hasn't been
+            // resolved.
             state.error = None;
+            state.load_error = None;
             iced::Task::none()
         }
 
@@ -259,7 +281,10 @@ fn spawn_load(
     cube_id: Option<u64>,
 ) -> iced::Task<Message> {
     if client.is_none() || cube_id.is_none() {
-        state.error = Some("Not ready — the cube is still registering.".to_string());
+        // This is a load-path failure (the fetch couldn't even fire)
+        // so it belongs on `load_error`. `Enter` uses that slot to
+        // decide whether to retry.
+        state.load_error = Some("Not ready — the cube is still registering.".to_string());
         return iced::Task::none();
     }
     spawn_load_silent(state, client, cube_id)
@@ -408,7 +433,10 @@ mod tests {
     }
 
     #[test]
-    fn loaded_err_surfaces_error() {
+    fn loaded_err_surfaces_on_load_error_not_action_error() {
+        // Fetch failures route to `load_error` so `Enter`'s auto-retry
+        // fires on them and so they don't collide with any standing
+        // user-action error in `state.error`.
         let mut state = ConnectCubeMembersState::new();
         let gen = state.bump_generation();
         state.loading = true;
@@ -418,7 +446,8 @@ mod tests {
             ConnectCubeMembersMessage::Loaded(Err("boom".to_string()), gen),
         );
         assert!(!state.loading);
-        assert_eq!(state.error.as_deref(), Some("boom"));
+        assert_eq!(state.load_error.as_deref(), Some("boom"));
+        assert!(state.error.is_none(), "load errors must not touch `error`");
     }
 
     #[test]
@@ -556,24 +585,65 @@ mod tests {
         // error banner.
         let mut state = ConnectCubeMembersState::new();
         state.members = vec![sample_member(7, "alice@example.com")];
-        state.error = Some("previous load failed".to_string());
-        // generation starts at 0
+        state.loaded_once = true;
+        state.load_error = Some("previous load failed".to_string());
         assert_eq!(state.load_generation, 0);
 
-        // None/None for client/cube_id — we assert on the load-generation
-        // bump as a proxy for "spawn_load was invoked". spawn_load's
-        // guarded branch sets state.error and returns Task::none when the
-        // client is missing, so we expect the error message to be
-        // replaced with the "not ready" copy.
+        // None/None for client/cube_id — `spawn_load`'s guarded branch
+        // replaces `load_error` with the "Not ready" message when the
+        // client is missing, so we expect the stale load error to be
+        // overwritten — proving the retry path fired.
         run(&mut state, ConnectCubeMembersMessage::Enter);
-        // `spawn_load` short-circuits on missing client, which in turn
-        // replaces `state.error` with the "Not ready" message. The stale
-        // error from the prior failed load is cleared as a side effect —
-        // proving the retry path fired.
         assert_ne!(
-            state.error.as_deref(),
+            state.load_error.as_deref(),
             Some("previous load failed"),
-            "Enter should have attempted a fresh load, clearing the stale error"
+            "Enter should have attempted a fresh load, overwriting the stale error"
+        );
+    }
+
+    #[test]
+    fn enter_does_not_retry_when_only_action_error_is_set() {
+        // Regression for the bot-flagged cross-contamination: a
+        // pending invite-validation error should NOT trigger an
+        // unnecessary network reload on Enter. Only `load_error`
+        // counts as a load-level signal.
+        let mut state = ConnectCubeMembersState::new();
+        state.members = vec![sample_member(7, "alice@example.com")];
+        state.loaded_once = true;
+        state.error = Some("Please enter a valid email address".to_string());
+        let gen_before = state.load_generation;
+        let loading_before = state.loading;
+        run(&mut state, ConnectCubeMembersMessage::Enter);
+        assert_eq!(
+            state.load_generation, gen_before,
+            "validation error must not trigger a reload"
+        );
+        assert_eq!(state.loading, loading_before);
+        // And the action error survives.
+        assert_eq!(
+            state.error.as_deref(),
+            Some("Please enter a valid email address")
+        );
+    }
+
+    #[test]
+    fn invite_email_change_does_not_clear_load_error() {
+        // Regression for the bot-flagged cross-contamination: typing
+        // into the invite-email field clears `state.error` (the
+        // validation-message slot), but must leave `state.load_error`
+        // alone so a standing fetch-failure banner isn't masked.
+        let mut state = ConnectCubeMembersState::new();
+        state.error = Some("Please enter a valid email address".to_string());
+        state.load_error = Some("network unreachable".to_string());
+        run(
+            &mut state,
+            ConnectCubeMembersMessage::InviteEmailChanged("a@b.c".to_string()),
+        );
+        assert!(state.error.is_none(), "validation error should be cleared");
+        assert_eq!(
+            state.load_error.as_deref(),
+            Some("network unreachable"),
+            "load error must survive invite-email edits"
         );
     }
 
@@ -641,11 +711,15 @@ mod tests {
     }
 
     #[test]
-    fn dismiss_error_clears_slots() {
+    fn dismiss_error_clears_both_error_slots() {
+        // DismissError clears whichever banner was visible — both the
+        // action-error and the load-error slots.
         let mut state = ConnectCubeMembersState::new();
-        state.error = Some("oops".to_string());
+        state.error = Some("action oops".to_string());
+        state.load_error = Some("load oops".to_string());
         run(&mut state, ConnectCubeMembersMessage::DismissError);
         assert!(state.error.is_none());
+        assert!(state.load_error.is_none());
 
         state.remove_conflict = Some("vault conflict".to_string());
         run(&mut state, ConnectCubeMembersMessage::DismissRemoveConflict);

--- a/coincube-gui/src/app/state/connect/cube_members.rs
+++ b/coincube-gui/src/app/state/connect/cube_members.rs
@@ -34,6 +34,12 @@ pub struct ConnectCubeMembersState {
     /// Monotonic counter used to discard stale `Loaded` responses when the
     /// user issues multiple `Reload`s in quick succession.
     load_generation: u32,
+    /// `true` once a `Loaded(Ok(_))` has landed. Distinguishes a fresh
+    /// panel from a panel that's *successfully* loaded an empty cube —
+    /// both have empty `members` and `pending_invites` but only the
+    /// former should auto-fetch on `Enter`. Failed loads do not set
+    /// this flag, so `Enter` keeps retrying them.
+    loaded_once: bool,
 }
 
 impl ConnectCubeMembersState {
@@ -68,12 +74,12 @@ pub fn update(
             if state.loading {
                 return iced::Task::none();
             }
-            // Retry when (a) we have no data yet, or (b) the previous load
-            // failed and the panel is showing stale/empty data plus an
-            // error banner. Successful cached data is left alone — the
-            // Reload button is the explicit "force refresh" path.
-            let needs_load = state.error.is_some()
-                || (state.members.is_empty() && state.pending_invites.is_empty());
+            // Retry when (a) no successful load has happened yet, or
+            // (b) the previous load failed (error is set). Once a
+            // successful load has landed — even for an empty cube —
+            // `loaded_once` is true and the Reload button is the
+            // explicit "force refresh" path.
+            let needs_load = state.error.is_some() || !state.loaded_once;
             if needs_load {
                 return spawn_load(state, client, cube_id);
             }
@@ -92,8 +98,11 @@ pub fn update(
                     state.members = cube.members;
                     state.pending_invites = cube.pending_invites;
                     state.error = None;
+                    state.loaded_once = true;
                 }
                 Err(e) => {
+                    // Leave `loaded_once` alone — a failed load doesn't
+                    // count as loaded; the next `Enter` will retry.
                     state.error = Some(e);
                 }
             }
@@ -570,19 +579,55 @@ mod tests {
 
     #[test]
     fn enter_skips_when_loaded_successfully_and_no_error() {
-        // Happy cached state: members present, no error, not loading.
-        // Enter should be a no-op — the explicit Reload button is the
+        // Happy cached state: members present, no error, not loading,
+        // and — critically — `loaded_once` set by a prior successful
+        // load. Enter should be a no-op; Reload is the explicit
         // "force refresh" path.
         let mut state = ConnectCubeMembersState::new();
         state.members = vec![sample_member(7, "alice@example.com")];
         state.error = None;
-        // Need a client for spawn_load to fire the network task; we
-        // assert the generation DOESN'T bump instead.
+        state.loaded_once = true;
         let gen_before = state.load_generation;
         let loading_before = state.loading;
         run(&mut state, ConnectCubeMembersMessage::Enter);
         assert_eq!(state.load_generation, gen_before);
         assert_eq!(state.loading, loading_before);
+    }
+
+    #[test]
+    fn enter_skips_after_successful_empty_load() {
+        // Regression: a cube that genuinely has zero members and zero
+        // pending invites used to re-fetch on every Enter because the
+        // "has loaded" check reused the emptiness of the lists.
+        // After a `Loaded(Ok(empty))` lands, `loaded_once` is true and
+        // Enter must no-op.
+        let mut state = ConnectCubeMembersState::new();
+        let gen = state.bump_generation();
+        state.loading = true;
+        let empty_cube = CubeResponse {
+            id: 42,
+            uuid: "abc".to_string(),
+            name: "Empty".to_string(),
+            network: "bitcoin".to_string(),
+            lightning_address: None,
+            bolt12_offer: None,
+            status: "active".to_string(),
+            members: vec![],
+            pending_invites: vec![],
+        };
+        run(
+            &mut state,
+            ConnectCubeMembersMessage::Loaded(Ok(empty_cube), gen),
+        );
+        assert!(state.loaded_once);
+
+        let gen_before = state.load_generation;
+        run(&mut state, ConnectCubeMembersMessage::Enter);
+        assert_eq!(
+            state.load_generation, gen_before,
+            "Enter must not spawn a new load after a successful empty load"
+        );
+        assert!(!state.loading);
     }
 
     #[test]

--- a/coincube-gui/src/app/state/connect/cube_members.rs
+++ b/coincube-gui/src/app/state/connect/cube_members.rs
@@ -45,14 +45,6 @@ impl ConnectCubeMembersState {
         *self = Self::default();
     }
 
-    /// True once a successful load has populated state. The view uses this to
-    /// decide whether to render the empty-state placeholder vs. a spinner.
-    pub fn has_loaded(&self) -> bool {
-        !self.loading && self.error.is_none()
-            || !self.members.is_empty()
-            || !self.pending_invites.is_empty()
-    }
-
     fn bump_generation(&mut self) -> u32 {
         self.load_generation = self.load_generation.wrapping_add(1);
         self.load_generation
@@ -313,10 +305,7 @@ mod tests {
         }
     }
 
-    fn run(
-        state: &mut ConnectCubeMembersState,
-        msg: ConnectCubeMembersMessage,
-    ) {
+    fn run(state: &mut ConnectCubeMembersState, msg: ConnectCubeMembersMessage) {
         // None/None for client/cube_id — every test here exercises the pure
         // state transitions, not the async branches. Tasks returned when the
         // client is missing are `Task::none()`.

--- a/coincube-gui/src/app/state/connect/mod.rs
+++ b/coincube-gui/src/app/state/connect/mod.rs
@@ -1,5 +1,6 @@
 pub mod account;
 pub mod cube;
+pub mod cube_members;
 
 pub(crate) const CONNECT_KEYRING_SERVICE: &str = if cfg!(debug_assertions) {
     "dev.coincube.Connect"
@@ -10,9 +11,11 @@ pub(crate) const CONNECT_KEYRING_SERVICE: &str = if cfg!(debug_assertions) {
 pub(crate) const CONNECT_KEYRING_USER: &str = "global_session";
 
 pub use account::{
-    CheckoutPhase, CheckoutState, ConnectAccountPanel, ConnectFlowStep, ContactsState, ContactsStep,
+    CheckoutPhase, CheckoutState, ConnectAccountPanel, ConnectFlowStep, ContactsState,
+    ContactsStep, InviteCubeOption,
 };
 pub use cube::ConnectCubePanel;
+pub use cube_members::ConnectCubeMembersState;
 
 use std::sync::Arc;
 

--- a/coincube-gui/src/app/state/connect/mod.rs
+++ b/coincube-gui/src/app/state/connect/mod.rs
@@ -11,8 +11,8 @@ pub(crate) const CONNECT_KEYRING_SERVICE: &str = if cfg!(debug_assertions) {
 pub(crate) const CONNECT_KEYRING_USER: &str = "global_session";
 
 pub use account::{
-    CheckoutPhase, CheckoutState, ConnectAccountPanel, ConnectFlowStep, ContactsState,
-    ContactsStep, InviteCubeOption,
+    AddToCubeDialog, CheckoutPhase, CheckoutState, ConnectAccountPanel, ConnectFlowStep,
+    ContactsState, ContactsStep, InviteCubeOption,
 };
 pub use cube::ConnectCubePanel;
 pub use cube_members::ConnectCubeMembersState;
@@ -60,10 +60,24 @@ impl ConnectPanel {
         cube_name: String,
         cube_network: String,
     ) -> Self {
+        let mut account = ConnectAccountPanel::new();
+        // W12 §2.7 tweak #1 / W14: propagate the active cube's network
+        // into ContactsState so the invite-form + add-to-cube dialogs
+        // can filter their candidate-cube lists.
+        account.set_active_network(Some(cube_network.clone()));
         ConnectPanel {
-            account: ConnectAccountPanel::new(),
+            account,
             cube: ConnectCubePanel::new(breez_client, cube_uuid, cube_name, cube_network),
         }
+    }
+
+    /// Mirror the active Cube's server-side numeric id onto
+    /// `ContactsState` so the W14 "Add to Current Cube" action can
+    /// target the exact loaded cube (works even when the user has
+    /// multiple cubes on the same network).
+    fn sync_active_cube_server_id(&mut self) {
+        self.account
+            .set_active_cube_server_id(self.cube.server_cube_id);
     }
 
     /// Sync the authenticated client from account panel to cube panel.
@@ -134,6 +148,7 @@ impl State for ConnectPanel {
                 let was_authenticated = self.account.is_authenticated();
                 let task = self.account.update_message(msg);
                 self.sync_client();
+                self.sync_active_cube_server_id();
                 // After first login, register the cube with the backend
                 // (idempotent — returns existing if already registered).
                 // The response includes lightning address if already claimed.
@@ -144,7 +159,15 @@ impl State for ConnectPanel {
                 }
                 task
             }
-            Message::View(view::Message::ConnectCube(msg)) => self.cube.update_message(msg),
+            Message::View(view::Message::ConnectCube(msg)) => {
+                let task = self.cube.update_message(msg);
+                // `CubeRegistered(Ok)` populates `server_cube_id`; mirror
+                // it into the account panel so the "Add to Current
+                // Cube" button becomes enabled as soon as the cube is
+                // known to the backend.
+                self.sync_active_cube_server_id();
+                task
+            }
             _ => iced::Task::none(),
         }
     }

--- a/coincube-gui/src/app/view/connect/contacts.rs
+++ b/coincube-gui/src/app/view/connect/contacts.rs
@@ -281,22 +281,6 @@ fn invite_form_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAcco
     )
     .is_ok();
 
-    let role_chips = Row::new()
-        .push(role_chip(
-            "Keyholder",
-            ContactRole::Keyholder,
-            cs.invite_role,
-        ))
-        .push(iced::widget::Space::new().width(Length::Fixed(8.0)))
-        .push(role_chip(
-            "Beneficiary",
-            ContactRole::Beneficiary,
-            cs.invite_role,
-        ))
-        .push(iced::widget::Space::new().width(Length::Fixed(8.0)))
-        .push(role_chip("Observer", ContactRole::Observer, cs.invite_role))
-        .align_y(Alignment::Center);
-
     let submit: Element<ConnectAccountMessage> = if cs.invite_sending {
         iced::widget::button(
             container(text::p1_regular("Sending\u{2026}").color(color::GREY_3))
@@ -334,10 +318,10 @@ fn invite_form_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAcco
                 .size(16)
                 .padding(15),
         )
-        .push(iced::widget::Space::new().height(Length::Fixed(16.0)))
-        .push(text::p2_regular("Role").color(color::GREY_3))
-        .push(iced::widget::Space::new().height(Length::Fixed(4.0)))
-        .push(role_chips);
+        .push(iced::widget::Space::new().height(Length::Fixed(16.0)));
+    // Role selector removed 2026-04-20 per PR 5 §2.7 tweak #2 —
+    // Keyholder is the only usable role today; invite_role stays in
+    // ContactsState pre-initialised so reintroduction is a small diff.
 
     // W12: optional cube multi-select. Only rendered when the backend
     // returned a non-empty cube list.
@@ -429,26 +413,6 @@ fn invite_cube_conflict_card<'a>(msg: &str) -> Element<'a, ConnectAccountMessage
     })
     .width(Length::Fill)
     .into()
-}
-
-fn role_chip<'a>(
-    label: &'static str,
-    role: ContactRole,
-    selected: ContactRole,
-) -> Element<'a, ConnectAccountMessage> {
-    if role == selected {
-        button::primary(None, label)
-            .on_press(ConnectAccountMessage::Contacts(
-                ContactsMessage::InviteRoleChanged(role),
-            ))
-            .into()
-    } else {
-        button::secondary(None, label)
-            .on_press(ConnectAccountMessage::Contacts(
-                ContactsMessage::InviteRoleChanged(role),
-            ))
-            .into()
-    }
 }
 
 // =============================================================================
@@ -609,7 +573,53 @@ fn contact_detail_ux<'a>(
         }
     };
 
-    Column::new()
+    // W14: entry points for "add this contact to a cube". Only rendered
+    // when the contact has a linked user — an orphaned contact can't be
+    // added to a cube anyway.
+    let can_add = contact.contact_user.is_some();
+    let current_cube_err = cs.add_to_current_cube_errors.get(&contact_id);
+    let add_actions: Option<Element<ConnectAccountMessage>> = can_add.then(|| {
+        let mut row = Row::new()
+            .spacing(8)
+            .align_y(Alignment::Center)
+            .push(
+                // One-click "Add to Current Cube" — primary action,
+                // gated on having the active cube's server-side id
+                // resolved (populated post `register_cube`). Works
+                // regardless of how many other cubes the user owns on
+                // the same network — the action targets the specific
+                // loaded cube, not a network-matching guess.
+                button::primary(None, "Add to Current Cube").on_press_maybe(
+                    cs.active_cube_server_id.is_some().then_some(
+                        ConnectAccountMessage::Contacts(
+                            ContactsMessage::AddContactToCurrentCube(contact_id),
+                        ),
+                    ),
+                ),
+            )
+            .push(
+                // Multi-select — secondary action, always available.
+                button::secondary(None, "Add to Cube(s)…").on_press(
+                    ConnectAccountMessage::Contacts(
+                        ContactsMessage::OpenAddToCubeDialog(contact_id),
+                    ),
+                ),
+            );
+        if let Some(err) = current_cube_err {
+            row = row
+                .push(iced::widget::Space::new().width(Length::Fixed(12.0)))
+                .push(text::p2_regular(err.clone()).color(color::RED));
+        }
+        row.into()
+    });
+
+    let add_to_cube_dialog = cs
+        .add_to_cube_target
+        .as_ref()
+        .filter(|d| d.contact_id == contact_id)
+        .map(add_to_cube_dialog_card);
+
+    let mut col = Column::new()
         .push(back_button)
         .push(iced::widget::Space::new().height(Length::Fixed(15.0)))
         .push(contact_header)
@@ -620,10 +630,122 @@ fn contact_detail_ux<'a>(
             container(Column::new().push(cubes_section).padding(16).spacing(2))
                 .style(card_style)
                 .width(Length::Fill),
+        );
+
+    if let Some(actions) = add_actions {
+        col = col
+            .push(iced::widget::Space::new().height(Length::Fixed(14.0)))
+            .push(actions);
+    }
+
+    if let Some(dialog) = add_to_cube_dialog {
+        col = col
+            .push(iced::widget::Space::new().height(Length::Fixed(14.0)))
+            .push(dialog);
+    }
+
+    col.spacing(0).width(Length::Fill).into()
+}
+
+/// W14 multi-select dialog body. Rendered inline beneath the Associated
+/// Cubes card in the contact detail view when
+/// `contacts_state.add_to_cube_target` is set for this contact.
+fn add_to_cube_dialog_card<'a>(
+    dialog: &'a crate::app::state::connect::AddToCubeDialog,
+) -> Element<'a, ConnectAccountMessage> {
+    let header = Row::new()
+        .push(text::p1_bold("Add to Cube(s)").style(theme::text::primary))
+        .push(iced::widget::Space::new().width(Length::Fill))
+        .push(
+            iced::widget::button(cross_icon().color(color::GREY_3))
+                .padding([4, 6])
+                .style(theme::button::transparent)
+                .on_press(ConnectAccountMessage::Contacts(
+                    ContactsMessage::CloseAddToCubeDialog,
+                )),
         )
-        .spacing(0)
-        .width(Length::Fill)
-        .into()
+        .align_y(Alignment::Center);
+
+    let body: Element<ConnectAccountMessage> = match dialog.candidate_cubes.as_deref() {
+        None => text::p2_regular("Loading eligible cubes\u{2026}")
+            .color(color::GREY_3)
+            .into(),
+        Some([]) => text::p2_regular(
+            "No eligible cubes — the contact is already in all of your \
+             active-network cubes, or you have none.",
+        )
+        .color(color::GREY_3)
+        .into(),
+        Some(cubes) => {
+            let mut col = Column::new().spacing(6);
+            for cube in cubes {
+                let checked = dialog.selections.contains(&cube.id);
+                let id = cube.id;
+                let mut row = Row::new()
+                    .spacing(8)
+                    .align_y(Alignment::Center)
+                    .push(
+                        CheckBox::new(checked)
+                            .label(format!("{} ({})", cube.name, cube.network))
+                            .on_toggle(move |_| {
+                                ConnectAccountMessage::Contacts(
+                                    ContactsMessage::ToggleAddToCubeSelection(id),
+                                )
+                            })
+                            .style(theme::checkbox::primary)
+                            .size(18),
+                    );
+                if let Some(err) = dialog.failures.get(&id) {
+                    row = row
+                        .push(iced::widget::Space::new().width(Length::Fill))
+                        .push(text::p2_regular(err.clone()).color(color::RED));
+                }
+                col = col.push(row);
+            }
+            col.into()
+        }
+    };
+
+    let can_confirm =
+        !dialog.submitting && !dialog.selections.is_empty() && dialog.candidate_cubes.is_some();
+    let confirm_label = if dialog.submitting {
+        "Adding\u{2026}"
+    } else {
+        "Add"
+    };
+    let confirm_btn = button::primary(None, confirm_label).on_press_maybe(can_confirm.then_some(
+        ConnectAccountMessage::Contacts(ContactsMessage::ConfirmAddToCube),
+    ));
+
+    let footer = Row::new()
+        .spacing(8)
+        .align_y(Alignment::Center)
+        .push(iced::widget::Space::new().width(Length::Fill))
+        .push(
+            button::secondary(None, "Cancel").on_press(ConnectAccountMessage::Contacts(
+                ContactsMessage::CloseAddToCubeDialog,
+            )),
+        )
+        .push(confirm_btn);
+
+    container(
+        Column::new()
+            .spacing(12)
+            .push(header)
+            .push(
+                text::p2_regular(format!(
+                    "Add {} to the selected cubes.",
+                    dialog.contact_email
+                ))
+                .color(color::GREY_3),
+            )
+            .push(body)
+            .push(footer)
+            .padding(16),
+    )
+    .style(card_style)
+    .width(Length::Fill)
+    .into()
 }
 
 // =============================================================================

--- a/coincube-gui/src/app/view/connect/contacts.rs
+++ b/coincube-gui/src/app/view/connect/contacts.rs
@@ -405,7 +405,7 @@ fn invite_cube_conflict_card<'a>(msg: &str) -> Element<'a, ConnectAccountMessage
             .push(text::p2_regular(msg.to_string()).style(theme::text::primary))
             .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
             .push(
-                text::p2_regular("Review your cube selection below and try again.")
+                text::p2_regular("Review your cube selection above and try again.")
                     .color(color::GREY_3),
             )
             .padding(16)

--- a/coincube-gui/src/app/view/connect/contacts.rs
+++ b/coincube-gui/src/app/view/connect/contacts.rs
@@ -132,7 +132,14 @@ fn contacts_list_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAc
         col = col.push(iced::widget::Space::new().height(Length::Fixed(8.0)));
 
         for contact in contacts {
-            let email = &contact.contact_user.email;
+            // Contact responses with no linked user are rare (backend
+            // marks the field `omitempty`) — render a placeholder and
+            // still list them so the user can revoke/clean up.
+            let email = contact
+                .contact_user
+                .as_ref()
+                .map(|u| u.email.as_str())
+                .unwrap_or("unknown contact");
             let first_char = email
                 .chars()
                 .next()
@@ -160,7 +167,7 @@ fn contacts_list_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAc
                 .push(iced::widget::Space::new().width(Length::Fixed(12.0)))
                 .push(
                     Column::new()
-                        .push(text::p1_regular(email.as_str()).style(theme::text::primary))
+                        .push(text::p1_regular(email).style(theme::text::primary))
                         .push(text::p2_regular(role_label).color(role_color(&contact.role)))
                         .spacing(2),
                 )
@@ -481,7 +488,11 @@ fn contact_detail_ux<'a>(
             .into();
     };
 
-    let email = &contact.contact_user.email;
+    let email = contact
+        .contact_user
+        .as_ref()
+        .map(|u| u.email.as_str())
+        .unwrap_or("unknown contact");
     let first_char = email
         .chars()
         .next()
@@ -527,7 +538,7 @@ fn contact_detail_ux<'a>(
         Column::new()
             .push(avatar)
             .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
-            .push(text::h4_bold(email.as_str()).style(theme::text::primary))
+            .push(text::h4_bold(email).style(theme::text::primary))
             .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
             .push(role_badge)
             .push(iced::widget::Space::new().height(Length::Fixed(6.0)))

--- a/coincube-gui/src/app/view/connect/contacts.rs
+++ b/coincube-gui/src/app/view/connect/contacts.rs
@@ -577,12 +577,18 @@ fn contact_detail_ux<'a>(
     // when the contact has a linked user — an orphaned contact can't be
     // added to a cube anyway.
     let can_add = contact.contact_user.is_some();
+    // Hide the "Add to Current Cube" button entirely when the contact
+    // is already a member of the loaded cube — the Associated Cubes
+    // list right above already communicates the state, and clicking
+    // would only 409 on duplicate. The multi-select "Add to Cube(s)…"
+    // stays available so the user can still attach them to *other*
+    // cubes they own.
+    let show_add_current = !cs.contact_is_in_active_cube(contact_id);
     let current_cube_err = cs.add_to_current_cube_errors.get(&contact_id);
     let add_actions: Option<Element<ConnectAccountMessage>> = can_add.then(|| {
-        let mut row = Row::new()
-            .spacing(8)
-            .align_y(Alignment::Center)
-            .push(
+        let mut row = Row::new().spacing(8).align_y(Alignment::Center);
+        if show_add_current {
+            row = row.push(
                 // One-click "Add to Current Cube" — primary action,
                 // gated on having the active cube's server-side id
                 // resolved (populated post `register_cube`). Works
@@ -590,21 +596,20 @@ fn contact_detail_ux<'a>(
                 // the same network — the action targets the specific
                 // loaded cube, not a network-matching guess.
                 button::primary(None, "Add to Current Cube").on_press_maybe(
-                    cs.active_cube_server_id.is_some().then_some(
-                        ConnectAccountMessage::Contacts(
+                    cs.active_cube_server_id
+                        .is_some()
+                        .then_some(ConnectAccountMessage::Contacts(
                             ContactsMessage::AddContactToCurrentCube(contact_id),
-                        ),
-                    ),
-                ),
-            )
-            .push(
-                // Multi-select — secondary action, always available.
-                button::secondary(None, "Add to Cube(s)…").on_press(
-                    ConnectAccountMessage::Contacts(
-                        ContactsMessage::OpenAddToCubeDialog(contact_id),
-                    ),
+                        )),
                 ),
             );
+        }
+        row = row.push(
+            // Multi-select — secondary action, always available.
+            button::secondary(None, "Add to Cube(s)…").on_press(ConnectAccountMessage::Contacts(
+                ContactsMessage::OpenAddToCubeDialog(contact_id),
+            )),
+        );
         if let Some(err) = current_cube_err {
             row = row
                 .push(iced::widget::Space::new().width(Length::Fixed(12.0)))
@@ -681,20 +686,17 @@ fn add_to_cube_dialog_card<'a>(
             for cube in cubes {
                 let checked = dialog.selections.contains(&cube.id);
                 let id = cube.id;
-                let mut row = Row::new()
-                    .spacing(8)
-                    .align_y(Alignment::Center)
-                    .push(
-                        CheckBox::new(checked)
-                            .label(format!("{} ({})", cube.name, cube.network))
-                            .on_toggle(move |_| {
-                                ConnectAccountMessage::Contacts(
-                                    ContactsMessage::ToggleAddToCubeSelection(id),
-                                )
-                            })
-                            .style(theme::checkbox::primary)
-                            .size(18),
-                    );
+                let mut row = Row::new().spacing(8).align_y(Alignment::Center).push(
+                    CheckBox::new(checked)
+                        .label(format!("{} ({})", cube.name, cube.network))
+                        .on_toggle(move |_| {
+                            ConnectAccountMessage::Contacts(
+                                ContactsMessage::ToggleAddToCubeSelection(id),
+                            )
+                        })
+                        .style(theme::checkbox::primary)
+                        .size(18),
+                );
                 if let Some(err) = dialog.failures.get(&id) {
                     row = row
                         .push(iced::widget::Space::new().width(Length::Fill))

--- a/coincube-gui/src/app/view/connect/contacts.rs
+++ b/coincube-gui/src/app/view/connect/contacts.rs
@@ -330,7 +330,24 @@ fn invite_form_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAcco
         .push(iced::widget::Space::new().height(Length::Fixed(16.0)))
         .push(text::p2_regular("Role").color(color::GREY_3))
         .push(iced::widget::Space::new().height(Length::Fixed(4.0)))
-        .push(role_chips)
+        .push(role_chips);
+
+    // W12: optional cube multi-select. Only rendered when the backend
+    // returned a non-empty cube list.
+    if let Some(cubes) = cs.invite_available_cubes.as_deref() {
+        if !cubes.is_empty() {
+            form = form
+                .push(iced::widget::Space::new().height(Length::Fixed(20.0)))
+                .push(
+                    text::p2_regular("Also add to Cube(s) (optional)")
+                        .color(color::GREY_3),
+                )
+                .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+                .push(invite_cubes_section(cubes, &cs.invite_cube_selections));
+        }
+    }
+
+    form = form
         .push(iced::widget::Space::new().height(Length::Fixed(20.0)))
         .push(submit)
         .spacing(0)
@@ -343,7 +360,73 @@ fn invite_form_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAcco
             .push(text::p2_regular(err).color(color::RED));
     }
 
+    if let Some(msg) = cs.invite_cube_error.as_deref() {
+        form = form
+            .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
+            .push(invite_cube_conflict_card(msg));
+    }
+
     form.into()
+}
+
+/// Renders the cube multi-select list. Each row is a labelled
+/// [`CheckBox`] emitting `ToggleInviteCube(id)` on toggle.
+fn invite_cubes_section<'a>(
+    cubes: &'a [crate::app::state::connect::InviteCubeOption],
+    selections: &'a [u64],
+) -> Element<'a, ConnectAccountMessage> {
+    let mut col = Column::new().spacing(6);
+    for cube in cubes {
+        let checked = selections.contains(&cube.id);
+        let id = cube.id;
+        let label = format!("{} ({})", cube.name, cube.network);
+        col = col.push(
+            CheckBox::new(checked)
+                .label(label)
+                .on_toggle(move |_| {
+                    ConnectAccountMessage::Contacts(ContactsMessage::ToggleInviteCube(id))
+                })
+                .style(theme::checkbox::primary)
+                .size(18),
+        );
+    }
+    container(col.padding(4)).width(Length::Fill).into()
+}
+
+/// Banner shown when `POST /connect/invites` 403'd on a cube id. The
+/// message suggests the user re-pick — the cube list has already been
+/// reloaded at this point so the new checkboxes reflect current
+/// membership.
+fn invite_cube_conflict_card<'a>(msg: &str) -> Element<'a, ConnectAccountMessage> {
+    container(
+        Column::new()
+            .push(
+                text::p1_bold("One or more selected cubes is no longer available")
+                    .color(color::RED),
+            )
+            .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+            .push(text::p2_regular(msg.to_string()).style(theme::text::primary))
+            .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+            .push(
+                text::p2_regular(
+                    "Review your cube selection below and try again.",
+                )
+                .color(color::GREY_3),
+            )
+            .padding(16)
+            .spacing(0),
+    )
+    .style(|t| container::Style {
+        background: Some(iced::Background::Color(t.colors.cards.simple.background)),
+        border: iced::Border {
+            color: color::RED,
+            width: 1.0,
+            radius: 12.0.into(),
+        },
+        ..Default::default()
+    })
+    .width(Length::Fill)
+    .into()
 }
 
 fn role_chip<'a>(

--- a/coincube-gui/src/app/view/connect/contacts.rs
+++ b/coincube-gui/src/app/view/connect/contacts.rs
@@ -338,10 +338,7 @@ fn invite_form_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAcco
         if !cubes.is_empty() {
             form = form
                 .push(iced::widget::Space::new().height(Length::Fixed(20.0)))
-                .push(
-                    text::p2_regular("Also add to Cube(s) (optional)")
-                        .color(color::GREY_3),
-                )
+                .push(text::p2_regular("Also add to Cube(s) (optional)").color(color::GREY_3))
                 .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
                 .push(invite_cubes_section(cubes, &cs.invite_cube_selections));
         }
@@ -408,10 +405,8 @@ fn invite_cube_conflict_card<'a>(msg: &str) -> Element<'a, ConnectAccountMessage
             .push(text::p2_regular(msg.to_string()).style(theme::text::primary))
             .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
             .push(
-                text::p2_regular(
-                    "Review your cube selection below and try again.",
-                )
-                .color(color::GREY_3),
+                text::p2_regular("Review your cube selection below and try again.")
+                    .color(color::GREY_3),
             )
             .padding(16)
             .spacing(0),

--- a/coincube-gui/src/app/view/connect/contacts.rs
+++ b/coincube-gui/src/app/view/connect/contacts.rs
@@ -15,7 +15,7 @@ use crate::{
     services::coincube::{ContactRole, Invite},
 };
 
-use super::card_style;
+use super::{card_style, format_date};
 
 /// Top-level contacts dispatcher.
 pub fn contacts_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMessage> {
@@ -636,10 +636,4 @@ fn role_color(role: &ContactRole) -> iced::Color {
         ContactRole::Beneficiary => color::GREEN,
         ContactRole::Observer => color::GREY_3,
     }
-}
-
-fn format_date(iso: &str) -> String {
-    chrono::DateTime::parse_from_rfc3339(iso)
-        .map(|dt| dt.format("%b %d, %Y").to_string())
-        .unwrap_or_else(|_| iso.to_string())
 }

--- a/coincube-gui/src/app/view/connect/contacts.rs
+++ b/coincube-gui/src/app/view/connect/contacts.rs
@@ -598,9 +598,9 @@ fn contact_detail_ux<'a>(
                 button::primary(None, "Add to Current Cube").on_press_maybe(
                     (cs.active_cube_server_id.is_some()
                         && !cs.add_to_current_cube_pending.contains(&contact_id))
-                        .then_some(ConnectAccountMessage::Contacts(
-                            ContactsMessage::AddContactToCurrentCube(contact_id),
-                        )),
+                    .then_some(ConnectAccountMessage::Contacts(
+                        ContactsMessage::AddContactToCurrentCube(contact_id),
+                    )),
                 ),
             );
         }

--- a/coincube-gui/src/app/view/connect/contacts.rs
+++ b/coincube-gui/src/app/view/connect/contacts.rs
@@ -596,8 +596,8 @@ fn contact_detail_ux<'a>(
                 // the same network — the action targets the specific
                 // loaded cube, not a network-matching guess.
                 button::primary(None, "Add to Current Cube").on_press_maybe(
-                    cs.active_cube_server_id
-                        .is_some()
+                    (cs.active_cube_server_id.is_some()
+                        && !cs.add_to_current_cube_pending.contains(&contact_id))
                         .then_some(ConnectAccountMessage::Contacts(
                             ContactsMessage::AddContactToCurrentCube(contact_id),
                         )),

--- a/coincube-gui/src/app/view/connect/cube_members.rs
+++ b/coincube-gui/src/app/view/connect/cube_members.rs
@@ -368,13 +368,15 @@ fn expiry_element<'a>(expires_at: &str) -> Element<'a, ConnectCubeMessage> {
         return text::p2_regular("").into();
     };
     let now = chrono::Utc::now();
-    let days = (expiry.date_naive() - now.date_naive()).num_days();
-    // Handle the negative branch up front so the match below is
-    // exhaustive via a binding arm (match guards don't contribute to
-    // exhaustiveness — a wildcard arm would be unreachable).
-    if days < 0 {
+    // Check the full timestamp first. If we only compared
+    // `expiry.date_naive() - now.date_naive()` we'd bucket an invite
+    // that expired at 08:00 today as "Expires today" at 18:00 even
+    // though it's already past.
+    let expiry_utc = expiry.with_timezone(&chrono::Utc);
+    if expiry_utc <= now {
         return text::p2_regular("Expired").color(color::RED).into();
     }
+    let days = (expiry_utc.date_naive() - now.date_naive()).num_days();
     match days {
         0 => text::p2_regular("Expires today")
             .color(color::ORANGE)

--- a/coincube-gui/src/app/view/connect/cube_members.rs
+++ b/coincube-gui/src/app/view/connect/cube_members.rs
@@ -68,8 +68,14 @@ pub fn cube_members_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectCu
         col = col.push(iced::widget::Space::new().height(Length::Fixed(16.0)));
     }
 
-    // Members list
-    if panel.members.is_empty() && panel.pending_invites.is_empty() && !panel.loading {
+    // Members list. Skip the "No members yet" placeholder when there's
+    // an error — we don't actually know the cube is empty, the load just
+    // failed. The `error_banner` below communicates that state instead.
+    if panel.members.is_empty()
+        && panel.pending_invites.is_empty()
+        && !panel.loading
+        && panel.error.is_none()
+    {
         col = col.push(empty_state());
     } else if !panel.members.is_empty() {
         col = col.push(text::p1_bold("Members").style(theme::text::primary));
@@ -363,18 +369,22 @@ fn expiry_element<'a>(expires_at: &str) -> Element<'a, ConnectCubeMessage> {
     };
     let now = chrono::Utc::now();
     let days = (expiry.date_naive() - now.date_naive()).num_days();
+    // Handle the negative branch up front so the match below is
+    // exhaustive via a binding arm (match guards don't contribute to
+    // exhaustiveness — a wildcard arm would be unreachable).
+    if days < 0 {
+        return text::p2_regular("Expired").color(color::RED).into();
+    }
     match days {
-        1 => text::p2_regular("Expires in 1 day")
-            .color(color::GREY_3)
-            .into(),
-        d if d > 0 => text::p2_regular(format!("Expires in {} days", d))
-            .color(color::GREY_3)
-            .into(),
         0 => text::p2_regular("Expires today")
             .color(color::ORANGE)
             .into(),
-        d if d < 0 => text::p2_regular("Expired").color(color::RED).into(),
-        _ => text::p2_regular("").into(),
+        1 => text::p2_regular("Expires in 1 day")
+            .color(color::GREY_3)
+            .into(),
+        d => text::p2_regular(format!("Expires in {} days", d))
+            .color(color::GREY_3)
+            .into(),
     }
 }
 

--- a/coincube-gui/src/app/view/connect/cube_members.rs
+++ b/coincube-gui/src/app/view/connect/cube_members.rs
@@ -34,17 +34,17 @@ pub fn cube_members_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectCu
             Column::new()
                 .push(text::h4_bold("Members").style(theme::text::primary))
                 .push(
-                    text::p2_regular(
-                        "People who can view this Cube and contribute signing keys.",
-                    )
-                    .color(color::GREY_3),
+                    text::p2_regular("People who can view this Cube and contribute signing keys.")
+                        .color(color::GREY_3),
                 )
                 .spacing(2),
         )
         .push(iced::widget::Space::new().width(Length::Fill))
         .push(
             button::secondary(None, "Refresh")
-                .on_press(ConnectCubeMessage::Members(ConnectCubeMembersMessage::Reload))
+                .on_press(ConnectCubeMessage::Members(
+                    ConnectCubeMembersMessage::Reload,
+                ))
                 .width(Length::Shrink),
         )
         .align_y(Alignment::Center);
@@ -130,9 +130,7 @@ fn invite_form<'a>(
     };
 
     let input = TextInput::new("email@example.com", &panel.invite_email)
-        .on_input(|s| {
-            ConnectCubeMessage::Members(ConnectCubeMembersMessage::InviteEmailChanged(s))
-        })
+        .on_input(|s| ConnectCubeMessage::Members(ConnectCubeMembersMessage::InviteEmailChanged(s)))
         .on_submit_maybe(can_submit.then_some(ConnectCubeMessage::Members(
             ConnectCubeMembersMessage::SubmitInvite,
         )))
@@ -225,10 +223,7 @@ fn pending_invite_card<'a>(invite: &'a CubeInviteSummary) -> Element<'a, Connect
         .push(text::p1_regular(invite.email.as_str()).style(theme::text::primary))
         .push(
             Row::new()
-                .push(
-                    text::p2_regular(invite.status.as_str())
-                        .color(status_color(&invite.status)),
-                )
+                .push(text::p2_regular(invite.status.as_str()).color(status_color(&invite.status)))
                 .push(iced::widget::Space::new().width(Length::Fixed(12.0)))
                 .push(expiry_elem)
                 .align_y(Alignment::Center),
@@ -320,20 +315,18 @@ fn remove_conflict_banner<'a>(msg: &str) -> Element<'a, ConnectCubeMessage> {
             .push(text::p2_regular(msg.to_string()).style(theme::text::primary))
             .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
             .push(
-                text::p2_regular(
-                    "Wind down the Vault(s) first, then try again.",
-                )
-                .color(color::GREY_3),
+                text::p2_regular("Wind down the Vault(s) first, then try again.")
+                    .color(color::GREY_3),
             )
             .push(iced::widget::Space::new().height(Length::Fixed(10.0)))
             .push(
                 Row::new()
                     .push(iced::widget::Space::new().width(Length::Fill))
-                    .push(
-                        button::secondary(None, "Dismiss").on_press(ConnectCubeMessage::Members(
+                    .push(button::secondary(None, "Dismiss").on_press(
+                        ConnectCubeMessage::Members(
                             ConnectCubeMembersMessage::DismissRemoveConflict,
-                        )),
-                    ),
+                        ),
+                    )),
             )
             .padding(16)
             .spacing(0),
@@ -377,7 +370,9 @@ fn expiry_element<'a>(expires_at: &str) -> Element<'a, ConnectCubeMessage> {
         d if d > 0 => text::p2_regular(format!("Expires in {} days", d))
             .color(color::GREY_3)
             .into(),
-        0 => text::p2_regular("Expires today").color(color::ORANGE).into(),
+        0 => text::p2_regular("Expires today")
+            .color(color::ORANGE)
+            .into(),
         d if d < 0 => text::p2_regular("Expired").color(color::RED).into(),
         _ => text::p2_regular("").into(),
     }

--- a/coincube-gui/src/app/view/connect/cube_members.rs
+++ b/coincube-gui/src/app/view/connect/cube_members.rs
@@ -1,0 +1,390 @@
+//! Cube-scoped members panel view (W8).
+//!
+//! Rendered when the user navigates to `ConnectSubMenu::CubeMembers` inside a
+//! loaded cube. Consumes [`ConnectCubePanel`] state and emits
+//! [`ConnectCubeMessage::Members`] messages.
+
+use coincube_ui::{
+    color,
+    component::{button, text},
+    icon::*,
+    theme,
+    widget::*,
+};
+use iced::{widget::container, Alignment, Length};
+
+use crate::{
+    app::{
+        state::connect::ConnectCubePanel,
+        view::{ConnectCubeMembersMessage, ConnectCubeMessage},
+    },
+    services::coincube::{CubeInviteSummary, CubeMember},
+};
+
+use super::card_style;
+
+/// Top-level Members view. Composes the invite form, member list, and
+/// pending-invite list. Dialogs (error banner, stranded-vault conflict) are
+/// rendered at the bottom.
+pub fn cube_members_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectCubeMessage> {
+    let panel = &state.members;
+
+    let header = Row::new()
+        .push(
+            Column::new()
+                .push(text::h4_bold("Members").style(theme::text::primary))
+                .push(
+                    text::p2_regular(
+                        "People who can view this Cube and contribute signing keys.",
+                    )
+                    .color(color::GREY_3),
+                )
+                .spacing(2),
+        )
+        .push(iced::widget::Space::new().width(Length::Fill))
+        .push(
+            button::secondary(None, "Refresh")
+                .on_press(ConnectCubeMessage::Members(ConnectCubeMembersMessage::Reload))
+                .width(Length::Shrink),
+        )
+        .align_y(Alignment::Center);
+
+    let mut col = Column::new()
+        .push(header)
+        .push(iced::widget::Space::new().height(Length::Fixed(16.0)))
+        .push(invite_form(panel))
+        .push(iced::widget::Space::new().height(Length::Fixed(20.0)))
+        .spacing(0)
+        .width(Length::Fill);
+
+    // Pending invites section
+    if !panel.pending_invites.is_empty() {
+        col = col.push(text::p1_bold("Pending Invites").style(theme::text::primary));
+        col = col.push(iced::widget::Space::new().height(Length::Fixed(8.0)));
+        for invite in &panel.pending_invites {
+            col = col.push(pending_invite_card(invite));
+            col = col.push(iced::widget::Space::new().height(Length::Fixed(6.0)));
+        }
+        col = col.push(iced::widget::Space::new().height(Length::Fixed(16.0)));
+    }
+
+    // Members list
+    if panel.members.is_empty() && panel.pending_invites.is_empty() && !panel.loading {
+        col = col.push(empty_state());
+    } else if !panel.members.is_empty() {
+        col = col.push(text::p1_bold("Members").style(theme::text::primary));
+        col = col.push(iced::widget::Space::new().height(Length::Fixed(8.0)));
+        for member in &panel.members {
+            col = col.push(member_card(member));
+            col = col.push(iced::widget::Space::new().height(Length::Fixed(6.0)));
+        }
+    } else if panel.loading {
+        col = col.push(text::p1_regular("Loading\u{2026}").color(color::GREY_3));
+    }
+
+    if let Some(err) = panel.error.as_deref() {
+        col = col.push(iced::widget::Space::new().height(Length::Fixed(12.0)));
+        col = col.push(error_banner(err));
+    }
+
+    if let Some(conflict) = panel.remove_conflict.as_deref() {
+        col = col.push(iced::widget::Space::new().height(Length::Fixed(12.0)));
+        col = col.push(remove_conflict_banner(conflict));
+    }
+
+    col.into()
+}
+
+// =============================================================================
+// Invite Form
+// =============================================================================
+
+fn invite_form<'a>(
+    panel: &'a crate::app::state::connect::ConnectCubeMembersState,
+) -> Element<'a, ConnectCubeMessage> {
+    let email = panel.invite_email.trim();
+    let email_valid = email_address::EmailAddress::parse_with_options(
+        email,
+        email_address::Options::default().with_required_tld(),
+    )
+    .is_ok();
+    let can_submit = email_valid && !email.is_empty() && !panel.invite_sending;
+
+    let submit: Element<ConnectCubeMessage> = if panel.invite_sending {
+        iced::widget::button(
+            container(text::p1_regular("Sending\u{2026}").color(color::GREY_3))
+                .center_x(Length::Fill)
+                .center_y(Length::Fill),
+        )
+        .width(Length::Shrink)
+        .height(Length::Fixed(44.0))
+        .style(theme::button::primary)
+        .into()
+    } else {
+        button::primary(None, "Add Member")
+            .on_press_maybe(can_submit.then_some(ConnectCubeMessage::Members(
+                ConnectCubeMembersMessage::SubmitInvite,
+            )))
+            .width(Length::Shrink)
+            .into()
+    };
+
+    let input = TextInput::new("email@example.com", &panel.invite_email)
+        .on_input(|s| {
+            ConnectCubeMessage::Members(ConnectCubeMembersMessage::InviteEmailChanged(s))
+        })
+        .on_submit_maybe(can_submit.then_some(ConnectCubeMessage::Members(
+            ConnectCubeMembersMessage::SubmitInvite,
+        )))
+        .size(16)
+        .padding(15)
+        .width(Length::Fill);
+
+    let row = Row::new()
+        .push(input)
+        .push(iced::widget::Space::new().width(Length::Fixed(8.0)))
+        .push(submit)
+        .align_y(Alignment::Center);
+
+    container(
+        Column::new()
+            .push(
+                text::p2_regular(
+                    "Invite by email. Existing contacts are added immediately; new emails \
+                     get an invite and join on accept.",
+                )
+                .color(color::GREY_3),
+            )
+            .push(iced::widget::Space::new().height(Length::Fixed(10.0)))
+            .push(row)
+            .padding(16)
+            .spacing(0),
+    )
+    .style(card_style)
+    .width(Length::Fill)
+    .into()
+}
+
+// =============================================================================
+// Member & Invite cards
+// =============================================================================
+
+fn member_card<'a>(member: &'a CubeMember) -> Element<'a, ConnectCubeMessage> {
+    let email = &member.user.email;
+    let initial = email
+        .chars()
+        .next()
+        .unwrap_or('?')
+        .to_uppercase()
+        .to_string();
+
+    let avatar = container(text::p1_bold(initial).color(color::WHITE))
+        .width(Length::Fixed(36.0))
+        .height(Length::Fixed(36.0))
+        .center_x(Length::Fixed(36.0))
+        .center_y(Length::Fixed(36.0))
+        .style(|_t| container::Style {
+            background: Some(iced::Background::Color(color::ORANGE)),
+            border: iced::Border {
+                radius: 18.0.into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+    let joined = format_date(&member.joined_at);
+    let info = Column::new()
+        .push(text::p1_regular(email.as_str()).style(theme::text::primary))
+        .push(text::p2_regular(format!("Joined {}", joined)).color(color::GREY_3))
+        .spacing(2);
+
+    let member_id = member.id;
+    let remove_btn = button::secondary(None, "Remove").on_press(ConnectCubeMessage::Members(
+        ConnectCubeMembersMessage::RemoveMember(member_id),
+    ));
+
+    container(
+        Row::new()
+            .push(avatar)
+            .push(iced::widget::Space::new().width(Length::Fixed(12.0)))
+            .push(info)
+            .push(iced::widget::Space::new().width(Length::Fill))
+            .push(remove_btn)
+            .align_y(Alignment::Center)
+            .padding(12),
+    )
+    .style(card_style)
+    .width(Length::Fill)
+    .into()
+}
+
+fn pending_invite_card<'a>(invite: &'a CubeInviteSummary) -> Element<'a, ConnectCubeMessage> {
+    let expiry_elem = expiry_element(&invite.expires_at);
+
+    let info = Column::new()
+        .push(text::p1_regular(invite.email.as_str()).style(theme::text::primary))
+        .push(
+            Row::new()
+                .push(
+                    text::p2_regular(invite.status.as_str())
+                        .color(status_color(&invite.status)),
+                )
+                .push(iced::widget::Space::new().width(Length::Fixed(12.0)))
+                .push(expiry_elem)
+                .align_y(Alignment::Center),
+        )
+        .spacing(2);
+
+    let invite_id = invite.id;
+    let actions = Row::new()
+        .push(
+            button::secondary(None, "Revoke").on_press(ConnectCubeMessage::Members(
+                ConnectCubeMembersMessage::RevokeInvite(invite_id),
+            )),
+        )
+        .align_y(Alignment::Center);
+
+    container(
+        Row::new()
+            .push(info)
+            .push(iced::widget::Space::new().width(Length::Fill))
+            .push(actions)
+            .align_y(Alignment::Center)
+            .padding(12),
+    )
+    .style(card_style)
+    .width(Length::Fill)
+    .into()
+}
+
+// =============================================================================
+// Empty state, error banners
+// =============================================================================
+
+fn empty_state<'a>() -> Element<'a, ConnectCubeMessage> {
+    container(
+        Column::new()
+            .push(person_icon().size(40).color(color::GREY_3))
+            .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
+            .push(text::p1_bold("No members yet").style(theme::text::primary))
+            .push(iced::widget::Space::new().height(Length::Fixed(4.0)))
+            .push(
+                text::p2_regular(
+                    "Add a contact by email to let them contribute a signing key to this Cube.",
+                )
+                .color(color::GREY_3),
+            )
+            .align_x(Alignment::Center)
+            .padding(24)
+            .spacing(0),
+    )
+    .style(card_style)
+    .width(Length::Fill)
+    .into()
+}
+
+fn error_banner<'a>(err: &str) -> Element<'a, ConnectCubeMessage> {
+    container(
+        Row::new()
+            .push(text::p2_regular(err.to_string()).color(color::RED))
+            .push(iced::widget::Space::new().width(Length::Fill))
+            .push(
+                iced::widget::button(cross_icon().color(color::GREY_3))
+                    .padding([6, 8])
+                    .style(theme::button::transparent)
+                    .on_press(ConnectCubeMessage::Members(
+                        ConnectCubeMembersMessage::DismissError,
+                    )),
+            )
+            .align_y(Alignment::Center)
+            .padding(12),
+    )
+    .style(|t| container::Style {
+        background: Some(iced::Background::Color(t.colors.cards.simple.background)),
+        border: iced::Border {
+            color: color::RED,
+            width: 0.5,
+            radius: 8.0.into(),
+        },
+        ..Default::default()
+    })
+    .width(Length::Fill)
+    .into()
+}
+
+fn remove_conflict_banner<'a>(msg: &str) -> Element<'a, ConnectCubeMessage> {
+    container(
+        Column::new()
+            .push(text::p1_bold("Can't remove this member").color(color::RED))
+            .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+            .push(text::p2_regular(msg.to_string()).style(theme::text::primary))
+            .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+            .push(
+                text::p2_regular(
+                    "Wind down the Vault(s) first, then try again.",
+                )
+                .color(color::GREY_3),
+            )
+            .push(iced::widget::Space::new().height(Length::Fixed(10.0)))
+            .push(
+                Row::new()
+                    .push(iced::widget::Space::new().width(Length::Fill))
+                    .push(
+                        button::secondary(None, "Dismiss").on_press(ConnectCubeMessage::Members(
+                            ConnectCubeMembersMessage::DismissRemoveConflict,
+                        )),
+                    ),
+            )
+            .padding(16)
+            .spacing(0),
+    )
+    .style(|t| container::Style {
+        background: Some(iced::Background::Color(t.colors.cards.simple.background)),
+        border: iced::Border {
+            color: color::RED,
+            width: 1.0,
+            radius: 12.0.into(),
+        },
+        ..Default::default()
+    })
+    .width(Length::Fill)
+    .into()
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn status_color(status: &str) -> iced::Color {
+    match status {
+        "pending" => color::ORANGE,
+        "accepted" => color::GREEN,
+        "revoked" | "expired" => color::GREY_3,
+        _ => color::GREY_3,
+    }
+}
+
+fn expiry_element<'a>(expires_at: &str) -> Element<'a, ConnectCubeMessage> {
+    let Ok(expiry) = chrono::DateTime::parse_from_rfc3339(expires_at) else {
+        return text::p2_regular("").into();
+    };
+    let now = chrono::Utc::now();
+    let days = (expiry.date_naive() - now.date_naive()).num_days();
+    match days {
+        1 => text::p2_regular("Expires in 1 day")
+            .color(color::GREY_3)
+            .into(),
+        d if d > 0 => text::p2_regular(format!("Expires in {} days", d))
+            .color(color::GREY_3)
+            .into(),
+        0 => text::p2_regular("Expires today").color(color::ORANGE).into(),
+        d if d < 0 => text::p2_regular("Expired").color(color::RED).into(),
+        _ => text::p2_regular("").into(),
+    }
+}
+
+fn format_date(iso: &str) -> String {
+    chrono::DateTime::parse_from_rfc3339(iso)
+        .map(|dt| dt.format("%b %d, %Y").to_string())
+        .unwrap_or_else(|_| iso.to_string())
+}

--- a/coincube-gui/src/app/view/connect/cube_members.rs
+++ b/coincube-gui/src/app/view/connect/cube_members.rs
@@ -21,7 +21,7 @@ use crate::{
     services::coincube::{CubeInviteSummary, CubeMember},
 };
 
-use super::card_style;
+use super::{card_style, format_date};
 
 /// Top-level Members view. Composes the invite form, member list, and
 /// pending-invite list. Dialogs (error banner, stranded-vault conflict) are
@@ -388,10 +388,4 @@ fn expiry_element<'a>(expires_at: &str) -> Element<'a, ConnectCubeMessage> {
             .color(color::GREY_3)
             .into(),
     }
-}
-
-fn format_date(iso: &str) -> String {
-    chrono::DateTime::parse_from_rfc3339(iso)
-        .map(|dt| dt.format("%b %d, %Y").to_string())
-        .unwrap_or_else(|_| iso.to_string())
 }

--- a/coincube-gui/src/app/view/connect/cube_members.rs
+++ b/coincube-gui/src/app/view/connect/cube_members.rs
@@ -69,12 +69,13 @@ pub fn cube_members_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectCu
     }
 
     // Members list. Skip the "No members yet" placeholder when there's
-    // an error — we don't actually know the cube is empty, the load just
-    // failed. The `error_banner` below communicates that state instead.
+    // a *load* error — we don't actually know the cube is empty, the
+    // fetch just failed. An action error (e.g. invite validation) is
+    // unrelated to list shape, so it doesn't gate the empty state.
     if panel.members.is_empty()
         && panel.pending_invites.is_empty()
         && !panel.loading
-        && panel.error.is_none()
+        && panel.load_error.is_none()
     {
         col = col.push(empty_state());
     } else if !panel.members.is_empty() {
@@ -88,7 +89,14 @@ pub fn cube_members_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectCu
         col = col.push(text::p1_regular("Loading\u{2026}").color(color::GREY_3));
     }
 
-    if let Some(err) = panel.error.as_deref() {
+    // Load errors take precedence — they describe a structural issue
+    // (can't render data) and are more severe than a transient action
+    // failure. An action error below is surfaced only when there's no
+    // load error to supersede it.
+    if let Some(err) = panel.load_error.as_deref() {
+        col = col.push(iced::widget::Space::new().height(Length::Fixed(12.0)));
+        col = col.push(error_banner(err));
+    } else if let Some(err) = panel.error.as_deref() {
         col = col.push(iced::widget::Space::new().height(Length::Fixed(12.0)));
         col = col.push(error_banner(err));
     }

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -1,4 +1,5 @@
 mod contacts;
+mod cube_members;
 
 use coincube_ui::{
     color,
@@ -78,6 +79,9 @@ pub fn connect_panel<'a>(state: &'a ConnectPanel) -> Element<'a, ViewMessage> {
                 contacts::contacts_ux(acct).map(ViewMessage::ConnectAccount)
             }
             ConnectSubMenu::Invites => invites_ux(acct).map(ViewMessage::ConnectAccount),
+            ConnectSubMenu::CubeMembers => {
+                cube_members::cube_members_ux(cube).map(ViewMessage::ConnectCube)
+            }
         },
     };
 

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -191,6 +191,16 @@ pub fn connect_account_panel<'a>(
     col.push(body).into()
 }
 
+/// Parse an RFC 3339 timestamp and render it as `"Mon DD, YYYY"`
+/// (e.g. `"Apr 20, 2026"`). Falls back to the raw input on parse
+/// failure. Shared helper used by both the Contacts and Cube Members
+/// views.
+pub(super) fn format_date(iso: &str) -> String {
+    chrono::DateTime::parse_from_rfc3339(iso)
+        .map(|dt| dt.format("%b %d, %Y").to_string())
+        .unwrap_or_else(|_| iso.to_string())
+}
+
 fn card_style(t: &theme::Theme) -> container::Style {
     container::Style {
         background: Some(iced::Background::Color(t.colors.cards.simple.background)),

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -816,10 +816,16 @@ pub enum ContactsMessage {
     /// User confirmed the dialog — fires `create_cube_invite` per
     /// selection.
     ConfirmAddToCube,
-    /// Result of the parallel `create_cube_invite` calls. The `Ok`
-    /// branch carries the list of (cube_id, Result<(), String>) so the
-    /// handler can distinguish full success from partial failure.
-    AddToCubeResult(Vec<(u64, Result<(), String>)>),
+    /// Result of the parallel `create_cube_invite` calls. Carries the
+    /// originating contact id and session generation so late responses
+    /// are dropped instead of landing on a stale or unrelated dialog.
+    /// The payload lists per-cube outcomes so the handler can
+    /// distinguish full success from partial failure.
+    AddToCubeResult(
+        u64, /* contact id */
+        u64, /* session generation */
+        Vec<(u64, Result<(), String>)>,
+    ),
     /// Close the dialog without submitting.
     CloseAddToCubeDialog,
     /// One-click "Add to Current Cube" on a contact row. Fires a

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -775,8 +775,6 @@ pub enum ContactsMessage {
     ShowDetail(u64),
     /// Email input changed (invite form).
     InviteEmailChanged(String),
-    /// Role changed (invite form).
-    InviteRoleChanged(crate::services::coincube::ContactRole),
     /// Submit invite.
     SubmitInvite,
     /// Invite created successfully — reload list.
@@ -802,6 +800,34 @@ pub enum ContactsMessage {
     /// A cube id from the last submit was 403'd by the backend (W12).
     /// Triggers an "unavailable cubes" dialog and reloads the cube list.
     InviteCubeForbidden(String),
+    // --- W14: add-existing-contact-to-cube ---
+    /// Open the multi-select "Add to Cube(s)…" dialog for an existing
+    /// contact. Kicks off the candidate-cube fetch.
+    OpenAddToCubeDialog(u64 /* contact id */),
+    /// Candidate cubes loaded for the dialog (after network filter,
+    /// unjoined filter, and owner-or-member filter).
+    AddToCubeCandidatesLoaded(
+        u64, /* contact id */
+        Vec<crate::app::state::connect::InviteCubeOption>,
+        u64, /* session generation */
+    ),
+    /// User toggled a cube checkbox in the dialog.
+    ToggleAddToCubeSelection(u64 /* cube id */),
+    /// User confirmed the dialog — fires `create_cube_invite` per
+    /// selection.
+    ConfirmAddToCube,
+    /// Result of the parallel `create_cube_invite` calls. The `Ok`
+    /// branch carries the list of (cube_id, Result<(), String>) so the
+    /// handler can distinguish full success from partial failure.
+    AddToCubeResult(Vec<(u64, Result<(), String>)>),
+    /// Close the dialog without submitting.
+    CloseAddToCubeDialog,
+    /// One-click "Add to Current Cube" on a contact row. Fires a
+    /// single `create_cube_invite` for the active cube.
+    AddContactToCurrentCube(u64 /* contact id */),
+    /// Result of the one-click add. `Ok(cube_id)` for success,
+    /// `Err((contact_id, msg))` for failure.
+    AddContactToCurrentCubeResult(u64 /* contact id */, Result<u64, String>),
     /// Error.
     Error(String),
 }

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -793,6 +793,18 @@ pub enum ContactsMessage {
     ContactCubesLoaded(u64, Vec<crate::services::coincube::ContactCube>, u64),
     /// Contact detail cubes fetch failed — includes contact_id for stale guard.
     ContactCubesFailed(u64, String),
+    // --- W12: cube multi-select on invite form ---
+    /// Available cubes loaded for the invite form (from `list_cubes`).
+    /// Carries `session_generation` for stale-response guarding.
+    InviteCubesAvailable(
+        Vec<crate::app::state::connect::InviteCubeOption>,
+        u64,
+    ),
+    /// User toggled a cube checkbox in the invite form.
+    ToggleInviteCube(u64),
+    /// A cube id from the last submit was 403'd by the backend (W12).
+    /// Triggers an "unavailable cubes" dialog and reloads the cube list.
+    InviteCubeForbidden(String),
     /// Error.
     Error(String),
 }
@@ -816,6 +828,33 @@ pub enum ConnectCubeMessage {
     CopyToClipboard(String),
     Error(String),
     Avatar(AvatarMessage),
+    /// Cube-scoped members management (W8 — see
+    /// `plans/PLAN-cube-membership-desktop.md`).
+    Members(ConnectCubeMembersMessage),
+}
+
+/// Messages for the cube-scoped Members panel. Carries a `load_gen` token on
+/// async results so stale responses (e.g. from a prior `Reload`) can be
+/// discarded.
+#[derive(Debug, Clone)]
+pub enum ConnectCubeMembersMessage {
+    /// Enter the panel — fires `Reload` if state is empty.
+    Enter,
+    /// Fetch `GET /connect/cubes/{id}` to refresh members + pending invites.
+    Reload,
+    Loaded(
+        Result<crate::services::coincube::CubeResponse, String>,
+        u32, // load generation
+    ),
+    InviteEmailChanged(String),
+    SubmitInvite,
+    InviteResult(Result<crate::services::coincube::CubeInviteOrAddResult, String>),
+    RevokeInvite(u64),
+    RevokeInviteResult(u64, Result<(), String>),
+    RemoveMember(u64),
+    RemoveMemberResult(u64, Result<(), String>),
+    DismissError,
+    DismissRemoveConflict,
 }
 
 #[derive(Debug, Clone)]

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -796,10 +796,7 @@ pub enum ContactsMessage {
     // --- W12: cube multi-select on invite form ---
     /// Available cubes loaded for the invite form (from `list_cubes`).
     /// Carries `session_generation` for stale-response guarding.
-    InviteCubesAvailable(
-        Vec<crate::app::state::connect::InviteCubeOption>,
-        u64,
-    ),
+    InviteCubesAvailable(Vec<crate::app::state::connect::InviteCubeOption>, u64),
     /// User toggled a cube checkbox in the invite form.
     ToggleInviteCube(u64),
     /// A cube id from the last submit was 403'd by the backend (W12).

--- a/coincube-gui/src/app/view/mod.rs
+++ b/coincube-gui/src/app/view/mod.rs
@@ -1058,6 +1058,31 @@ pub fn sidebar<'a>(
             .push(connect_avatar_button)
             .push(connect_contacts_button)
             .push(connect_invites_button);
+
+        // Cube Members sub-menu (W8) — behind the CUBE_MEMBERS_UI_ENABLED
+        // build-time flag while the backend rolls out.
+        if crate::feature_flags::CUBE_MEMBERS_UI_ENABLED {
+            let connect_members_button =
+                if matches!(menu, Menu::Connect(ConnectSubMenu::CubeMembers)) {
+                    row!(
+                        Space::new().width(Length::Fixed(20.0)),
+                        button::menu_active(Some(person_icon()), "Members")
+                            .on_press(Message::Reload)
+                            .width(iced::Length::Fill),
+                        menu_bar_highlight()
+                    )
+                    .width(Length::Fill)
+                } else {
+                    row!(
+                        Space::new().width(Length::Fixed(20.0)),
+                        button::menu(Some(person_icon()), "Members")
+                            .on_press(Message::Menu(Menu::Connect(ConnectSubMenu::CubeMembers)))
+                            .width(iced::Length::Fill),
+                    )
+                    .width(Length::Fill)
+                };
+            menu_column = menu_column.push(connect_members_button);
+        }
     }
 
     // Global Settings button (always visible at bottom of main menu)

--- a/coincube-gui/src/app/view/vault/psbt.rs
+++ b/coincube-gui/src/app/view/vault/psbt.rs
@@ -1115,7 +1115,6 @@ fn border_wallet_recon_phrase_view(
 ) -> Element<'_, Message> {
     let header = modal::header(
         Some("Reconstruct Border Wallet".to_string()),
-        None::<fn() -> Message>,
         Some(|| {
             Message::Spend(SpendTxMessage::BorderWalletRecon(
                 BorderWalletReconMessage::Cancel,
@@ -1189,7 +1188,6 @@ fn border_wallet_recon_phrase_view(
 fn border_wallet_recon_grid_view(recon: &BorderWalletReconstructionState) -> Element<'_, Message> {
     let header = modal::header(
         Some("Select Pattern".to_string()),
-        None::<fn() -> Message>,
         Some(|| {
             Message::Spend(SpendTxMessage::BorderWalletRecon(
                 BorderWalletReconMessage::Cancel,

--- a/coincube-gui/src/feature_flags.rs
+++ b/coincube-gui/src/feature_flags.rs
@@ -22,6 +22,16 @@
 /// non-macOS, native AuthenticationServices on macOS).
 pub const PASSKEY_ENABLED: bool = is_truthy(option_env!("COINCUBE_ENABLE_PASSKEY"));
 
+/// Whether the cube-scoped Members UI (W8 / PLAN-cube-membership-desktop) is
+/// shown in the Connect sidebar.
+///
+/// Controlled by the `COINCUBE_CUBE_MEMBERS_UI` env var at build time.
+/// Defaults to `false` while the backend dependencies are rolling out. When
+/// `false`, the `Members` sub-menu button is hidden from the sidebar — the
+/// rest of the panel code still compiles but is unreachable via UI.
+pub const CUBE_MEMBERS_UI_ENABLED: bool =
+    is_truthy(option_env!("COINCUBE_CUBE_MEMBERS_UI"));
+
 /// `const`-compatible truthy check: accepts `"1"`, `"true"`, `"yes"`
 /// (case-insensitive for the latter two). Anything else, including `None`,
 /// is `false`.

--- a/coincube-gui/src/feature_flags.rs
+++ b/coincube-gui/src/feature_flags.rs
@@ -29,8 +29,7 @@ pub const PASSKEY_ENABLED: bool = is_truthy(option_env!("COINCUBE_ENABLE_PASSKEY
 /// Defaults to `false` while the backend dependencies are rolling out. When
 /// `false`, the `Members` sub-menu button is hidden from the sidebar — the
 /// rest of the panel code still compiles but is unreachable via UI.
-pub const CUBE_MEMBERS_UI_ENABLED: bool =
-    is_truthy(option_env!("COINCUBE_CUBE_MEMBERS_UI"));
+pub const CUBE_MEMBERS_UI_ENABLED: bool = is_truthy(option_env!("COINCUBE_CUBE_MEMBERS_UI"));
 
 /// `const`-compatible truthy check: accepts `"1"`, `"true"`, `"yes"`
 /// (case-insensitive for the latter two). Anything else, including `None`,

--- a/coincube-gui/src/installer/connect_vault.rs
+++ b/coincube-gui/src/installer/connect_vault.rs
@@ -1,0 +1,378 @@
+//! Orchestrates creation of the backend `ConnectVault` shell and its
+//! `ConnectVaultMember` rows after the local wallet install completes.
+//!
+//! Design decisions (2026-04-18, `PLAN-cube-membership-desktop.md`):
+//! - **Timelock days** = `ceil(max_recovery_blocks / 144)` (≈ blocks per
+//!   day), clamped to a minimum of 1. Carried through in
+//!   `Context::connect_vault_timelock_days`. Inherently approximate —
+//!   surfaced as such in the Final step's outcome caption.
+//! - **Member mapping** is restricted to `KeySource::KeychainKey`. HW,
+//!   xpub, master-signer, token, and border-wallet keys are skipped
+//!   (with a `tracing::info!` log). Rationale: only keychain keys have
+//!   backend `keys.id` rows, and W9's "used in another vault" guard
+//!   only matters for those.
+//! - **Role** defaults to `Keyholder` for every member. Refinement into
+//!   Beneficiary/Observer is a follow-up.
+//! - **Failure UX**: the W9 409 (`KEY_ALREADY_USED_IN_VAULT`) rolls
+//!   back the just-created vault so the user can restart with a clean
+//!   slate; other errors leave the partial vault in place and surface a
+//!   retry-able warning.
+
+use crate::services::coincube::{
+    AddVaultMemberRequest, CoincubeClient, ConnectVaultResponse, CreateConnectVaultRequest,
+    RegisterCubeRequest, VaultMemberRole,
+};
+
+use super::context::ConnectVaultMemberPayload;
+
+/// Successful outcome of the vault-create fan-out.
+#[derive(Debug, Clone)]
+pub struct ConnectVaultOutcome {
+    pub vault_id: u64,
+    pub cube_server_id: u64,
+    pub timelock_days: i32,
+    pub members_added: usize,
+    pub members_skipped_non_keychain: usize,
+}
+
+/// Error kinds surfaced to the Final step so it can pick the right UX.
+#[derive(Debug, Clone)]
+pub enum ConnectVaultError {
+    /// The inputs don't support backend vault creation — no authenticated
+    /// client, no cube id, or no members to attach. Treated as
+    /// "silently skipped" by the Final step (user sees nothing).
+    NotApplicable,
+    /// W9 409 `KEY_ALREADY_USED_IN_VAULT`. The vault shell was rolled
+    /// back before the error surfaced, so the user can restart. Carries
+    /// the offending `key_id` for the dialog.
+    KeyAlreadyUsedInVault { key_id: u64 },
+    /// Any other failure (network, backend 5xx, partial success). The
+    /// caller gets a message suitable for display.
+    Other(String),
+}
+
+impl std::fmt::Display for ConnectVaultError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotApplicable => write!(f, "Not applicable"),
+            Self::KeyAlreadyUsedInVault { key_id } => {
+                write!(
+                    f,
+                    "Key #{} is already used in another Vault. A key can \
+                     only participate in one Vault. Remove it from this \
+                     configuration and pick a different key.",
+                    key_id
+                )
+            }
+            Self::Other(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+/// Run the full vault-create + member-attach flow. Safe to call when
+/// Connect isn't authenticated — returns `NotApplicable` in that case.
+///
+/// Cube registration is idempotent on `(user_id, uuid)` server-side so
+/// calling `register_cube` every time is safe — it just reaches into
+/// the existing row.
+pub async fn create_connect_vault(
+    client: Option<CoincubeClient>,
+    cube_uuid: Option<String>,
+    cube_name: Option<String>,
+    network: String,
+    members: Vec<ConnectVaultMemberPayload>,
+    timelock_days: Option<i32>,
+) -> Result<ConnectVaultOutcome, ConnectVaultError> {
+    let (Some(client), Some(cube_uuid), Some(cube_name)) = (client, cube_uuid, cube_name) else {
+        return Err(ConnectVaultError::NotApplicable);
+    };
+    if members.is_empty() {
+        // No keychain-sourced members means nothing for the backend to
+        // track. Skip silently — the Final step translates this into a
+        // no-op.
+        return Err(ConnectVaultError::NotApplicable);
+    }
+    // `div_ceil` upstream already clamps to ≥ 1; defensive default here
+    // in case we're called with `None` (shouldn't happen when members
+    // is non-empty because a recovery path always exists in a valid
+    // descriptor, but cheap insurance).
+    let timelock_days = timelock_days.unwrap_or(1).max(1);
+
+    // 1. Register cube (idempotent — returns the existing row if the
+    //    uuid + owner already match).
+    let cube = client
+        .register_cube(RegisterCubeRequest {
+            uuid: cube_uuid,
+            name: cube_name,
+            network,
+        })
+        .await
+        .map_err(|e| ConnectVaultError::Other(format!("Failed to register cube: {}", e)))?;
+
+    // 2. Create the vault shell.
+    let vault: ConnectVaultResponse = client
+        .create_connect_vault(
+            cube.id,
+            CreateConnectVaultRequest {
+                timelock_days,
+            },
+        )
+        .await
+        .map_err(|e| ConnectVaultError::Other(format!("Failed to create Connect vault: {}", e)))?;
+
+    // 3. Fan out member rows. On W9 409, roll back and bail.
+    let mut members_added = 0usize;
+    for payload in &members {
+        let req = AddVaultMemberRequest {
+            contact_id: payload.contact_id,
+            key_id: Some(payload.key_id),
+            role: VaultMemberRole::Keyholder,
+        };
+        match client.add_vault_member(cube.id, req).await {
+            Ok(_) => {
+                members_added += 1;
+            }
+            Err(e) if e.is_key_already_used_in_vault() => {
+                // Roll back the vault we just created so the user can
+                // restart the Vault Builder with a clean slate. The
+                // delete is best-effort — a failure to roll back just
+                // means the user will see a "vault already exists" on
+                // their next attempt and the backend's `delete_connect_vault`
+                // can be retried.
+                if let Err(rollback_err) = client.delete_connect_vault(cube.id).await {
+                    tracing::warn!(
+                        "W9 rollback failed to delete vault {}: {}",
+                        vault.id,
+                        rollback_err
+                    );
+                }
+                return Err(ConnectVaultError::KeyAlreadyUsedInVault {
+                    key_id: payload.key_id,
+                });
+            }
+            Err(e) => {
+                return Err(ConnectVaultError::Other(format!(
+                    "Failed to add vault member (key {}): {}",
+                    payload.key_id, e
+                )));
+            }
+        }
+    }
+
+    Ok(ConnectVaultOutcome {
+        vault_id: vault.id,
+        cube_server_id: cube.id,
+        timelock_days: vault.timelock_days,
+        members_added,
+        members_skipped_non_keychain: 0, // already filtered upstream
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::installer::descriptor::PathKind;
+    use coincube_core::miniscript::bitcoin::bip32::Fingerprint;
+    use httpmock::{Method, MockServer};
+    use serde_json::json;
+    use std::str::FromStr;
+
+    fn sample_member(fp: &str, key_id: u64, contact_id: Option<u64>) -> ConnectVaultMemberPayload {
+        ConnectVaultMemberPayload {
+            fingerprint: Fingerprint::from_str(fp).expect("valid fp"),
+            key_id,
+            contact_id,
+            path_kind: PathKind::Primary,
+        }
+    }
+
+    #[tokio::test]
+    async fn not_applicable_when_client_missing() {
+        let err = create_connect_vault(
+            None,
+            Some("uuid".to_string()),
+            Some("My Cube".to_string()),
+            "mainnet".to_string(),
+            vec![sample_member("deadbeef", 1, None)],
+            Some(180),
+        )
+        .await
+        .expect_err("should short-circuit");
+        assert!(matches!(err, ConnectVaultError::NotApplicable));
+    }
+
+    #[tokio::test]
+    async fn not_applicable_when_members_empty() {
+        let server = MockServer::start();
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = create_connect_vault(
+            Some(client),
+            Some("uuid".to_string()),
+            Some("My Cube".to_string()),
+            "mainnet".to_string(),
+            vec![],
+            Some(180),
+        )
+        .await
+        .expect_err("should short-circuit");
+        assert!(matches!(err, ConnectVaultError::NotApplicable));
+    }
+
+    #[tokio::test]
+    async fn happy_path_registers_creates_and_adds_members() {
+        let server = MockServer::start();
+
+        let register = server.mock(|when, then| {
+            when.method(Method::POST).path("/api/v1/connect/cubes");
+            then.status(200).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": {
+                    "id": 42,
+                    "uuid": "abc-uuid",
+                    "name": "My Cube",
+                    "network": "mainnet",
+                    "lightningAddress": null,
+                    "bolt12Offer": null,
+                    "status": "active"
+                }
+            }));
+        });
+
+        let create_vault = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/vault")
+                .json_body(json!({ "timelockDays": 180 }));
+            then.status(201).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": {
+                    "id": 5,
+                    "cubeId": 42,
+                    "timelockDays": 180,
+                    "timelockExpiresAt": "2026-10-15T00:00:00Z",
+                    "lastResetAt": "2026-04-18T00:00:00Z",
+                    "status": "active",
+                    "members": [],
+                    "createdAt": "2026-04-18T00:00:00Z",
+                    "updatedAt": "2026-04-18T00:00:00Z"
+                }
+            }));
+        });
+
+        let add_member = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/vault/members");
+            then.status(201).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": {
+                    "id": 7,
+                    "keyId": 99,
+                    "role": "keyholder",
+                    "createdAt": "2026-04-18T00:00:00Z"
+                }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let outcome = create_connect_vault(
+            Some(client),
+            Some("abc-uuid".to_string()),
+            Some("My Cube".to_string()),
+            "mainnet".to_string(),
+            vec![sample_member("deadbeef", 99, None)],
+            Some(180),
+        )
+        .await
+        .expect("happy path");
+
+        register.assert();
+        create_vault.assert();
+        add_member.assert();
+        assert_eq!(outcome.vault_id, 5);
+        assert_eq!(outcome.cube_server_id, 42);
+        assert_eq!(outcome.timelock_days, 180);
+        assert_eq!(outcome.members_added, 1);
+    }
+
+    #[tokio::test]
+    async fn w9_409_rolls_back_vault_and_surfaces_key_id() {
+        let server = MockServer::start();
+
+        let register = server.mock(|when, then| {
+            when.method(Method::POST).path("/api/v1/connect/cubes");
+            then.status(200).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": {
+                    "id": 42,
+                    "uuid": "abc-uuid",
+                    "name": "My Cube",
+                    "network": "mainnet",
+                    "lightningAddress": null,
+                    "bolt12Offer": null,
+                    "status": "active"
+                }
+            }));
+        });
+
+        let create_vault = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/vault");
+            then.status(201).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": {
+                    "id": 5,
+                    "cubeId": 42,
+                    "timelockDays": 180,
+                    "timelockExpiresAt": "2026-10-15T00:00:00Z",
+                    "lastResetAt": "2026-04-18T00:00:00Z",
+                    "status": "active",
+                    "members": [],
+                    "createdAt": "2026-04-18T00:00:00Z",
+                    "updatedAt": "2026-04-18T00:00:00Z"
+                }
+            }));
+        });
+
+        let add_member = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/vault/members");
+            then.status(409).header("content-type", "application/json").json_body(json!({
+                "success": false,
+                "error": {
+                    "code": "KEY_ALREADY_USED_IN_VAULT",
+                    "message": "Key has already been used in another vault"
+                }
+            }));
+        });
+
+        let rollback = server.mock(|when, then| {
+            when.method(Method::DELETE)
+                .path("/api/v1/connect/cubes/42/vault");
+            then.status(200).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": { "deleted": true }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = create_connect_vault(
+            Some(client),
+            Some("abc-uuid".to_string()),
+            Some("My Cube".to_string()),
+            "mainnet".to_string(),
+            vec![sample_member("deadbeef", 99, None)],
+            Some(180),
+        )
+        .await
+        .expect_err("expected W9 409 error");
+
+        register.assert();
+        create_vault.assert();
+        add_member.assert();
+        rollback.assert();
+        assert!(
+            matches!(err, ConnectVaultError::KeyAlreadyUsedInVault { key_id: 99 }),
+            "expected W9 error with key_id=99, got: {:?}",
+            err
+        );
+    }
+}

--- a/coincube-gui/src/installer/connect_vault.rs
+++ b/coincube-gui/src/installer/connect_vault.rs
@@ -111,12 +111,7 @@ pub async fn create_connect_vault(
 
     // 2. Create the vault shell.
     let vault: ConnectVaultResponse = client
-        .create_connect_vault(
-            cube.id,
-            CreateConnectVaultRequest {
-                timelock_days,
-            },
-        )
+        .create_connect_vault(cube.id, CreateConnectVaultRequest { timelock_days })
         .await
         .map_err(|e| ConnectVaultError::Other(format!("Failed to create Connect vault: {}", e)))?;
 
@@ -224,52 +219,58 @@ mod tests {
 
         let register = server.mock(|when, then| {
             when.method(Method::POST).path("/api/v1/connect/cubes");
-            then.status(200).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": {
-                    "id": 42,
-                    "uuid": "abc-uuid",
-                    "name": "My Cube",
-                    "network": "mainnet",
-                    "lightningAddress": null,
-                    "bolt12Offer": null,
-                    "status": "active"
-                }
-            }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 42,
+                        "uuid": "abc-uuid",
+                        "name": "My Cube",
+                        "network": "mainnet",
+                        "lightningAddress": null,
+                        "bolt12Offer": null,
+                        "status": "active"
+                    }
+                }));
         });
 
         let create_vault = server.mock(|when, then| {
             when.method(Method::POST)
                 .path("/api/v1/connect/cubes/42/vault")
                 .json_body(json!({ "timelockDays": 180 }));
-            then.status(201).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": {
-                    "id": 5,
-                    "cubeId": 42,
-                    "timelockDays": 180,
-                    "timelockExpiresAt": "2026-10-15T00:00:00Z",
-                    "lastResetAt": "2026-04-18T00:00:00Z",
-                    "status": "active",
-                    "members": [],
-                    "createdAt": "2026-04-18T00:00:00Z",
-                    "updatedAt": "2026-04-18T00:00:00Z"
-                }
-            }));
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 5,
+                        "cubeId": 42,
+                        "timelockDays": 180,
+                        "timelockExpiresAt": "2026-10-15T00:00:00Z",
+                        "lastResetAt": "2026-04-18T00:00:00Z",
+                        "status": "active",
+                        "members": [],
+                        "createdAt": "2026-04-18T00:00:00Z",
+                        "updatedAt": "2026-04-18T00:00:00Z"
+                    }
+                }));
         });
 
         let add_member = server.mock(|when, then| {
             when.method(Method::POST)
                 .path("/api/v1/connect/cubes/42/vault/members");
-            then.status(201).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": {
-                    "id": 7,
-                    "keyId": 99,
-                    "role": "keyholder",
-                    "createdAt": "2026-04-18T00:00:00Z"
-                }
-            }));
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 7,
+                        "keyId": 99,
+                        "role": "keyholder",
+                        "createdAt": "2026-04-18T00:00:00Z"
+                    }
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -299,58 +300,66 @@ mod tests {
 
         let register = server.mock(|when, then| {
             when.method(Method::POST).path("/api/v1/connect/cubes");
-            then.status(200).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": {
-                    "id": 42,
-                    "uuid": "abc-uuid",
-                    "name": "My Cube",
-                    "network": "mainnet",
-                    "lightningAddress": null,
-                    "bolt12Offer": null,
-                    "status": "active"
-                }
-            }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 42,
+                        "uuid": "abc-uuid",
+                        "name": "My Cube",
+                        "network": "mainnet",
+                        "lightningAddress": null,
+                        "bolt12Offer": null,
+                        "status": "active"
+                    }
+                }));
         });
 
         let create_vault = server.mock(|when, then| {
             when.method(Method::POST)
                 .path("/api/v1/connect/cubes/42/vault");
-            then.status(201).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": {
-                    "id": 5,
-                    "cubeId": 42,
-                    "timelockDays": 180,
-                    "timelockExpiresAt": "2026-10-15T00:00:00Z",
-                    "lastResetAt": "2026-04-18T00:00:00Z",
-                    "status": "active",
-                    "members": [],
-                    "createdAt": "2026-04-18T00:00:00Z",
-                    "updatedAt": "2026-04-18T00:00:00Z"
-                }
-            }));
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 5,
+                        "cubeId": 42,
+                        "timelockDays": 180,
+                        "timelockExpiresAt": "2026-10-15T00:00:00Z",
+                        "lastResetAt": "2026-04-18T00:00:00Z",
+                        "status": "active",
+                        "members": [],
+                        "createdAt": "2026-04-18T00:00:00Z",
+                        "updatedAt": "2026-04-18T00:00:00Z"
+                    }
+                }));
         });
 
         let add_member = server.mock(|when, then| {
             when.method(Method::POST)
                 .path("/api/v1/connect/cubes/42/vault/members");
-            then.status(409).header("content-type", "application/json").json_body(json!({
-                "success": false,
-                "error": {
-                    "code": "KEY_ALREADY_USED_IN_VAULT",
-                    "message": "Key has already been used in another vault"
-                }
-            }));
+            then.status(409)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": false,
+                    "error": {
+                        "code": "KEY_ALREADY_USED_IN_VAULT",
+                        "message": "Key has already been used in another vault"
+                    }
+                }));
         });
 
         let rollback = server.mock(|when, then| {
             when.method(Method::DELETE)
                 .path("/api/v1/connect/cubes/42/vault");
-            then.status(200).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": { "deleted": true }
-            }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": { "deleted": true }
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());

--- a/coincube-gui/src/installer/context.rs
+++ b/coincube-gui/src/installer/context.rs
@@ -6,6 +6,7 @@ use crate::{
     app::settings::KeySetting,
     backup::Backup,
     dir::CoincubeDirectory,
+    installer::descriptor::PathKind,
     node::bitcoind::{Bitcoind, InternalBitcoindConfig},
     services::{
         coincube::CoincubeClient,
@@ -14,8 +15,32 @@ use crate::{
     signer::Signer,
 };
 use async_hwi::DeviceKind;
-use coincube_core::{descriptors::CoincubeDescriptor, miniscript::bitcoin};
+use coincube_core::{
+    descriptors::CoincubeDescriptor,
+    miniscript::bitcoin::{self, bip32::Fingerprint},
+};
 use coincubed::config::{BitcoinBackend, BitcoinConfig};
+
+/// One backend `ConnectVaultMember` row to create after the descriptor
+/// is installed. Only keychain-sourced descriptor keys (W8 / W3) produce
+/// a payload — hardware-wallet, xpub-entered, master-signer and
+/// token-sourced keys are intentionally skipped (per
+/// `plans/PLAN-cube-membership-desktop.md` design decision,
+/// 2026-04-18: "only keychain-sourced keys become VaultMember rows").
+#[derive(Debug, Clone)]
+pub struct ConnectVaultMemberPayload {
+    pub fingerprint: Fingerprint,
+    /// Backend `keys.id` captured when the user selected this key in the
+    /// Vault Builder picker.
+    pub key_id: u64,
+    /// Populated when the key belongs to a contact-Keyholder, `None` when
+    /// the key belongs to the vault owner themselves.
+    pub contact_id: Option<u64>,
+    /// Path the key participates in. Carried through for future role
+    /// inference; all members currently default to `Keyholder` per the
+    /// 2026-04-18 plan direction.
+    pub path_kind: PathKind,
+}
 
 #[derive(Debug, Clone)]
 pub enum RemoteBackend {
@@ -89,6 +114,22 @@ pub struct Context {
     /// fetch Cube-scoped Keychain keys.  `None` when launched from
     /// the Loader (user hasn't done coincube-api auth yet).
     pub coincube_client: Option<CoincubeClient>,
+    /// Cube display name used when idempotently registering the cube
+    /// with the backend during Final. `None` when no cube settings
+    /// were passed in.
+    pub cube_name: Option<String>,
+    /// Vault members to fan out to the backend after the local install
+    /// completes. Populated by `DefineDescriptor::apply()` for every
+    /// keychain-sourced descriptor key. Empty when no such keys exist
+    /// in the descriptor.
+    pub connect_vault_members: Vec<ConnectVaultMemberPayload>,
+    /// Approximate timelock (in days) used for the backend vault's
+    /// `timelockDays` field. Derived from the longest Recovery path's
+    /// `PathSequence::Recovery(blocks)` via `max(blocks / 144, 1)` —
+    /// inherently approximate because block cadence varies. Surfaced
+    /// with an "approximate" caveat in the Final step's success caption.
+    /// `None` when the descriptor has no recovery paths.
+    pub connect_vault_timelock_days: Option<i32>,
 }
 
 impl Context {
@@ -125,6 +166,9 @@ impl Context {
             backup: None,
             cube_id: cube_settings.map(|cs| cs.id.clone()),
             coincube_client,
+            cube_name: cube_settings.map(|cs| cs.name.clone()),
+            connect_vault_members: Vec::new(),
+            connect_vault_timelock_days: None,
         }
     }
 }

--- a/coincube-gui/src/installer/decrypt.rs
+++ b/coincube-gui/src/installer/decrypt.rs
@@ -46,8 +46,6 @@ use crate::{
     utils::{default_derivation_path, example_xpub},
 };
 
-type FnMsg = fn() -> installer::Message;
-
 #[allow(unused, clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy)]
 pub enum Error {
@@ -726,7 +724,6 @@ pub fn mnemonic_input_button<'a>(
 pub fn decrypt_view<'a>(state: &DecryptModal) -> Container<'a, installer::Message> {
     let header = modal::header(
         Some("Decrypt backup file".to_string()),
-        None::<FnMsg>,
         Some(|| installer::Message::Decrypt(Decrypt::Close)),
     );
 

--- a/coincube-gui/src/installer/message.rs
+++ b/coincube-gui/src/installer/message.rs
@@ -85,6 +85,12 @@ pub enum Message {
     ),
     CubeSaveFailed(String),
     RetryCubeSave,
+    /// Result of the post-install `create_connect_vault` orchestration
+    /// (see `installer/connect_vault.rs`). Emitted after
+    /// `Installed(Ok)` so the Final step can surface the outcome.
+    ConnectVaultCreated(
+        Result<super::connect_vault::ConnectVaultOutcome, super::connect_vault::ConnectVaultError>,
+    ),
     CoincubeConnect(CoincubeConnectMsg),
     BorderWalletWizard(
         super::step::descriptor::editor::border_wallet_wizard::BorderWalletWizardMessage,

--- a/coincube-gui/src/installer/message.rs
+++ b/coincube-gui/src/installer/message.rs
@@ -226,6 +226,11 @@ pub enum DefineDescriptor {
     AliasEdited(Fingerprint, String /* alias*/),
     /// Open the Border Wallet wizard for the given path coordinates.
     OpenBorderWalletWizard(Vec<(usize, usize)>),
+    /// Close the current modal and re-open the Select-key-source picker
+    /// for the given coordinates. Used by the Border Wallet wizard's
+    /// intro "Back" button to return to the picker instead of dropping
+    /// the user back to the descriptor editor.
+    ReopenKeyModal(Vec<(usize, usize)>),
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/coincube-gui/src/installer/mod.rs
+++ b/coincube-gui/src/installer/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod connect_vault;
 mod context;
 mod decrypt;
 mod descriptor;

--- a/coincube-gui/src/installer/mod.rs
+++ b/coincube-gui/src/installer/mod.rs
@@ -202,7 +202,7 @@ impl Installer {
                 UserFlow::CreateWallet => vec![
                     ChooseDescriptorTemplate::default().into(),
                     DescriptorTemplateDescription::default().into(),
-                    DefineDescriptor::new(network, signer.clone(), developer_mode).into(),
+                    DefineDescriptor::new(network, signer.clone()).into(),
                     BackupMnemonic::new(signer.clone()).into(),
                     BackupDescriptor::default().into(),
                     RegisterDescriptor::new_create_wallet().into(),

--- a/coincube-gui/src/installer/step/descriptor/editor/border_wallet_wizard.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/border_wallet_wizard.rs
@@ -15,7 +15,11 @@ use coincube_core::{
         descriptor::{DescriptorPublicKey, DescriptorXKey, Wildcard},
     },
 };
-use iced::{alignment::Horizontal, widget::scrollable, Length, Task};
+use iced::{
+    alignment::{Horizontal, Vertical},
+    widget::{scrollable, Space},
+    Length, Task,
+};
 use zeroize::{Zeroize, Zeroizing};
 
 use coincube_ui::{
@@ -339,11 +343,7 @@ impl BorderWalletWizard {
     }
 
     fn view_intro(&self) -> Element<Message> {
-        let header = modal::header(
-            Some("Border Wallet".to_string()),
-            None::<fn() -> Message>,
-            Some(|| Message::Close),
-        );
+        let header = modal::header(Some("Border Wallet".to_string()), Some(|| Message::Close));
 
         let description = Column::new()
             .spacing(8)
@@ -371,14 +371,29 @@ impl BorderWalletWizard {
             ));
 
         let next_btn = button::primary(None, "Get Started")
-            .on_press(self.wizard_msg(BorderWalletWizardMessage::Next))
-            .width(Length::Fill);
+            .on_press(self.wizard_msg(BorderWalletWizardMessage::Next));
+
+        // Footer: [Back] [spacer] [Get Started]. Intro is the first step
+        // of the wizard, so "Back" returns the user to the
+        // Select-key-source picker for this slot (via
+        // `DefineDescriptor::ReopenKeyModal`) rather than dropping
+        // them all the way back to the descriptor editor.
+        let coordinates = self.coordinates.clone();
+        let footer = Row::new()
+            .push(modal::back_button(move || {
+                Message::DefineDescriptor(message::DefineDescriptor::ReopenKeyModal(
+                    coordinates.clone(),
+                ))
+            }))
+            .push(Space::new().width(Length::Fill))
+            .push(next_btn)
+            .align_y(Vertical::Center);
 
         let col = Column::new()
             .spacing(15)
             .push(header)
             .push(description)
-            .push(next_btn)
+            .push(footer)
             .width(500);
 
         Container::new(col)
@@ -388,11 +403,7 @@ impl BorderWalletWizard {
     }
 
     fn view_recovery_phrase(&self) -> Element<Message> {
-        let header = modal::header(
-            Some("Recovery Phrase".to_string()),
-            None::<fn() -> Message>,
-            Some(|| Message::Close),
-        );
+        let header = modal::header(Some("Recovery Phrase".to_string()), Some(|| Message::Close));
 
         let back_btn = button::transparent(Some(icon::previous_icon()), "Back")
             .on_press(self.wizard_msg(BorderWalletWizardMessage::Previous));
@@ -465,11 +476,7 @@ impl BorderWalletWizard {
     }
 
     fn view_grid(&self) -> Element<Message> {
-        let header = modal::header(
-            Some("Select Pattern".to_string()),
-            None::<fn() -> Message>,
-            Some(|| Message::Close),
-        );
+        let header = modal::header(Some("Select Pattern".to_string()), Some(|| Message::Close));
 
         let back_btn = button::transparent(Some(icon::previous_icon()), "Back")
             .on_press(self.wizard_msg(BorderWalletWizardMessage::Previous));
@@ -584,11 +591,7 @@ impl BorderWalletWizard {
     }
 
     fn view_checksum(&self) -> Element<Message> {
-        let header = modal::header(
-            Some("Checksum & Key".to_string()),
-            None::<fn() -> Message>,
-            Some(|| Message::Close),
-        );
+        let header = modal::header(Some("Checksum & Key".to_string()), Some(|| Message::Close));
 
         let back_btn = button::transparent(Some(icon::previous_icon()), "Back")
             .on_press(self.wizard_msg(BorderWalletWizardMessage::Previous));
@@ -637,11 +640,7 @@ impl BorderWalletWizard {
     }
 
     fn view_confirm(&self) -> Element<Message> {
-        let header = modal::header(
-            Some("Confirm".to_string()),
-            None::<fn() -> Message>,
-            Some(|| Message::Close),
-        );
+        let header = modal::header(Some("Confirm".to_string()), Some(|| Message::Close));
 
         let back_btn = button::transparent(Some(icon::previous_icon()), "Back")
             .on_press(self.wizard_msg(BorderWalletWizardMessage::Previous));

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -1641,10 +1641,20 @@ impl SelectKeySource {
         let paste_btn = button::secondary(Some(icon::paste_icon()), "Paste")
             .on_press(Self::route(SelectKeySourceMessage::PasteXpub));
 
-        let error = self
-            .import_xpub_error
-            .as_ref()
-            .map(|e| p1_regular(e.clone()).color(color::RED));
+        // Parse errors live in two places depending on entry path:
+        //   * `form_xpub.warning` — set by `on_update_xpub` for manual
+        //     paste errors ("Invalid Xpub", "Wrong network", "Wrong
+        //     derivation path", "Origin missing", "Key already used").
+        //   * `import_xpub_error` — set by `on_import_xpub` on the
+        //     file-picker path.
+        // Surface whichever is present; prefer the inline manual-paste
+        // warning because it reflects the user's latest action.
+        let error_text: Option<String> = self
+            .form_xpub
+            .warning
+            .map(|w| w.to_string())
+            .or_else(|| self.import_xpub_error.clone());
+        let error = error_text.map(|e| p1_regular(e).color(color::RED));
 
         // Footer: [Back] [spacer] [Paste]. Paste is the primary action
         // on this screen (it pulls clipboard contents into the text

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -960,8 +960,12 @@ impl SelectKeySource {
                 let mut contact_keys = Vec::new();
 
                 for key in raw_keys {
-                    let owner_id = key.primary_owner_id;
-                    if owner_id == current_user_id {
+                    let owner_id = key.effective_owner_user_id();
+                    // Prefer the server's viewer-relative `is_own_key` when
+                    // it's set; fall back to a local id comparison for
+                    // pre-W3 backends where the field is always false.
+                    let is_own = key.is_own_key || owner_id == current_user_id;
+                    if is_own {
                         my_keys.push(ResolvedCubeKey {
                             raw: key,
                             owner: KeychainKeyOwner::SelfUser {
@@ -972,12 +976,21 @@ impl SelectKeySource {
                         c.contact_user_id == owner_id
                             && c.role == crate::services::coincube::ContactRole::Keyholder
                     }) {
+                        // Prefer the server-supplied `ownerEmail` when the
+                        // W3 backend populated it; the contact-list lookup
+                        // still runs because we need `contact_id` for the
+                        // keychain-key `KeySource` enum.
+                        let contact_email = if !key.owner_email.is_empty() {
+                            key.owner_email.clone()
+                        } else {
+                            contact.contact_user.email.clone()
+                        };
                         contact_keys.push(ResolvedCubeKey {
                             raw: key,
                             owner: KeychainKeyOwner::Contact {
                                 primary_owner_id: owner_id,
                                 contact_id: contact.id,
-                                contact_email: contact.contact_user.email.clone(),
+                                contact_email,
                             },
                         });
                     }
@@ -1149,7 +1162,11 @@ impl SelectKeySource {
         }
 
         for rk in &self.my_keychain_keys {
-            let disabled = self.is_owner_already_placed(rk.raw.primary_owner_id);
+            let owner_id = rk.raw.effective_owner_user_id();
+            let already_placed = self.is_owner_already_placed(owner_id);
+            // W9 pre-check: reject keys that another Vault already claims.
+            let used_elsewhere = rk.raw.used_by_vault;
+            let disabled = already_placed || used_elsewhere;
             let fp_short: String = rk.raw.fingerprint.chars().take(8).collect();
             let fingerprint = Some(format!("#{}", fp_short));
             let msg = if disabled {
@@ -1160,7 +1177,16 @@ impl SelectKeySource {
                     Self::route(SelectKeySourceMessage::SelectKeychainKey(rk_clone.clone()))
                 })
             };
-            let warning = disabled.then(|| "Already selected".to_string());
+            // Surface the more specific reason when both apply: once a key
+            // is in another Vault, that's the blocking constraint even if
+            // the owner is also placed elsewhere in this build.
+            let warning = if used_elsewhere {
+                Some("Used by another Vault".to_string())
+            } else if already_placed {
+                Some("Already selected".to_string())
+            } else {
+                None
+            };
             col = col.push(modal::key_entry(
                 Some(icon::round_key_icon()),
                 rk.raw.name.clone(),
@@ -1204,7 +1230,7 @@ impl SelectKeySource {
             std::collections::BTreeMap::new();
         for rk in &self.contact_keychain_keys {
             seen_contacts
-                .entry(rk.raw.primary_owner_id)
+                .entry(rk.raw.effective_owner_user_id())
                 .or_default()
                 .push(rk);
         }
@@ -1218,7 +1244,10 @@ impl SelectKeySource {
                 };
                 col = col.push(p1_bold(contact_label));
                 for rk in keys {
-                    let disabled = self.is_owner_already_placed(rk.raw.primary_owner_id);
+                    let owner_id = rk.raw.effective_owner_user_id();
+                    let already_placed = self.is_owner_already_placed(owner_id);
+                    let used_elsewhere = rk.raw.used_by_vault;
+                    let disabled = already_placed || used_elsewhere;
                     let fp = &rk.raw.fingerprint;
                     let fingerprint = Some(format!("#{}", &fp[..fp.len().min(8)]));
                     let msg = if disabled {
@@ -1229,7 +1258,13 @@ impl SelectKeySource {
                             Self::route(SelectKeySourceMessage::SelectKeychainKey(rk_clone.clone()))
                         })
                     };
-                    let warning = disabled.then(|| "Already selected".to_string());
+                    let warning = if used_elsewhere {
+                        Some("Used by another Vault".to_string())
+                    } else if already_placed {
+                        Some("Already selected".to_string())
+                    } else {
+                        None
+                    };
                     col = col.push(modal::key_entry(
                         Some(icon::round_key_icon()),
                         rk.raw.name.clone(),

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -1086,20 +1086,6 @@ impl SelectKeySource {
         self.cube_id.is_some() && self.coincube_client.is_some()
     }
 
-    /// Check if a key's owner already has a key placed in this vault.
-    /// Self-contained: reads `primary_owner_id` directly from the
-    /// `KeychainKeyOwner` stored on each placed key, so it works
-    /// regardless of the fetched key list state.
-    fn is_owner_already_placed(&self, primary_owner_id: u64) -> bool {
-        self.keys.values().any(|(_, k)| {
-            if let KeySource::KeychainKey { owner, .. } = &k.source {
-                owner.primary_owner_id() == primary_owner_id
-            } else {
-                false
-            }
-        })
-    }
-
     /// Backstop for `on_select_keychain_key`: returns true if accepting
     /// the candidate Keychain key would violate "one Keychain key per
     /// owner per Vault".  A conflict exists when a *different* Keychain
@@ -1162,10 +1148,20 @@ impl SelectKeySource {
 
         for rk in &self.my_keychain_keys {
             let owner_id = rk.raw.effective_owner_user_id();
-            let already_placed = self.is_owner_already_placed(owner_id);
+            // Match the submit-side `on_select_keychain_key` backstop:
+            // a row is "owner-blocked" only when a DIFFERENT key from
+            // the same owner occupies coordinates outside the
+            // currently-edited slot. Replacing the key at the active
+            // slot is allowed. An unparseable fingerprint disables the
+            // row defensively — the submit path would also reject it.
+            let candidate_fp = Fingerprint::from_str(&rk.raw.fingerprint).ok();
+            let owner_blocked = match candidate_fp {
+                Some(fp) => self.owner_placed_elsewhere(owner_id, fp),
+                None => true,
+            };
             // W9 pre-check: reject keys that another Vault already claims.
             let used_elsewhere = rk.raw.used_by_vault;
-            let disabled = already_placed || used_elsewhere;
+            let disabled = owner_blocked || used_elsewhere;
             let fp_short: String = rk.raw.fingerprint.chars().take(8).collect();
             let fingerprint = Some(format!("#{}", fp_short));
             let msg = if disabled {
@@ -1181,7 +1177,7 @@ impl SelectKeySource {
             // the owner is also placed elsewhere in this build.
             let warning = if used_elsewhere {
                 Some("Used by another Vault".to_string())
-            } else if already_placed {
+            } else if owner_blocked {
                 Some("Already selected".to_string())
             } else {
                 None
@@ -1244,9 +1240,17 @@ impl SelectKeySource {
                 col = col.push(p1_bold(contact_label));
                 for rk in keys {
                     let owner_id = rk.raw.effective_owner_user_id();
-                    let already_placed = self.is_owner_already_placed(owner_id);
+                    // See `view_my_keychain_keys` above — we mirror the
+                    // coordinate-aware `owner_placed_elsewhere` check
+                    // used by the submit-side backstop so row-disabled
+                    // state matches what clicking actually rejects.
+                    let candidate_fp = Fingerprint::from_str(&rk.raw.fingerprint).ok();
+                    let owner_blocked = match candidate_fp {
+                        Some(fp) => self.owner_placed_elsewhere(owner_id, fp),
+                        None => true,
+                    };
                     let used_elsewhere = rk.raw.used_by_vault;
-                    let disabled = already_placed || used_elsewhere;
+                    let disabled = owner_blocked || used_elsewhere;
                     let fp = &rk.raw.fingerprint;
                     let fingerprint = Some(format!("#{}", &fp[..fp.len().min(8)]));
                     let msg = if disabled {
@@ -1259,7 +1263,7 @@ impl SelectKeySource {
                     };
                     let warning = if used_elsewhere {
                         Some("Used by another Vault".to_string())
-                    } else if already_placed {
+                    } else if owner_blocked {
                         Some("Already selected".to_string())
                     } else {
                         None

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -1,4 +1,3 @@
-use crate::utils::example_xpub;
 use std::{
     collections::HashMap,
     str::FromStr,
@@ -30,7 +29,7 @@ use coincube_ui::{
         tooltip,
     },
     icon, theme,
-    widget::{Container, Element},
+    widget::{Button, ColumnExt, Container, Element, Text},
 };
 
 use crate::{
@@ -51,7 +50,6 @@ use crate::{
 };
 
 const MAX_ALIAS_LEN: usize = 24;
-pub type FnMsg = fn() -> Message;
 
 /// A `CubeKeyRaw` enriched with resolved owner identity (self vs. contact).
 #[derive(Debug, Clone)]
@@ -103,9 +101,24 @@ pub fn check_key_network(key: &DescriptorPublicKey, network: Network) -> bool {
     }
 }
 
+/// Top-level navigation state inside the "Select key source" modal.
+///
+/// After the card-grid redesign (2026-04-18) the picker is organised
+/// around a 3×2 grid of key-source cards. Three cards open dedicated
+/// sub-screens (`HardwareListen`, `KeychainKeys`, `PasteXpubEntry`)
+/// with a Back button; the others trigger existing flows that land at
+/// `Details` for alias entry.
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum Step {
-    Select,
+    /// The 3×2 card grid — modal entry point.
+    Grid,
+    /// Sub-screen: USB prompt + detected hardware signers.
+    HardwareListen,
+    /// Sub-screen: My Keychain Keys + Contact Keychain Keys.
+    KeychainKeys,
+    /// Sub-screen: paste-an-xpub entry form.
+    PasteXpubEntry,
+    /// Alias-entry step after a key has been selected.
     Details,
 }
 
@@ -151,6 +164,10 @@ pub enum SelectKeySourceMessage {
     FetchCubeKeys,
     CubeKeysLoaded(Result<ResolvedCubeKeys, String>),
     SelectKeychainKey(ResolvedCubeKey),
+    // Grid sub-screen navigation (2026-04-18 redesign)
+    ShowHardwareListen,
+    ShowKeychainKeys,
+    BackToGrid,
 }
 
 /// This struct represent metadata about a spending path, including whether it's
@@ -201,7 +218,6 @@ pub struct SelectKeySource {
     /// Informations about the actual spending path.
     actual_path: PathData,
     master_signer: Arc<Mutex<Signer>>,
-    developer_mode: bool,
     /// Cube UUID for fetching Keychain keys from the API.
     cube_id: Option<String>,
     /// Authenticated coincube-api client for fetching Keychain keys.
@@ -245,7 +261,6 @@ impl SelectKeySource {
         keys: HashMap<Fingerprint, (Vec<(usize, usize)>, Key)>,
         accounts: HashMap<Fingerprint, ChildNumber>,
         master_signer: Arc<Mutex<Signer>>,
-        developer_mode: bool,
         cube_id: Option<String>,
         coincube_client: Option<crate::services::coincube::CoincubeClient>,
     ) -> Self {
@@ -256,7 +271,6 @@ impl SelectKeySource {
             accounts,
             actual_path,
             master_signer,
-            developer_mode,
             cube_id,
             coincube_client,
             my_keychain_keys: Vec::new(),
@@ -265,7 +279,7 @@ impl SelectKeySource {
             keychain_keys_error: None,
             keychain_keys_fetched: false,
             selected_key: SelectedKey::None,
-            step: Step::Select,
+            step: Step::Grid,
             focus: Focus::None,
             modal: None,
             processing: false,
@@ -529,6 +543,16 @@ impl SelectKeySource {
     }
     fn on_select_enter_xpub(&mut self) -> Task<Message> {
         self.focus = Focus::EnterXpub;
+        // Card-grid redesign: route into the dedicated paste-entry
+        // sub-screen (previously this just flipped a focus flag that
+        // revealed a collapsible input inside the old flat layout).
+        self.step = Step::PasteXpubEntry;
+        self.form_xpub = form::Value {
+            value: String::new(),
+            valid: true,
+            warning: None,
+        };
+        self.import_xpub_error = None;
         Task::none()
     }
     fn on_select_generate_hot_key(&mut self) -> Task<Message> {
@@ -849,7 +873,12 @@ impl SelectKeySource {
     fn on_next(&mut self) -> Task<Message> {
         if !self.processing {
             match self.step {
-                Step::Select => {
+                // All picker-style steps (Grid, HardwareListen,
+                // KeychainKeys, PasteXpubEntry) behave the same on Next:
+                // if an already-placed key was chosen we forward it to
+                // the descriptor, otherwise we advance to the alias-entry
+                // Details step.
+                Step::Grid | Step::HardwareListen | Step::KeychainKeys | Step::PasteXpubEntry => {
                     if let SelectedKey::Existing(_) = &self.selected_key {
                         return Task::done(Message::DefineDescriptor(
                             message::DefineDescriptor::KeysEdited(
@@ -880,7 +909,14 @@ impl SelectKeySource {
     }
     fn on_previous(&mut self) -> Task<Message> {
         if self.step == Step::Details {
-            self.step = Step::Select;
+            // Pop back to the sub-screen the user came from: HW device
+            // picker when the selection came from a hardware signer,
+            // otherwise the main grid.
+            self.step = if matches!(self.focus, Focus::Device(_)) {
+                Step::HardwareListen
+            } else {
+                Step::Grid
+            };
             self.focus = Focus::None;
 
             self.form_safety_net_token.value = "".to_string();
@@ -973,7 +1009,10 @@ impl SelectKeySource {
                             },
                         });
                     } else if let Some(contact) = contacts.iter().find(|c| {
-                        c.contact_user_id == owner_id
+                        // Backend's lean `ContactResponse` doesn't include
+                        // a flat `contact_user_id` — fall back to the
+                        // nested `contact_user.id` via the helper.
+                        c.effective_contact_user_id() == Some(owner_id)
                             && c.role == crate::services::coincube::ContactRole::Keyholder
                     }) {
                         // Prefer the server-supplied `ownerEmail` when the
@@ -982,8 +1021,12 @@ impl SelectKeySource {
                         // keychain-key `KeySource` enum.
                         let contact_email = if !key.owner_email.is_empty() {
                             key.owner_email.clone()
+                        } else if let Some(user) = contact.contact_user.as_ref() {
+                            user.email.clone()
                         } else {
-                            contact.contact_user.email.clone()
+                            // Contact with no linked user — render a
+                            // placeholder rather than failing.
+                            "unknown contact".to_string()
                         };
                         contact_keys.push(ResolvedCubeKey {
                             raw: key,
@@ -1283,9 +1326,20 @@ impl SelectKeySource {
         col.into()
     }
 
-    fn main_view(
+    // ── Card-grid entry point (2026-04-18 redesign) ───────────────────
+    //
+    // The picker is organised around a 3×2 grid of key-source cards.
+    // `view_grid` is the modal's default landing screen; two cards drill
+    // into `view_hardware_listen` and `view_keychain_keys_screen`, the
+    // rest fire their existing selection flows directly and end up at
+    // `details_view` for alias entry.
+
+    fn view_grid(
         &self,
-        hws: Vec<(
+        // `hws` is unused on the grid screen — hardware listing lives
+        // on the dedicated Hardware Device sub-screen. Kept as a
+        // parameter because the view dispatcher already resolves it.
+        _hws: Vec<(
             String, /* alias */
             Option<Fingerprint>,
             HwState,
@@ -1295,38 +1349,361 @@ impl SelectKeySource {
         let only_safety_net = self.actual_path.token_kind.contains(&KeyKind::SafetyNet)
             && self.actual_path.token_kind.len() == 1;
 
-        let no_devices = (hws.is_empty() && self.keys.is_empty() && !only_safety_net)
-            .then_some(self.view_no_devices());
-
-        let devices = ((!hws.is_empty() || !self.keys.is_empty()) && !only_safety_net)
-            .then_some(self.view_signing_devices(&hws));
-
-        let keys = (!self.keys.is_empty() && !only_safety_net).then_some(self.view_keys());
-
         let header = modal::header(
             Some("Select key source".to_string()),
-            None::<FnMsg>,
             Some(|| Message::Close),
         );
 
-        let my_keychain =
-            (self.keychain_available() && !only_safety_net).then(|| self.view_my_keychain_keys());
-        let contact_keychain = (self.keychain_available() && !only_safety_net)
-            .then(|| self.view_contact_keychain_keys());
+        // If the path is "safety-net-only" there's nothing to pick
+        // *but* a safety-net token — surface just that widget and
+        // skip the grid entirely (matches the pre-redesign flow).
+        if only_safety_net {
+            let col = Column::new()
+                .spacing(10)
+                .push(header)
+                .push(self.widget_paste_safety_net_token())
+                .align_x(Horizontal::Center)
+                .width(modal::MODAL_WIDTH);
+            return Container::new(col)
+                .padding(15)
+                .style(theme::card::modal)
+                .into();
+        }
+
+        let already_used = (!self.keys.is_empty()).then(|| self.view_keys());
+
+        // Row 1: Hardware Device · Keychain Keys · Cube Key
+        let row1 = Row::new()
+            .spacing(modal::V_SPACING)
+            .push(self.view_card(
+                icon::usb_icon(),
+                "Hardware Device",
+                Some(
+                    "Use a plugged-in hardware signer. Supported: Ledger Nano S/S+/X, \
+                     Coldcard Mk3/Mk4/Q, Jade, BitBox02, Trezor, Specter-DIY.",
+                ),
+                Some(SelectKeySourceMessage::ShowHardwareListen),
+            ))
+            .push({
+                let enabled = self.keychain_available();
+                let on_press = enabled.then_some(SelectKeySourceMessage::ShowKeychainKeys);
+                let tip: Option<&str> = if enabled {
+                    None
+                } else {
+                    Some("Sign in to Connect to use Keychain keys.")
+                };
+                self.view_card(icon::key_icon(), "Keychain Keys", tip, on_press)
+            })
+            .push({
+                // "Cube Key" replaces the old Developer-mode "Generate
+                // hot key" button. Disabled when the master signer is
+                // already placed in the vault (matches the old gate).
+                let master_fg = self.master_signer.lock().expect("poisoned").fingerprint();
+                let enabled = !self.keys.contains_key(&master_fg);
+                let on_press = enabled.then_some(SelectKeySourceMessage::SelectGenerateMasterKey);
+                let tip = if enabled {
+                    Some(
+                        "A key generated on this device, stored either encrypted with your \
+                         Cube PIN or derived from a Passkey.",
+                    )
+                } else {
+                    Some("Your Cube Key is already placed in this vault.")
+                };
+                self.view_card(icon::cube_icon(), "Cube Key", tip, on_press)
+            });
+
+        // Row 2: Border Wallet · Import xpub · Paste xpub
+        let row2 = Row::new()
+            .spacing(modal::V_SPACING)
+            .push(self.view_card(
+                // Placeholder icon — replace with a grid-pattern SVG in
+                // a follow-up.
+                icon::grid_icon(),
+                "Border Wallet",
+                Some(
+                    "A deterministic key derived from a Border Wallet Grid Generation Seed — \
+                     a visual 2048-cell grid you memorise or back up. The Grid Generation Seed \
+                     itself is derived from your encrypted local seed or Passkey.",
+                ),
+                Some(SelectKeySourceMessage::SelectBorderWalletSafetyNet),
+            ))
+            .push(self.view_card(
+                icon::import_icon(),
+                "Import xpub File",
+                None,
+                Some(SelectKeySourceMessage::SelectLoadXpub),
+            ))
+            .push(self.view_card(
+                icon::clipboard_icon(),
+                "Paste xpub",
+                None,
+                Some(SelectKeySourceMessage::SelectEnterXpub),
+            ));
+
+        let advanced = self.view_advanced_options();
 
         let column = Column::new()
             .spacing(10)
             .push(header)
-            .push(no_devices)
-            .push(devices)
-            .push(keys)
-            .push(my_keychain)
-            .push(contact_keychain)
-            .push(self.view_other_options())
+            .push(already_used)
+            .push(row1)
+            .push(row2)
+            .push(advanced)
             .align_x(Horizontal::Center)
             .width(modal::MODAL_WIDTH);
-        let cont = Container::new(column).padding(15).style(theme::card::modal);
-        cont.into()
+        Container::new(column)
+            .padding(15)
+            .style(theme::card::modal)
+            .into()
+    }
+
+    /// Render a single grid card.
+    ///
+    /// Visuals:
+    ///   * Active — theme-aware card fill, muted border, primary text.
+    ///   * Hovered / pressed — border and text (+ inherited icon colour)
+    ///     flip to `ORANGE`. Fill stays flat (no "orange flood" on
+    ///     hover).
+    ///   * Disabled (`on_press == None`) — same fill, muted `text.secondary`
+    ///     border and text so the shape is still legible but clearly
+    ///     non-interactive.
+    ///
+    /// Colours are read from the active theme so light mode gets the
+    /// warm-paper card tone and a soft taupe border automatically.
+    fn view_card<'a>(
+        &'a self,
+        icon_el: Text<'static>,
+        title: &'static str,
+        tooltip_copy: Option<&'static str>,
+        on_press: Option<SelectKeySourceMessage>,
+    ) -> Element<'a, Message> {
+        let enabled = on_press.is_some();
+        let icon_size: f32 = 42.0;
+
+        // Top row — pushes the ⓘ icon to the right when present.
+        let tip_row: Element<Message> = if let Some(copy) = tooltip_copy {
+            Row::new()
+                .push(Space::new().width(Length::Fill))
+                .push(tooltip::tooltip(copy))
+                .into()
+        } else {
+            Space::new().height(Length::Fixed(18.0)).into()
+        };
+
+        // Icon + title: no explicit colour — they inherit the button's
+        // `text_color`, which flips to ORANGE on hover and to the
+        // theme's secondary (muted) text colour when disabled.
+        let inner = Column::new()
+            .push(tip_row)
+            .push(Space::new().height(Length::Fill))
+            .push(icon_el.size(icon_size))
+            .push(Space::new().height(Length::Fixed(8.0)))
+            .push(p1_bold(title.to_string()))
+            .push(Space::new().height(Length::Fill))
+            .align_x(Horizontal::Center)
+            .width(Length::Fill)
+            .height(Length::Fill);
+
+        let mut btn: Button<'a, Message> = Button::new(inner)
+            .width(Length::FillPortion(1))
+            .height(Length::Fixed(170.0))
+            .padding(12)
+            .style(move |theme: &theme::Theme, status| {
+                use iced::widget::button::Status;
+                let bg = theme.colors.cards.simple.background;
+                // `cards.border.border` is the palette entry that's
+                // guaranteed-visible in both themes (GREY_7 dark /
+                // LIGHT_BORDER light); `cards.simple.border` is
+                // transparent by design.
+                let default_border = theme.colors.cards.border.border.unwrap_or(color::GREY_3);
+                let (border_color, text_color) = if !enabled {
+                    // `text.secondary` is actually quite bright in dark
+                    // mode (`GREY_2 = #CCCCCC`), which makes the
+                    // disabled card read as "selected". Use `GREY_3`
+                    // (#717171) for both border and text — a true
+                    // midtone that looks muted on the dark card
+                    // (lighter than bg, darker than primary text) and
+                    // still-legible-but-clearly-muted on the light
+                    // card.
+                    (color::GREY_3, color::GREY_3)
+                } else {
+                    match status {
+                        Status::Hovered | Status::Pressed => (color::ORANGE, color::ORANGE),
+                        Status::Active | Status::Disabled => {
+                            (default_border, theme.colors.text.primary)
+                        }
+                    }
+                };
+                iced::widget::button::Style {
+                    background: Some(iced::Background::Color(bg)),
+                    text_color,
+                    border: iced::Border {
+                        color: border_color,
+                        width: 1.5,
+                        radius: 16.0.into(),
+                    },
+                    ..Default::default()
+                }
+            });
+        if let Some(msg) = on_press {
+            btn = btn.on_press(Self::route(msg));
+        }
+        btn.into()
+    }
+
+    fn view_hardware_listen(
+        &self,
+        hws: Vec<(
+            String, /* alias */
+            Option<Fingerprint>,
+            HwState,
+            bool, /* support taproot */
+        )>,
+    ) -> Element<Message> {
+        let header = modal::header(Some("Hardware Device".to_string()), Some(|| Message::Close));
+
+        let listening = column![
+            icon::usb_icon().size(100),
+            p1_regular("Plug in a hardware device ..."),
+        ]
+        .align_x(Horizontal::Center)
+        .spacing(20);
+
+        // Reuse the existing detected-devices rendering.
+        let devices =
+            (!hws.is_empty() || !self.keys.is_empty()).then(|| self.view_signing_devices(&hws));
+        let already_used = (!self.keys.is_empty()).then(|| self.view_keys());
+
+        // Footer Back button — left-aligned, standalone (no primary
+        // action on this screen; the user picks a device from the list
+        // above to proceed).
+        let footer = Row::new()
+            .push(modal::back_button(|| {
+                Self::route(SelectKeySourceMessage::BackToGrid)
+            }))
+            .push(Space::new().width(Length::Fill))
+            .align_y(Vertical::Center);
+
+        let column = Column::new()
+            .spacing(20)
+            .push(header)
+            .push(listening)
+            .push(devices)
+            .push(already_used)
+            .push(footer)
+            .align_x(Horizontal::Center)
+            .width(modal::MODAL_WIDTH);
+        Container::new(column)
+            .padding(15)
+            .style(theme::card::modal)
+            .into()
+    }
+
+    fn view_keychain_keys_screen(&self) -> Element<Message> {
+        let header = modal::header(Some("Keychain Keys".to_string()), Some(|| Message::Close));
+
+        let footer = Row::new()
+            .push(modal::back_button(|| {
+                Self::route(SelectKeySourceMessage::BackToGrid)
+            }))
+            .push(Space::new().width(Length::Fill))
+            .align_y(Vertical::Center);
+
+        let column = Column::new()
+            .spacing(15)
+            .push(header)
+            .push(self.view_my_keychain_keys())
+            .push(self.view_contact_keychain_keys())
+            .push(footer)
+            .align_x(Horizontal::Center)
+            .width(modal::MODAL_WIDTH);
+        Container::new(column)
+            .padding(15)
+            .style(theme::card::modal)
+            .into()
+    }
+
+    /// Dedicated paste-xpub sub-screen, opened from the grid's "Paste
+    /// xpub" card. On successful parse, `on_update_xpub` advances the
+    /// modal to `Step::Details` for alias entry. Parse errors stay on
+    /// this screen with `import_xpub_error` rendered below the input.
+    fn view_paste_xpub_screen(&self) -> Element<Message> {
+        let header = modal::header(Some("Paste xpub".to_string()), Some(|| Message::Close));
+
+        let input = iced::widget::TextInput::new("xpub…", &self.form_xpub.value)
+            .on_input(|s| Self::route(SelectKeySourceMessage::Xpub(s)))
+            .on_submit(Self::route(SelectKeySourceMessage::Xpub(
+                self.form_xpub.value.clone(),
+            )))
+            .size(16)
+            .padding(12);
+
+        let paste_btn = button::secondary(Some(icon::paste_icon()), "Paste")
+            .on_press(Self::route(SelectKeySourceMessage::PasteXpub));
+
+        let error = self
+            .import_xpub_error
+            .as_ref()
+            .map(|e| p1_regular(e.clone()).color(color::RED));
+
+        // Footer: [Back] [spacer] [Paste]. Paste is the primary action
+        // on this screen (it pulls clipboard contents into the text
+        // input and kicks the parse).
+        let footer = Row::new()
+            .push(modal::back_button(|| {
+                Self::route(SelectKeySourceMessage::BackToGrid)
+            }))
+            .push(Space::new().width(Length::Fill))
+            .push(paste_btn)
+            .align_y(Vertical::Center);
+
+        let column = Column::new()
+            .spacing(12)
+            .push(header)
+            .push(p1_regular(
+                "Paste an extended public key (xpub) to add it as a signer.",
+            ))
+            .push(input)
+            .push_maybe(error)
+            .push(footer)
+            .align_x(Horizontal::Center)
+            .width(modal::MODAL_WIDTH);
+
+        Container::new(column)
+            .padding(15)
+            .style(theme::card::modal)
+            .into()
+    }
+
+    /// Conditional section rendered below the grid when the current
+    /// descriptor path enables safety-net or cosigner tokens. The rest
+    /// of the old `view_other_options` content moved into the grid.
+    fn view_advanced_options(&self) -> Option<Element<Message>> {
+        if !self.safety_net_enabled() && !self.cosigner_enabled() {
+            return None;
+        }
+
+        let header = modal::optional_section(
+            self.options_collapsed,
+            "Advanced options".into(),
+            || Self::route(SelectKeySourceMessage::Collapse(true)),
+            || Self::route(SelectKeySourceMessage::Collapse(false)),
+        );
+
+        let mut col = Column::new()
+            .push(header)
+            .spacing(modal::V_SPACING)
+            .width(modal::BTN_W);
+
+        if self.options_collapsed {
+            if self.safety_net_enabled() {
+                col = col.push(self.widget_paste_safety_net_token());
+            }
+            if self.cosigner_enabled() {
+                col = col.push(self.widget_paste_cosigner_token());
+            }
+        }
+        Some(col.into())
     }
     fn details_view(&self) -> Element<Message> {
         let apply = match (
@@ -1346,11 +1723,7 @@ impl SelectKeySource {
                 SelectedKey::None => unreachable!(),
             },
         };
-        let header = modal::header(
-            None,
-            Some(|| Self::route(SelectKeySourceMessage::Previous)),
-            Some(|| Message::Close),
-        );
+        let header = modal::header(None, Some(|| Message::Close));
 
         let accounts: Vec<_> = (0..10)
             .map(|i| {
@@ -1387,16 +1760,8 @@ impl SelectKeySource {
             apply,
             Some(Self::route(SelectKeySourceMessage::Retry)),
             None,
+            Some(Self::route(SelectKeySourceMessage::Previous)),
         )
-    }
-    fn view_no_devices(&self) -> Element<Message> {
-        column![
-            icon::usb_icon().size(100),
-            p1_regular("Plug in a hardware device ...")
-        ]
-        .align_x(Horizontal::Center)
-        .spacing(20)
-        .into()
     }
     fn view_signing_devices(
         &self,
@@ -1435,53 +1800,6 @@ impl SelectKeySource {
     }
     fn cosigner_enabled(&self) -> bool {
         self.actual_path.token_kind.contains(&KeyKind::Cosigner)
-    }
-    fn view_other_options(&self) -> Element<Message> {
-        let safety_net_token = self
-            .safety_net_enabled()
-            .then_some(self.widget_paste_safety_net_token());
-
-        let border_wallet = Some(self.widget_border_wallet_safety_net());
-
-        let cosigner_token = self
-            .cosigner_enabled()
-            .then_some(self.widget_paste_cosigner_token());
-
-        let paste_xpub = safety_net_token
-            .is_none()
-            .then_some(self.widget_paste_xpub());
-
-        let collapsed = self.options_collapsed || safety_net_token.is_some();
-
-        let option_section = modal::optional_section(
-            collapsed,
-            "Other options".into(),
-            || Self::route(SelectKeySourceMessage::Collapse(true)),
-            || Self::route(SelectKeySourceMessage::Collapse(false)),
-        );
-
-        let master_signer_fg = self.master_signer.lock().expect("poisoned").fingerprint();
-        let master_signer = (self.developer_mode
-            && !self.keys.contains_key(&master_signer_fg)
-            && safety_net_token.is_none())
-        .then_some(self.widget_generate_hot_key());
-
-        let load_key = safety_net_token.is_none().then_some(self.widget_load_key());
-
-        let mut col = Column::new()
-            .push(option_section)
-            .spacing(modal::V_SPACING)
-            .width(modal::BTN_W);
-        if collapsed {
-            col = col
-                .push(load_key)
-                .push(paste_xpub)
-                .push(master_signer)
-                .push(cosigner_token)
-                .push(border_wallet)
-                .push(safety_net_token);
-        }
-        col.into()
     }
     fn widget_signing_device(
         &self,
@@ -1583,50 +1901,6 @@ impl SelectKeySource {
             on_press,
         )
     }
-    fn widget_load_key(&self) -> Element<Message> {
-        modal::button_entry(
-            Some(icon::import_icon()),
-            "Import extended public key file",
-            None,
-            self.import_xpub_error.clone(),
-            Some(|| Self::route(SelectKeySourceMessage::SelectLoadXpub)),
-        )
-    }
-    fn widget_generate_hot_key(&self) -> Element<Message> {
-        let subtitle = if self.developer_mode {
-            "⚠ Dev mode: derived from master seed — not for production use"
-        } else {
-            "We recommend to use this option only for test purposes"
-        };
-        modal::button_entry(
-            Some(icon::round_key_icon().color(color::RED)),
-            "Generate hot key stored on this computer",
-            Some(subtitle),
-            None,
-            Some(|| Self::route(SelectKeySourceMessage::SelectGenerateMasterKey)),
-        )
-    }
-    fn widget_paste_xpub(&self) -> Element<Message> {
-        collapsible_input_button(
-            self.focus == Focus::EnterXpub,
-            Some(icon::paste_icon()),
-            "Paste extended public key".to_string(),
-            example_xpub(self.network),
-            &self.form_xpub,
-            Some(|xpub| Self::route(SelectKeySourceMessage::Xpub(xpub))),
-            Some(|| Self::route(SelectKeySourceMessage::PasteXpub)),
-            || Self::route(SelectKeySourceMessage::SelectEnterXpub),
-        )
-    }
-    fn widget_border_wallet_safety_net(&self) -> Element<Message> {
-        modal::button_entry(
-            Some(icon::round_key_icon()),
-            "Border Wallet",
-            Some("Derive a key from a visual grid pattern"),
-            None,
-            Some(|| Self::route(SelectKeySourceMessage::SelectBorderWalletSafetyNet)),
-        )
-    }
     fn widget_paste_safety_net_token(&self) -> Element<Message> {
         collapsible_input_button(
             self.focus == Focus::EnterSafetyNetToken,
@@ -1658,28 +1932,22 @@ impl super::DescriptorEditModal for SelectKeySource {
         self.processing
     }
     fn update(&mut self, hws: &mut HardwareWallets, message: Message) -> Task<Message> {
-        // Trigger initial Keychain keys fetch on first update.
-        // Batched with the normal message handling so the incoming
-        // message is not dropped.
-        let fetch_task = if !self.keychain_keys_fetched && self.keychain_available() {
-            Some(self.on_fetch_cube_keys())
-        } else {
-            None
-        };
-        // step back if selected device disconnected
+        // step back if selected device disconnected — pop back into
+        // the HW listening sub-screen rather than all the way to the
+        // grid so the user sees "Plug in a hardware device…" again.
         if self.step == Step::Details {
             if let Focus::Device(fg) = self.focus {
                 if !hws.list.iter().any(|d| d.fingerprint() == Some(fg)) {
-                    self.step = Step::Select;
+                    self.step = Step::HardwareListen;
                     self.focus = Focus::None;
                     self.selected_key = SelectedKey::None;
                 }
             }
         }
-        let msg_task = match message {
+        match message {
             Message::ImportExport(ImportExportMessage::Close) => {
                 self.modal = None;
-                if self.step == Step::Select {
+                if self.step == Step::Grid {
                     self.focus = Focus::None;
                 }
                 Task::none()
@@ -1709,12 +1977,12 @@ impl super::DescriptorEditModal for SelectKeySource {
                 SelectKeySourceMessage::PasteXpub => self.on_paste_xpub(),
                 SelectKeySourceMessage::Xpub(xpub) => self.on_update_xpub(xpub),
                 SelectKeySourceMessage::SelectGenerateMasterKey => {
-                    if self.developer_mode {
-                        self.on_select_generate_hot_key()
-                    } else {
-                        tracing::warn!("hot-signer message received in production mode — ignoring");
-                        Task::none()
-                    }
+                    // Card-grid redesign: "Cube Key" is a first-class
+                    // user-facing card (previously gated behind
+                    // `developer_mode`). The hot-key payload is stored
+                    // encrypted with the Cube PIN or derived from a
+                    // Passkey; see the card's info tooltip.
+                    self.on_select_generate_hot_key()
                 }
                 SelectKeySourceMessage::FetchFromMasterSigner(account) => {
                     self.on_fetch_from_hotsigner(account)
@@ -1749,13 +2017,31 @@ impl super::DescriptorEditModal for SelectKeySource {
                 SelectKeySourceMessage::SelectKeychainKey(resolved) => {
                     self.on_select_keychain_key(resolved)
                 }
+                SelectKeySourceMessage::ShowHardwareListen => {
+                    self.step = Step::HardwareListen;
+                    Task::none()
+                }
+                SelectKeySourceMessage::ShowKeychainKeys => {
+                    self.step = Step::KeychainKeys;
+                    // Lazy fetch: only hit the API the first time the
+                    // user opens this sub-screen. Replaces the old
+                    // always-on trigger that fired on every `update()`.
+                    if !self.keychain_keys_fetched && self.keychain_available() {
+                        self.on_fetch_cube_keys()
+                    } else {
+                        Task::none()
+                    }
+                }
+                SelectKeySourceMessage::BackToGrid => {
+                    self.step = Step::Grid;
+                    self.focus = Focus::None;
+                    self.error = None;
+                    self.details_error = None;
+                    self.import_xpub_error = None;
+                    Task::none()
+                }
             },
             _ => Task::none(),
-        };
-        // Batch the one-shot fetch alongside the normal message result.
-        match fetch_task {
-            Some(ft) => Task::batch([ft, msg_task]),
-            None => msg_task,
         }
     }
     fn subscription(&self, hws: &HardwareWallets) -> Subscription<Message> {
@@ -1775,7 +2061,10 @@ impl super::DescriptorEditModal for SelectKeySource {
     fn view<'a>(&'a self, hws: &'a HardwareWallets) -> Element<'a, Message> {
         let detected_hws = self.detected_hws(hws);
         let content = match self.step {
-            Step::Select => self.main_view(detected_hws),
+            Step::Grid => self.view_grid(detected_hws),
+            Step::HardwareListen => self.view_hardware_listen(detected_hws),
+            Step::KeychainKeys => self.view_keychain_keys_screen(),
+            Step::PasteXpubEntry => self.view_paste_xpub_screen(),
             Step::Details => self.details_view(),
         };
         let content = Column::new()
@@ -1800,6 +2089,11 @@ pub fn details_view<'a, Alias>(
     apply_msg: Option<Message>,
     retry_msg: Option<Message>,
     replace_message: Option<Message>,
+    // Optional Back-button message. When present, a standard
+    // `modal::back_button` is rendered at the left of the footer row
+    // next to the Apply/Retry primary action. Pass `None` when the
+    // modal has no back navigation.
+    back_msg: Option<Message>,
 ) -> Element<'a, Message>
 where
     Alias: 'static + Fn(String) -> Message,
@@ -1819,26 +2113,35 @@ where
         btn
     });
 
+    // Optional left-aligned Back button shared across all three btn_row
+    // layouts. When absent the row layout is unchanged (spacer + Apply).
+    let back = back_msg.map(|m| modal::back_button(move || m.clone()));
+
     let btn_row = if error.is_none() {
         Row::new()
+            .push(back)
             .push(Space::new().width(Length::Fill))
             .push(replace_btn)
             .push(spacer)
             .push(button::primary(None, "Apply").on_press_maybe(apply_msg))
+            .align_y(Vertical::Center)
     } else if let Some(retry_msg) = retry_msg {
-        row![
-            Space::new().width(Length::Fill),
-            button::primary(None, "Retry").on_press(retry_msg),
-            button::secondary(None, "Apply")
-        ]
-        .spacing(5)
-        .align_y(Vertical::Center)
+        Row::new()
+            .push(back)
+            .push(Space::new().width(Length::Fill))
+            .push(button::primary(None, "Retry").on_press(retry_msg))
+            .push(Space::new().width(5))
+            .push(button::secondary(None, "Apply"))
+            .spacing(5)
+            .align_y(Vertical::Center)
     } else {
         Row::new()
+            .push(back)
             .push(Space::new().width(Length::Fill))
             .push(replace_btn)
             .push(spacer)
             .push(button::primary(None, "Apply"))
+            .align_y(Vertical::Center)
     };
     let column = Column::new()
         .spacing(5)
@@ -1950,7 +2253,7 @@ impl super::DescriptorEditModal for EditKeyAlias {
     }
 
     fn view<'a>(&'a self, _hws: &'a HardwareWallets) -> Element<'a, Message> {
-        let header = modal::header(None, None::<FnMsg>, Some(|| Message::Close));
+        let header = modal::header(None, Some(|| Message::Close));
         details_view(
             header,
             None,
@@ -1960,6 +2263,7 @@ impl super::DescriptorEditModal for EditKeyAlias {
             Some(Message::EditKeyAlias(EditKeyAliasMessage::Save)),
             None,
             Some(Message::EditKeyAlias(EditKeyAliasMessage::Replace)),
+            None, // no Back — edit-alias modal only has an X
         )
     }
 }
@@ -2069,5 +2373,124 @@ mod tests {
     #[should_panic]
     fn unhardened_derivation_path() {
         derivation_path(Network::Bitcoin, ChildNumber::Normal { index: 0 }).to_string();
+    }
+
+    // ── Card-grid redesign state tests (2026-04-18) ──────────────────
+    //
+    // These exercise `Step` transitions driven by the three new
+    // navigation messages (`ShowHardwareListen`, `ShowKeychainKeys`,
+    // `BackToGrid`) on a freshly-constructed `SelectKeySource`. We
+    // ignore the returned `Task<Message>` — the state transitions are
+    // synchronous and what the tests care about.
+
+    use super::super::DescriptorEditModal;
+    use crate::dir::CoincubeDirectory;
+    use crate::hw::HardwareWallets;
+    use crate::signer::Signer;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::str::FromStr;
+    use std::sync::{Arc, Mutex};
+
+    fn empty_picker() -> SelectKeySource {
+        SelectKeySource::new(
+            Network::Signet,
+            false,
+            PathData {
+                coordinates: vec![],
+                keys: vec![],
+                token_kind: vec![],
+            },
+            HashMap::new(),
+            HashMap::new(),
+            Arc::new(Mutex::new(Signer::generate(Network::Signet).unwrap())),
+            None,
+            None,
+        )
+    }
+
+    fn sandbox_hws() -> HardwareWallets {
+        HardwareWallets::new(
+            CoincubeDirectory::new(PathBuf::from_str("/").unwrap()),
+            Network::Bitcoin,
+        )
+    }
+
+    #[test]
+    fn default_step_is_grid() {
+        let picker = empty_picker();
+        assert_eq!(picker.step, Step::Grid);
+    }
+
+    #[test]
+    fn show_hardware_listen_transitions_step() {
+        let mut picker = empty_picker();
+        let mut hws = sandbox_hws();
+        let _ = picker.update(
+            &mut hws,
+            SelectKeySource::route(SelectKeySourceMessage::ShowHardwareListen),
+        );
+        assert_eq!(picker.step, Step::HardwareListen);
+    }
+
+    #[test]
+    fn show_keychain_keys_transitions_step() {
+        let mut picker = empty_picker();
+        let mut hws = sandbox_hws();
+        let _ = picker.update(
+            &mut hws,
+            SelectKeySource::route(SelectKeySourceMessage::ShowKeychainKeys),
+        );
+        assert_eq!(picker.step, Step::KeychainKeys);
+    }
+
+    #[test]
+    fn back_to_grid_returns_and_clears_errors() {
+        let mut picker = empty_picker();
+        let mut hws = sandbox_hws();
+
+        // Jump into a sub-screen and pre-populate some error state so
+        // we can prove `BackToGrid` clears it.
+        picker.step = Step::HardwareListen;
+        picker.focus = Focus::EnterXpub;
+        picker.error = Some("stale".to_string());
+        picker.details_error = Some("stale".to_string());
+        picker.import_xpub_error = Some("stale".to_string());
+
+        let _ = picker.update(
+            &mut hws,
+            SelectKeySource::route(SelectKeySourceMessage::BackToGrid),
+        );
+        assert_eq!(picker.step, Step::Grid);
+        assert_eq!(picker.focus, Focus::None);
+        assert!(picker.error.is_none());
+        assert!(picker.details_error.is_none());
+        assert!(picker.import_xpub_error.is_none());
+    }
+
+    #[test]
+    fn keychain_fetch_not_triggered_on_construction() {
+        // Pre-redesign regression: the fetch used to fire on the first
+        // `update()` call regardless of user action. After the
+        // redesign it only fires when the Keychain sub-screen is
+        // opened.
+        let picker = empty_picker();
+        assert!(!picker.keychain_keys_fetched);
+        assert!(!picker.keychain_keys_loading);
+    }
+
+    #[test]
+    fn keychain_fetch_skipped_when_connect_unavailable() {
+        // No `coincube_client` / `cube_id` on the picker — Connect
+        // isn't signed in. ShowKeychainKeys should still flip the
+        // step but must not attempt the fetch.
+        let mut picker = empty_picker();
+        let mut hws = sandbox_hws();
+        let _ = picker.update(
+            &mut hws,
+            SelectKeySource::route(SelectKeySourceMessage::ShowKeychainKeys),
+        );
+        assert_eq!(picker.step, Step::KeychainKeys);
+        assert!(!picker.keychain_keys_fetched);
     }
 }

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -1053,9 +1053,8 @@ impl SelectKeySource {
         }
 
         if self.owner_placed_elsewhere(resolved.owner.primary_owner_id(), fingerprint) {
-            self.error = Some(
-                "This owner already has a Keychain key placed in this Vault.".to_string(),
-            );
+            self.error =
+                Some("This owner already has a Keychain key placed in this Vault.".to_string());
             return Task::none();
         }
 

--- a/coincube-gui/src/installer/step/descriptor/editor/mod.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/mod.rs
@@ -617,9 +617,11 @@ impl Step for DefineDescriptor {
                 let KeySource::KeychainKey { owner, key_id, .. } = &key.source else {
                     // HW, xpub, master-signer, token, and border-wallet
                     // keys have no backend row — they stay local-only per
-                    // the 2026-04-18 plan direction. Log so operators can
-                    // spot silently-skipped signers.
-                    tracing::info!(
+                    // the 2026-04-18 plan direction. Logged at `debug!`:
+                    // this is an informational "skipped as expected"
+                    // message, not actionable, and we'd rather keep
+                    // per-wallet identifiers out of info-level telemetry.
+                    tracing::debug!(
                         "Skipping non-keychain key {} for backend vault (source kind = {:?}); \
                          backend ConnectVault will be local-key-free for this signer",
                         fingerprint,

--- a/coincube-gui/src/installer/step/descriptor/editor/mod.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/mod.rs
@@ -57,7 +57,6 @@ pub struct DefineDescriptor {
 
     modal: Option<Box<dyn DescriptorEditModal>>,
     signer: Arc<Mutex<Signer>>,
-    developer_mode: bool,
 
     keys: HashMap<Fingerprint, Key>,
     paths: Vec<Path>,
@@ -74,14 +73,17 @@ pub struct DefineDescriptor {
 }
 
 impl DefineDescriptor {
-    pub fn new(network: Network, signer: Arc<Mutex<Signer>>, developer_mode: bool) -> Self {
+    // Formerly took a `developer_mode` flag that gated the
+    // "Generate hot key" button in the old Other-options list. The
+    // card-grid redesign promotes that flow to a first-class "Cube
+    // Key" card, so the gate is gone.
+    pub fn new(network: Network, signer: Arc<Mutex<Signer>>) -> Self {
         Self {
             network,
             use_taproot: false,
             modal: None,
 
             signer,
-            developer_mode,
             error: None,
             keys: HashMap::new(),
             descriptor_template: DescriptorTemplate::default(),
@@ -223,7 +225,6 @@ impl DefineDescriptor {
             keys,
             self.accounts.clone(),
             self.signer.clone(),
-            self.developer_mode,
             self.cube_id.clone(),
             self.coincube_client.clone(),
         )
@@ -331,6 +332,18 @@ impl Step for DefineDescriptor {
             )) => {
                 let modal = self.edit_key_modal(path_kind, coordinates);
                 self.modal = Some(Box::new(modal));
+            }
+            Message::DefineDescriptor(message::DefineDescriptor::ReopenKeyModal(coordinates)) => {
+                // Derive path_kind from the first coordinate's path
+                // index (every coordinate in the Vec belongs to the
+                // same path, by construction of the picker call sites).
+                if let Some((path_idx, _)) = coordinates.first() {
+                    if let Some(path) = self.paths.get(*path_idx) {
+                        let path_kind = path.sequence.into();
+                        let modal = self.edit_key_modal(path_kind, coordinates);
+                        self.modal = Some(Box::new(modal));
+                    }
+                }
             }
             Message::DefineDescriptor(message::DefineDescriptor::AliasEdited(fg, alias)) => {
                 if let Some(key) = self.keys.get_mut(&fg) {
@@ -917,7 +930,6 @@ mod tests {
         let sandbox: Sandbox<DefineDescriptor> = Sandbox::new(DefineDescriptor::new(
             Network::Signet,
             Arc::new(Mutex::new(Signer::generate(Network::Signet).unwrap())),
-            true,
         ));
         sandbox.load(&ctx).await;
 
@@ -1002,7 +1014,6 @@ mod tests {
         let sandbox: Sandbox<DefineDescriptor> = Sandbox::new(DefineDescriptor::new(
             Network::Testnet,
             Arc::new(Mutex::new(Signer::generate(Network::Testnet).unwrap())),
-            true, // developer_mode=true: test exercises the hot-signer path
         ));
         sandbox.load(&ctx).await;
 

--- a/coincube-gui/src/installer/step/descriptor/editor/mod.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/mod.rs
@@ -494,6 +494,11 @@ impl Step for DefineDescriptor {
 
         ctx.bitcoin_config.network = self.network;
         ctx.keys = HashMap::new();
+        // Reset backend-vault payloads — `apply()` runs every time the
+        // user re-confirms the descriptor, including after going back
+        // and editing, so we can't append incrementally.
+        ctx.connect_vault_members = Vec::new();
+        ctx.connect_vault_timelock_days = None;
         let mut hw_is_used = false;
         let mut spending_keys: Vec<DescriptorPublicKey> = Vec::new();
         let mut key_derivation_index = HashMap::<Fingerprint, usize>::new();
@@ -586,6 +591,69 @@ impl Step for DefineDescriptor {
         if spending_keys.is_empty() {
             return false;
         }
+
+        // Harvest keychain-sourced keys across all paths into backend-vault
+        // member payloads. Dedup by fingerprint — a key reused across
+        // paths still only produces one `ConnectVaultMember` row. We rely
+        // on the first occurrence's path_kind (primary > recovery) as a
+        // tiebreaker for the logged role hint.
+        use crate::installer::context::ConnectVaultMemberPayload;
+        use crate::installer::descriptor::{KeySource, KeychainKeyOwner, PathKind};
+        let mut seen_fingerprints: std::collections::HashSet<Fingerprint> =
+            std::collections::HashSet::new();
+        for path in self.paths.iter() {
+            let path_kind = path.sequence.path_kind();
+            for maybe_key in path.keys.iter() {
+                let Some(editor_key_ref) = maybe_key.as_ref() else {
+                    continue;
+                };
+                let fingerprint = editor_key_ref.fingerprint;
+                if !seen_fingerprints.insert(fingerprint) {
+                    continue;
+                }
+                let Some(key) = self.keys.get(&fingerprint) else {
+                    continue;
+                };
+                let KeySource::KeychainKey { owner, key_id, .. } = &key.source else {
+                    // HW, xpub, master-signer, token, and border-wallet
+                    // keys have no backend row — they stay local-only per
+                    // the 2026-04-18 plan direction. Log so operators can
+                    // spot silently-skipped signers.
+                    tracing::info!(
+                        "Skipping non-keychain key {} for backend vault (source kind = {:?}); \
+                         backend ConnectVault will be local-key-free for this signer",
+                        fingerprint,
+                        key.source.kind()
+                    );
+                    continue;
+                };
+                let contact_id = match owner {
+                    KeychainKeyOwner::SelfUser { .. } => None,
+                    KeychainKeyOwner::Contact { contact_id, .. } => Some(*contact_id),
+                };
+                ctx.connect_vault_members.push(ConnectVaultMemberPayload {
+                    fingerprint,
+                    key_id: *key_id,
+                    contact_id,
+                    path_kind,
+                });
+            }
+        }
+
+        // Approximate timelock from the longest Recovery path's sequence
+        // (blocks). Skip SafetyNet (u16::MAX) — it's not a real timelock.
+        let longest_recovery_blocks = self
+            .paths
+            .iter()
+            .filter(|p| p.sequence.path_kind() == PathKind::Recovery)
+            .map(|p| p.sequence.as_u16() as u32)
+            .max();
+        ctx.connect_vault_timelock_days = longest_recovery_blocks.map(|blocks| {
+            // Bitcoin averages ~144 blocks/day. Round up so the server
+            // timelock never expires before the on-chain timelock.
+            let days = blocks.div_ceil(144);
+            days.max(1) as i32
+        });
 
         let spending_keys = if spending_keys.len() == 1 {
             PathInfo::Single(spending_keys[0].clone())

--- a/coincube-gui/src/installer/step/mod.rs
+++ b/coincube-gui/src/installer/step/mod.rs
@@ -91,9 +91,6 @@ pub struct Final {
     /// `Some` once the vault-create round-trip resolves. Drives the
     /// success caption in the Final view.
     connect_vault_outcome: Option<ConnectVaultOutcome>,
-    /// `Some` when a W9 409 rolls back the vault — carries the key id so
-    /// the user knows which key to change.
-    connect_vault_key_conflict_id: Option<u64>,
 }
 
 impl Final {
@@ -111,7 +108,6 @@ impl Final {
             connect_vault_members: Vec::new(),
             connect_vault_timelock_days: None,
             connect_vault_outcome: None,
-            connect_vault_key_conflict_id: None,
         }
     }
 }
@@ -223,7 +219,6 @@ impl Step for Final {
             Message::ConnectVaultCreated(result) => match result {
                 Ok(outcome) => {
                     self.connect_vault_outcome = Some(outcome);
-                    self.connect_vault_key_conflict_id = None;
                     // Clear any previous warning so the success caption
                     // wins over a transient banner from an earlier retry.
                     self.warning = None;
@@ -241,7 +236,6 @@ impl Step for Final {
                     // continue with redemption so the local install
                     // doesn't stall. The user can re-run the installer
                     // to retry the vault.
-                    self.connect_vault_key_conflict_id = Some(key_id);
                     self.warning = Some(format!(
                         "This key (#{}) was already used in another Vault. \
                          A key can only participate in one Vault. Your local \

--- a/coincube-gui/src/installer/step/mod.rs
+++ b/coincube-gui/src/installer/step/mod.rs
@@ -37,9 +37,14 @@ use coincube_ui::widget::*;
 use crate::{
     app::settings::{ProviderKey, WalletSettings},
     hw::HardwareWallets,
-    installer::{context::Context, message::Message, view},
+    installer::{
+        connect_vault::{self, ConnectVaultError, ConnectVaultOutcome},
+        context::{ConnectVaultMemberPayload, Context},
+        message::Message,
+        view,
+    },
     node::bitcoind::Bitcoind,
-    services,
+    services::{self, coincube::CoincubeClient},
 };
 
 pub trait Step {
@@ -76,6 +81,19 @@ pub struct Final {
     warning: Option<String>,
     wallet_settings: Option<WalletSettings>,
     key_redemptions: HashMap<ProviderKey, Option<Result<(), services::keys::Error>>>,
+    // --- Backend `ConnectVault` hand-off (populated in `load_context`) ---
+    coincube_client: Option<CoincubeClient>,
+    cube_uuid: Option<String>,
+    cube_name: Option<String>,
+    network: String,
+    connect_vault_members: Vec<ConnectVaultMemberPayload>,
+    connect_vault_timelock_days: Option<i32>,
+    /// `Some` once the vault-create round-trip resolves. Drives the
+    /// success caption in the Final view.
+    connect_vault_outcome: Option<ConnectVaultOutcome>,
+    /// `Some` when a W9 409 rolls back the vault — carries the key id so
+    /// the user knows which key to change.
+    connect_vault_key_conflict_id: Option<u64>,
 }
 
 impl Final {
@@ -86,6 +104,14 @@ impl Final {
             warning: None,
             wallet_settings: None,
             key_redemptions: HashMap::new(),
+            coincube_client: None,
+            cube_uuid: None,
+            cube_name: None,
+            network: String::new(),
+            connect_vault_members: Vec::new(),
+            connect_vault_timelock_days: None,
+            connect_vault_outcome: None,
+            connect_vault_key_conflict_id: None,
         }
     }
 }
@@ -104,6 +130,16 @@ impl Step for Final {
             .values()
             .filter_map(|ks| ks.provider_key.as_ref().map(|pk| (pk.clone(), None)))
             .collect();
+        self.coincube_client.clone_from(&ctx.coincube_client);
+        self.cube_uuid.clone_from(&ctx.cube_id);
+        self.cube_name.clone_from(&ctx.cube_name);
+        self.network = match ctx.bitcoin_config.network {
+            coincube_core::miniscript::bitcoin::Network::Bitcoin => "mainnet".to_string(),
+            other => other.to_string(),
+        };
+        self.connect_vault_members
+            .clone_from(&ctx.connect_vault_members);
+        self.connect_vault_timelock_days = ctx.connect_vault_timelock_days;
     }
     fn load(&self) -> Task<Message> {
         if self.generating {
@@ -165,7 +201,65 @@ impl Step for Final {
                 }
                 Ok(wallet_settings) => {
                     self.wallet_settings = Some(wallet_settings);
-                    // Now redeem any provider keys.
+                    // Kick off the backend vault-create orchestration
+                    // before token redemption. If it isn't applicable
+                    // (no Connect client or no keychain members) the
+                    // inner function short-circuits and the Final step
+                    // treats the `NotApplicable` error as a no-op.
+                    let client = self.coincube_client.clone();
+                    let cube_uuid = self.cube_uuid.clone();
+                    let cube_name = self.cube_name.clone();
+                    let network = self.network.clone();
+                    let members = self.connect_vault_members.clone();
+                    let timelock = self.connect_vault_timelock_days;
+                    return Task::perform(
+                        connect_vault::create_connect_vault(
+                            client, cube_uuid, cube_name, network, members, timelock,
+                        ),
+                        Message::ConnectVaultCreated,
+                    );
+                }
+            },
+            Message::ConnectVaultCreated(result) => match result {
+                Ok(outcome) => {
+                    self.connect_vault_outcome = Some(outcome);
+                    self.connect_vault_key_conflict_id = None;
+                    // Clear any previous warning so the success caption
+                    // wins over a transient banner from an earlier retry.
+                    self.warning = None;
+                    return Task::perform(async move {}, |_| Message::RedeemNextKey);
+                }
+                Err(ConnectVaultError::NotApplicable) => {
+                    // No Connect client, no cube, or no keychain
+                    // members — silently continue with the local-only
+                    // install.
+                    return Task::perform(async move {}, |_| Message::RedeemNextKey);
+                }
+                Err(ConnectVaultError::KeyAlreadyUsedInVault { key_id }) => {
+                    // W9 race condition: the vault shell was rolled
+                    // back upstream. Surface the dedicated copy and
+                    // continue with redemption so the local install
+                    // doesn't stall. The user can re-run the installer
+                    // to retry the vault.
+                    self.connect_vault_key_conflict_id = Some(key_id);
+                    self.warning = Some(format!(
+                        "This key (#{}) was already used in another Vault. \
+                         A key can only participate in one Vault. Your local \
+                         wallet is installed; restart the Vault Builder and \
+                         pick a different key to create the Connect vault.",
+                        key_id
+                    ));
+                    return Task::perform(async move {}, |_| Message::RedeemNextKey);
+                }
+                Err(ConnectVaultError::Other(msg)) => {
+                    // Transient / unexpected failure. Warn but continue
+                    // — the local wallet is already persisted, and the
+                    // user can retry via the in-app Connect flow later.
+                    self.warning = Some(format!(
+                        "Connect vault sync failed: {}. Your local wallet is \
+                         installed; the Connect vault can be retried later.",
+                        msg
+                    ));
                     return Task::perform(async move {}, |_| Message::RedeemNextKey);
                 }
             },
@@ -209,12 +303,26 @@ impl Step for Final {
         progress: (usize, usize),
         email: Option<&'a str>,
     ) -> Element<'a, Message> {
+        // Surface the approximate-timelock caveat here — the days
+        // value is derived client-side from block-count, which varies
+        // with block cadence, so the user should know it's a best-effort
+        // figure rather than an exact day count.
+        let caption = self.connect_vault_outcome.as_ref().map(|out| {
+            format!(
+                "Connect vault attached — approx. {}-day timelock ({} signer{}). \
+                 The timelock is approximate; on-chain block time drives the actual expiry.",
+                out.timelock_days,
+                out.members_added,
+                if out.members_added == 1 { "" } else { "s" }
+            )
+        });
         view::install(
             progress,
             email,
             self.generating,
             self.wallet_settings.is_some() && self.warning.is_none(),
             self.warning.as_ref(),
+            caption,
         )
     }
 }

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -1901,6 +1901,7 @@ pub fn install<'a>(
     generating: bool,
     installed: bool,
     warning: Option<&'a String>,
+    connect_vault_caption: Option<String>,
 ) -> Element<'a, Message> {
     let prev_msg = if !generating && warning.is_some() {
         Some(Message::Previous)
@@ -1926,6 +1927,9 @@ pub fn install<'a>(
             } else {
                 Container::new(Space::new().height(Length::Fixed(25.0)))
             })
+            .push(connect_vault_caption.map(|caption| {
+                card::simple(text(caption).style(theme::text::secondary)).padding(10)
+            }))
             .spacing(10)
             .width(Length::Fill),
         true,

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -1,13 +1,14 @@
 use super::{
-    get_countries, ApiErrorResponse, ApiResponse, AvatarGenerateData, AvatarGenerateRequest,
-    AvatarSelectData, AvatarSelectRequest, BillingHistoryEntry, ChargeStatusResponse,
-    CheckUsernameResponse, CheckoutRequest, CheckoutResponse, ClaimLightningAddressRequest,
-    CoincubeError, ConnectPlan, Contact, ContactCube, Country, CreateInviteRequest, CubeKeyRaw,
-    CubeLimitsResponse, CubeResponse, DownloadStats, FeaturesResponse, GetAvatarData, Invite,
-    LightningAddress, LoginActivity, LoginResponse, OtpRequest, OtpVerifyRequest, PublicAvatarData,
-    RefreshTokenRequest, RegenerationData, RegisterCubeRequest, SaveQuoteRequest,
+    get_countries, AddVaultMemberRequest, ApiErrorResponse, ApiResponse, AvatarGenerateData,
+    AvatarGenerateRequest, AvatarSelectData, AvatarSelectRequest, BillingHistoryEntry,
+    ChargeStatusResponse, CheckUsernameResponse, CheckoutRequest, CheckoutResponse,
+    ClaimLightningAddressRequest, CoincubeError, ConnectPlan, ConnectVaultResponse, Contact,
+    ContactCube, Country, CreateConnectVaultRequest, CreateInviteRequest, CubeInviteOrAddResult,
+    CubeKeyRaw, CubeLimitsResponse, CubeResponse, DownloadStats, FeaturesResponse, GetAvatarData,
+    Invite, LightningAddress, LoginActivity, LoginResponse, OtpRequest, OtpVerifyRequest,
+    PublicAvatarData, RefreshTokenRequest, RegenerationData, RegisterCubeRequest, SaveQuoteRequest,
     SaveQuoteResponse, StatsPeriod, TimeseriesResponse, TodayStats, UpdateCubeRequest, User,
-    VerifiedDevice,
+    VaultMemberResponse, VerifiedDevice,
 };
 use reqwest::{Client, Method};
 use serde::Deserialize;
@@ -334,6 +335,22 @@ impl CoincubeClient {
         Ok(resp.data)
     }
 
+    /// Test-only constructor that points the client at an arbitrary base URL
+    /// (typically an `httpmock` MockServer). Skips `https_only` so `http://`
+    /// loopback URLs are accepted.
+    #[cfg(test)]
+    pub fn for_test(base_url: impl Into<String>) -> Self {
+        Self {
+            client: reqwest::ClientBuilder::new()
+                .timeout(std::time::Duration::from_secs(5))
+                .https_only(false)
+                .build()
+                .unwrap(),
+            base_url: base_url.into(),
+            token: None,
+        }
+    }
+
     // --- Cube-scoped endpoints (Lightning Address, Avatar) ---
     // All use /connect/cubes/{cubeId}/... paths (server-side numeric ID)
 
@@ -640,5 +657,710 @@ impl CoincubeClient {
         let res = res.check_success().await?;
         let resp: ApiResponse<Vec<ContactCube>> = res.json().await?;
         Ok(resp.data)
+    }
+}
+
+// =============================================================================
+// Cube members & cube-scoped invites (W8)
+// =============================================================================
+
+impl CoincubeClient {
+    /// GET /api/v1/connect/cubes/{cubeId} — fetch a single cube, including
+    /// members and pending invites.
+    pub async fn get_cube(&self, cube_id: u64) -> Result<CubeResponse, CoincubeError> {
+        let url = format!("{}/api/v1/connect/cubes/{}", self.base_url, cube_id);
+        let res = self.client.get(&url).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<CubeResponse> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// POST /api/v1/connect/cubes/{cubeId}/invites — smart invite. If `email`
+    /// matches an existing contact the user is added as a member immediately
+    /// (`Added`); otherwise an invite is created and a pending-attachment row
+    /// is recorded against this cube (`Invited`).
+    pub async fn create_cube_invite(
+        &self,
+        cube_id: u64,
+        email: &str,
+    ) -> Result<CubeInviteOrAddResult, CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/invites",
+            self.base_url, cube_id
+        );
+        let body = serde_json::json!({ "email": email });
+        let res = self.client.post(&url).json(&body).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<CubeInviteOrAddResult> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// DELETE /api/v1/connect/cubes/{cubeId}/invites/{inviteId} — revoke a
+    /// pending cube-scoped invite.
+    pub async fn revoke_cube_invite(
+        &self,
+        cube_id: u64,
+        invite_id: u64,
+    ) -> Result<(), CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/invites/{}",
+            self.base_url, cube_id, invite_id
+        );
+        let res = self.client.delete(&url).send().await?;
+        res.check_success().await?;
+        Ok(())
+    }
+
+    /// DELETE /api/v1/connect/cubes/{cubeId}/members/{memberId} — remove a
+    /// cube member. Fails 409 if the member's keys are in an active Vault
+    /// (stranded-vault guard, W4).
+    pub async fn remove_cube_member(
+        &self,
+        cube_id: u64,
+        member_id: u64,
+    ) -> Result<(), CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/members/{}",
+            self.base_url, cube_id, member_id
+        );
+        let res = self.client.delete(&url).send().await?;
+        res.check_success().await?;
+        Ok(())
+    }
+}
+
+// =============================================================================
+// Connect Vault lifecycle
+// =============================================================================
+//
+// The Vault Builder (installer/step/descriptor/editor) uses these to
+// create the server-side `ConnectVault` shell after the local descriptor
+// is persisted. See `plans/PLAN-cube-membership-desktop.md` §2.6 for the
+// W9 race-to-409 fallback flow.
+
+impl CoincubeClient {
+    /// POST /api/v1/connect/cubes/{cubeId}/vault — create the vault shell
+    /// for a cube. Owner-only. Returns the (empty-members) vault.
+    pub async fn create_connect_vault(
+        &self,
+        cube_id: u64,
+        req: CreateConnectVaultRequest,
+    ) -> Result<ConnectVaultResponse, CoincubeError> {
+        let url = format!("{}/api/v1/connect/cubes/{}/vault", self.base_url, cube_id);
+        let res = self.client.post(&url).json(&req).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<ConnectVaultResponse> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// GET /api/v1/connect/cubes/{cubeId}/vault — fetch the existing vault
+    /// (404s if none exists).
+    pub async fn get_connect_vault(
+        &self,
+        cube_id: u64,
+    ) -> Result<ConnectVaultResponse, CoincubeError> {
+        let url = format!("{}/api/v1/connect/cubes/{}/vault", self.base_url, cube_id);
+        let res = self.client.get(&url).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<ConnectVaultResponse> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// DELETE /api/v1/connect/cubes/{cubeId}/vault — tear down the vault.
+    /// Useful as a rollback when `add_vault_member` fails partway through
+    /// a Vault Builder finalisation.
+    pub async fn delete_connect_vault(&self, cube_id: u64) -> Result<(), CoincubeError> {
+        let url = format!("{}/api/v1/connect/cubes/{}/vault", self.base_url, cube_id);
+        let res = self.client.delete(&url).send().await?;
+        res.check_success().await?;
+        Ok(())
+    }
+
+    /// POST /api/v1/connect/cubes/{cubeId}/vault/members — attach a member
+    /// (contact + key, contact-only, or key-only) to a vault.
+    ///
+    /// Fails 409 with `KEY_ALREADY_USED_IN_VAULT` when the supplied `keyId`
+    /// is already referenced by any vault (W9). Callers should check
+    /// `CoincubeError::is_key_already_used_in_vault()` and surface the
+    /// conflict dialog.
+    pub async fn add_vault_member(
+        &self,
+        cube_id: u64,
+        req: AddVaultMemberRequest,
+    ) -> Result<VaultMemberResponse, CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/vault/members",
+            self.base_url, cube_id
+        );
+        let res = self.client.post(&url).json(&req).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<VaultMemberResponse> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// DELETE /api/v1/connect/cubes/{cubeId}/vault/members/{memberId} —
+    /// remove a vault member. Used by rollback paths.
+    pub async fn remove_vault_member(
+        &self,
+        cube_id: u64,
+        member_id: u64,
+    ) -> Result<(), CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/vault/members/{}",
+            self.base_url, cube_id, member_id
+        );
+        let res = self.client.delete(&url).send().await?;
+        res.check_success().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod cube_member_tests {
+    use super::*;
+    use httpmock::{Method, MockServer};
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn create_cube_invite_returns_added_on_existing_contact() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/invites")
+                .json_body(json!({ "email": "new@example.com" }));
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "status": "added",
+                        "member": {
+                            "id": 7,
+                            "userId": 99,
+                            "user": { "email": "new@example.com" },
+                            "joinedAt": "2026-04-18T00:00:00Z"
+                        },
+                        "invite": null
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let result = client
+            .create_cube_invite(42, "new@example.com")
+            .await
+            .expect("create_cube_invite should succeed");
+
+        mock.assert();
+        match result {
+            CubeInviteOrAddResult::Added(member) => {
+                assert_eq!(member.id, 7);
+                assert_eq!(member.user_id, 99);
+                assert_eq!(member.user.email, "new@example.com");
+            }
+            CubeInviteOrAddResult::Invited(_) => panic!("expected Added, got Invited"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_cube_invite_returns_invited_on_new_email() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/invites");
+            then.status(201).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": {
+                    "status": "invited",
+                    "member": null,
+                    "invite": {
+                        "id": 314,
+                        "cubeId": 42,
+                        "email": "brand-new@example.com",
+                        "status": "pending",
+                        "expiresAt": "2026-05-18T00:00:00Z",
+                        "createdAt": "2026-04-18T00:00:00Z"
+                    }
+                }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let result = client
+            .create_cube_invite(42, "brand-new@example.com")
+            .await
+            .expect("create_cube_invite should succeed");
+
+        mock.assert();
+        match result {
+            CubeInviteOrAddResult::Invited(invite) => {
+                assert_eq!(invite.id, 314);
+                assert_eq!(invite.cube_id, 42);
+                assert_eq!(invite.email, "brand-new@example.com");
+                assert_eq!(invite.expires_at, "2026-05-18T00:00:00Z");
+            }
+            CubeInviteOrAddResult::Added(_) => panic!("expected Invited, got Added"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_cube_invite_409_on_duplicate_member() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/invites");
+            then.status(409).header("content-type", "application/json").json_body(json!({
+                "success": false,
+                "error": {
+                    "code": "CUBE_DUPLICATE_MEMBER",
+                    "message": "User is already a member of this cube"
+                }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .create_cube_invite(42, "dup@example.com")
+            .await
+            .expect_err("expected 409 error");
+        mock.assert();
+
+        let rendered = format!("{}", err);
+        assert!(
+            rendered.contains("already a member"),
+            "error message should surface API text, got: {}",
+            rendered
+        );
+    }
+
+    #[tokio::test]
+    async fn revoke_cube_invite_ok_on_success() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::DELETE)
+                .path("/api/v1/connect/cubes/42/invites/314");
+            then.status(200).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": { "status": "revoked" }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        client
+            .revoke_cube_invite(42, 314)
+            .await
+            .expect("revoke_cube_invite should succeed");
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn remove_cube_member_409_propagates_error() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::DELETE)
+                .path("/api/v1/connect/cubes/42/members/7");
+            then.status(409).header("content-type", "application/json").json_body(json!({
+                "success": false,
+                "error": {
+                    "code": "CONTACT_HAS_KEYS_IN_ACTIVE_VAULTS",
+                    "message": "Cannot remove member — keys are signing an active Vault"
+                }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .remove_cube_member(42, 7)
+            .await
+            .expect_err("expected 409 error");
+        mock.assert();
+
+        let rendered = format!("{}", err);
+        assert!(
+            rendered.contains("active Vault"),
+            "error message should surface API text, got: {}",
+            rendered
+        );
+    }
+
+    #[tokio::test]
+    async fn get_cube_deserializes_members_and_pending_invites() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::GET).path("/api/v1/connect/cubes/42");
+            then.status(200).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": {
+                    "id": 42,
+                    "uuid": "abc-123",
+                    "name": "My Cube",
+                    "network": "bitcoin",
+                    "lightningAddress": "me@coincube.io",
+                    "bolt12Offer": null,
+                    "status": "active",
+                    "members": [
+                        {
+                            "id": 7,
+                            "userId": 99,
+                            "user": { "email": "alice@example.com" },
+                            "joinedAt": "2026-04-18T00:00:00Z"
+                        }
+                    ],
+                    "pendingInvites": [
+                        {
+                            "id": 314,
+                            "cubeId": 42,
+                            "email": "bob@example.com",
+                            "status": "pending",
+                            "expiresAt": "2026-05-18T00:00:00Z",
+                            "createdAt": "2026-04-18T00:00:00Z"
+                        }
+                    ]
+                }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let cube = client.get_cube(42).await.expect("get_cube should succeed");
+        mock.assert();
+
+        assert_eq!(cube.id, 42);
+        assert_eq!(cube.members.len(), 1);
+        assert_eq!(cube.members[0].user.email, "alice@example.com");
+        assert_eq!(cube.pending_invites.len(), 1);
+        assert_eq!(cube.pending_invites[0].email, "bob@example.com");
+    }
+
+    #[tokio::test]
+    async fn get_cube_keys_deserialises_w3_payload() {
+        use crate::services::coincube::CubeKeyRaw;
+        // W3 shape: `ownerUserId`, `ownerEmail`, `isOwnKey`, `usedByVault`
+        // populated; legacy fields absent.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/api/v1/connect/cubes/abc-uuid/keys");
+            then.status(200).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": [
+                    {
+                        "id": 1,
+                        "name": "Alice's Key",
+                        "xpub": "xpub661...",
+                        "fingerprint": "deadbeef",
+                        "derivationPath": "m/48'/0'/0'/2'",
+                        "network": "bitcoin",
+                        "status": "active",
+                        "ownerUserId": 99,
+                        "ownerEmail": "alice@example.com",
+                        "isOwnKey": false,
+                        "usedByVault": true
+                    }
+                ]
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let keys = client
+            .get_cube_keys("abc-uuid")
+            .await
+            .expect("get_cube_keys should succeed");
+        mock.assert();
+
+        assert_eq!(keys.len(), 1);
+        let k: &CubeKeyRaw = &keys[0];
+        assert_eq!(k.owner_user_id, 99);
+        assert_eq!(k.effective_owner_user_id(), 99);
+        assert_eq!(k.owner_email, "alice@example.com");
+        assert!(!k.is_own_key);
+        assert!(k.used_by_vault);
+        // Legacy fields default out.
+        assert_eq!(k.primary_owner_id, 0);
+    }
+
+    #[tokio::test]
+    async fn get_cube_keys_deserialises_legacy_payload() {
+        use crate::services::coincube::CubeKeyRaw;
+        // Pre-W3 shape: only legacy fields; new fields defaulted.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/api/v1/connect/cubes/abc-uuid/keys");
+            then.status(200).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": [
+                    {
+                        "id": 1,
+                        "primaryOwnerId": 7,
+                        "keychainId": 42,
+                        "name": "Legacy Key",
+                        "curve": "secp256k1",
+                        "taproot": false,
+                        "xpub": "xpub661...",
+                        "fingerprint": "deadbeef",
+                        "derivationPath": "m/48'/0'/0'/2'",
+                        "network": "bitcoin",
+                        "cubeId": 5,
+                        "status": "active",
+                        "createdAt": "2026-04-18T00:00:00Z",
+                        "updatedAt": "2026-04-18T00:00:00Z"
+                    }
+                ]
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let keys = client
+            .get_cube_keys("abc-uuid")
+            .await
+            .expect("get_cube_keys should succeed");
+        mock.assert();
+
+        assert_eq!(keys.len(), 1);
+        let k: &CubeKeyRaw = &keys[0];
+        assert_eq!(k.primary_owner_id, 7);
+        assert_eq!(k.effective_owner_user_id(), 7);
+        assert!(k.owner_email.is_empty());
+        assert!(!k.is_own_key);
+        assert!(!k.used_by_vault);
+    }
+
+    #[tokio::test]
+    async fn create_connect_vault_returns_empty_shell() {
+        use crate::services::coincube::CreateConnectVaultRequest;
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/vault")
+                .json_body(json!({ "timelockDays": 180 }));
+            then.status(201).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": {
+                    "id": 5,
+                    "cubeId": 42,
+                    "timelockDays": 180,
+                    "timelockExpiresAt": "2026-10-15T00:00:00Z",
+                    "lastResetAt": "2026-04-18T00:00:00Z",
+                    "status": "active",
+                    "members": [],
+                    "createdAt": "2026-04-18T00:00:00Z",
+                    "updatedAt": "2026-04-18T00:00:00Z"
+                }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let vault = client
+            .create_connect_vault(42, CreateConnectVaultRequest { timelock_days: 180 })
+            .await
+            .expect("create_connect_vault should succeed");
+        mock.assert();
+        assert_eq!(vault.id, 5);
+        assert_eq!(vault.cube_id, 42);
+        assert_eq!(vault.timelock_days, 180);
+        assert!(vault.members.is_empty());
+    }
+
+    #[tokio::test]
+    async fn add_vault_member_omits_optional_fields_when_none() {
+        use crate::services::coincube::{AddVaultMemberRequest, VaultMemberRole};
+        // Verify that `contactId` is omitted from the JSON when None
+        // (self-member case). `keyId` is present.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/vault/members")
+                .json_body(json!({ "keyId": 99, "role": "keyholder" }));
+            then.status(201).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": {
+                    "id": 7,
+                    "keyId": 99,
+                    "role": "keyholder",
+                    "createdAt": "2026-04-18T00:00:00Z"
+                }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let member = client
+            .add_vault_member(
+                42,
+                AddVaultMemberRequest {
+                    contact_id: None,
+                    key_id: Some(99),
+                    role: VaultMemberRole::Keyholder,
+                },
+            )
+            .await
+            .expect("add_vault_member should succeed");
+        mock.assert();
+        assert_eq!(member.id, 7);
+        assert_eq!(member.key_id, Some(99));
+        assert_eq!(member.role, VaultMemberRole::Keyholder);
+    }
+
+    #[tokio::test]
+    async fn add_vault_member_409_key_already_used_maps_to_helper() {
+        use crate::services::coincube::{AddVaultMemberRequest, VaultMemberRole};
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/vault/members");
+            then.status(409).header("content-type", "application/json").json_body(json!({
+                "success": false,
+                "error": {
+                    "code": "KEY_ALREADY_USED_IN_VAULT",
+                    "message": "Key has already been used in another vault; a key can participate in at most one vault."
+                },
+                "keyId": 99,
+                "vaultId": 17
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .add_vault_member(
+                42,
+                AddVaultMemberRequest {
+                    contact_id: None,
+                    key_id: Some(99),
+                    role: VaultMemberRole::Keyholder,
+                },
+            )
+            .await
+            .expect_err("expected 409");
+        mock.assert();
+        assert!(
+            err.is_key_already_used_in_vault(),
+            "is_key_already_used_in_vault() should match: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn add_vault_member_generic_409_not_matched_by_helper() {
+        use crate::services::coincube::{AddVaultMemberRequest, VaultMemberRole};
+        // A 409 with a different error code must NOT trip the helper.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/vault/members");
+            then.status(409).header("content-type", "application/json").json_body(json!({
+                "success": false,
+                "error": {
+                    "code": "DUPLICATE_RESOURCE",
+                    "message": "This member already exists on the vault"
+                }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .add_vault_member(
+                42,
+                AddVaultMemberRequest {
+                    contact_id: Some(1),
+                    key_id: Some(2),
+                    role: VaultMemberRole::Keyholder,
+                },
+            )
+            .await
+            .expect_err("expected 409");
+        mock.assert();
+        assert!(
+            !err.is_key_already_used_in_vault(),
+            "generic 409 must not match the W9 helper"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_invite_with_cube_ids_posts_expected_json_body() {
+        use crate::services::coincube::{ContactRole, CreateInviteRequest};
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/invites")
+                .json_body(json!({
+                    "email": "friend@example.com",
+                    "role": "keyholder",
+                    "cubeIds": [1, 7, 42]
+                }));
+            then.status(201).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": { "id": 100 }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        client
+            .create_invite(CreateInviteRequest {
+                email: "friend@example.com".to_string(),
+                role: ContactRole::Keyholder,
+                cube_ids: vec![1, 7, 42],
+            })
+            .await
+            .expect("create_invite should succeed");
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn create_invite_without_cube_ids_omits_field() {
+        // Backward-compat with pre-W10 staging backends: when cube_ids is
+        // empty, the JSON body must NOT carry the field.
+        use crate::services::coincube::{ContactRole, CreateInviteRequest};
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/invites")
+                .json_body(json!({
+                    "email": "friend@example.com",
+                    "role": "keyholder"
+                }));
+            then.status(201).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": { "id": 100 }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        client
+            .create_invite(CreateInviteRequest {
+                email: "friend@example.com".to_string(),
+                role: ContactRole::Keyholder,
+                cube_ids: Vec::new(),
+            })
+            .await
+            .expect("create_invite should succeed");
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn get_cube_tolerates_missing_members_and_invites() {
+        // `list_cubes()` may return cubes without the members/pending_invites
+        // fields; serde(default) should keep those call sites working.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::GET).path("/api/v1/connect/cubes/42");
+            then.status(200).header("content-type", "application/json").json_body(json!({
+                "success": true,
+                "data": {
+                    "id": 42,
+                    "uuid": "abc-123",
+                    "name": "My Cube",
+                    "network": "bitcoin",
+                    "lightningAddress": null,
+                    "bolt12Offer": null,
+                    "status": "active"
+                }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let cube = client.get_cube(42).await.expect("get_cube should succeed");
+        mock.assert();
+
+        assert!(cube.members.is_empty());
+        assert!(cube.pending_invites.is_empty());
     }
 }

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -684,10 +684,7 @@ impl CoincubeClient {
         cube_id: u64,
         email: &str,
     ) -> Result<CubeInviteOrAddResult, CoincubeError> {
-        let url = format!(
-            "{}/api/v1/connect/cubes/{}/invites",
-            self.base_url, cube_id
-        );
+        let url = format!("{}/api/v1/connect/cubes/{}/invites", self.base_url, cube_id);
         let body = serde_json::json!({ "email": email });
         let res = self.client.post(&url).json(&body).send().await?;
         let res = res.check_success().await?;
@@ -868,21 +865,23 @@ mod cube_member_tests {
         let mock = server.mock(|when, then| {
             when.method(Method::POST)
                 .path("/api/v1/connect/cubes/42/invites");
-            then.status(201).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": {
-                    "status": "invited",
-                    "member": null,
-                    "invite": {
-                        "id": 314,
-                        "cubeId": 42,
-                        "email": "brand-new@example.com",
-                        "status": "pending",
-                        "expiresAt": "2026-05-18T00:00:00Z",
-                        "createdAt": "2026-04-18T00:00:00Z"
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "status": "invited",
+                        "member": null,
+                        "invite": {
+                            "id": 314,
+                            "cubeId": 42,
+                            "email": "brand-new@example.com",
+                            "status": "pending",
+                            "expiresAt": "2026-05-18T00:00:00Z",
+                            "createdAt": "2026-04-18T00:00:00Z"
+                        }
                     }
-                }
-            }));
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -909,13 +908,15 @@ mod cube_member_tests {
         let mock = server.mock(|when, then| {
             when.method(Method::POST)
                 .path("/api/v1/connect/cubes/42/invites");
-            then.status(409).header("content-type", "application/json").json_body(json!({
-                "success": false,
-                "error": {
-                    "code": "CUBE_DUPLICATE_MEMBER",
-                    "message": "User is already a member of this cube"
-                }
-            }));
+            then.status(409)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": false,
+                    "error": {
+                        "code": "CUBE_DUPLICATE_MEMBER",
+                        "message": "User is already a member of this cube"
+                    }
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -939,10 +940,12 @@ mod cube_member_tests {
         let mock = server.mock(|when, then| {
             when.method(Method::DELETE)
                 .path("/api/v1/connect/cubes/42/invites/314");
-            then.status(200).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": { "status": "revoked" }
-            }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": { "status": "revoked" }
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -959,13 +962,15 @@ mod cube_member_tests {
         let mock = server.mock(|when, then| {
             when.method(Method::DELETE)
                 .path("/api/v1/connect/cubes/42/members/7");
-            then.status(409).header("content-type", "application/json").json_body(json!({
-                "success": false,
-                "error": {
-                    "code": "CONTACT_HAS_KEYS_IN_ACTIVE_VAULTS",
-                    "message": "Cannot remove member — keys are signing an active Vault"
-                }
-            }));
+            then.status(409)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": false,
+                    "error": {
+                        "code": "CONTACT_HAS_KEYS_IN_ACTIVE_VAULTS",
+                        "message": "Cannot remove member — keys are signing an active Vault"
+                    }
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -988,36 +993,38 @@ mod cube_member_tests {
         let server = MockServer::start();
         let mock = server.mock(|when, then| {
             when.method(Method::GET).path("/api/v1/connect/cubes/42");
-            then.status(200).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": {
-                    "id": 42,
-                    "uuid": "abc-123",
-                    "name": "My Cube",
-                    "network": "bitcoin",
-                    "lightningAddress": "me@coincube.io",
-                    "bolt12Offer": null,
-                    "status": "active",
-                    "members": [
-                        {
-                            "id": 7,
-                            "userId": 99,
-                            "user": { "email": "alice@example.com" },
-                            "joinedAt": "2026-04-18T00:00:00Z"
-                        }
-                    ],
-                    "pendingInvites": [
-                        {
-                            "id": 314,
-                            "cubeId": 42,
-                            "email": "bob@example.com",
-                            "status": "pending",
-                            "expiresAt": "2026-05-18T00:00:00Z",
-                            "createdAt": "2026-04-18T00:00:00Z"
-                        }
-                    ]
-                }
-            }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 42,
+                        "uuid": "abc-123",
+                        "name": "My Cube",
+                        "network": "bitcoin",
+                        "lightningAddress": "me@coincube.io",
+                        "bolt12Offer": null,
+                        "status": "active",
+                        "members": [
+                            {
+                                "id": 7,
+                                "userId": 99,
+                                "user": { "email": "alice@example.com" },
+                                "joinedAt": "2026-04-18T00:00:00Z"
+                            }
+                        ],
+                        "pendingInvites": [
+                            {
+                                "id": 314,
+                                "cubeId": 42,
+                                "email": "bob@example.com",
+                                "status": "pending",
+                                "expiresAt": "2026-05-18T00:00:00Z",
+                                "createdAt": "2026-04-18T00:00:00Z"
+                            }
+                        ]
+                    }
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -1040,24 +1047,26 @@ mod cube_member_tests {
         let mock = server.mock(|when, then| {
             when.method(Method::GET)
                 .path("/api/v1/connect/cubes/abc-uuid/keys");
-            then.status(200).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": [
-                    {
-                        "id": 1,
-                        "name": "Alice's Key",
-                        "xpub": "xpub661...",
-                        "fingerprint": "deadbeef",
-                        "derivationPath": "m/48'/0'/0'/2'",
-                        "network": "bitcoin",
-                        "status": "active",
-                        "ownerUserId": 99,
-                        "ownerEmail": "alice@example.com",
-                        "isOwnKey": false,
-                        "usedByVault": true
-                    }
-                ]
-            }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": [
+                        {
+                            "id": 1,
+                            "name": "Alice's Key",
+                            "xpub": "xpub661...",
+                            "fingerprint": "deadbeef",
+                            "derivationPath": "m/48'/0'/0'/2'",
+                            "network": "bitcoin",
+                            "status": "active",
+                            "ownerUserId": 99,
+                            "ownerEmail": "alice@example.com",
+                            "isOwnKey": false,
+                            "usedByVault": true
+                        }
+                    ]
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -1086,27 +1095,29 @@ mod cube_member_tests {
         let mock = server.mock(|when, then| {
             when.method(Method::GET)
                 .path("/api/v1/connect/cubes/abc-uuid/keys");
-            then.status(200).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": [
-                    {
-                        "id": 1,
-                        "primaryOwnerId": 7,
-                        "keychainId": 42,
-                        "name": "Legacy Key",
-                        "curve": "secp256k1",
-                        "taproot": false,
-                        "xpub": "xpub661...",
-                        "fingerprint": "deadbeef",
-                        "derivationPath": "m/48'/0'/0'/2'",
-                        "network": "bitcoin",
-                        "cubeId": 5,
-                        "status": "active",
-                        "createdAt": "2026-04-18T00:00:00Z",
-                        "updatedAt": "2026-04-18T00:00:00Z"
-                    }
-                ]
-            }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": [
+                        {
+                            "id": 1,
+                            "primaryOwnerId": 7,
+                            "keychainId": 42,
+                            "name": "Legacy Key",
+                            "curve": "secp256k1",
+                            "taproot": false,
+                            "xpub": "xpub661...",
+                            "fingerprint": "deadbeef",
+                            "derivationPath": "m/48'/0'/0'/2'",
+                            "network": "bitcoin",
+                            "cubeId": 5,
+                            "status": "active",
+                            "createdAt": "2026-04-18T00:00:00Z",
+                            "updatedAt": "2026-04-18T00:00:00Z"
+                        }
+                    ]
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -1133,20 +1144,22 @@ mod cube_member_tests {
             when.method(Method::POST)
                 .path("/api/v1/connect/cubes/42/vault")
                 .json_body(json!({ "timelockDays": 180 }));
-            then.status(201).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": {
-                    "id": 5,
-                    "cubeId": 42,
-                    "timelockDays": 180,
-                    "timelockExpiresAt": "2026-10-15T00:00:00Z",
-                    "lastResetAt": "2026-04-18T00:00:00Z",
-                    "status": "active",
-                    "members": [],
-                    "createdAt": "2026-04-18T00:00:00Z",
-                    "updatedAt": "2026-04-18T00:00:00Z"
-                }
-            }));
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 5,
+                        "cubeId": 42,
+                        "timelockDays": 180,
+                        "timelockExpiresAt": "2026-10-15T00:00:00Z",
+                        "lastResetAt": "2026-04-18T00:00:00Z",
+                        "status": "active",
+                        "members": [],
+                        "createdAt": "2026-04-18T00:00:00Z",
+                        "updatedAt": "2026-04-18T00:00:00Z"
+                    }
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -1171,15 +1184,17 @@ mod cube_member_tests {
             when.method(Method::POST)
                 .path("/api/v1/connect/cubes/42/vault/members")
                 .json_body(json!({ "keyId": 99, "role": "keyholder" }));
-            then.status(201).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": {
-                    "id": 7,
-                    "keyId": 99,
-                    "role": "keyholder",
-                    "createdAt": "2026-04-18T00:00:00Z"
-                }
-            }));
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 7,
+                        "keyId": 99,
+                        "role": "keyholder",
+                        "createdAt": "2026-04-18T00:00:00Z"
+                    }
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -1246,13 +1261,15 @@ mod cube_member_tests {
         let mock = server.mock(|when, then| {
             when.method(Method::POST)
                 .path("/api/v1/connect/cubes/42/vault/members");
-            then.status(409).header("content-type", "application/json").json_body(json!({
-                "success": false,
-                "error": {
-                    "code": "DUPLICATE_RESOURCE",
-                    "message": "This member already exists on the vault"
-                }
-            }));
+            then.status(409)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": false,
+                    "error": {
+                        "code": "DUPLICATE_RESOURCE",
+                        "message": "This member already exists on the vault"
+                    }
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -1286,10 +1303,12 @@ mod cube_member_tests {
                     "role": "keyholder",
                     "cubeIds": [1, 7, 42]
                 }));
-            then.status(201).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": { "id": 100 }
-            }));
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": { "id": 100 }
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -1317,10 +1336,12 @@ mod cube_member_tests {
                     "email": "friend@example.com",
                     "role": "keyholder"
                 }));
-            then.status(201).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": { "id": 100 }
-            }));
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": { "id": 100 }
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -1342,18 +1363,20 @@ mod cube_member_tests {
         let server = MockServer::start();
         let mock = server.mock(|when, then| {
             when.method(Method::GET).path("/api/v1/connect/cubes/42");
-            then.status(200).header("content-type", "application/json").json_body(json!({
-                "success": true,
-                "data": {
-                    "id": 42,
-                    "uuid": "abc-123",
-                    "name": "My Cube",
-                    "network": "bitcoin",
-                    "lightningAddress": null,
-                    "bolt12Offer": null,
-                    "status": "active"
-                }
-            }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 42,
+                        "uuid": "abc-123",
+                        "name": "My Cube",
+                        "network": "bitcoin",
+                        "lightningAddress": null,
+                        "bolt12Offer": null,
+                        "status": "active"
+                    }
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -847,19 +847,60 @@ impl std::fmt::Display for ContactRole {
 pub struct ContactUser {
     pub id: u64,
     pub email: String,
+    /// Backend's `ContactResponse.ContactUser` omits this (it's a
+    /// `UserSummary`, not a full user); desktop was overly strict before.
+    #[serde(default)]
     pub email_verified: Option<bool>,
 }
 
+/// A contact row returned by `GET /api/v1/connect/contacts`.
+///
+/// The backend's `ContactResponse` is intentionally a lean summary —
+/// only `{id, contactUser, role, createdAt}`. The flat fields
+/// `userId`, `contactUserId`, `inviteId` aren't part of the wire shape;
+/// they're marked `#[serde(default)]` so legacy payloads still
+/// deserialise. Callers that need the contact's user id should use
+/// [`Contact::effective_contact_user_id`] which prefers the nested
+/// `contact_user.id` over the flat field.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Contact {
     pub id: u64,
+    /// Relationship-owner's user id — tautological from the caller's
+    /// perspective. Not in the current backend response.
+    #[serde(default)]
     pub user_id: u64,
+    /// Flat `contactUserId` from the legacy shape. Use
+    /// [`Contact::effective_contact_user_id`] rather than reading this
+    /// field directly — it will be zero when talking to the current
+    /// backend.
+    #[serde(default)]
     pub contact_user_id: u64,
+    #[serde(default)]
     pub invite_id: Option<u64>,
     pub role: ContactRole,
-    pub contact_user: ContactUser,
+    /// Nested user summary. The current backend marks this optional
+    /// (`omitempty`); an entry without a contact user is skippable at
+    /// the call site.
+    #[serde(default)]
+    pub contact_user: Option<ContactUser>,
     pub created_at: String,
+}
+
+impl Contact {
+    /// Returns the contact's user id, falling back to the nested
+    /// `contact_user.id` when the flat `contact_user_id` is absent/zero.
+    /// Returns `None` when the contact has no linked user at all.
+    pub fn effective_contact_user_id(&self) -> Option<u64> {
+        if self.contact_user_id != 0 {
+            Some(self.contact_user_id)
+        } else {
+            self.contact_user
+                .as_ref()
+                .map(|u| u.id)
+                .filter(|id| *id != 0)
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -378,29 +378,143 @@ pub struct CubeResponse {
     pub lightning_address: Option<String>,
     pub bolt12_offer: Option<String>,
     pub status: String,
+    /// Populated by `GET /connect/cubes/{id}` (not by `list_cubes`). Defaults
+    /// to empty so existing list-based code paths keep working.
+    #[serde(default)]
+    pub members: Vec<CubeMember>,
+    #[serde(default)]
+    pub pending_invites: Vec<CubeInviteSummary>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CubeMember {
+    pub id: u64,
+    pub user_id: u64,
+    pub user: CubeMemberUser,
+    pub joined_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CubeMemberUser {
+    pub email: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CubeInviteSummary {
+    pub id: u64,
+    pub cube_id: u64,
+    pub email: String,
+    pub status: String,
+    pub expires_at: String,
+    pub created_at: String,
+}
+
+/// Result of `POST /connect/cubes/{cubeId}/invites`. The backend returns
+/// `{status, member, invite}` where exactly one of `member`/`invite` is set
+/// depending on `status`. We normalise that into an enum.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(try_from = "CubeInviteOrAddResultRaw")]
+pub enum CubeInviteOrAddResult {
+    /// The invitee was already a contact — they were added as a member
+    /// immediately.
+    Added(CubeMember),
+    /// The invitee is not yet a contact — an invite was created and the
+    /// pending-cube-attachment row will be fanned out on accept.
+    Invited(CubeInviteSummary),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CubeInviteOrAddResultRaw {
+    status: String,
+    #[serde(default)]
+    member: Option<CubeMember>,
+    #[serde(default)]
+    invite: Option<CubeInviteSummary>,
+}
+
+impl std::convert::TryFrom<CubeInviteOrAddResultRaw> for CubeInviteOrAddResult {
+    type Error = String;
+
+    fn try_from(raw: CubeInviteOrAddResultRaw) -> Result<Self, Self::Error> {
+        match raw.status.as_str() {
+            "added" => raw
+                .member
+                .map(CubeInviteOrAddResult::Added)
+                .ok_or_else(|| "expected `member` when status=added".to_string()),
+            "invited" => raw
+                .invite
+                .map(CubeInviteOrAddResult::Invited)
+                .ok_or_else(|| "expected `invite` when status=invited".to_string()),
+            other => Err(format!("unexpected cube-invite status: {}", other)),
+        }
+    }
 }
 
 /// A key returned by `GET /api/v1/connect/cubes/{cubeUuid}/keys`.
-/// The response is a flat array — owner resolution (self vs. contact)
-/// is done client-side by comparing `primary_owner_id` against the
-/// authenticated user's ID.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
+///
+/// Two backend shapes coexist during the W3 rollout:
+///
+/// 1. **Legacy** — the flat `models.Key` dump with `primaryOwnerId`,
+///    `keychainId`, `curve`, `taproot`, `cubeId`, `createdAt`,
+///    `updatedAt`. Owner resolution (self vs. contact) is done client-side.
+/// 2. **W3 (post-PLAN-cube-membership-backend)** — a purpose-built
+///    `CubeKeyResponse` that drops most of the above and adds the
+///    viewer-relative `ownerUserId` / `ownerEmail` / `isOwnKey` /
+///    `usedByVault` fields.
+///
+/// Every field is `#[serde(default)]` so either shape deserialises cleanly.
+/// The new fields default to zero-values, and legacy callers (pre-W3
+/// backend) keep working via the legacy fields. See
+/// `plans/PLAN-cube-membership-desktop.md` §2.3.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
 pub struct CubeKeyRaw {
     pub id: u64,
-    pub primary_owner_id: u64,
-    pub keychain_id: Option<u64>,
     pub name: String,
-    pub curve: String,
-    pub taproot: bool,
     pub xpub: String,
     pub fingerprint: String,
     pub derivation_path: String,
     pub network: String,
-    pub cube_id: u64,
     pub status: String,
+
+    // --- Legacy fields (may disappear post-W3) ---
+    pub primary_owner_id: u64,
+    pub keychain_id: Option<u64>,
+    pub curve: String,
+    pub taproot: bool,
+    pub cube_id: u64,
     pub created_at: String,
     pub updated_at: String,
+
+    // --- W3 fields (post-PLAN-cube-membership-backend) ---
+    /// Server-supplied owner id; falls back to `primary_owner_id` when
+    /// talking to a pre-W3 backend.
+    pub owner_user_id: u64,
+    /// Email of the key's primary owner. Empty on a pre-W3 backend; the
+    /// desktop falls back to a contact-list lookup in that case.
+    pub owner_email: String,
+    /// `true` iff the authenticated caller is the owner of this key.
+    /// Pre-W3 this is always `false` from the server; the desktop computes
+    /// it locally.
+    pub is_own_key: bool,
+    /// `true` iff this key is currently referenced by any active Vault.
+    /// Drives the W9 pre-check in the Vault Builder key picker.
+    pub used_by_vault: bool,
+}
+
+impl CubeKeyRaw {
+    /// Returns the server-supplied `ownerUserId` when present, falling back
+    /// to the legacy `primaryOwnerId`. Callers should prefer this over
+    /// reading either field directly.
+    pub fn effective_owner_user_id(&self) -> u64 {
+        if self.owner_user_id != 0 {
+            self.owner_user_id
+        } else {
+            self.primary_owner_id
+        }
+    }
 }
 
 /// Response from GET /api/v1/connect/cubes/limits
@@ -747,9 +861,16 @@ pub struct Invite {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateInviteRequest {
     pub email: String,
     pub role: ContactRole,
+    /// Optional list of cube ids to pre-attach the invitee to. When empty
+    /// the field is omitted from the JSON body so older staging servers
+    /// (pre-W10, which don't recognise the field) keep working.
+    /// See `plans/PLAN-cube-membership-desktop.md` §2.7.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub cube_ids: Vec<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -760,4 +881,135 @@ pub struct ContactCube {
     pub name: String,
     pub network: String,
     pub has_recovery_kit: bool,
+}
+
+// =============================================================================
+// Connect Vault types
+// =============================================================================
+//
+// The backend's `ConnectVault` is attached to a cube. A vault owns many
+// `ConnectVaultMember` rows, each referencing a `ConnectContact` and/or a
+// `Key`. The desktop installer creates the vault shell via
+// `POST /connect/cubes/{cubeId}/vault` and fans out member rows via
+// `POST /connect/cubes/{cubeId}/vault/members`.
+//
+// W9 guard: adding a member with a `keyId` that's already attached to
+// another vault returns 409 with error code `KEY_ALREADY_USED_IN_VAULT`.
+// The helper `CoincubeError::is_key_already_used_in_vault()` (below)
+// lets callers route that into the Vault Builder's "key conflict" dialog.
+
+/// Role a contact plays on a vault (mirrors `models.InviteRole`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VaultMemberRole {
+    Keyholder,
+    Beneficiary,
+    Observer,
+}
+
+impl std::fmt::Display for VaultMemberRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Keyholder => write!(f, "Keyholder"),
+            Self::Beneficiary => write!(f, "Beneficiary"),
+            Self::Observer => write!(f, "Observer"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateConnectVaultRequest {
+    pub timelock_days: i32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddVaultMemberRequest {
+    /// `Some` for contact-scoped members (a contact's key is being added).
+    /// `None` when the vault owner adds their own key.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contact_id: Option<u64>,
+    /// Backend key id. `None` for contact-only members (e.g. Beneficiary)
+    /// that don't contribute a signing key.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_id: Option<u64>,
+    pub role: VaultMemberRole,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultMemberKeySummary {
+    pub id: u64,
+    pub name: String,
+    pub xpub: String,
+    pub derivation_path: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultMemberContactSummary {
+    pub id: u64,
+    #[serde(default)]
+    pub contact_user: Option<VaultMemberContactUserSummary>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultMemberContactUserSummary {
+    pub id: u64,
+    pub email: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultMemberResponse {
+    pub id: u64,
+    #[serde(default)]
+    pub contact_id: Option<u64>,
+    #[serde(default)]
+    pub key_id: Option<u64>,
+    pub role: VaultMemberRole,
+    #[serde(default)]
+    pub contact: Option<VaultMemberContactSummary>,
+    #[serde(default)]
+    pub key: Option<VaultMemberKeySummary>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectVaultResponse {
+    pub id: u64,
+    pub cube_id: u64,
+    pub timelock_days: i32,
+    pub timelock_expires_at: String,
+    pub last_reset_at: String,
+    pub status: String,
+    #[serde(default)]
+    pub members: Vec<VaultMemberResponse>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Error code string returned by the backend's W9 guard. Public so callers
+/// can match on it when routing 409s.
+pub const ERR_KEY_ALREADY_USED_IN_VAULT: &str = "KEY_ALREADY_USED_IN_VAULT";
+
+impl CoincubeError {
+    /// Returns `true` if this error is a W9 "key already used in another
+    /// vault" conflict from `POST /connect/cubes/{id}/vault/members`.
+    /// Drives the Vault Builder's key-conflict dialog.
+    pub fn is_key_already_used_in_vault(&self) -> bool {
+        let CoincubeError::Unsuccessful(info) = self else {
+            return false;
+        };
+        if info.status_code != 409 {
+            return false;
+        }
+        if let Ok(env) = serde_json::from_str::<ApiErrorResponse>(&info.text) {
+            return env.error.code == ERR_KEY_ALREADY_USED_IN_VAULT;
+        }
+        false
+    }
 }

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -888,18 +888,17 @@ pub struct Contact {
 }
 
 impl Contact {
-    /// Returns the contact's user id, falling back to the nested
-    /// `contact_user.id` when the flat `contact_user_id` is absent/zero.
+    /// Returns the contact's user id, preferring the nested
+    /// `contact_user.id` (the source of truth in the current backend's
+    /// `ContactResponse`) and falling back to the legacy flat
+    /// `contact_user_id` only when the nested object is missing.
     /// Returns `None` when the contact has no linked user at all.
     pub fn effective_contact_user_id(&self) -> Option<u64> {
-        if self.contact_user_id != 0 {
-            Some(self.contact_user_id)
-        } else {
-            self.contact_user
-                .as_ref()
-                .map(|u| u.id)
-                .filter(|id| *id != 0)
-        }
+        self.contact_user
+            .as_ref()
+            .map(|u| u.id)
+            .filter(|id| *id != 0)
+            .or_else(|| (self.contact_user_id != 0).then_some(self.contact_user_id))
     }
 }
 

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -464,13 +464,17 @@ impl std::convert::TryFrom<CubeInviteOrAddResultRaw> for CubeInviteOrAddResult {
 ///    viewer-relative `ownerUserId` / `ownerEmail` / `isOwnKey` /
 ///    `usedByVault` fields.
 ///
-/// Every field is `#[serde(default)]` so either shape deserialises cleanly.
-/// The new fields default to zero-values, and legacy callers (pre-W3
-/// backend) keep working via the legacy fields. See
-/// `plans/PLAN-cube-membership-desktop.md` §2.3.
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+/// Fields that appear in *both* shapes (`id`, `name`, `xpub`,
+/// `fingerprint`, `derivationPath`, `network`, `status`) are required —
+/// missing them indicates a broken backend response and should fail
+/// deserialisation fast. Rollout-specific fields (the legacy-only and
+/// W3-only sets below) are individually `#[serde(default)]` so the
+/// desktop keeps working against whichever shape the server happens to
+/// serve. See `plans/PLAN-cube-membership-desktop.md` §2.3.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CubeKeyRaw {
+    // --- Required fields (present in both legacy and W3 shapes) ---
     pub id: u64,
     pub name: String,
     pub xpub: String,
@@ -480,27 +484,38 @@ pub struct CubeKeyRaw {
     pub status: String,
 
     // --- Legacy fields (may disappear post-W3) ---
+    #[serde(default)]
     pub primary_owner_id: u64,
+    #[serde(default)]
     pub keychain_id: Option<u64>,
+    #[serde(default)]
     pub curve: String,
+    #[serde(default)]
     pub taproot: bool,
+    #[serde(default)]
     pub cube_id: u64,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
 
     // --- W3 fields (post-PLAN-cube-membership-backend) ---
     /// Server-supplied owner id; falls back to `primary_owner_id` when
     /// talking to a pre-W3 backend.
+    #[serde(default)]
     pub owner_user_id: u64,
     /// Email of the key's primary owner. Empty on a pre-W3 backend; the
     /// desktop falls back to a contact-list lookup in that case.
+    #[serde(default)]
     pub owner_email: String,
     /// `true` iff the authenticated caller is the owner of this key.
     /// Pre-W3 this is always `false` from the server; the desktop computes
     /// it locally.
+    #[serde(default)]
     pub is_own_key: bool,
     /// `true` iff this key is currently referenced by any active Vault.
     /// Drives the W9 pre-check in the Vault Builder key picker.
+    #[serde(default)]
     pub used_by_vault: bool,
 }
 

--- a/coincube-ui/src/component/modal.rs
+++ b/coincube-ui/src/component/modal.rs
@@ -10,7 +10,6 @@ use iced::{
 use crate::{
     color,
     component::{
-        button,
         form::{self, Value},
         text, tooltip,
     },
@@ -30,28 +29,65 @@ pub fn widget_style(theme: &Theme, status: Status) -> Style {
     theme::button::secondary(theme, status)
 }
 
-pub fn header<'a, Message, Back, Close>(
+/// Standard modal header used across the app: left-aligned title plus a
+/// right-aligned close ×. Back navigation — when the modal has it — now
+/// lives in a footer row rendered via [`back_button`] placed next to the
+/// primary action (matches the Recovery Phrase / Border Wallet pattern).
+/// The × is sized to match the chevron glyph used by [`back_button`] so
+/// the two nav controls read as the same visual weight.
+pub fn header<'a, Message, Close>(
     label: Option<String>,
-    back_message: Option<Back>,
     close_message: Option<Close>,
 ) -> Element<'a, Message>
 where
-    Back: 'static + Fn() -> Message,
     Close: 'static + Fn() -> Message,
     Message: Clone + 'static,
 {
-    let back = back_message
-        .map(|m| button::transparent(Some(icon::arrow_back().size(25)), "").on_press(m()));
     let title = label.map(text::h3);
-    let close = close_message
-        .map(|m| button::transparent(Some(icon::cross_icon().size(40)), "").on_press(m()));
+    // Build the close button without the `button::transparent` helper:
+    // that helper assumes an icon+text pair and pads for the spacing
+    // gap + empty label, which leaves a visible gutter between the ×
+    // and the modal's right edge. A minimal `Button::new(icon)` with
+    // zero padding sits flush to the right instead.
+    let close = close_message.map(|m| {
+        iced::widget::Button::new(icon::cross_icon())
+            .style(theme::button::transparent)
+            .padding(0)
+            .on_press(m())
+    });
+    // Layout: [title] [flex-fill] [close]. The `width(Fill)` on the Row
+    // is what makes the flex spacer actually push `close` to the right
+    // edge of the modal — without it the Row defaults to `Shrink` and
+    // both children collapse together in the middle.
     Row::new()
-        .push(back)
         .push(title)
         .push(Space::new().width(Length::Fill))
         .push(close)
         .align_y(Vertical::Center)
+        .spacing(H_SPACING)
+        .width(Length::Fill)
         .into()
+}
+
+/// Reusable "⟨ Back" button placed in a modal footer row (left-aligned,
+/// next to the primary action). Matches the style already used by the
+/// Recovery Phrase / Select Pattern / etc. Border Wallet wizard screens.
+pub fn back_button<'a, Message, F>(on_press: F) -> Element<'a, Message>
+where
+    Message: Clone + 'a,
+    F: 'static + Fn() -> Message,
+{
+    iced::widget::Button::new(
+        Row::new()
+            .push(icon::previous_icon().style(theme::text::secondary))
+            .push(Space::new().width(Length::Fixed(4.0)))
+            .push(text::p1_medium("Back").style(theme::text::secondary))
+            .spacing(4)
+            .align_y(Vertical::Center),
+    )
+    .style(theme::button::transparent)
+    .on_press(on_press())
+    .into()
 }
 
 pub fn optional_section<'a, Message, Collapse, Fold>(

--- a/coincube-ui/src/component/tooltip.rs
+++ b/coincube-ui/src/component/tooltip.rs
@@ -1,12 +1,20 @@
 use crate::{icon, theme, widget::Container};
 
+/// Maximum width (logical pixels) of the tooltip bubble. Forces long
+/// copy to wrap instead of extending off the edge of the window.
+const TOOLTIP_MAX_WIDTH: f32 = 320.0;
+
 pub fn tooltip<'a, T: 'a>(help: &'a str) -> Container<'a, T> {
-    Container::new(
-        iced::widget::tooltip::Tooltip::new(
-            icon::tooltip_icon(),
-            help,
-            iced::widget::tooltip::Position::Right,
-        )
-        .style(theme::card::simple),
-    )
+    // Wrap the help string inside a sized container so long copy soft-wraps
+    // at `TOOLTIP_MAX_WIDTH` rather than shooting off the edge of the modal.
+    let tip = Container::new(iced::widget::text(help).size(14))
+        .max_width(TOOLTIP_MAX_WIDTH)
+        .padding([6, 10])
+        .style(theme::card::simple);
+
+    Container::new(iced::widget::tooltip::Tooltip::new(
+        icon::tooltip_icon(),
+        tip,
+        iced::widget::tooltip::Position::Right,
+    ))
 }

--- a/coincube-ui/src/icon.rs
+++ b/coincube-ui/src/icon.rs
@@ -368,10 +368,18 @@ pub fn shield_icon<'a>() -> Text<'a> {
     bootstrap_icon('\u{F53F}')
 }
 
+pub fn shield_plus_icon<'a>() -> Text<'a> {
+    bootstrap_icon('\u{F53A}')
+}
+
 pub fn cloud_check_icon<'a>() -> Text<'a> {
     bootstrap_icon('\u{F299}')
 }
 
 pub fn cloud_slash_icon<'a>() -> Text<'a> {
     bootstrap_icon('\u{F2B8}')
+}
+
+pub fn grid_icon<'a>() -> Text<'a> {
+    bootstrap_icon('\u{F3FA}')
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new cube membership management flows plus post-install backend vault creation, touching UI state machines and multiple API calls; main risk is regressions in Connect/Contacts UX and error-handling around cube registration and membership permissions.
> 
> **Overview**
> Adds a **feature-flagged** `Members` sub-menu under Connect for cube-scoped membership management, including loading members/pending invites, inviting by email, revoking invites, and removing members with dedicated load/action error handling.
> 
> Extends the Connect **Contacts** invite flow to optionally attach invites to selected cubes (network-filtered), removes the role selector, and adds W14 actions to add an existing contact to the current cube (using the synced `active_cube_server_id`) or via an "Add to Cube(s)…" multi-select dialog with per-cube outcomes.
> 
> Introduces post-install **Connect Vault** orchestration that registers the cube, creates a backend vault, and attaches keychain-derived members with rollback on the W9 `KEY_ALREADY_USED_IN_VAULT` conflict; adds `httpmock` dev-dependency and tests for the new request shapes and flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e7d6884fce68fd1539a461b917c3a2bd95b867e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cube Members panel to view/manage members and pending invites
  * Multi-select "Also add to Cube(s)" and one-click "Add to Current Cube" for contacts
  * Automatic Connect Vault creation after wallet install with outcome/caption shown

* **UI**
  * Conditional "Members" sidebar entry (feature-flagged)
  * Invite form: removed role selector, added cube multi-select, conflict banner, per-contact add errors, refresh/loading/empty states, pending-invite/member cards
  * Modal header/footer updated (back button moved to footer)

* **Visual**
  * New shield and grid icons; improved tooltip wrapping/layout

* **Chores**
  * Added dev test dependency for HTTP mocking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->