### PR TITLE
Initial commit

### DIFF
--- a/coincube-gui/src/app/state/connect/cube_members.rs
+++ b/coincube-gui/src/app/state/connect/cube_members.rs
@@ -123,8 +123,11 @@ pub fn update(
                     // count as loaded; the next `Enter` will retry.
                     // Route to `load_error` so a standing validation
                     // message in `error` isn't overwritten.
+                    // `members`, `pending_invites`, and `vault_created_at`
+                    // are all left intact so the panel keeps rendering the
+                    // last-good snapshot — including the "Joined after
+                    // Vault" badges — instead of a half-cleared view.
                     state.load_error = Some(e);
-                    state.vault_created_at = None;
                 }
             }
             iced::Task::none()
@@ -476,6 +479,55 @@ mod tests {
         assert!(!state.loading);
         assert_eq!(state.load_error.as_deref(), Some("boom"));
         assert!(state.error.is_none(), "load errors must not touch `error`");
+    }
+
+    #[test]
+    fn loaded_err_preserves_last_good_snapshot() {
+        // Regression: a reload failure must leave `members`,
+        // `pending_invites`, and `vault_created_at` intact so the panel
+        // keeps rendering the last-good snapshot. Wiping any one of them
+        // (in particular `vault_created_at`) breaks the "Joined after
+        // Vault" badges on stale member rows — the rows still render,
+        // but their badges silently vanish.
+        let mut state = ConnectCubeMembersState::new();
+        let gen1 = state.bump_generation();
+        state.loading = true;
+        let late_member = sample_member_joined(7, "late@example.com", "2026-02-01T00:00:00Z");
+        let mut cube = sample_cube(
+            "Cube",
+            vec![late_member.clone()],
+            vec![sample_invite(9, "p@example.com")],
+        );
+        cube.vault = Some(sample_vault("2026-01-01T00:00:00Z"));
+        run(
+            &mut state,
+            ConnectCubeMembersMessage::Loaded(Ok(cube), gen1),
+        );
+        assert!(badge_visible(&state, &late_member));
+
+        // A subsequent reload fails — stale snapshot must survive.
+        let gen2 = state.bump_generation();
+        state.loading = true;
+        run(
+            &mut state,
+            ConnectCubeMembersMessage::Loaded(Err("boom".to_string()), gen2),
+        );
+        assert_eq!(state.load_error.as_deref(), Some("boom"));
+        assert_eq!(state.members.len(), 1, "stale member list should survive");
+        assert_eq!(
+            state.pending_invites.len(),
+            1,
+            "stale invites should survive"
+        );
+        assert_eq!(
+            state.vault_created_at.as_deref(),
+            Some("2026-01-01T00:00:00Z"),
+            "stale vault_created_at must survive so badges stay consistent"
+        );
+        assert!(
+            badge_visible(&state, &late_member),
+            "badge must still render on the stale row after a failed reload"
+        );
     }
 
     #[test]

--- a/coincube-gui/src/app/state/connect/cube_members.rs
+++ b/coincube-gui/src/app/state/connect/cube_members.rs
@@ -40,6 +40,12 @@ pub struct ConnectCubeMembersState {
     /// The payload is the raw server message — W4's structured conflict body
     /// is parsed in PR 3, for now we surface the text verbatim.
     pub remove_conflict: Option<String>,
+    /// `created_at` of the cube's attached Vault, when one exists. Drives
+    /// the W16-desktop "Joined after Vault" badge on each member row:
+    /// members whose `joined_at` strictly exceeds this landed after the
+    /// Vault's signing quorum was sealed. `None` when the cube has no
+    /// vault or the `Loaded` response omitted it.
+    pub vault_created_at: Option<String>,
     /// Monotonic counter used to discard stale `Loaded` responses when the
     /// user issues multiple `Reload`s in quick succession.
     load_generation: u32,
@@ -108,6 +114,7 @@ pub fn update(
                 Ok(cube) => {
                     state.members = cube.members;
                     state.pending_invites = cube.pending_invites;
+                    state.vault_created_at = cube.vault.as_ref().map(|v| v.created_at.clone());
                     state.load_error = None;
                     state.loaded_once = true;
                 }
@@ -117,6 +124,7 @@ pub fn update(
                     // Route to `load_error` so a standing validation
                     // message in `error` isn't overwritten.
                     state.load_error = Some(e);
+                    state.vault_created_at = None;
                 }
             }
             iced::Task::none()
@@ -327,16 +335,58 @@ fn is_stranded_vault_conflict(err: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::services::coincube::{CubeInviteSummary, CubeMember, CubeMemberUser};
+    use crate::services::coincube::{
+        ConnectVaultResponse, CubeInviteSummary, CubeMember, CubeMemberUser, VaultStatus,
+    };
+
+    /// Builder for a bare `CubeResponse` without a vault — most tests just
+    /// exercise the member/invite plumbing and don't care about the W16
+    /// badge fields.
+    fn sample_cube(
+        name: &str,
+        members: Vec<CubeMember>,
+        pending_invites: Vec<CubeInviteSummary>,
+    ) -> CubeResponse {
+        CubeResponse {
+            id: 42,
+            uuid: "abc".to_string(),
+            name: name.to_string(),
+            network: "bitcoin".to_string(),
+            lightning_address: None,
+            bolt12_offer: None,
+            status: "active".to_string(),
+            members,
+            pending_invites,
+            vault: None,
+        }
+    }
+
+    fn sample_vault(created_at: &str) -> ConnectVaultResponse {
+        ConnectVaultResponse {
+            id: 1,
+            cube_id: 42,
+            timelock_days: 90,
+            timelock_expires_at: "2027-01-01T00:00:00Z".to_string(),
+            last_reset_at: created_at.to_string(),
+            status: VaultStatus::Active,
+            members: vec![],
+            created_at: created_at.to_string(),
+            updated_at: created_at.to_string(),
+        }
+    }
 
     fn sample_member(id: u64, email: &str) -> CubeMember {
+        sample_member_joined(id, email, "2026-04-18T00:00:00Z")
+    }
+
+    fn sample_member_joined(id: u64, email: &str, joined_at: &str) -> CubeMember {
         CubeMember {
             id,
             user_id: id + 100,
             user: CubeMemberUser {
                 email: email.to_string(),
             },
-            joined_at: "2026-04-18T00:00:00Z".to_string(),
+            joined_at: joined_at.to_string(),
         }
     }
 
@@ -365,17 +415,11 @@ mod tests {
         let gen = state.bump_generation();
         state.loading = true;
 
-        let cube = CubeResponse {
-            id: 42,
-            uuid: "abc".to_string(),
-            name: "My Cube".to_string(),
-            network: "bitcoin".to_string(),
-            lightning_address: None,
-            bolt12_offer: None,
-            status: "active".to_string(),
-            members: vec![sample_member(7, "alice@example.com")],
-            pending_invites: vec![sample_invite(9, "bob@example.com")],
-        };
+        let cube = sample_cube(
+            "My Cube",
+            vec![sample_member(7, "alice@example.com")],
+            vec![sample_invite(9, "bob@example.com")],
+        );
         run(&mut state, ConnectCubeMembersMessage::Loaded(Ok(cube), gen));
 
         assert!(!state.loading);
@@ -394,17 +438,7 @@ mod tests {
         let gen2 = state.bump_generation(); // gen = 2 (current)
         state.loading = true;
 
-        let stale_cube = CubeResponse {
-            id: 42,
-            uuid: "abc".to_string(),
-            name: "Stale".to_string(),
-            network: "bitcoin".to_string(),
-            lightning_address: None,
-            bolt12_offer: None,
-            status: "active".to_string(),
-            members: vec![sample_member(1, "stale@example.com")],
-            pending_invites: vec![],
-        };
+        let stale_cube = sample_cube("Stale", vec![sample_member(1, "stale@example.com")], vec![]);
         run(
             &mut state,
             ConnectCubeMembersMessage::Loaded(Ok(stale_cube), 1),
@@ -412,17 +446,11 @@ mod tests {
         assert!(state.members.is_empty());
         assert!(state.loading, "stale response should not clear loading");
 
-        let current_cube = CubeResponse {
-            id: 42,
-            uuid: "abc".to_string(),
-            name: "Current".to_string(),
-            network: "bitcoin".to_string(),
-            lightning_address: None,
-            bolt12_offer: None,
-            status: "active".to_string(),
-            members: vec![sample_member(2, "current@example.com")],
-            pending_invites: vec![],
-        };
+        let current_cube = sample_cube(
+            "Current",
+            vec![sample_member(2, "current@example.com")],
+            vec![],
+        );
         run(
             &mut state,
             ConnectCubeMembersMessage::Loaded(Ok(current_cube), gen2),
@@ -674,17 +702,7 @@ mod tests {
         let mut state = ConnectCubeMembersState::new();
         let gen = state.bump_generation();
         state.loading = true;
-        let empty_cube = CubeResponse {
-            id: 42,
-            uuid: "abc".to_string(),
-            name: "Empty".to_string(),
-            network: "bitcoin".to_string(),
-            lightning_address: None,
-            bolt12_offer: None,
-            status: "active".to_string(),
-            members: vec![],
-            pending_invites: vec![],
-        };
+        let empty_cube = sample_cube("Empty", vec![], vec![]);
         run(
             &mut state,
             ConnectCubeMembersMessage::Loaded(Ok(empty_cube), gen),
@@ -724,5 +742,61 @@ mod tests {
         state.remove_conflict = Some("vault conflict".to_string());
         run(&mut state, ConnectCubeMembersMessage::DismissRemoveConflict);
         assert!(state.remove_conflict.is_none());
+    }
+
+    // --- §3.5 W16-desktop: "Joined after Vault" badge ---
+
+    /// Helper: true when the view-layer would render the "Joined after
+    /// Vault" badge for `member`, given the state's cached
+    /// `vault_created_at`. Mirrors the predicate used in the view so the
+    /// state-layer tests match the render gate exactly.
+    fn badge_visible(state: &ConnectCubeMembersState, member: &CubeMember) -> bool {
+        state.vault_created_at.as_deref().is_some_and(|v| {
+            crate::services::coincube::member_joined_after_vault(&member.joined_at, v)
+        })
+    }
+
+    #[test]
+    fn member_row_renders_joined_after_vault_badge_when_joined_after() {
+        let mut state = ConnectCubeMembersState::new();
+        let gen = state.bump_generation();
+        state.loading = true;
+        // Vault sealed on 2026-01-01; member joined after.
+        let late_member = sample_member_joined(7, "late@example.com", "2026-02-01T00:00:00Z");
+        let mut cube = sample_cube("Cube", vec![late_member.clone()], vec![]);
+        cube.vault = Some(sample_vault("2026-01-01T00:00:00Z"));
+        run(&mut state, ConnectCubeMembersMessage::Loaded(Ok(cube), gen));
+        assert_eq!(
+            state.vault_created_at.as_deref(),
+            Some("2026-01-01T00:00:00Z")
+        );
+        assert!(badge_visible(&state, &late_member));
+    }
+
+    #[test]
+    fn member_row_hides_badge_when_joined_before_vault() {
+        let mut state = ConnectCubeMembersState::new();
+        let gen = state.bump_generation();
+        state.loading = true;
+        // Member joined before the Vault was sealed — still in the quorum.
+        let early_member = sample_member_joined(7, "early@example.com", "2025-12-01T00:00:00Z");
+        let mut cube = sample_cube("Cube", vec![early_member.clone()], vec![]);
+        cube.vault = Some(sample_vault("2026-01-01T00:00:00Z"));
+        run(&mut state, ConnectCubeMembersMessage::Loaded(Ok(cube), gen));
+        assert!(!badge_visible(&state, &early_member));
+    }
+
+    #[test]
+    fn member_row_hides_badge_when_cube_has_no_vault() {
+        let mut state = ConnectCubeMembersState::new();
+        let gen = state.bump_generation();
+        state.loading = true;
+        let member = sample_member_joined(7, "m@example.com", "2026-02-01T00:00:00Z");
+        // No vault attached — `vault_created_at` should stay `None`
+        // and the badge must not render.
+        let cube = sample_cube("Cube", vec![member.clone()], vec![]);
+        run(&mut state, ConnectCubeMembersMessage::Loaded(Ok(cube), gen));
+        assert!(state.vault_created_at.is_none());
+        assert!(!badge_visible(&state, &member));
     }
 }

--- a/coincube-gui/src/app/view/connect/cube_members.rs
+++ b/coincube-gui/src/app/view/connect/cube_members.rs
@@ -6,7 +6,7 @@
 
 use coincube_ui::{
     color,
-    component::{button, text},
+    component::{button, text, tooltip},
     icon::*,
     theme,
     widget::*,
@@ -18,7 +18,7 @@ use crate::{
         state::connect::ConnectCubePanel,
         view::{ConnectCubeMembersMessage, ConnectCubeMessage},
     },
-    services::coincube::{CubeInviteSummary, CubeMember},
+    services::coincube::{member_joined_after_vault, CubeInviteSummary, CubeMember},
 };
 
 use super::{card_style, format_date};
@@ -81,8 +81,9 @@ pub fn cube_members_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectCu
     } else if !panel.members.is_empty() {
         col = col.push(text::p1_bold("Members").style(theme::text::primary));
         col = col.push(iced::widget::Space::new().height(Length::Fixed(8.0)));
+        let vault_created_at = panel.vault_created_at.as_deref();
         for member in &panel.members {
-            col = col.push(member_card(member));
+            col = col.push(member_card(member, vault_created_at));
             col = col.push(iced::widget::Space::new().height(Length::Fixed(6.0)));
         }
     } else if panel.loading {
@@ -181,7 +182,10 @@ fn invite_form<'a>(
 // Member & Invite cards
 // =============================================================================
 
-fn member_card<'a>(member: &'a CubeMember) -> Element<'a, ConnectCubeMessage> {
+fn member_card<'a>(
+    member: &'a CubeMember,
+    vault_created_at: Option<&str>,
+) -> Element<'a, ConnectCubeMessage> {
     let email = &member.user.email;
     let initial = email
         .chars()
@@ -204,9 +208,34 @@ fn member_card<'a>(member: &'a CubeMember) -> Element<'a, ConnectCubeMessage> {
             ..Default::default()
         });
 
+    // W16-desktop: show a subdued "Joined after Vault" badge on members
+    // who landed after the attached Vault's signing quorum was sealed.
+    // Their keys can attach to a future Vault rebuild but won't sign
+    // the current one. Tooltip spells out the implication on hover.
+    let joined_after_vault =
+        vault_created_at.is_some_and(|v| member_joined_after_vault(&member.joined_at, v));
+    let badge_row: Option<Element<'_, ConnectCubeMessage>> = if joined_after_vault {
+        Some(
+            Row::new()
+                .push(text::p2_regular("Joined after Vault").color(color::GREY_3))
+                .push(iced::widget::Space::new().width(Length::Fixed(4.0)))
+                .push(tooltip(
+                    "This member can attach keys but won't be in the current Vault's \
+                     signing quorum. Their keys will be available when the Vault is rebuilt.",
+                ))
+                .align_y(Alignment::Center)
+                .into(),
+        )
+    } else {
+        None
+    };
+
     let joined = format_date(&member.joined_at);
-    let info = Column::new()
-        .push(text::p1_regular(email.as_str()).style(theme::text::primary))
+    let mut info = Column::new().push(text::p1_regular(email.as_str()).style(theme::text::primary));
+    if let Some(badge) = badge_row {
+        info = info.push(badge);
+    }
+    let info = info
         .push(text::p2_regular(format!("Joined {}", joined)).color(color::GREY_3))
         .spacing(2);
 

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -780,6 +780,12 @@ impl CoincubeClient {
     /// is already referenced by any vault (W9). Callers should check
     /// `CoincubeError::is_key_already_used_in_vault()` and surface the
     /// conflict dialog.
+    ///
+    /// W16-desktop: a 409 with code `VAULT_KEYHOLDER_LOCKED` (from
+    /// adding `role=keyholder` to an `active` Vault) is reclassified
+    /// into `CoincubeError::VaultKeyholderLocked { vault_id }` before
+    /// returning — callers pattern-match on the variant rather than
+    /// re-parsing the error body.
     pub async fn add_vault_member(
         &self,
         cube_id: u64,
@@ -790,7 +796,14 @@ impl CoincubeClient {
             self.base_url, cube_id
         );
         let res = self.client.post(&url).json(&req).send().await?;
-        let res = res.check_success().await?;
+        let res = res.check_success().await.map_err(|e| {
+            // Reclassify the W16 409 at the boundary so downstream
+            // handlers can `match` on a typed variant.
+            if let Some(vault_id) = super::vault_keyholder_locked_vault_id(&e) {
+                return CoincubeError::VaultKeyholderLocked { vault_id };
+            }
+            CoincubeError::from(e)
+        })?;
         let resp: ApiResponse<VaultMemberResponse> = res.json().await?;
         Ok(resp.data)
     }
@@ -1288,6 +1301,79 @@ mod cube_member_tests {
         assert!(
             !err.is_key_already_used_in_vault(),
             "generic 409 must not match the W9 helper"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_vault_member_409_vault_keyholder_locked_maps_to_error_variant() {
+        // W16-desktop: 409 with code `VAULT_KEYHOLDER_LOCKED` must be
+        // reclassified into the typed `CoincubeError::VaultKeyholderLocked`
+        // variant so the UI can render the tailored "quorum is fixed"
+        // dialog rather than the generic error banner.
+        use crate::services::coincube::{AddVaultMemberRequest, CoincubeError, VaultMemberRole};
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/vault/members");
+            then.status(409)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": false,
+                    "error": {
+                        "code": "VAULT_KEYHOLDER_LOCKED",
+                        "message": "Cannot add a keyholder to an active Vault."
+                    },
+                    "vaultId": 42
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .add_vault_member(
+                42,
+                AddVaultMemberRequest {
+                    contact_id: Some(1),
+                    key_id: Some(2),
+                    role: VaultMemberRole::Keyholder,
+                },
+            )
+            .await
+            .expect_err("expected 409");
+        mock.assert();
+        assert!(
+            matches!(err, CoincubeError::VaultKeyholderLocked { vault_id: 42 }),
+            "expected VaultKeyholderLocked {{ vault_id: 42 }}, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn add_vault_member_role_chooser_hides_keyholder_on_active_vault() {
+        // W16-desktop: the Keyholder role must not be offered when the
+        // target Vault's status is `Active` — the signing quorum is
+        // sealed, so adding a keyholder row would have no on-chain effect.
+        use crate::services::coincube::{allowed_vault_member_roles, VaultMemberRole, VaultStatus};
+        let roles = allowed_vault_member_roles(Some(&VaultStatus::Active));
+        assert!(
+            !roles.contains(&VaultMemberRole::Keyholder),
+            "Active vault must hide the Keyholder role; got {:?}",
+            roles
+        );
+        assert!(roles.contains(&VaultMemberRole::Beneficiary));
+        assert!(roles.contains(&VaultMemberRole::Observer));
+    }
+
+    #[test]
+    fn add_vault_member_role_chooser_shows_keyholder_on_expired_vault() {
+        // On `Expired` (and on any status other than `Active`) the role
+        // picker still offers Keyholder because rebuilding the Vault is
+        // a legitimate follow-up and the backend accepts it.
+        use crate::services::coincube::{allowed_vault_member_roles, VaultMemberRole, VaultStatus};
+        let roles = allowed_vault_member_roles(Some(&VaultStatus::Expired));
+        assert!(
+            roles.contains(&VaultMemberRole::Keyholder),
+            "non-Active vault must include Keyholder; got {:?}",
+            roles
         );
     }
 

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -22,6 +22,15 @@ pub enum CoincubeError {
     Api(String),
     Parse(serde_json::Error),
     SseError(reqwest_sse::error::EventSourceError),
+    /// Typed variant for W16-desktop's 409
+    /// `VAULT_KEYHOLDER_LOCKED`. Reclassified from `Unsuccessful` by
+    /// `add_vault_member` so the dialog handler can match by variant
+    /// instead of re-parsing the error body. `vault_id` is the
+    /// backend's numeric id for the locked vault (extracted from the
+    /// 409 body); `0` when the body is malformed.
+    VaultKeyholderLocked {
+        vault_id: u64,
+    },
 }
 
 impl From<serde_json::Error> for CoincubeError {
@@ -62,6 +71,11 @@ impl std::fmt::Display for CoincubeError {
             CoincubeError::Api(msg) => write!(f, "API error: {}", msg),
             CoincubeError::Parse(msg) => write!(f, "Parse error: {}", msg),
             CoincubeError::SseError(e) => write!(f, "SSE Error: {}", e),
+            CoincubeError::VaultKeyholderLocked { vault_id } => write!(
+                f,
+                "Can't add a keyholder to Vault #{} — the signing quorum is fixed at build time.",
+                vault_id
+            ),
         }
     }
 }
@@ -384,6 +398,13 @@ pub struct CubeResponse {
     pub members: Vec<CubeMember>,
     #[serde(default)]
     pub pending_invites: Vec<CubeInviteSummary>,
+    /// The cube's attached Vault when one exists. Populated by
+    /// `GET /connect/cubes/{id}`; `None` when the cube has no vault
+    /// yet or when served from `list_cubes()` (which omits the
+    /// association). Drives the W16-desktop "Joined after Vault"
+    /// badge and the Keyholder-role gate.
+    #[serde(default)]
+    pub vault: Option<ConnectVaultResponse>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1032,6 +1053,41 @@ pub struct VaultMemberResponse {
     pub created_at: String,
 }
 
+/// Vault lifecycle status. Drives W16-desktop's Keyholder-role gate:
+/// the signing quorum is immutable on `Active` vaults, so the UI must
+/// hide the Keyholder role option there.
+///
+/// `Other(String)` is a forward-compat fallback so an unknown backend
+/// value deserialises as a readable string instead of failing the
+/// whole `ConnectVaultResponse`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(from = "String")]
+pub enum VaultStatus {
+    Active,
+    Expired,
+    Archived,
+    Other(String),
+}
+
+impl From<String> for VaultStatus {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "active" => VaultStatus::Active,
+            "expired" => VaultStatus::Expired,
+            "archived" => VaultStatus::Archived,
+            _ => VaultStatus::Other(s),
+        }
+    }
+}
+
+impl VaultStatus {
+    /// True for vaults whose signing quorum is still sealed — the
+    /// Keyholder-role gate hides the option for these.
+    pub fn is_active(&self) -> bool {
+        matches!(self, VaultStatus::Active)
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectVaultResponse {
@@ -1040,16 +1096,96 @@ pub struct ConnectVaultResponse {
     pub timelock_days: i32,
     pub timelock_expires_at: String,
     pub last_reset_at: String,
-    pub status: String,
+    pub status: VaultStatus,
     #[serde(default)]
     pub members: Vec<VaultMemberResponse>,
     pub created_at: String,
     pub updated_at: String,
 }
 
+/// Which `VaultMemberRole` options the Vault-member add UI should
+/// expose, given the target Vault's current status.
+///
+/// W16-desktop (2026-04-20 product decision): the Bitcoin multisig
+/// descriptor is sealed at Vault-build time. Adding a Keyholder after
+/// the fact would create a DB row that has no effect on signing, so
+/// we hide the option on `Active` vaults and the backend 409s if it
+/// slips through.
+///
+/// On `Expired` / `Archived` vaults (and on any unknown status —
+/// fail-open) Keyholder stays in the list because the backend will
+/// accept it.
+pub fn allowed_vault_member_roles(vault_status: Option<&VaultStatus>) -> Vec<VaultMemberRole> {
+    let mut roles = vec![VaultMemberRole::Beneficiary, VaultMemberRole::Observer];
+    let hide_keyholder = vault_status.is_some_and(|s| s.is_active());
+    if !hide_keyholder {
+        roles.insert(0, VaultMemberRole::Keyholder);
+    }
+    roles
+}
+
+/// True when `member.joined_at` lands strictly after the Vault's
+/// `created_at`. Callers can pass both values as RFC 3339 strings
+/// (what the backend emits); the comparison falls back to
+/// string-lexical order when either value fails to parse, which is
+/// still correct for the `2006-01-02T15:04:05Z` layout the backend
+/// uses.
+pub fn member_joined_after_vault(member_joined_at: &str, vault_created_at: &str) -> bool {
+    // Parse both as RFC 3339; if either fails, fall back to
+    // lex-compare — the backend's fixed `yyyy-MM-ddTHH:mm:ssZ`
+    // format sorts correctly lexically.
+    let member = chrono::DateTime::parse_from_rfc3339(member_joined_at).ok();
+    let vault = chrono::DateTime::parse_from_rfc3339(vault_created_at).ok();
+    match (member, vault) {
+        (Some(m), Some(v)) => m > v,
+        _ => member_joined_at > vault_created_at,
+    }
+}
+
 /// Error code string returned by the backend's W9 guard. Public so callers
 /// can match on it when routing 409s.
 pub const ERR_KEY_ALREADY_USED_IN_VAULT: &str = "KEY_ALREADY_USED_IN_VAULT";
+
+/// Error code returned by the backend's W16 guard (see
+/// `coincube-api` PR 8): 409 from
+/// `POST /connect/cubes/{cubeId}/vault/members` when `role=keyholder`
+/// targets a Vault whose status is `active`. The 409 body carries the
+/// `vaultId` of the locked vault; `add_vault_member` reclassifies
+/// these into `CoincubeError::VaultKeyholderLocked { vault_id }`.
+pub const ERR_VAULT_KEYHOLDER_LOCKED: &str = "VAULT_KEYHOLDER_LOCKED";
+
+/// Body shape of the 409 response for `VAULT_KEYHOLDER_LOCKED`. The
+/// backend inlines `vaultId` at the top level alongside the usual
+/// `error: {code, message}` envelope (same pattern as
+/// `KEY_ALREADY_USED_IN_VAULT`).
+#[derive(Debug, Deserialize)]
+struct VaultKeyholderLockedBody {
+    #[serde(rename = "vaultId", default)]
+    vault_id: u64,
+}
+
+/// Returns `Some(vault_id)` when `info` is a 409 whose error envelope
+/// carries the `VAULT_KEYHOLDER_LOCKED` code. Used by
+/// `add_vault_member` to reclassify the raw `Unsuccessful` into the
+/// typed `CoincubeError::VaultKeyholderLocked` variant.
+pub(crate) fn vault_keyholder_locked_vault_id(
+    info: &crate::services::http::NotSuccessResponseInfo,
+) -> Option<u64> {
+    if info.status_code != 409 {
+        return None;
+    }
+    let env = serde_json::from_str::<ApiErrorResponse>(&info.text).ok()?;
+    if env.error.code != ERR_VAULT_KEYHOLDER_LOCKED {
+        return None;
+    }
+    // vault_id is best-effort: if the backend omits it or sends a
+    // non-u64, fall back to 0 — the caller still gets the typed
+    // variant which is the whole point.
+    let vault_id = serde_json::from_str::<VaultKeyholderLockedBody>(&info.text)
+        .map(|b| b.vault_id)
+        .unwrap_or(0);
+    Some(vault_id)
+}
 
 impl CoincubeError {
     /// Returns `true` if this error is a W9 "key already used in another

--- a/coincube-gui/src/services/mavapay/api.rs
+++ b/coincube-gui/src/services/mavapay/api.rs
@@ -27,6 +27,7 @@ impl<T> From<coincube::CoincubeError> for MavapayApiResult<T> {
             coincube::CoincubeError::Api(msg) => msg.clone(),
             coincube::CoincubeError::Parse(e) => format!("Parse error: {e:?}"),
             coincube::CoincubeError::SseError(e) => format!("EventSource error: {:?}", e),
+            coincube::CoincubeError::VaultKeyholderLocked { .. } => e.to_string(),
         };
 
         MavapayApiResult::Error { message }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes API response models (`CubeResponse`, `ConnectVaultResponse.status`) and reclassifies specific 409 errors into a new `CoincubeError` variant, which can affect deserialization and error handling paths.
> 
> **Overview**
> Adds **Vault-aware state/UI** to the Cube Members panel by storing `vault_created_at` from `GET /connect/cubes/{id}` and rendering a new *"Joined after Vault"* badge (with tooltip) on member rows when a member’s `joined_at` is after the Vault’s `created_at`.
> 
> Extends the coincube service layer to include an optional `vault` on `CubeResponse`, introduces a typed `VaultStatus` enum plus helpers (`allowed_vault_member_roles`, `member_joined_after_vault`), and maps the new backend 409 `VAULT_KEYHOLDER_LOCKED` into `CoincubeError::VaultKeyholderLocked { vault_id }` at the `add_vault_member` boundary. Updates error-to-message conversion in `mavapay/api.rs` and adds focused tests around snapshot preservation, badge gating, role gating, and the new 409 mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f49adff03efacc45b8ed741389b842d0784f49c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->