### PR TITLE
Design cleanup

### DIFF
--- a/coincube-gui/src/app/state/spark/overview.rs
+++ b/coincube-gui/src/app/state/spark/overview.rs
@@ -187,11 +187,15 @@ impl State for SparkOverview {
                 view::SparkOverviewMessage::History => {
                     return redirect(Menu::Spark(SparkSubMenu::Transactions(None)));
                 }
-                view::SparkOverviewMessage::SelectTransaction(_idx) => {
-                    // Spark doesn't expose a transaction-detail panel yet —
-                    // fall back to routing to the Transactions list so the
-                    // user lands somewhere sensible.
-                    return redirect(Menu::Spark(SparkSubMenu::Transactions(None)));
+                view::SparkOverviewMessage::SelectTransaction(idx) => {
+                    if let Some(payment) = self.recent_transactions.get(idx).cloned() {
+                        return Task::batch(vec![
+                            redirect(Menu::Spark(SparkSubMenu::Transactions(None))),
+                            Task::done(Message::View(view::Message::SparkTransactions(
+                                view::SparkTransactionsMessage::Preselect(payment),
+                            ))),
+                        ]);
+                    }
                 }
                 view::SparkOverviewMessage::FlipDisplayMode => {
                     return Task::done(Message::View(view::Message::FlipDisplayMode));
@@ -241,8 +245,10 @@ pub(crate) fn payment_summary_to_recent_tx(
     });
 
     SparkRecentTransaction {
+        id: p.id.clone(),
         description,
         time_ago: format_time_ago(p.timestamp as i64),
+        timestamp: p.timestamp,
         amount,
         fees_sat,
         fiat_amount,

--- a/coincube-gui/src/app/state/spark/receive.rs
+++ b/coincube-gui/src/app/state/spark/receive.rs
@@ -442,16 +442,19 @@ impl State for SparkReceive {
                 self.recent_transactions.clear();
                 Task::none()
             }
-            SparkReceiveMessage::SelectTransaction(_idx) => {
-                // Spark doesn't expose a per-tx detail panel yet —
-                // fall back to the full Transactions list so the user
-                // lands somewhere sensible. When a detail panel lands,
-                // plumb a payment-id field through `SparkRecentTransaction`
-                // and route via a new `SparkSubMenu::Transactions(Some(id))`
-                // shape (the current `Option<Txid>` payload is ignored by
-                // the transactions panel and the wrong type for
-                // Spark-native payment ids, which are strings).
-                redirect(Menu::Spark(SparkSubMenu::Transactions(None)))
+            SparkReceiveMessage::SelectTransaction(idx) => {
+                if let Some(payment) = self.recent_transactions.get(idx).cloned() {
+                    Task::batch(vec![
+                        redirect(Menu::Spark(SparkSubMenu::Transactions(None))),
+                        Task::done(Message::View(
+                            crate::app::view::Message::SparkTransactions(
+                                crate::app::view::SparkTransactionsMessage::Preselect(payment),
+                            ),
+                        )),
+                    ])
+                } else {
+                    Task::none()
+                }
             }
             SparkReceiveMessage::History => redirect(Menu::Spark(SparkSubMenu::Transactions(None))),
         }

--- a/coincube-gui/src/app/state/spark/receive.rs
+++ b/coincube-gui/src/app/state/spark/receive.rs
@@ -446,11 +446,9 @@ impl State for SparkReceive {
                 if let Some(payment) = self.recent_transactions.get(idx).cloned() {
                     Task::batch(vec![
                         redirect(Menu::Spark(SparkSubMenu::Transactions(None))),
-                        Task::done(Message::View(
-                            crate::app::view::Message::SparkTransactions(
-                                crate::app::view::SparkTransactionsMessage::Preselect(payment),
-                            ),
-                        )),
+                        Task::done(Message::View(crate::app::view::Message::SparkTransactions(
+                            crate::app::view::SparkTransactionsMessage::Preselect(payment),
+                        ))),
                     ])
                 } else {
                     Task::none()

--- a/coincube-gui/src/app/state/spark/send.rs
+++ b/coincube-gui/src/app/state/spark/send.rs
@@ -300,11 +300,19 @@ impl State for SparkSend {
                 self.recent_transactions.clear();
                 Task::none()
             }
-            SparkSendMessage::SelectTransaction(_idx) => {
-                // No per-tx detail pane for Spark yet — fall back to
-                // the full transactions list so the user lands
-                // somewhere sensible.
-                redirect(Menu::Spark(SparkSubMenu::Transactions(None)))
+            SparkSendMessage::SelectTransaction(idx) => {
+                if let Some(payment) = self.recent_transactions.get(idx).cloned() {
+                    Task::batch(vec![
+                        redirect(Menu::Spark(SparkSubMenu::Transactions(None))),
+                        Task::done(Message::View(
+                            crate::app::view::Message::SparkTransactions(
+                                crate::app::view::SparkTransactionsMessage::Preselect(payment),
+                            ),
+                        )),
+                    ])
+                } else {
+                    Task::none()
+                }
             }
             SparkSendMessage::History => redirect(Menu::Spark(SparkSubMenu::Transactions(None))),
         }

--- a/coincube-gui/src/app/state/spark/send.rs
+++ b/coincube-gui/src/app/state/spark/send.rs
@@ -304,11 +304,9 @@ impl State for SparkSend {
                 if let Some(payment) = self.recent_transactions.get(idx).cloned() {
                     Task::batch(vec![
                         redirect(Menu::Spark(SparkSubMenu::Transactions(None))),
-                        Task::done(Message::View(
-                            crate::app::view::Message::SparkTransactions(
-                                crate::app::view::SparkTransactionsMessage::Preselect(payment),
-                            ),
-                        )),
+                        Task::done(Message::View(crate::app::view::Message::SparkTransactions(
+                            crate::app::view::SparkTransactionsMessage::Preselect(payment),
+                        ))),
                     ])
                 } else {
                     Task::none()

--- a/coincube-gui/src/app/state/spark/transactions.rs
+++ b/coincube-gui/src/app/state/spark/transactions.rs
@@ -105,7 +105,7 @@ impl State for SparkTransactions {
                 cache,
                 crate::app::view::spark::transactions::transaction_detail_view(
                     payment,
-                    fiat_converter.clone(),
+                    fiat_converter,
                     cache.bitcoin_unit,
                 ),
             );

--- a/coincube-gui/src/app/state/spark/transactions.rs
+++ b/coincube-gui/src/app/state/spark/transactions.rs
@@ -44,6 +44,9 @@ pub struct SparkTransactions {
     loading: bool,
     error: Option<String>,
     modal: SparkTransactionsModal,
+    /// When `Some`, render the detail pane for this payment instead
+    /// of the list. Cleared via `Message::Close` (the back button).
+    selected_payment: Option<SparkRecentTransaction>,
     /// Empty-state Kage quote + image. Picked once when the panel is
     /// constructed so repeated reloads don't re-randomize the quote.
     empty_state_quote: Quote,
@@ -61,6 +64,7 @@ impl SparkTransactions {
             loading: false,
             error: None,
             modal: SparkTransactionsModal::None,
+            selected_payment: None,
             empty_state_quote,
             empty_state_image_handle,
         }
@@ -90,6 +94,21 @@ impl State for SparkTransactions {
     ) -> Element<'a, crate::app::view::Message> {
         let fiat_converter: Option<FiatAmountConverter> =
             cache.fiat_price.as_ref().and_then(|p| p.try_into().ok());
+
+        // When a payment has been selected (via tapping a row here, or
+        // preselected from Overview/Send/Receive), take over the panel
+        // body with the detail view; the back button clears the state
+        // via `Message::Close` and we fall through to the list again.
+        if let Some(payment) = &self.selected_payment {
+            return crate::app::view::dashboard(
+                menu,
+                cache,
+                crate::app::view::spark::transactions::transaction_detail_view(
+                    payment,
+                    cache.bitcoin_unit,
+                ),
+            );
+        }
 
         let status = if self.backend.is_none() {
             SparkTransactionsStatus::Unavailable
@@ -188,8 +207,11 @@ impl State for SparkTransactions {
                         self.loading = false;
                         self.error = Some(err);
                     }
-                    view::SparkTransactionsMessage::Select(_idx) => {
-                        // No detail pane yet — tapping a row is a no-op.
+                    view::SparkTransactionsMessage::Select(idx) => {
+                        self.selected_payment = self.recent_transactions.get(idx).cloned();
+                    }
+                    view::SparkTransactionsMessage::Preselect(payment) => {
+                        self.selected_payment = Some(payment);
                     }
                     view::SparkTransactionsMessage::SendBtc => {
                         return redirect(Menu::Spark(SparkSubMenu::Send));
@@ -198,6 +220,11 @@ impl State for SparkTransactions {
                         return redirect(Menu::Spark(SparkSubMenu::Receive));
                     }
                 }
+            }
+            // Detail pane's back button emits `Message::Close`. Clear
+            // the selection so the next render falls back to the list.
+            Message::View(view::Message::Close) => {
+                self.selected_payment = None;
             }
             // Export flow. Mirrors the Liquid transactions handler:
             // Open → prompt for path → run export → show modal →

--- a/coincube-gui/src/app/state/spark/transactions.rs
+++ b/coincube-gui/src/app/state/spark/transactions.rs
@@ -105,6 +105,7 @@ impl State for SparkTransactions {
                 cache,
                 crate::app::view::spark::transactions::transaction_detail_view(
                     payment,
+                    fiat_converter.clone(),
                     cache.bitcoin_unit,
                 ),
             );
@@ -195,32 +196,30 @@ impl State for SparkTransactions {
         message: Message,
     ) -> Task<Message> {
         match message {
-            Message::View(view::Message::SparkTransactions(msg)) => {
-                match msg {
-                    view::SparkTransactionsMessage::DataLoaded(payments) => {
-                        self.loading = false;
-                        self.payments = payments;
-                        self.error = None;
-                        self.rebuild_rows(cache);
-                    }
-                    view::SparkTransactionsMessage::Error(err) => {
-                        self.loading = false;
-                        self.error = Some(err);
-                    }
-                    view::SparkTransactionsMessage::Select(idx) => {
-                        self.selected_payment = self.recent_transactions.get(idx).cloned();
-                    }
-                    view::SparkTransactionsMessage::Preselect(payment) => {
-                        self.selected_payment = Some(payment);
-                    }
-                    view::SparkTransactionsMessage::SendBtc => {
-                        return redirect(Menu::Spark(SparkSubMenu::Send));
-                    }
-                    view::SparkTransactionsMessage::ReceiveBtc => {
-                        return redirect(Menu::Spark(SparkSubMenu::Receive));
-                    }
+            Message::View(view::Message::SparkTransactions(msg)) => match msg {
+                view::SparkTransactionsMessage::DataLoaded(payments) => {
+                    self.loading = false;
+                    self.payments = payments;
+                    self.error = None;
+                    self.rebuild_rows(cache);
                 }
-            }
+                view::SparkTransactionsMessage::Error(err) => {
+                    self.loading = false;
+                    self.error = Some(err);
+                }
+                view::SparkTransactionsMessage::Select(idx) => {
+                    self.selected_payment = self.recent_transactions.get(idx).cloned();
+                }
+                view::SparkTransactionsMessage::Preselect(payment) => {
+                    self.selected_payment = Some(payment);
+                }
+                view::SparkTransactionsMessage::SendBtc => {
+                    return redirect(Menu::Spark(SparkSubMenu::Send));
+                }
+                view::SparkTransactionsMessage::ReceiveBtc => {
+                    return redirect(Menu::Spark(SparkSubMenu::Receive));
+                }
+            },
             // Detail pane's back button emits `Message::Close`. Clear
             // the selection so the next render falls back to the list.
             Message::View(view::Message::Close) => {

--- a/coincube-gui/src/app/view/buysell/mavapay/ui.rs
+++ b/coincube-gui/src/app/view/buysell/mavapay/ui.rs
@@ -122,15 +122,9 @@ fn buy_input_form<'a>(state: &'a MavapayState) -> widget::Column<'a, BuySellMess
     .style(theme::card::simple)
     .width(Length::Fixed(600.0));
 
-    let previous_btn = widget::button(
-        widget::Row::new()
-            .spacing(5)
-            .align_y(Alignment::Center)
-            .push(previous_icon().style(theme::text::secondary))
-            .push(text::p1_medium("Previous").style(theme::text::secondary)),
-    )
-    .on_press(BuySellMessage::Mavapay(MavapayMessage::NavigateBack))
-    .style(theme::button::transparent);
+    let previous_btn = button::secondary(Some(previous_icon()), "Back")
+        .width(Length::Fixed(150.0))
+        .on_press(BuySellMessage::Mavapay(MavapayMessage::NavigateBack));
 
     widget::column![
         widget::container(previous_btn).width(Length::Fill),
@@ -362,15 +356,9 @@ fn sell_input_form<'a>(
     .spacing(10)
     .width(iced::Length::Fill);
 
-    let previous_btn = widget::button(
-        widget::Row::new()
-            .spacing(5)
-            .align_y(Alignment::Center)
-            .push(previous_icon().style(theme::text::secondary))
-            .push(text::p1_medium("Previous").style(theme::text::secondary)),
-    )
-    .on_press(BuySellMessage::Mavapay(MavapayMessage::NavigateBack))
-    .style(theme::button::transparent);
+    let previous_btn = button::secondary(Some(previous_icon()), "Back")
+        .width(Length::Fixed(150.0))
+        .on_press(BuySellMessage::Mavapay(MavapayMessage::NavigateBack));
 
     widget::column![
         widget::container(previous_btn).width(Length::Fill),
@@ -775,8 +763,8 @@ fn history_view<'a>(state: &'a MavapayState) -> widget::Column<'a, BuySellMessag
     };
 
     widget::column![
-        button::transparent(Some(previous_icon()), "Previous")
-            .width(Length::Shrink)
+        button::secondary(Some(previous_icon()), "Back")
+            .width(Length::Fixed(150.0))
             .on_press(BuySellMessage::ResetWidget),
         widget::Space::new().height(10),
         text::h4_bold("Order History"),

--- a/coincube-gui/src/app/view/buysell/panel.rs
+++ b/coincube-gui/src/app/view/buysell/panel.rs
@@ -276,18 +276,11 @@ impl BuySellPanel {
         // TODO: include form validation messages
         iced::widget::column![
             // Top bar with previous
-            Button::new(
-                Row::new()
-                    .push(previous_icon().style(theme::text::secondary))
-                    .push(Space::new().width(Length::Fixed(5.0)))
-                    .push(text::p1_medium("Previous").style(theme::text::secondary))
-                    .spacing(5)
-                    .align_y(Alignment::Center),
-            )
-            .style(theme::button::transparent)
-            .on_press_maybe(
-                (!*loading).then_some(ViewMessage::BuySell(BuySellMessage::ResetWidget))
-            ),
+            button::secondary(Some(previous_icon()), "Back")
+                .width(Length::Fixed(150.0))
+                .on_press_maybe(
+                    (!*loading).then_some(ViewMessage::BuySell(BuySellMessage::ResetWidget))
+                ),
             Space::new().height(Length::Fixed(10.0)),
             // Title and subtitle
             iced::widget::column![
@@ -337,16 +330,9 @@ impl BuySellPanel {
         // Top bar with previous
         let top_bar = Row::new()
             .push(
-                Button::new(
-                    Row::new()
-                        .push(previous_icon().style(theme::text::secondary))
-                        .push(Space::new().width(Length::Fixed(5.0)))
-                        .push(text::text("Previous").style(theme::text::secondary))
-                        .spacing(5)
-                        .align_y(Alignment::Center),
-                )
-                .style(theme::button::transparent)
-                .on_press_maybe((!*sending).then_some(BuySellMessage::ResetWidget)),
+                button::secondary(Some(previous_icon()), "Back")
+                    .width(Length::Fixed(150.0))
+                    .on_press_maybe((!*sending).then_some(BuySellMessage::ResetWidget)),
             )
             .align_y(Alignment::Center);
 

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -283,16 +283,9 @@ fn register_ux<'a>(email: &'a str, loading: bool) -> Element<'a, ConnectAccountM
 
     Column::new()
         .push(
-            iced::widget::button(
-                Row::new()
-                    .push(previous_icon().color(color::GREY_2))
-                    .push(iced::widget::Space::new().width(Length::Fixed(5.0)))
-                    .push(text::p1_medium("Previous").style(theme::text::secondary))
-                    .spacing(5)
-                    .align_y(Alignment::Center),
-            )
-            .style(theme::button::transparent)
-            .on_press_maybe((!loading).then_some(ConnectAccountMessage::LogOut)),
+            button::secondary(Some(previous_icon()), "Back")
+                .width(Length::Fixed(150.0))
+                .on_press_maybe((!loading).then_some(ConnectAccountMessage::LogOut)),
         )
         .push(iced::widget::Space::new().height(Length::Fixed(10.0)))
         .push(text::h3("Create an Account").style(theme::text::primary))

--- a/coincube-gui/src/app/view/global_home.rs
+++ b/coincube-gui/src/app/view/global_home.rs
@@ -672,7 +672,7 @@ fn enter_amount_view<'a>(
                 .push(
                     Row::new()
                         .push(
-                            button::secondary(None, "< Previous")
+                            button::secondary(None, "< Back")
                                 .width(Length::Fixed(150.0))
                                 .on_press(Message::Home(HomeMessage::PreviousStep)),
                         )
@@ -769,7 +769,7 @@ fn confirm_transfer_view<'a>(
         .width(Length::Fill)
         .push(Space::new().height(Length::Fixed(60.0)))
         .push(
-            button::secondary(None, "< Previous")
+            button::secondary(None, "< Back")
                 .width(Length::Fixed(150.0))
                 .on_press_maybe((!is_sending).then_some(Message::Home(HomeMessage::PreviousStep))),
         )

--- a/coincube-gui/src/app/view/liquid/overview.rs
+++ b/coincube-gui/src/app/view/liquid/overview.rs
@@ -98,7 +98,7 @@ pub fn liquid_overview_view<'a>(
     // L-BTC asset row
     let lbtc_fiat_str = btc_fiat
         .as_ref()
-        .map(|f| format!("~{} {}", f.to_rounded_string(), f.currency()))
+        .map(|f| format!("{} {}", f.to_rounded_string(), f.currency()))
         .unwrap_or_default();
     let lbtc_row = Row::new()
         .spacing(10)
@@ -136,7 +136,7 @@ pub fn liquid_overview_view<'a>(
 
     // USDt asset row
     let usdt_display = format!("{} USDt", format_usdt_display(usdt_balance));
-    let usdt_fiat_str = format!("~${:.2}", usdt_fiat_value);
+    let usdt_fiat_str = format!("${:.2}", usdt_fiat_value);
     let usdt_row = Row::new()
         .spacing(10)
         .align_y(Alignment::Center)
@@ -229,7 +229,7 @@ pub fn liquid_overview_view<'a>(
                 let fiat_str = tx
                     .fiat_amount
                     .as_ref()
-                    .map(|fiat| format!("~{} {}", fiat.to_rounded_string(), fiat.currency()));
+                    .map(|fiat| format!("{} {}", fiat.to_rounded_string(), fiat.currency()));
                 if let Some(fiat) = fiat_str {
                     item = item.with_fiat_amount(fiat);
                 }

--- a/coincube-gui/src/app/view/liquid/receive.rs
+++ b/coincube-gui/src/app/view/liquid/receive.rs
@@ -232,7 +232,7 @@ pub fn liquid_receive_view<'a>(
                 let fiat_str = tx
                     .fiat_amount
                     .as_ref()
-                    .map(|fiat| format!("~{} {}", fiat.to_rounded_string(), fiat.currency()));
+                    .map(|fiat| format!("{} {}", fiat.to_rounded_string(), fiat.currency()));
                 if let Some(fiat) = fiat_str {
                     item = item.with_fiat_amount(fiat);
                 }

--- a/coincube-gui/src/app/view/liquid/send.rs
+++ b/coincube-gui/src/app/view/liquid/send.rs
@@ -474,7 +474,7 @@ pub fn liquid_send_view<'a>(
             } else {
                 tx.fiat_amount
                     .as_ref()
-                    .map(|fiat| format!("~{} {}", fiat.to_rounded_string(), fiat.currency()))
+                    .map(|fiat| format!("{} {}", fiat.to_rounded_string(), fiat.currency()))
             };
 
             let display_amount = if tx.usdt_display.is_some() {
@@ -1308,9 +1308,11 @@ pub fn final_check_page<'a>(
 ) -> Element<'a, LiquidSendMessage> {
     let header = Row::new()
         .push(
-            button::transparent(Some(icon::previous_icon()), "Previous").on_press(
-                LiquidSendMessage::PopupMessage(view::SendPopupMessage::Close),
-            ),
+            button::secondary(Some(icon::previous_icon()), "Back")
+                .width(Length::Fixed(150.0))
+                .on_press(LiquidSendMessage::PopupMessage(
+                    view::SendPopupMessage::Close,
+                )),
         )
         .push(Space::new().width(Length::Fill))
         .width(Length::Fill)

--- a/coincube-gui/src/app/view/liquid/sideshift_receive.rs
+++ b/coincube-gui/src/app/view/liquid/sideshift_receive.rs
@@ -111,15 +111,9 @@ fn external_setup_view<'a>(
     loading: bool,
     error: Option<&'a str>,
 ) -> Element<'a, SideshiftReceiveMessage> {
-    let back_btn = iced::widget::button(
-        Row::new()
-            .spacing(5)
-            .align_y(Alignment::Center)
-            .push(previous_icon().style(theme::text::secondary))
-            .push(text("Previous").size(P1_SIZE).style(theme::text::secondary)),
-    )
-    .on_press(SideshiftReceiveMessage::Back)
-    .style(theme::button::transparent);
+    let back_btn = button::secondary(Some(previous_icon()), "Back")
+        .width(Length::Fixed(150.0))
+        .on_press(SideshiftReceiveMessage::Back);
 
     let title = Column::new()
         .spacing(4)

--- a/coincube-gui/src/app/view/liquid/sideshift_send.rs
+++ b/coincube-gui/src/app/view/liquid/sideshift_send.rs
@@ -301,15 +301,9 @@ fn disambiguation_view<'a>(
     detected_networks: &[SideshiftNetwork],
     error: Option<&'a str>,
 ) -> Element<'a, SideshiftSendMessage> {
-    let back_btn = iced::widget::button(
-        Row::new()
-            .spacing(5)
-            .align_y(Alignment::Center)
-            .push(previous_icon().style(theme::text::secondary))
-            .push(text("Previous").size(P1_SIZE).style(theme::text::secondary)),
-    )
-    .on_press(SideshiftSendMessage::Back)
-    .style(theme::button::transparent);
+    let back_btn = button::secondary(Some(previous_icon()), "Back")
+        .width(Length::Fixed(150.0))
+        .on_press(SideshiftSendMessage::Back);
 
     let title = Column::new().spacing(4).push(h3("Select Network")).push(
         text("This address is compatible with multiple networks. Please select one.")
@@ -418,15 +412,9 @@ fn amount_input_view<'a>(
         .copied()
         .unwrap_or(SideshiftNetwork::Ethereum);
 
-    let back_btn = iced::widget::button(
-        Row::new()
-            .spacing(5)
-            .align_y(Alignment::Center)
-            .push(previous_icon().style(theme::text::secondary))
-            .push(text("Previous").size(P1_SIZE).style(theme::text::secondary)),
-    )
-    .on_press(SideshiftSendMessage::Back)
-    .style(theme::button::transparent);
+    let back_btn = button::secondary(Some(previous_icon()), "Back")
+        .width(Length::Fixed(150.0))
+        .on_press(SideshiftSendMessage::Back);
 
     let title = Column::new()
         .spacing(4)
@@ -609,16 +597,9 @@ fn review_view<'a>(
     .style(theme::card::simple)
     .width(Length::Fill);
 
-    let back_btn = iced::widget::button(
-        Row::new()
-            .spacing(5)
-            .align_y(Alignment::Center)
-            .push(previous_icon().style(theme::text::secondary))
-            .push(text("Previous").size(P1_SIZE).style(theme::text::secondary)),
-    )
-    .on_press(SideshiftSendMessage::Back)
-    .style(theme::button::transparent)
-    .width(Length::FillPortion(1));
+    let back_btn = button::secondary(Some(previous_icon()), "Back")
+        .on_press(SideshiftSendMessage::Back)
+        .width(Length::FillPortion(1));
 
     let confirm_btn = button::primary(None, "Confirm & Send")
         .on_press(SideshiftSendMessage::ConfirmSend)

--- a/coincube-gui/src/app/view/liquid/transactions.rs
+++ b/coincube-gui/src/app/view/liquid/transactions.rs
@@ -315,7 +315,7 @@ fn transaction_row<'a>(
 
     if let Some(fiat_amount) = fiat_converter.map(|converter| {
         let fiat = converter.convert(btc_amount);
-        format!("~{} {}", fiat.to_rounded_string(), fiat.currency())
+        format!("{} {}", fiat.to_rounded_string(), fiat.currency())
     }) {
         item = item.with_fiat_amount(fiat_amount);
     }
@@ -359,7 +359,7 @@ fn refundable_row<'a>(
 
     if let Some(fiat_amount) = fiat_converter.map(|converter| {
         let fiat = converter.convert(btc_amount);
-        format!("~{} {}", fiat.to_rounded_string(), fiat.currency())
+        format!("{} {}", fiat.to_rounded_string(), fiat.currency())
     }) {
         item = item.with_fiat_amount(fiat_amount);
     }
@@ -879,16 +879,10 @@ pub fn refundable_detail_view<'a>(
 }
 
 fn detail_back_button() -> Element<'static, Message> {
-    iced::widget::button(
-        Row::new()
-            .spacing(5)
-            .align_y(Alignment::Center)
-            .push(icon::previous_icon().style(theme::text::secondary))
-            .push(text("Previous").size(14).style(theme::text::secondary)),
-    )
-    .on_press(Message::Close)
-    .style(theme::button::transparent)
-    .into()
+    button::secondary(None, "< Back")
+        .width(Length::Fixed(150.0))
+        .on_press(Message::Close)
+        .into()
 }
 
 #[cfg(test)]

--- a/coincube-gui/src/app/view/mod.rs
+++ b/coincube-gui/src/app/view/mod.rs
@@ -209,7 +209,9 @@ pub fn modal<'a, T: Into<Element<'a, Message>>, F: Into<Element<'a, Message>>>(
                     .push(if is_previous {
                         Column::new()
                             .push(
-                                button::transparent(None, "< Previous").on_press(Message::Previous),
+                                button::secondary(None, "< Back")
+                                    .width(Length::Fixed(150.0))
+                                    .on_press(Message::Previous),
                             )
                             .width(Length::Fill)
                     } else {

--- a/coincube-gui/src/app/view/settings/backup.rs
+++ b/coincube-gui/src/app/view/settings/backup.rs
@@ -23,14 +23,14 @@ fn wrap(msg: BackupWalletMessage) -> Message {
     Message::Settings(SettingsMessage::BackupMasterSeed(msg))
 }
 
-/// Header for backup wizard screens: a single "< Previous" button
+/// Header for backup wizard screens: a single "< Back" button
 /// that rolls back one step in the flow.
 fn header<'a>(_title: &'a str) -> Element<'a, Message> {
     Row::new()
         .spacing(10)
         .align_y(Alignment::Center)
         .push(
-            ui_button::secondary(None, "< Previous")
+            ui_button::secondary(None, "< Back")
                 .on_press(wrap(BackupWalletMessage::PreviousStep))
                 .padding([8, 16])
                 .width(Length::Fixed(150.0)),

--- a/coincube-gui/src/app/view/spark/last_tx.rs
+++ b/coincube-gui/src/app/view/spark/last_tx.rs
@@ -69,7 +69,7 @@ pub fn last_transactions_section<'a, M: 'a + Clone + 'static>(
 
         if let Some(fiat) = tx.fiat_amount.as_ref() {
             item =
-                item.with_fiat_amount(format!("~{} {}", fiat.to_rounded_string(), fiat.currency()));
+                item.with_fiat_amount(format!("{} {}", fiat.to_rounded_string(), fiat.currency()));
         }
 
         if matches!(tx.status, DomainPaymentStatus::Pending) {

--- a/coincube-gui/src/app/view/spark/mod.rs
+++ b/coincube-gui/src/app/view/spark/mod.rs
@@ -51,10 +51,14 @@ pub enum SparkTransactionsMessage {
     DataLoaded(Vec<coincube_spark_protocol::PaymentSummary>),
     /// Bridge returned an error response for `list_payments`.
     Error(String),
-    /// User clicked a row. Today this just no-ops — a Spark
-    /// transaction-detail pane is a future polish pass, so a click
-    /// stays on the list rather than navigating away.
+    /// User clicked a row. Opens the detail pane for the payment
+    /// at that index in the current `recent_transactions` list.
     Select(usize),
+    /// Preselect a specific payment to display in the detail pane —
+    /// used by Overview / Send / Receive to hand off a row when the
+    /// user taps there. The panel switches into detail mode without
+    /// needing an index lookup against its own list.
+    Preselect(crate::app::view::spark::SparkRecentTransaction),
     /// Empty-state navigation: "Send sats" button.
     SendBtc,
     /// Empty-state navigation: "Receive sats" button.

--- a/coincube-gui/src/app/view/spark/overview.rs
+++ b/coincube-gui/src/app/view/spark/overview.rs
@@ -62,9 +62,16 @@ pub enum SparkPaymentMethod {
 /// Row data the overview renderer needs for each recent payment.
 /// Mirrors `view::liquid::RecentTransaction` but drops the USDt-only
 /// `usdt_display` field (Spark has no USDt support).
+///
+/// Carries the Spark payment `id` and raw `timestamp` so the detail
+/// view can render a full date and a copy-to-clipboard payment ID
+/// without needing to hold onto the originating `PaymentSummary`.
+#[derive(Debug, Clone)]
 pub struct SparkRecentTransaction {
+    pub id: String,
     pub description: String,
     pub time_ago: String,
+    pub timestamp: u64,
     pub amount: Amount,
     pub fees_sat: Amount,
     pub fiat_amount: Option<FiatAmount>,
@@ -176,7 +183,7 @@ fn connected_view<'a>(
 
     let btc_fiat_str = btc_fiat
         .as_ref()
-        .map(|f| format!("~{} {}", f.to_rounded_string(), f.currency()))
+        .map(|f| format!("{} {}", f.to_rounded_string(), f.currency()))
         .unwrap_or_default();
     let btc_row = Row::new()
         .spacing(10)

--- a/coincube-gui/src/app/view/spark/overview.rs
+++ b/coincube-gui/src/app/view/spark/overview.rs
@@ -264,7 +264,7 @@ fn connected_view<'a>(
 
             if let Some(fiat) = tx.fiat_amount.as_ref() {
                 item = item.with_fiat_amount(format!(
-                    "~{} {}",
+                    "{} {}",
                     fiat.to_rounded_string(),
                     fiat.currency()
                 ));

--- a/coincube-gui/src/app/view/spark/transactions.rs
+++ b/coincube-gui/src/app/view/spark/transactions.rs
@@ -223,6 +223,7 @@ fn transaction_row<'a>(
 /// emit — not just Complete/Pending.
 pub fn transaction_detail_view<'a>(
     tx: &'a SparkRecentTransaction,
+    fiat_converter: Option<FiatAmountConverter>,
     bitcoin_unit: BitcoinDisplayUnit,
 ) -> Element<'a, Message> {
     let is_incoming = tx.is_incoming;
@@ -232,6 +233,17 @@ pub fn transaction_detail_view<'a>(
         "Outgoing payment"
     };
     let sign = if is_incoming { "+" } else { "-" };
+
+    // For outgoing, the headline number bundles fees so the detail
+    // matches the list-row total the user tapped. Fees are still listed
+    // separately further down. Recompute the fiat off the same total
+    // rather than reusing `tx.fiat_amount`, which is amount-only.
+    let total_amount = if is_incoming {
+        tx.amount
+    } else {
+        tx.amount + tx.fees_sat
+    };
+    let total_fiat = fiat_converter.as_ref().map(|c| c.convert(total_amount));
 
     let method_icon = match tx.method {
         SparkPaymentMethod::Lightning => asset_network_logo::<Message>("btc", "lightning", 56.0),
@@ -260,8 +272,7 @@ pub fn transaction_detail_view<'a>(
         DomainPaymentStatus::WaitingFeeAcceptance => "Awaiting fee",
     };
     let date_text = format_timestamp(tx.timestamp).unwrap_or_else(|| "Unknown".to_string());
-    let fiat_str = tx
-        .fiat_amount
+    let fiat_str = total_fiat
         .as_ref()
         .map(|f| format!("{} {}", f.to_rounded_string(), f.currency()));
 
@@ -270,7 +281,7 @@ pub fn transaction_detail_view<'a>(
         .align_y(Alignment::Center)
         .push(text(sign).size(H1_SIZE))
         .push(amount_with_size_and_unit::<Message>(
-            &tx.amount,
+            &total_amount,
             H1_SIZE,
             bitcoin_unit,
         ));

--- a/coincube-gui/src/app/view/spark/transactions.rs
+++ b/coincube-gui/src/app/view/spark/transactions.rs
@@ -20,11 +20,13 @@ use coincube_core::miniscript::bitcoin::Amount;
 use coincube_spark_protocol::PaymentSummary;
 use iced::widget::image;
 
+use crate::app::wallets::DomainPaymentStatus;
 use crate::export::ImportExportMessage;
+use crate::utils::{format_timestamp, truncate_middle};
 use coincube_ui::{
     component::{
-        amount::BitcoinDisplayUnit,
-        button,
+        amount::{amount_with_size_and_unit, BitcoinDisplayUnit},
+        button, card,
         quote_display::{self, Quote, QuoteDisplayProps},
         text::*,
         transaction::{TransactionDirection, TransactionListItem},
@@ -34,10 +36,7 @@ use coincube_ui::{
     theme,
     widget::*,
 };
-use iced::{
-    widget::{Column, Container, Row, Space},
-    Alignment, Length,
-};
+use iced::{widget::Space, Alignment, Length};
 
 use crate::app::menu::{Menu, SparkSubMenu};
 use crate::app::view::message::Message;
@@ -200,7 +199,7 @@ fn transaction_row<'a>(
 
     if let Some(fiat_amount) = fiat_converter.map(|converter| {
         let fiat = converter.convert(display_amount);
-        format!("~{} {}", fiat.to_rounded_string(), fiat.currency())
+        format!("{} {}", fiat.to_rounded_string(), fiat.currency())
     }) {
         item = item.with_fiat_amount(fiat_amount);
     }
@@ -212,6 +211,137 @@ fn transaction_row<'a>(
         crate::app::view::spark::SparkTransactionsMessage::Select(i),
     ))
     .into()
+}
+
+/// Render the single-payment detail pane. Consumed by
+/// `SparkTransactions` state when `selected_payment` is `Some`, and
+/// also by Overview/Send/Receive's preselect flow. Richer than the
+/// Liquid detail view: surfaces the raw Spark payment ID (with a
+/// copy-to-clipboard affordance), a humanised payment-method row
+/// (Lightning / On-chain Bitcoin / Spark transfer), and a Status row
+/// that reflects every `DomainPaymentStatus` variant the bridge can
+/// emit — not just Complete/Pending.
+pub fn transaction_detail_view<'a>(
+    tx: &'a SparkRecentTransaction,
+    bitcoin_unit: BitcoinDisplayUnit,
+) -> Element<'a, Message> {
+    let is_incoming = tx.is_incoming;
+    let title = if is_incoming {
+        "Incoming payment"
+    } else {
+        "Outgoing payment"
+    };
+    let sign = if is_incoming { "+" } else { "-" };
+
+    let method_icon = match tx.method {
+        SparkPaymentMethod::Lightning => asset_network_logo::<Message>("btc", "lightning", 56.0),
+        SparkPaymentMethod::OnChainBitcoin => asset_network_logo::<Message>("btc", "bitcoin", 56.0),
+        SparkPaymentMethod::Spark => asset_network_logo::<Message>("btc", "spark", 56.0),
+    };
+    let method_text = match tx.method {
+        SparkPaymentMethod::Lightning => "Lightning payment",
+        SparkPaymentMethod::OnChainBitcoin => {
+            if is_incoming {
+                "On-chain deposit"
+            } else {
+                "On-chain withdrawal"
+            }
+        }
+        SparkPaymentMethod::Spark => "Spark transfer",
+    };
+    let status_text = match tx.status {
+        DomainPaymentStatus::Complete => "Completed",
+        DomainPaymentStatus::Pending => "Pending",
+        DomainPaymentStatus::Failed => "Failed",
+        DomainPaymentStatus::TimedOut => "Timed out",
+        DomainPaymentStatus::Created => "Created",
+        DomainPaymentStatus::Refundable => "Refundable",
+        DomainPaymentStatus::RefundPending => "Refund pending",
+        DomainPaymentStatus::WaitingFeeAcceptance => "Awaiting fee",
+    };
+    let date_text = format_timestamp(tx.timestamp).unwrap_or_else(|| "Unknown".to_string());
+    let fiat_str = tx
+        .fiat_amount
+        .as_ref()
+        .map(|f| format!("{} {}", f.to_rounded_string(), f.currency()));
+
+    let amount_row = Row::new()
+        .spacing(10)
+        .align_y(Alignment::Center)
+        .push(text(sign).size(H1_SIZE))
+        .push(amount_with_size_and_unit::<Message>(
+            &tx.amount,
+            H1_SIZE,
+            bitcoin_unit,
+        ));
+
+    let mut amount_block = Column::new().spacing(4).push(amount_row);
+    if let Some(s) = fiat_str {
+        amount_block = amount_block.push(text(s).size(P1_SIZE).style(theme::text::secondary));
+    }
+
+    let kv = |label: &'static str, value: Element<'a, Message>| -> Row<'a, Message> {
+        Row::new()
+            .spacing(20)
+            .push(
+                Column::new()
+                    .width(Length::FillPortion(1))
+                    .push(text(label).bold()),
+            )
+            .push(Column::new().width(Length::FillPortion(2)).push(value))
+    };
+
+    let payment_id_display = truncate_middle(&tx.id, 10, 10);
+    let payment_id_row: Element<'a, Message> = Row::new()
+        .spacing(8)
+        .align_y(Alignment::Center)
+        .push(text(payment_id_display).small())
+        .push(
+            iced::widget::Button::new(icon::clipboard_icon())
+                .on_press(Message::Clipboard(tx.id.clone()))
+                .style(theme::button::transparent_border),
+        )
+        .into();
+
+    let mut info = Column::new()
+        .spacing(15)
+        .push(kv("Date", text(date_text).into()))
+        .push(kv("Status", text(status_text).into()))
+        .push(kv("Method", text(method_text).into()))
+        .push(kv("Payment ID", payment_id_row));
+
+    if tx.fees_sat.to_sat() > 0 {
+        info = info.push(kv(
+            "Fees",
+            amount_with_size_and_unit::<Message>(&tx.fees_sat, P1_SIZE, bitcoin_unit).into(),
+        ));
+    }
+
+    Column::new()
+        .spacing(20)
+        .push(detail_back_button())
+        .push(Container::new(h3(title)).width(Length::Fill))
+        .push(
+            Row::new()
+                .spacing(16)
+                .align_y(Alignment::Center)
+                .push(method_icon)
+                .push(amount_block),
+        )
+        .push(
+            text(tx.description.clone())
+                .size(P1_SIZE)
+                .style(theme::text::secondary),
+        )
+        .push(card::simple(info))
+        .into()
+}
+
+fn detail_back_button() -> Element<'static, Message> {
+    button::secondary(None, "< Back")
+        .width(Length::Fixed(150.0))
+        .on_press(Message::Close)
+        .into()
 }
 
 // `Amount` is kept in scope for future use (e.g. the detail pane).

--- a/coincube-gui/src/app/view/spark/transactions.rs
+++ b/coincube-gui/src/app/view/spark/transactions.rs
@@ -204,9 +204,6 @@ fn transaction_row<'a>(
         item = item.with_fiat_amount(fiat_amount);
     }
 
-    // Phase 7 fallback: clicking a row currently just no-ops via the
-    // panel's message handler. A detail pane can land later.
-    let _ = i;
     item.view(Message::SparkTransactions(
         crate::app::view::spark::SparkTransactionsMessage::Select(i),
     ))

--- a/coincube-gui/src/app/view/vault/fiat.rs
+++ b/coincube-gui/src/app/view/vault/fiat.rs
@@ -64,10 +64,13 @@ impl FiatAmount {
         format_f64_as_string(self.amount, "", self.currency().decimals(), false)
     }
 
-    /// Format a fiat amount as a `Text` widget with a tilde (~) prefix to indicate approximation.
+    /// Format a fiat amount as a `Text` widget: `<value> <currency-code>`
+    /// (e.g. "104.43 USD", "89.35 EUR"). Per design feedback, the leading
+    /// tilde that used to indicate approximation has been dropped across
+    /// all fiat display surfaces.
     pub fn to_text(&self) -> Text<'static> {
         text(format!(
-            "~{} {}",
+            "{} {}",
             self.to_formatted_string(),
             self.currency(),
         ))

--- a/coincube-gui/src/app/view/vault/overview.rs
+++ b/coincube-gui/src/app/view/vault/overview.rs
@@ -117,7 +117,7 @@ pub fn vault_overview_view<'a>(
     });
     let btc_fiat_str = fiat_balance
         .as_ref()
-        .map(|f| format!("~{} {}", f.to_rounded_string(), f.currency()))
+        .map(|f| format!("{} {}", f.to_rounded_string(), f.currency()))
         .unwrap_or_default();
     let vault_btc_row = Row::new()
         .spacing(10)
@@ -383,7 +383,7 @@ fn event_list_view(
 
     if let Some(fiat_amount) = fiat_converter.map(|converter| {
         let fiat = converter.convert(event.amount);
-        format!("~{} {}", fiat.to_rounded_string(), fiat.currency())
+        format!("{} {}", fiat.to_rounded_string(), fiat.currency())
     }) {
         item = item.with_fiat_amount(fiat_amount);
     }

--- a/coincube-gui/src/app/view/vault/spend/mod.rs
+++ b/coincube-gui/src/app/view/vault/spend/mod.rs
@@ -119,7 +119,7 @@ pub fn spend_view<'a>(
             } else {
                 Row::new()
                     .push(
-                        button::secondary(None, "< Previous")
+                        button::secondary(None, "< Back")
                             .width(Length::Fixed(150.0))
                             .on_press_maybe(if currently_signing {
                                 None
@@ -497,7 +497,7 @@ pub fn create_spend_tx<'a>(
                     }))
                     .push(
                         (!is_first_step).then_some(
-                            button::secondary(None, "< Previous")
+                            button::secondary(None, "< Back")
                                 .width(Length::Fixed(150.0))
                                 .on_press(Message::Previous),
                         ),
@@ -647,7 +647,7 @@ pub fn recipient_view<'a>(
                                     .align_y(Alignment::Center)
                                     .spacing(5)
                                     .push(Space::new().width(Length::Fixed(20.0))) // add some space between BTC and fiat amounts
-                                    .push(p1_bold(format!("~{}", conv.currency())))
+                                    .push(p1_bold(format!("{}", conv.currency())))
                                     .push(Space::new().width(Length::Fixed(5.0)))
                                     .push(if is_max_selected {
                                         let fiat_from_btc = btc_amt

--- a/coincube-gui/src/app/view/vault/transactions.rs
+++ b/coincube-gui/src/app/view/vault/transactions.rs
@@ -167,7 +167,7 @@ fn tx_list_view(
 
     if let Some(fiat_amount) = fiat_converter.map(|converter| {
         let fiat = converter.convert(*amount);
-        format!("~{} {}", fiat.to_rounded_string(), fiat.currency())
+        format!("{} {}", fiat.to_rounded_string(), fiat.currency())
     }) {
         item = item.with_fiat_amount(fiat_amount);
     }
@@ -314,16 +314,10 @@ pub fn transaction_detail_view<'a>(
     bitcoin_unit: BitcoinDisplayUnit,
 ) -> Element<'a, Message> {
     let txid = tx.tx.compute_txid().to_string();
-    let back_btn: Element<'_, Message> = iced::widget::button(
-        Row::new()
-            .spacing(5)
-            .align_y(Alignment::Center)
-            .push(icon::previous_icon().style(theme::text::secondary))
-            .push(text("Previous").size(14).style(theme::text::secondary)),
-    )
-    .on_press(Message::Close)
-    .style(theme::button::transparent)
-    .into();
+    let back_btn: Element<'_, Message> = button::secondary(Some(icon::previous_icon()), "Back")
+        .width(Length::Fixed(150.0))
+        .on_press(Message::Close)
+        .into();
 
     dashboard(
         menu,

--- a/coincube-gui/src/app/view/wallet_header.rs
+++ b/coincube-gui/src/app/view/wallet_header.rs
@@ -311,8 +311,6 @@ enum FiatStyle {
 }
 
 /// Render a fiat amount as a styled Row:
-/// - Leading "~" approximation marker at `value_size`, in `color::GREY_3`
-///   to match the SATS suffix on the bitcoin line.
 /// - For USD, the dollar sign is glued to the value as a prefix
 ///   (`$X.XX`) and styled like the value (bold + value_size in
 ///   Primary mode; dimmed + value_size in Secondary mode).
@@ -326,10 +324,7 @@ fn fiat_amount_row<'a, M: 'a>(fiat: &FiatAmount, value_size: u32, style: FiatSty
         FiatStyle::Secondary => text(value_str).size(value_size).color(color::GREY_3),
     };
 
-    let mut row = Row::<'a, M>::new()
-        .spacing(8)
-        .align_y(Alignment::Center)
-        .push(text("~").size(value_size).color(color::GREY_3));
+    let row = Row::<'a, M>::new().spacing(8).align_y(Alignment::Center);
 
     match fiat.currency() {
         Currency::USD => {
@@ -339,23 +334,20 @@ fn fiat_amount_row<'a, M: 'a>(fiat: &FiatAmount, value_size: u32, style: FiatSty
             };
             // Joined "$X.XX" — group prefix + value in an inner row with
             // zero spacing so the sigil sits flush against the number.
-            row = row.push(
+            row.push(
                 Row::<'a, M>::new()
                     .spacing(0)
                     .align_y(Alignment::Center)
                     .push(prefix)
                     .push(value_text),
-            );
+            )
         }
-        other => {
-            row = row.push(value_text).push(
-                text(other.to_string())
-                    .size(value_size)
-                    .color(color::GREY_3),
-            );
-        }
+        other => row.push(value_text).push(
+            text(other.to_string())
+                .size(value_size)
+                .color(color::GREY_3),
+        ),
     }
-    row
 }
 
 fn pending_row<'a, M: 'a>(

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -2586,8 +2586,8 @@ fn layout<'a>(
     padding_left: bool,
     previous_message: Option<Message>,
 ) -> Element<'a, Message> {
-    let mut prev_button = button::secondary(Some(icon::previous_icon()), "Back")
-        .width(Length::Fixed(150.0));
+    let mut prev_button =
+        button::secondary(Some(icon::previous_icon()), "Back").width(Length::Fixed(150.0));
     if let Some(msg) = previous_message {
         prev_button = prev_button.on_press(msg);
     }

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -2586,7 +2586,8 @@ fn layout<'a>(
     padding_left: bool,
     previous_message: Option<Message>,
 ) -> Element<'a, Message> {
-    let mut prev_button = button::transparent(Some(icon::previous_icon()), "Previous");
+    let mut prev_button = button::secondary(Some(icon::previous_icon()), "Back")
+        .width(Length::Fixed(150.0));
     if let Some(msg) = previous_message {
         prev_button = prev_button.on_press(msg);
     }

--- a/coincube-gui/src/pin_entry.rs
+++ b/coincube-gui/src/pin_entry.rs
@@ -127,8 +127,9 @@ impl PinEntry {
             .into();
         }
 
-        let back_button =
-            button::transparent(Some(icon::previous_icon()), "Previous").on_press(Message::Back);
+        let back_button = button::secondary(Some(icon::previous_icon()), "Back")
+            .width(Length::Fixed(150.0))
+            .on_press(Message::Back);
 
         let header = Row::new()
             .align_y(Alignment::Center)

--- a/coincube-gui/src/services/passkey/macos.rs
+++ b/coincube-gui/src/services/passkey/macos.rs
@@ -6,8 +6,11 @@
 //! the platform authenticator (Touch ID / Face ID via iCloud Keychain).
 //!
 //! Requires macOS 14 (Sonoma) or later for the PRF extension.
+//!
+//! Module gating lives on the `pub mod macos;` declaration in
+//! `services/passkey/mod.rs` — a redundant inner `#![cfg]` would be a
+//! clippy `duplicated_attributes` warning.
 
-#![cfg(target_os = "macos")]
 #![allow(unexpected_cfgs)]
 
 use std::cell::OnceCell;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new Spark transaction selection/detail navigation and cross-panel preselection, which touches view/state message flows and could introduce routing/selection edge cases; most other changes are low-risk UI text/styling tweaks.
> 
> **Overview**
> Adds a Spark transaction *detail pane*: transactions are now selectable (including via a new `Preselect` message from Overview/Send/Receive), showing status/method/date, total amounts (incl. outgoing fees), and a copy-to-clipboard Spark payment ID.
> 
> Standardizes navigation and formatting across the GUI by renaming “Previous” to “Back”, switching various screens to a consistent secondary back button (often fixed width), and removing the “~” approximation prefix from fiat displays (including `FiatAmount::to_text` and multiple wallet/transaction surfaces). Also removes redundant macOS-only `cfg` gating inside `services/passkey/macos.rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4ce95048b16ced2f5457821b213a8e3745b702c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spark gains a transaction detail pane showing full payment info, timestamp and copyable ID; Overview/Send/Receive can preselect and open a specific transaction.

* **UI/UX Improvements**
  * Standardized navigation labels to "Back" across the app.
  * Fiat amounts no longer show the approximation tilde.

* **Chores**
  * Unified secondary button styling and fixed widths for consistent layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->