### PR TITLE
Master Key usage cleanup for Vault

### DIFF
--- a/coincube-gui/src/installer/prompt.rs
+++ b/coincube-gui/src/installer/prompt.rs
@@ -3,10 +3,10 @@ Click “Back Up Descriptor” to download an encrypted file of your wallet conf
 You can also copy the plain-text descriptor string, but it’s less private.
 ⚠️ This file does not include your seed phrase(s). Back those up separately.";
 pub const BACKUP_DESCRIPTOR_HELP: &str = "In Bitcoin, to spend from a wallet that isn't a standard single-key setup, you need both your private keys (usually stored as seed words) to sign transactions, and your wallet descriptor to locate your coins — like a map of your addresses.
-Without the descriptor, your wallet may not find your coins — even if you still have the keys. 
-When you click “Back Up Descriptor”, Coincube creates an encrypted file that can only be decrypted using one of your wallet’s public keys. 
+Without the descriptor, your wallet may not find your coins — even if you still have the keys.
+When you click “Back Up Descriptor”, Coincube creates an encrypted file that can only be decrypted using one of your wallet’s public keys.
 Coincube handles this automatically during the restore of a wallet process by asking you to connect a device or enter a key.
 This file is safer and more private than copying the descriptor manually.";
 pub const REGISTER_DESCRIPTOR_HELP: &str = "To be used with the wallet, a signing device needs the descriptor. If the descriptor contains one or more keys imported from an external signing device, the descriptor must be registered on it. Registration confirms that the device is able to handle the policy. Registration on a device is not a substitute for backing up the descriptor.";
-pub const MNEMONIC_HELP: &str = "A hot key generated on this computer was used for creating this wallet. It needs to be backed up. \n Keep it in a safe place. Never share it with anyone.";
+pub const MNEMONIC_HELP: &str = "This Vault key is derived from your Master Key. If you haven't already, back up your Master Seed Phrase in Settings → Master Seed Phrase Back Up — it's required to recover your Cube and every Vault key derived from it.";
 pub const RECOVER_MNEMONIC_HELP: &str = "If you were using a hot key (a key stored on the computer) in your wallet, you will need to recover it from mnemonics to be able to sign transactions again. Otherwise you can directly go the next step.";

--- a/coincube-gui/src/installer/prompt.rs
+++ b/coincube-gui/src/installer/prompt.rs
@@ -4,9 +4,9 @@ You can also copy the plain-text descriptor string, but it’s less private.
 ⚠️ This file does not include your seed phrase(s). Back those up separately.";
 pub const BACKUP_DESCRIPTOR_HELP: &str = "In Bitcoin, to spend from a wallet that isn't a standard single-key setup, you need both your private keys (usually stored as seed words) to sign transactions, and your wallet descriptor to locate your coins — like a map of your addresses.
 Without the descriptor, your wallet may not find your coins — even if you still have the keys.
-When you click “Back Up Descriptor”, Coincube creates an encrypted file that can only be decrypted using one of your wallet’s public keys.
+When you click “Back Up Descriptor”, Coincube creates an encrypted file that can only be decrypted by the holder of the corresponding private key — meaning recovery requires one of your wallet’s private keys or signing devices, not a public key.
 Coincube handles this automatically during the restore of a wallet process by asking you to connect a device or enter a key.
 This file is safer and more private than copying the descriptor manually.";
 pub const REGISTER_DESCRIPTOR_HELP: &str = "To be used with the wallet, a signing device needs the descriptor. If the descriptor contains one or more keys imported from an external signing device, the descriptor must be registered on it. Registration confirms that the device is able to handle the policy. Registration on a device is not a substitute for backing up the descriptor.";
 pub const MNEMONIC_HELP: &str = "This Vault key is derived from your Master Key. If you haven't already, back up your Master Seed Phrase in Settings → Master Seed Phrase Back Up — it's required to recover your Cube and every Vault key derived from it.";
-pub const RECOVER_MNEMONIC_HELP: &str = "If you were using a hot key (a key stored on the computer) in your wallet, you will need to recover it from mnemonics to be able to sign transactions again. Otherwise you can directly go the next step.";
+pub const RECOVER_MNEMONIC_HELP: &str = "If you were using a Vault key stored locally in your wallet, you will need to recover it from your Master Seed Phrase to be able to sign transactions again. Otherwise you can directly go to the next step.";

--- a/coincube-gui/src/installer/step/mnemonic.rs
+++ b/coincube-gui/src/installer/step/mnemonic.rs
@@ -13,19 +13,12 @@ use crate::{
 };
 
 pub struct BackupMnemonic {
-    words: [&'static str; 12],
-    done: bool,
     signer: Arc<Mutex<Signer>>,
 }
 
 impl BackupMnemonic {
     pub fn new(signer: Arc<Mutex<Signer>>) -> Self {
-        let words = signer.lock().unwrap().mnemonic();
-        Self {
-            done: false,
-            words,
-            signer,
-        }
+        Self { signer }
     }
 }
 
@@ -36,10 +29,7 @@ impl From<BackupMnemonic> for Box<dyn Step> {
 }
 
 impl Step for BackupMnemonic {
-    fn update(&mut self, _hws: &mut HardwareWallets, message: Message) -> Task<Message> {
-        if let Message::UserActionDone(done) = message {
-            self.done = done;
-        }
+    fn update(&mut self, _hws: &mut HardwareWallets, _message: Message) -> Task<Message> {
         Task::none()
     }
     fn skip(&self, ctx: &Context) -> bool {
@@ -57,7 +47,7 @@ impl Step for BackupMnemonic {
         progress: (usize, usize),
         email: Option<&'a str>,
     ) -> Element<'a, Message> {
-        view::backup_mnemonic(progress, email, &self.words, self.done)
+        view::backup_mnemonic(progress, email)
     }
 }
 

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -2168,43 +2168,18 @@ pub fn hw_list_view<'a>(
 pub fn backup_mnemonic<'a>(
     progress: (usize, usize),
     email: Option<&'a str>,
-    words: &'a [&'static str; 12],
-    done: bool,
 ) -> Element<'a, Message> {
     layout(
         progress,
         email,
-        "Backup your mnemonic",
+        "Backup your Master Seed",
         Column::new()
             .push(text(prompt::MNEMONIC_HELP))
             .push(
-                words
-                    .iter()
-                    .enumerate()
-                    .fold(Column::new().spacing(5), |acc, (i, w)| {
-                        acc.push(
-                            Row::new()
-                                .align_y(Alignment::End)
-                                .push(
-                                    Container::new(text(format!("#{}", i + 1)).small())
-                                        .width(Length::Fixed(50.0)),
-                                )
-                                .push(text(*w).bold()),
-                        )
-                    }),
-            )
-            .push(
-                checkbox(done)
-                    .label("I have backed up my mnemonic")
-                    .on_toggle(Message::UserActionDone),
-            )
-            .push(if done {
                 button::secondary(None, "Next")
                     .on_press(Message::Next)
-                    .width(Length::Fixed(200.0))
-            } else {
-                button::secondary(None, "Next").width(Length::Fixed(200.0))
-            })
+                    .width(Length::Fixed(200.0)),
+            )
             .push(Space::new().height(20.0))
             .spacing(50),
         true,

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -2172,7 +2172,7 @@ pub fn backup_mnemonic<'a>(
     layout(
         progress,
         email,
-        "Backup your Master Seed",
+        "Reminder: Back Up Your Master Seed",
         Column::new()
             .push(text(prompt::MNEMONIC_HELP))
             .push(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily copy and installer-UI flow changes; main risk is unintended UX regression from removing the mnemonic display/confirmation gate before proceeding.
> 
> **Overview**
> Updates installer help text to clarify descriptor backup decryption/recovery requirements and to reframe mnemonic guidance around *Master Seed Phrase* recovery for Vault-derived keys.
> 
> Simplifies the `BackupMnemonic` step by removing the displayed 12-word mnemonic and the “I have backed up…” checkbox gating; the screen is now a reminder with an always-enabled `Next` button and a new title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f64fdca56425dc8555f6cd44adcfaf211d63545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help text to clarify "Vault key" terminology and backup instructions for Master Seed Phrase recovery.

* **UI/UX Changes**
  * Simplified the backup process by removing the mnemonic word list display and backup confirmation checkbox.
  * Changed backup page title from "Backup your mnemonic" to "Backup your Master Seed."
  * Standardized the Next button behavior for consistent navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->