### PR TITLE
Recovery Kit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,6 +1705,7 @@ dependencies = [
 name = "coincube-gui"
 version = "1.0.0"
 dependencies = [
+ "aes-gcm",
  "argon2",
  "async-fd-lock",
  "async-hwi",
@@ -1761,6 +1762,7 @@ dependencies = [
  "winresource",
  "zeroize",
  "zip",
+ "zxcvbn",
 ]
 
 [[package]]
@@ -2191,8 +2193,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
 ]
 
 [[package]]
@@ -2210,14 +2222,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2305,6 +2342,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.117",
 ]
 
@@ -2865,6 +2933,17 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -4849,6 +4928,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -8709,7 +8797,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -12378,4 +12466,21 @@ dependencies = [
  "serde",
  "syn 2.0.117",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "zxcvbn"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad76e35b00ad53688d6b90c431cabe3cbf51f7a4a154739e04b63004ab1c736c"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "fancy-regex",
+ "itertools 0.13.0",
+ "lazy_static",
+ "regex",
+ "time",
+ "wasm-bindgen",
+ "web-sys",
 ]

--- a/coincube-gui/Cargo.toml
+++ b/coincube-gui/Cargo.toml
@@ -109,9 +109,11 @@ encrypted_backup = { version = "0.0.1", default-features = false, features = [
 	"miniscript_12_0",
 ], package = "bitcoin-encrypted-backup" }
 
-zeroize = "1"
+zeroize = { version = "1", features = ["derive"] }
 chacha20poly1305 = "0.10.1"
+aes-gcm = { version = "0.10", features = ["aes"] }
 sha2 = "0.11.0"
+zxcvbn = "3"
 
 dotenvy = "0.15.7"
 

--- a/coincube-gui/src/app/cache.rs
+++ b/coincube-gui/src/app/cache.rs
@@ -76,6 +76,26 @@ pub struct Cache {
     /// `update_settings_file` closure can find the right cube when
     /// persisting the `default_lightning_backend` picker change.
     pub cube_id: String,
+    /// Connect's numeric id for the active Cube (mirror of
+    /// `ConnectCubePanel::server_cube_id`). `None` when the user isn't
+    /// signed in to Connect or the cube hasn't been registered yet.
+    /// Recovery-kit calls need this because the backend identifies
+    /// cubes by numeric id, not by the local UUID carried in
+    /// `cube_id` above.
+    pub current_cube_server_id: Option<u64>,
+    /// SHA-256 hex fingerprint of the *live* descriptor blob — i.e.
+    /// what `descriptor_blob_from_wallet(...)` currently produces
+    /// given the loaded wallet. `None` when there's no wallet.
+    /// Recomputed by `App` whenever the wallet changes.
+    pub current_descriptor_fingerprint: Option<String>,
+    /// SHA-256 hex fingerprint of the descriptor blob that was last
+    /// successfully uploaded to Connect for this Cube. Mirrors
+    /// `CubeSettings::recovery_kit_last_backed_up_descriptor_fingerprint`.
+    /// The Settings card compares this to `current_descriptor_fingerprint`
+    /// to surface the "your descriptor changed since your last backup"
+    /// drift banner (W12). `None` when no descriptor has ever been
+    /// backed up, or when the kit has been removed.
+    pub recovery_kit_last_backed_up_descriptor_fingerprint: Option<String>,
     /// Current preference for which backend fulfills incoming
     /// Lightning Address invoices. Mirrored from
     /// `CubeSettings::default_lightning_backend` so panels can read
@@ -111,6 +131,9 @@ impl std::default::Default for Cache {
             show_direction_badges: true,
             lightning_address: None,
             cube_id: String::new(),
+            current_cube_server_id: None,
+            current_descriptor_fingerprint: None,
+            recovery_kit_last_backed_up_descriptor_fingerprint: None,
             default_lightning_backend: crate::app::wallets::WalletKind::default(),
         }
     }

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1546,13 +1546,13 @@ impl App {
             }
             Message::View(view::Message::ShowError(msg)) => {
                 // Redirect ShowError to ShowToast with Error level
-                return self.update(Message::View(view::Message::ShowToast(
+                return self.update_dispatch(Message::View(view::Message::ShowToast(
                     log::Level::Error,
                     msg,
                 )));
             }
             Message::View(view::Message::ShowSuccess(msg)) => {
-                return self.update(Message::View(view::Message::ShowToast(
+                return self.update_dispatch(Message::View(view::Message::ShowToast(
                     log::Level::Info,
                     msg,
                 )));
@@ -1671,8 +1671,8 @@ impl App {
                                         self.cache.node_bitcoind_sync_progress = None;
                                         self.cache.node_bitcoind_ibd = None;
                                         self.cache.node_bitcoind_last_log = None;
-                                        let cfg_task =
-                                            self.update(Message::DaemonConfigLoaded(Ok(())));
+                                        let cfg_task = self
+                                            .update_dispatch(Message::DaemonConfigLoaded(Ok(())));
                                         return Task::batch([
                                             cfg_task,
                                             Task::done(Message::CacheUpdated),
@@ -1825,7 +1825,8 @@ impl App {
                             match self.load_daemon_config(datadir, new_cfg) {
                                 Ok(()) => {
                                     info!("Switched to COINCUBE | Connect fallback after Bitcoind failure");
-                                    let cfg_task = self.update(Message::DaemonConfigLoaded(Ok(())));
+                                    let cfg_task =
+                                        self.update_dispatch(Message::DaemonConfigLoaded(Ok(())));
                                     return Task::batch([
                                         cfg_task,
                                         Task::done(Message::CacheUpdated),
@@ -1916,7 +1917,7 @@ impl App {
                         self.cache.node_bitcoind_last_log = None;
                     }
                     let res = self.load_daemon_config(self.cache.datadir_path.clone(), *cfg);
-                    return self.update(Message::DaemonConfigLoaded(res));
+                    return self.update_dispatch(Message::DaemonConfigLoaded(res));
                 } else {
                     tracing::warn!("Attempted to load daemon config without vault");
                 }

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1498,30 +1498,48 @@ impl App {
     }
 
     pub fn update(&mut self, message: Message) -> Task<Message> {
-        // Cheap per-tick sync: mirror the authoritative server cube id
-        // off ConnectPanel into Cache so view layers (Recovery-Kit card,
-        // future dashboards) and `State::reload()` callbacks can see
-        // it without reaching into the panel hierarchy. Set to `None`
-        // until `CubeRegistered(Ok)` populates the id on the panel.
+        let task = self.update_dispatch(message);
+        // Sync *after* dispatch: if this update just mutated
+        // `self.panels.connect.cube.server_cube_id` (e.g. a
+        // `CubeRegistered(Ok)` result) or loaded a wallet, the cache
+        // must reflect that by the time the next view render runs.
+        // A pre-dispatch sync would miss those same-call mutations
+        // and leave view layers one full message cycle behind.
+        self.sync_panel_derived_cache_fields();
+        task
+    }
+
+    /// Mirrors panel-owned state into `Cache` for cheap read access
+    /// by view layers and `State::reload()` callbacks that don't
+    /// reach into the panel hierarchy. Runs after every `update`
+    /// dispatch so same-tick mutations are observable by the next
+    /// render.
+    fn sync_panel_derived_cache_fields(&mut self) {
+        // Authoritative server cube id lives on ConnectPanel; views
+        // (Recovery-Kit card, future dashboards) read the Cache
+        // mirror. `None` until `CubeRegistered(Ok)` populates the
+        // panel's id.
         self.cache.current_cube_server_id = self.panels.connect.cube.server_cube_id;
 
-        // W12 drift detection: recompute the live descriptor fingerprint
-        // off the loaded wallet. This is a SHA-256 over a JSON blob —
-        // microseconds — so running it every tick is fine and avoids a
-        // separate invalidation pathway tied to wallet changes. When
-        // the wallet is absent (no Vault yet) the fingerprint is
-        // `None`, which the card treats as "nothing to drift against".
+        // W12 drift detection: SHA-256 over a JSON blob —
+        // microseconds — so running it every tick is fine and
+        // avoids a separate invalidation pathway tied to wallet
+        // changes. When the wallet is absent (no Vault yet) the
+        // fingerprint is `None`, which the card treats as "nothing
+        // to drift against".
         self.cache.current_descriptor_fingerprint = self.wallet.as_ref().and_then(|w| {
             use crate::app::state::settings::recovery_kit as rk;
             // Canonical API string ("mainnet" for Bitcoin mainnet) —
-            // the fingerprint inputs must agree byte-for-byte with the
-            // string used at backup time (see `network_str` in
+            // the fingerprint inputs must agree byte-for-byte with
+            // the string used at backup time (see `network_str` in
             // `state::settings::recovery_kit`). Any divergence here
             // would make every tick report a spurious drift.
             let network = settings::network_to_api_string(self.cache.network);
             rk::live_descriptor_fingerprint(w.as_ref(), &self.cube_settings.id, &network)
         });
+    }
 
+    fn update_dispatch(&mut self, message: Message) -> Task<Message> {
         match message {
             Message::View(view::Message::DismissToast(id)) => {
                 self.errors.retain(|(i, ..)| *i != id);

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1513,14 +1513,13 @@ impl App {
         // `None`, which the card treats as "nothing to drift against".
         self.cache.current_descriptor_fingerprint = self.wallet.as_ref().and_then(|w| {
             use crate::app::state::settings::recovery_kit as rk;
-            let network = match self.cache.network {
-                coincube_core::miniscript::bitcoin::Network::Bitcoin => "bitcoin",
-                coincube_core::miniscript::bitcoin::Network::Testnet => "testnet",
-                coincube_core::miniscript::bitcoin::Network::Signet => "signet",
-                coincube_core::miniscript::bitcoin::Network::Regtest => "regtest",
-                _ => "unknown",
-            };
-            rk::live_descriptor_fingerprint(w.as_ref(), &self.cube_settings.id, network)
+            // Canonical API string ("mainnet" for Bitcoin mainnet) —
+            // the fingerprint inputs must agree byte-for-byte with the
+            // string used at backup time (see `network_str` in
+            // `state::settings::recovery_kit`). Any divergence here
+            // would make every tick report a spurious drift.
+            let network = settings::network_to_api_string(self.cache.network);
+            rk::live_descriptor_fingerprint(w.as_ref(), &self.cube_settings.id, &network)
         });
 
         match message {
@@ -1926,47 +1925,24 @@ impl App {
                     }
 
                     // W10 — nudge the user to back up the freshly-created
-                    // Vault to their Connect Recovery Kit. Gated on
-                    // Connect auth + "no recovery kit yet" so we don't
-                    // nag users who've already backed up (e.g. on
-                    // subsequent app restarts where this transition
-                    // also fires). `LoadStatus` is fired either way so
-                    // the card in Settings is fresh when the user
-                    // navigates there.
-                    let mut tasks: Vec<Task<Message>> = vec![Task::done(Message::View(
-                        view::Message::Settings(view::SettingsMessage::RecoveryKit(
-                            view::RecoveryKitMessage::LoadStatus,
-                        )),
-                    ))];
+                    // Vault to their Connect Recovery Kit. Fires
+                    // `LoadStatus` now; the `StatusLoaded` handler in
+                    // `state::settings::recovery_kit` reads this flag
+                    // and emits the toast only if the freshly-loaded
+                    // status shows the descriptor isn't already
+                    // backed up. Gating on the in-memory `status`
+                    // here (pre-fetch) would misfire: on app startup
+                    // and after Connect sign-out the cached value is
+                    // `None` even for users whose kit is complete.
                     if self.panels.connect.account.is_authenticated() {
-                        let kit_absent = self
-                            .panels
+                        self.panels
                             .global_settings
                             .recovery_kit
-                            .status
-                            .as_ref()
-                            .map(|s| !s.has_recovery_kit || !s.has_encrypted_wallet_descriptor)
-                            .unwrap_or(true);
-                        if kit_absent {
-                            tasks.push(Task::done(Message::View(view::Message::ShowToast(
-                                log::Level::Info,
-                                "Your new Vault is ready — back up your Wallet Descriptor in \
-                                 Settings → General → Cube Recovery Kit."
-                                    .to_string(),
-                            ))));
-                        }
+                            .nudge_on_next_status_load = true;
                     }
-                    // Fire the nudge + status refresh, then let the
-                    // normal "forward to current panel" path below
-                    // also run by re-entering `update`. Using
-                    // `Task::batch` here would bypass the panel
-                    // notification — instead return after the panel
-                    // forward further down.
-                    // We batch with the forward task below by stashing
-                    // the nudge tasks into a closure; but simplest:
-                    // issue them now via the Iced task pipeline by
-                    // chaining onto the return.
-                    let nudge_task = Task::batch(tasks);
+                    let nudge_task = Task::done(Message::View(view::Message::Settings(
+                        view::SettingsMessage::RecoveryKit(view::RecoveryKitMessage::LoadStatus),
+                    )));
                     // Forward to the current panel _and_ fire the nudge.
                     if let (Some(daemon), Some(panel)) =
                         (self.daemon.clone(), self.panels.current_mut())

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -875,6 +875,9 @@ impl App {
             current_cube_backed_up: cube_settings.backed_up,
             current_cube_is_passkey: cube_settings.is_passkey_cube(),
             cube_id: cube_settings.id.clone(),
+            recovery_kit_last_backed_up_descriptor_fingerprint: cube_settings
+                .recovery_kit_last_backed_up_descriptor_fingerprint
+                .clone(),
             default_lightning_backend: cube_settings.default_lightning_backend,
             ..Default::default()
         };
@@ -1495,6 +1498,31 @@ impl App {
     }
 
     pub fn update(&mut self, message: Message) -> Task<Message> {
+        // Cheap per-tick sync: mirror the authoritative server cube id
+        // off ConnectPanel into Cache so view layers (Recovery-Kit card,
+        // future dashboards) and `State::reload()` callbacks can see
+        // it without reaching into the panel hierarchy. Set to `None`
+        // until `CubeRegistered(Ok)` populates the id on the panel.
+        self.cache.current_cube_server_id = self.panels.connect.cube.server_cube_id;
+
+        // W12 drift detection: recompute the live descriptor fingerprint
+        // off the loaded wallet. This is a SHA-256 over a JSON blob —
+        // microseconds — so running it every tick is fine and avoids a
+        // separate invalidation pathway tied to wallet changes. When
+        // the wallet is absent (no Vault yet) the fingerprint is
+        // `None`, which the card treats as "nothing to drift against".
+        self.cache.current_descriptor_fingerprint = self.wallet.as_ref().and_then(|w| {
+            use crate::app::state::settings::recovery_kit as rk;
+            let network = match self.cache.network {
+                coincube_core::miniscript::bitcoin::Network::Bitcoin => "bitcoin",
+                coincube_core::miniscript::bitcoin::Network::Testnet => "testnet",
+                coincube_core::miniscript::bitcoin::Network::Signet => "signet",
+                coincube_core::miniscript::bitcoin::Network::Regtest => "regtest",
+                _ => "unknown",
+            };
+            rk::live_descriptor_fingerprint(w.as_ref(), &self.cube_settings.id, network)
+        });
+
         match message {
             Message::View(view::Message::DismissToast(id)) => {
                 self.errors.retain(|(i, ..)| *i != id);
@@ -1669,6 +1697,17 @@ impl App {
                         self.cube_settings.default_lightning_backend =
                             cube.default_lightning_backend;
                         self.cache.default_lightning_backend = cube.default_lightning_backend;
+                        // Mirror the drift fingerprint cache (W12). Refreshing
+                        // on every SettingsSaved keeps the Recovery-Kit card
+                        // in sync after a successful upload or remove.
+                        self.cache
+                            .recovery_kit_last_backed_up_descriptor_fingerprint = cube
+                            .recovery_kit_last_backed_up_descriptor_fingerprint
+                            .clone();
+                        self.cube_settings
+                            .recovery_kit_last_backed_up_descriptor_fingerprint = cube
+                            .recovery_kit_last_backed_up_descriptor_fingerprint
+                            .clone();
 
                         // Clear cached fiat display price if disabled.
                         // Note: btc_usd_price is NOT cleared — it's needed for
@@ -1885,6 +1924,61 @@ impl App {
                             self.breez_client.clone(),
                         );
                     }
+
+                    // W10 — nudge the user to back up the freshly-created
+                    // Vault to their Connect Recovery Kit. Gated on
+                    // Connect auth + "no recovery kit yet" so we don't
+                    // nag users who've already backed up (e.g. on
+                    // subsequent app restarts where this transition
+                    // also fires). `LoadStatus` is fired either way so
+                    // the card in Settings is fresh when the user
+                    // navigates there.
+                    let mut tasks: Vec<Task<Message>> = vec![Task::done(Message::View(
+                        view::Message::Settings(view::SettingsMessage::RecoveryKit(
+                            view::RecoveryKitMessage::LoadStatus,
+                        )),
+                    ))];
+                    if self.panels.connect.account.is_authenticated() {
+                        let kit_absent = self
+                            .panels
+                            .global_settings
+                            .recovery_kit
+                            .status
+                            .as_ref()
+                            .map(|s| !s.has_recovery_kit || !s.has_encrypted_wallet_descriptor)
+                            .unwrap_or(true);
+                        if kit_absent {
+                            tasks.push(Task::done(Message::View(view::Message::ShowToast(
+                                log::Level::Info,
+                                "Your new Vault is ready — back up your Wallet Descriptor in \
+                                 Settings → General → Cube Recovery Kit."
+                                    .to_string(),
+                            ))));
+                        }
+                    }
+                    // Fire the nudge + status refresh, then let the
+                    // normal "forward to current panel" path below
+                    // also run by re-entering `update`. Using
+                    // `Task::batch` here would bypass the panel
+                    // notification — instead return after the panel
+                    // forward further down.
+                    // We batch with the forward task below by stashing
+                    // the nudge tasks into a closure; but simplest:
+                    // issue them now via the Iced task pipeline by
+                    // chaining onto the return.
+                    let nudge_task = Task::batch(tasks);
+                    // Forward to the current panel _and_ fire the nudge.
+                    if let (Some(daemon), Some(panel)) =
+                        (self.daemon.clone(), self.panels.current_mut())
+                    {
+                        let panel_task = panel.update(
+                            Some(daemon),
+                            &self.cache,
+                            Message::WalletUpdated(Ok(wallet)),
+                        );
+                        return Task::batch([panel_task, nudge_task]);
+                    }
+                    return nudge_task;
                 }
 
                 // Forward the message to the current panel
@@ -2369,6 +2463,34 @@ impl App {
                     .panels
                     .global_settings
                     .update(self.daemon.clone(), &self.cache, msg);
+            }
+
+            // Cube Recovery Kit dispatch. Handled at App level because
+            // the handler needs the authenticated CoincubeClient, the
+            // Connect numeric cube id, and the live Wallet — none of
+            // which are plumbed through `State::update`. Mirrors the
+            // `cube_members::update(state, msg, client, cube_id)`
+            // pattern at `state/connect/cube_members.rs:79`.
+            Message::View(view::Message::Settings(view::SettingsMessage::RecoveryKit(msg))) => {
+                let seed_source = if self.cube_settings.is_passkey_cube() {
+                    crate::app::state::settings::recovery_kit::SeedSource::Passkey
+                } else {
+                    crate::app::state::settings::recovery_kit::SeedSource::Mnemonic
+                };
+                let client = self.authenticated_coincube_client();
+                let server_cube_id = self.panels.connect.cube.server_cube_id;
+                let wallet = self.wallet.clone();
+                let local_cube_id = self.cube_settings.id.clone();
+                return crate::app::state::settings::recovery_kit::update(
+                    &mut self.panels.global_settings.recovery_kit,
+                    msg,
+                    &self.cache,
+                    &local_cube_id,
+                    seed_source,
+                    client,
+                    server_cube_id,
+                    wallet,
+                );
             }
 
             // Route refundables updates directly to LiquidTransactions so that

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1934,16 +1934,29 @@ impl App {
                     // here (pre-fetch) would misfire: on app startup
                     // and after Connect sign-out the cached value is
                     // `None` even for users whose kit is complete.
-                    if self.panels.connect.account.is_authenticated() {
-                        self.panels
-                            .global_settings
-                            .recovery_kit
-                            .nudge_on_next_status_load = true;
-                    }
-                    let nudge_task = Task::done(Message::View(view::Message::Settings(
-                        view::SettingsMessage::RecoveryKit(view::RecoveryKitMessage::LoadStatus),
-                    )));
-                    // Forward to the current panel _and_ fire the nudge.
+                    //
+                    // Both the flag and the `LoadStatus` dispatch are
+                    // gated on auth — unauthenticated users have no
+                    // Connect account to fetch against, and dispatching
+                    // the message anyway would just round-trip through
+                    // `load_status`'s early-return. Skipping saves the
+                    // message-queue hop and keeps the intent obvious.
+                    let nudge_task: Option<Task<Message>> =
+                        if self.panels.connect.account.is_authenticated() {
+                            self.panels
+                                .global_settings
+                                .recovery_kit
+                                .nudge_on_next_status_load = true;
+                            Some(Task::done(Message::View(view::Message::Settings(
+                                view::SettingsMessage::RecoveryKit(
+                                    view::RecoveryKitMessage::LoadStatus,
+                                ),
+                            ))))
+                        } else {
+                            None
+                        };
+                    // Forward to the current panel; batch the nudge in
+                    // only when we actually constructed one.
                     if let (Some(daemon), Some(panel)) =
                         (self.daemon.clone(), self.panels.current_mut())
                     {
@@ -1952,9 +1965,12 @@ impl App {
                             &self.cache,
                             Message::WalletUpdated(Ok(wallet)),
                         );
-                        return Task::batch([panel_task, nudge_task]);
+                        return match nudge_task {
+                            Some(nudge) => Task::batch([panel_task, nudge]),
+                            None => panel_task,
+                        };
                     }
-                    return nudge_task;
+                    return nudge_task.unwrap_or_else(Task::none);
                 }
 
                 // Forward the message to the current panel

--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -213,6 +213,15 @@ pub struct CubeSettings {
     /// sessions so users don't have to re-hide on every launch.
     #[serde(default)]
     pub balance_masked: bool,
+    /// SHA-256 fingerprint (hex) of the `DescriptorBlob` plaintext that
+    /// was last successfully pushed to this Cube's Connect Recovery Kit.
+    /// `None` when no descriptor has ever been backed up. Used by W12 to
+    /// detect drift: if the live vault's descriptor/signers now hash to
+    /// a different value, the Settings card shows "descriptor changed
+    /// since last backup — update now." Cleared on vault deletion and
+    /// on `delete_recovery_kit`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovery_kit_last_backed_up_descriptor_fingerprint: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -245,6 +254,7 @@ impl CubeSettings {
             passkey_metadata: None,
             allow_random_grid_phrase: false,
             balance_masked: false,
+            recovery_kit_last_backed_up_descriptor_fingerprint: None,
         }
     }
 

--- a/coincube-gui/src/app/state/mod.rs
+++ b/coincube-gui/src/app/state/mod.rs
@@ -64,6 +64,18 @@ pub trait State {
     ) -> Task<Message> {
         Task::none()
     }
+
+    /// Opt-in escape hatch for concrete-type access through a
+    /// `Box<dyn State>`. Default is `None`; implementations that need
+    /// to be reached from their parent panel (e.g. the `SettingsState`
+    /// outer wrapper needs a `&GeneralSettingsState` to render the
+    /// Recovery-Kit card alongside the rest of the General page)
+    /// override this to return `Some(self)`. Keeps the refactor local
+    /// to the cases that need it rather than forcing every impl to
+    /// participate.
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        None
+    }
 }
 
 /// redirect to another state with a message menu

--- a/coincube-gui/src/app/state/settings/general.rs
+++ b/coincube-gui/src/app/state/settings/general.rs
@@ -509,7 +509,12 @@ impl GeneralSettingsState {
 /// Load the encrypted mnemonic from the datadir and return the 12 words
 /// as a `Vec<String>`. The password is verified by the decryption step —
 /// if the PIN is wrong, decryption returns an error.
-fn load_mnemonic_words(
+///
+/// Visible to sibling modules under `settings::` (specifically
+/// `recovery_kit.rs`, which reuses this helper for the same PIN →
+/// mnemonic path). Kept here rather than hoisted to `mod.rs` because
+/// this is where the backup flow's PIN gate already lives.
+pub(super) fn load_mnemonic_words(
     datadir: &std::path::Path,
     network: Network,
     fingerprint: Fingerprint,

--- a/coincube-gui/src/app/state/settings/general.rs
+++ b/coincube-gui/src/app/state/settings/general.rs
@@ -521,7 +521,40 @@ fn load_mnemonic_words(
     Ok(signer.words().iter().map(|w| (*w).to_string()).collect())
 }
 
+impl GeneralSettingsState {
+    /// Variant of `view` that also threads the Cube Recovery Kit
+    /// status through so the "Back up your Recovery Kit" card can
+    /// render. `SettingsState::view` (the outer wrapper) calls this
+    /// after downcasting via `as_any`; the plain `State::view` impl
+    /// below falls back to rendering without the card for callers
+    /// that don't have the recovery-kit data on hand.
+    pub fn view_with_recovery_kit<'a>(
+        &'a self,
+        menu: &'a Menu,
+        cache: &'a Cache,
+        rk: &'a super::recovery_kit::RecoveryKit,
+    ) -> Element<'a, view::Message> {
+        crate::app::view::settings::general::general_section(
+            menu,
+            cache,
+            &self.new_price_setting,
+            &self.new_unit_setting,
+            &self.currencies,
+            self.developer_mode,
+            self.show_direction_badges,
+            &self.backup_state,
+            &self.backup_pin,
+            self.backup_mnemonic.as_deref().map(|v| v.as_slice()),
+            Some(rk),
+        )
+    }
+}
+
 impl State for GeneralSettingsState {
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+
     fn view<'a>(&'a self, menu: &'a Menu, cache: &'a Cache) -> Element<'a, view::Message> {
         crate::app::view::settings::general::general_section(
             menu,
@@ -534,6 +567,7 @@ impl State for GeneralSettingsState {
             &self.backup_state,
             &self.backup_pin,
             self.backup_mnemonic.as_deref().map(|v| v.as_slice()),
+            None,
         )
     }
 

--- a/coincube-gui/src/app/state/settings/mod.rs
+++ b/coincube-gui/src/app/state/settings/mod.rs
@@ -2,6 +2,7 @@ mod about;
 pub mod general;
 mod install_stats;
 mod lightning;
+pub mod recovery_kit;
 
 use std::sync::Arc;
 
@@ -32,6 +33,12 @@ pub struct SettingsState {
     cube_id: String,
     current_price_setting: PriceSetting,
     current_unit_setting: crate::app::settings::unit::UnitSetting,
+    /// Cube Recovery Kit wizard + cached status. Lives on the outer
+    /// wrapper rather than `GeneralSettingsState` so `App::update` can
+    /// reach it without downcasting through `Box<dyn State>`. The
+    /// Recovery-Kit card is rendered inside the General section's
+    /// view, which reads this field through a parameter.
+    pub recovery_kit: recovery_kit::RecoveryKit,
 }
 
 impl SettingsState {
@@ -45,6 +52,7 @@ impl SettingsState {
             cube_id,
             current_price_setting: price_setting,
             current_unit_setting: unit_setting,
+            recovery_kit: recovery_kit::RecoveryKit::new(),
         }
     }
 }
@@ -67,10 +75,19 @@ impl State for SettingsState {
                     )
                     .into(),
                 );
-                self.setting
+                let reload_task = self
+                    .setting
                     .as_mut()
                     .map(|s| s.reload(daemon, None))
-                    .unwrap_or_else(Task::none)
+                    .unwrap_or_else(Task::none);
+                // Kick the Recovery-Kit status fetch so the card has
+                // fresh copy by the time the user looks at it. The
+                // handler is App-level (it needs the authenticated
+                // client); we just drop a message onto the queue.
+                let load_status = Task::done(Message::View(view::Message::Settings(
+                    view::SettingsMessage::RecoveryKit(view::RecoveryKitMessage::LoadStatus),
+                )));
+                Task::batch([reload_task, load_status])
             }
             Message::View(view::Message::Settings(view::SettingsMessage::LightningSection)) => {
                 self.setting = Some(LightningSettingsState::new(self.cube_id.clone()).into());
@@ -127,7 +144,36 @@ impl State for SettingsState {
     }
 
     fn view<'a>(&'a self, menu: &'a Menu, cache: &'a Cache) -> Element<'a, view::Message> {
+        use iced::widget::Column;
+        // Recovery-Kit wizard takes over the entire settings page
+        // when active, the same way `BackupSeedState != None` does.
+        if !matches!(
+            self.recovery_kit.flow,
+            recovery_kit::RecoveryKitState::None
+        ) {
+            if let Some(wizard) = crate::app::view::settings::recovery_kit::dispatch(
+                &self.recovery_kit.flow,
+                &self.recovery_kit.pin,
+            ) {
+                return crate::app::view::dashboard(
+                    menu,
+                    cache,
+                    Column::new().spacing(20).push(wizard),
+                );
+            }
+        }
         if let Some(setting) = &self.setting {
+            // Reach into the concrete `GeneralSettingsState` (when
+            // that's the active section) so its view can receive the
+            // Recovery-Kit status cached on this wrapper. The rest of
+            // the sections don't need it and go through the plain
+            // `State::view` path.
+            if let Some(general) = setting
+                .as_any()
+                .and_then(|a| a.downcast_ref::<GeneralSettingsState>())
+            {
+                return general.view_with_recovery_kit(menu, cache, &self.recovery_kit);
+            }
             setting.view(menu, cache)
         } else {
             // No setting installed yet — the tertiary rail's click would

--- a/coincube-gui/src/app/state/settings/mod.rs
+++ b/coincube-gui/src/app/state/settings/mod.rs
@@ -147,10 +147,7 @@ impl State for SettingsState {
         use iced::widget::Column;
         // Recovery-Kit wizard takes over the entire settings page
         // when active, the same way `BackupSeedState != None` does.
-        if !matches!(
-            self.recovery_kit.flow,
-            recovery_kit::RecoveryKitState::None
-        ) {
+        if !matches!(self.recovery_kit.flow, recovery_kit::RecoveryKitState::None) {
             if let Some(wizard) = crate::app::view::settings::recovery_kit::dispatch(
                 &self.recovery_kit.flow,
                 &self.recovery_kit.pin,

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -261,10 +261,7 @@ pub fn update(
         }
 
         RecoveryKitMessage::ConfirmChanged(value) => {
-            if let RecoveryKitState::PasswordEntry {
-                confirm, error, ..
-            } = &mut rk.flow
-            {
+            if let RecoveryKitState::PasswordEntry { confirm, error, .. } = &mut rk.flow {
                 *confirm = Zeroizing::new(value);
                 *error = None;
             }
@@ -278,7 +275,9 @@ pub fn update(
             Task::none()
         }
 
-        RecoveryKitMessage::SubmitPassword => submit_password(rk, cache, client, server_cube_id, wallet),
+        RecoveryKitMessage::SubmitPassword => {
+            submit_password(rk, cache, client, server_cube_id, wallet)
+        }
 
         RecoveryKitMessage::UploadResult(res) => {
             match res {
@@ -332,7 +331,12 @@ pub fn update(
             };
             rk.flow = RecoveryKitState::Removing;
             Task::perform(
-                async move { client.delete_recovery_kit(cube_id).await.map_err(|e| e.to_string()) },
+                async move {
+                    client
+                        .delete_recovery_kit(cube_id)
+                        .await
+                        .map_err(|e| e.to_string())
+                },
                 |res| {
                     Message::View(view::Message::Settings(view::SettingsMessage::RecoveryKit(
                         RecoveryKitMessage::RemoveResult(res),
@@ -518,10 +522,7 @@ fn submit_password(
                 return Task::none();
             }
             if !*acknowledged {
-                set_pw_error(
-                    rk,
-                    "Please confirm that you've written down this password.",
-                );
+                set_pw_error(rk, "Please confirm that you've written down this password.");
                 return Task::none();
             }
 
@@ -562,7 +563,9 @@ fn submit_password(
     };
 
     // Build descriptor blob when we have a live wallet.
-    let descriptor_blob = wallet.as_ref().map(|w| descriptor_blob_from_wallet(w, &cube_uuid, &network));
+    let descriptor_blob = wallet
+        .as_ref()
+        .map(|w| descriptor_blob_from_wallet(w, &cube_uuid, &network));
 
     rk.flow = RecoveryKitState::Uploading;
 
@@ -669,22 +672,37 @@ pub fn live_descriptor_fingerprint(
     descriptor_blob_fingerprint(&blob)
 }
 
+/// Decide which halves to include in the upload. Per master plan §5,
+/// every update re-encrypts **all present blobs** under the new
+/// password — otherwise the kit's two halves end up encrypted under
+/// different passwords and a single-password restore becomes
+/// impossible. The mode is therefore **not** a filter here: it only
+/// gates earlier UI decisions (whether to prompt for PIN, wizard
+/// copy). At upload time we always send every half for which we have
+/// plaintext available.
+///
+/// - `mnemonic.is_some()` → we have a mnemonic (mnemonic cubes after
+///   PIN verify). Passkey cubes never reach this branch because they
+///   never populate `mnemonic` in state.
+/// - `descriptor_blob.is_some()` → a live Vault exists on this
+///   device. Cubes without a Vault legitimately upload seed-only.
+fn include_halves(
+    mnemonic: &Option<Zeroizing<Vec<String>>>,
+    descriptor_blob: &Option<DescriptorBlob>,
+) -> (bool, bool) {
+    (mnemonic.is_some(), descriptor_blob.is_some())
+}
+
 async fn encrypt_and_upload(
     client: CoincubeClient,
     cube_id_num: u64,
-    mode: RecoveryKitMode,
+    _mode: RecoveryKitMode,
     mnemonic: Option<Zeroizing<Vec<String>>>,
     descriptor_blob: Option<DescriptorBlob>,
     cube_meta: SeedBlobCube,
     password: Zeroizing<String>,
 ) -> Result<RecoveryKitUploadOutcome, String> {
-    // Decide which halves to include based on mode + available data.
-    let include_seed = matches!(
-        mode,
-        RecoveryKitMode::Create | RecoveryKitMode::AddSeed | RecoveryKitMode::Rotate
-    ) && mnemonic.is_some();
-    let include_descriptor = descriptor_blob.is_some()
-        && !matches!(mode, RecoveryKitMode::AddSeed);
+    let (include_seed, include_descriptor) = include_halves(&mnemonic, &descriptor_blob);
 
     if !include_seed && !include_descriptor {
         return Err(
@@ -717,8 +735,7 @@ async fn encrypt_and_upload(
     // Descriptor blob.
     let (desc_ct, desc_fp) = if include_descriptor {
         let blob = descriptor_blob.as_ref().unwrap();
-        let bytes =
-            serde_json::to_vec(blob).map_err(|e| format!("serialize descriptor: {}", e))?;
+        let bytes = serde_json::to_vec(blob).map_err(|e| format!("serialize descriptor: {}", e))?;
         let ct = recovery::encrypt(&bytes, &password, KdfParams::DEFAULT_V1)
             .map_err(|e| format!("encrypt descriptor: {}", e))?;
         let fp = descriptor_blob_fingerprint(blob);
@@ -730,7 +747,12 @@ async fn encrypt_and_upload(
     let seed_ref = seed_ct.as_deref();
     let desc_ref = desc_ct.as_deref();
     let kit: ApiRecoveryKit = client
-        .put_recovery_kit(cube_id_num, seed_ref, desc_ref, RECOVERY_KIT_SCHEME_AES_256_GCM)
+        .put_recovery_kit(
+            cube_id_num,
+            seed_ref,
+            desc_ref,
+            RECOVERY_KIT_SCHEME_AES_256_GCM,
+        )
         .await
         .map_err(|e| e.to_string())?;
 
@@ -797,6 +819,80 @@ mod tests {
         let b = descriptor_blob_fingerprint(&blob).unwrap();
         assert_eq!(a, b, "fingerprint must be deterministic");
         assert_eq!(a.len(), 64, "SHA-256 hex is 64 chars");
+    }
+
+    fn mnemonic_some() -> Option<Zeroizing<Vec<String>>> {
+        Some(Zeroizing::new(vec!["word".to_string(); 12]))
+    }
+
+    fn descriptor_some() -> Option<DescriptorBlob> {
+        Some(DescriptorBlob {
+            version: BLOB_VERSION,
+            cube: DescriptorBlobCube {
+                uuid: "u".into(),
+                network: "bitcoin".into(),
+            },
+            vault: DescriptorBlobVault {
+                name: "n".into(),
+                descriptor: "d".into(),
+                change_descriptor: None,
+                signers: vec![],
+            },
+        })
+    }
+
+    // Regression tests for the AddDescriptor/AddSeed re-encryption
+    // bug: the upload decision must NOT be gated on mode, otherwise
+    // the two halves end up encrypted under different passwords.
+    // Plan §5 requires every update to re-encrypt all present blobs
+    // under the new password.
+
+    #[test]
+    fn include_halves_add_descriptor_uploads_seed_too() {
+        // User is in AddDescriptor mode on a mnemonic cube. The PIN
+        // verify populated `mnemonic`, and the local Vault provides
+        // `descriptor_blob`. Both halves must go up so the server
+        // state ends up with BOTH encrypted under the new password.
+        let m = mnemonic_some();
+        let d = descriptor_some();
+        assert_eq!(include_halves(&m, &d), (true, true));
+    }
+
+    #[test]
+    fn include_halves_add_seed_uploads_descriptor_too() {
+        // User is in AddSeed mode on a mnemonic cube with a Vault.
+        // Both halves must go up — the seed under the new password
+        // (the whole point of AddSeed) AND the descriptor re-encrypted
+        // from the live wallet under the new password.
+        let m = mnemonic_some();
+        let d = descriptor_some();
+        assert_eq!(include_halves(&m, &d), (true, true));
+    }
+
+    #[test]
+    fn include_halves_passkey_no_seed() {
+        // Passkey cubes never populate the mnemonic — the seed is
+        // unextractable on-device. Only the descriptor goes up.
+        let m: Option<Zeroizing<Vec<String>>> = None;
+        let d = descriptor_some();
+        assert_eq!(include_halves(&m, &d), (false, true));
+    }
+
+    #[test]
+    fn include_halves_no_vault_seed_only() {
+        // Mnemonic cube without a Vault (or user hasn't created one
+        // yet). Seed goes up alone; descriptor will be added later
+        // via AddDescriptor.
+        let m = mnemonic_some();
+        let d: Option<DescriptorBlob> = None;
+        assert_eq!(include_halves(&m, &d), (true, false));
+    }
+
+    #[test]
+    fn include_halves_nothing_is_rejected() {
+        let m: Option<Zeroizing<Vec<String>>> = None;
+        let d: Option<DescriptorBlob> = None;
+        assert_eq!(include_halves(&m, &d), (false, false));
     }
 
     #[test]

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -47,6 +47,20 @@ pub enum SeedSource {
     Passkey,
 }
 
+/// Snapshot of the user's `PasswordEntry` inputs at the moment they
+/// hit Submit. Carried through `Uploading` so a transient upload
+/// failure can restore the entry screen without making the user
+/// re-type their password (and, for mnemonic cubes, re-enter their
+/// PIN to re-decrypt the mnemonic).
+#[derive(Debug)]
+pub struct PasswordEntryPending {
+    pub mode: RecoveryKitMode,
+    pub mnemonic: Option<Zeroizing<Vec<String>>>,
+    pub password: Zeroizing<String>,
+    pub confirm: Zeroizing<String>,
+    pub acknowledged: bool,
+}
+
 /// The actual UI state of the wizard. `None` = card view; any other
 /// variant = wizard is taking over the settings page.
 #[derive(Debug)]
@@ -67,7 +81,13 @@ pub enum RecoveryKitState {
         acknowledged: bool,
         error: Option<String>,
     },
-    Uploading,
+    /// In-flight upload. Carries the pending `PasswordEntry` snapshot
+    /// so we can restore the entry screen intact if the upload fails —
+    /// previously the user had to re-type their password (and PIN) on
+    /// every transient network error.
+    Uploading {
+        pending: PasswordEntryPending,
+    },
     Completed {
         updated_at: String,
         now_has_seed: bool,
@@ -358,15 +378,12 @@ pub fn update(
                     }
                 }
                 Err(e) => {
-                    // Preserve any already-entered password so the user
-                    // doesn't have to retype it. Error shows inline.
-                    if let RecoveryKitState::PasswordEntry { error, .. } = &mut rk.flow {
-                        *error = Some(e.clone());
-                    } else {
-                        // Mid-flight cancel or state drift — fall back
-                        // to the Error screen.
-                        rk.flow = RecoveryKitState::Error { message: e.clone() };
-                    }
+                    // Restore the user's password-entry inputs from
+                    // the `Uploading` snapshot so a transient network
+                    // failure doesn't force them to retype their
+                    // password (and re-enter their PIN to decrypt
+                    // the mnemonic again). See `restore_entry_on_upload_error`.
+                    restore_entry_on_upload_error(&mut rk.flow, &e);
                     Task::done(Message::View(view::Message::ShowError(e)))
                 }
             }
@@ -391,12 +408,7 @@ pub fn update(
             };
             rk.flow = RecoveryKitState::Removing;
             Task::perform(
-                async move {
-                    client
-                        .delete_recovery_kit(cube_id)
-                        .await
-                        .map_err(|e| e.to_string())
-                },
+                async move { normalize_delete_result(client.delete_recovery_kit(cube_id).await) },
                 |res| {
                     Message::View(view::Message::Settings(view::SettingsMessage::RecoveryKit(
                         RecoveryKitMessage::RemoveResult(res),
@@ -537,9 +549,13 @@ fn submit_password(
     wallet: Option<Arc<Wallet>>,
 ) -> Task<Message> {
     // Pull validation + cloneable inputs out of the state without
-    // moving fields — we'll set `rk.flow = Uploading` once all checks
-    // pass and the task is on its way.
-    let (mode, password_copy, mnemonic_clone_opt) = match &rk.flow {
+    // moving fields — we'll set `rk.flow = Uploading { pending }`
+    // once all checks pass and the task is on its way. The `pending`
+    // snapshot lets us restore `PasswordEntry` intact if the upload
+    // fails, so a transient network error doesn't force the user to
+    // re-type their password (and re-enter their PIN to unlock the
+    // mnemonic again).
+    let (mode, password_copy, mnemonic_clone_opt, pending) = match &rk.flow {
         RecoveryKitState::PasswordEntry {
             mode: m,
             mnemonic,
@@ -574,7 +590,19 @@ fn submit_password(
                 set_pw_error(rk, "Please confirm that you've written down this password.");
                 return Task::none();
             }
-            (*m, Zeroizing::new(password.to_string()), mnemonic.clone())
+            let pending = PasswordEntryPending {
+                mode: *m,
+                mnemonic: mnemonic.clone(),
+                password: password.clone(),
+                confirm: confirm.clone(),
+                acknowledged: *acknowledged,
+            };
+            (
+                *m,
+                Zeroizing::new(password.to_string()),
+                mnemonic.clone(),
+                pending,
+            )
         }
         _ => return Task::none(),
     };
@@ -611,7 +639,7 @@ fn submit_password(
         .as_ref()
         .map(|w| descriptor_blob_from_wallet(w, &cube_uuid, &network));
 
-    rk.flow = RecoveryKitState::Uploading;
+    rk.flow = RecoveryKitState::Uploading { pending };
 
     let mnemonic = mnemonic_clone_opt;
     Task::perform(
@@ -721,8 +749,17 @@ fn descriptor_blob_from_wallet(wallet: &Wallet, cube_uuid: &str, network: &str) 
     // restorer from the descriptor itself. Leaving `xpub` empty here
     // is deliberate: we'd need a miniscript-level traversal to pull
     // per-fingerprint xpubs out cleanly, which is a larger change.
-    let signers: Vec<DescriptorBlobSigner> = wallet
-        .descriptor_keys()
+    //
+    // `descriptor_keys()` returns a `HashSet`, whose iteration order
+    // is randomised per-process by Rust's default hasher. We sort
+    // the fingerprints by their lowercase hex form before building
+    // the `DescriptorBlobSigner` list — otherwise every `App` tick
+    // serialises `signers` in a different order, making the
+    // SHA-256 descriptor fingerprint (W12 drift detection) flip
+    // randomly and fire a bogus drift banner on every refresh.
+    let mut fps: Vec<_> = wallet.descriptor_keys().into_iter().collect();
+    fps.sort_by_key(|fp| format!("{}", fp).to_lowercase());
+    let signers: Vec<DescriptorBlobSigner> = fps
         .into_iter()
         .map(|fp| DescriptorBlobSigner {
             name: wallet
@@ -792,6 +829,56 @@ fn include_halves(
     (mnemonic.is_some(), descriptor_blob.is_some())
 }
 
+/// Treat a `CoincubeError::NotFound` from `delete_recovery_kit` as
+/// success — the server state we wanted (no kit) is already what the
+/// server reports, so DELETE is idempotent from the caller's
+/// perspective. This lets the `RemoveResult(Ok)` branch run
+/// `persist_descriptor_fingerprint(None)` + `load_status(...)` just
+/// as it would on a first-time-successful delete, instead of hitting
+/// the Error screen and leaving a stale local fingerprint cache
+/// behind. Other errors (auth, 429, 5xx) propagate as `Err(String)`
+/// so the user can retry.
+fn normalize_delete_result(res: Result<(), CoincubeError>) -> Result<(), String> {
+    match res {
+        Ok(()) | Err(CoincubeError::NotFound) => Ok(()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// On upload failure, restore the `PasswordEntry` screen from the
+/// snapshot we stashed inside `Uploading { pending }` at submit
+/// time. The user keeps their password, confirm, acknowledge flag,
+/// and (for mnemonic cubes) the decrypted mnemonic — so a transient
+/// network error doesn't throw away their PIN-decryption work.
+///
+/// Uses `mem::replace` so the `Zeroizing`-wrapped fields stay
+/// wrapped the whole time (no plain-`String` copy on the stack).
+///
+/// If the incoming state isn't `Uploading` — which would only
+/// happen on a stale message arriving after `Cancel` or similar —
+/// we fall back to a terminal `Error` screen, preserving the old
+/// behavior for the edge case.
+fn restore_entry_on_upload_error(flow: &mut RecoveryKitState, err: &str) {
+    let prev = std::mem::replace(
+        flow,
+        RecoveryKitState::Error {
+            message: err.to_string(),
+        },
+    );
+    if let RecoveryKitState::Uploading { pending } = prev {
+        *flow = RecoveryKitState::PasswordEntry {
+            mode: pending.mode,
+            mnemonic: pending.mnemonic,
+            password: pending.password,
+            confirm: pending.confirm,
+            acknowledged: pending.acknowledged,
+            error: Some(err.to_string()),
+        };
+    }
+    // Otherwise `flow` has already been set to the Error variant by
+    // the `mem::replace` above — leave it.
+}
+
 async fn encrypt_and_upload(
     client: CoincubeClient,
     cube_id_num: u64,
@@ -810,19 +897,34 @@ async fn encrypt_and_upload(
         );
     }
 
-    // Seed blob.
+    // Seed blob. Zeroisation invariants we maintain here:
+    //
+    // 1. The `phrase` string is constructed inline into the
+    //    `SeedBlobMnemonic` initializer (no named binding) so it
+    //    moves straight into the field. `SeedBlobMnemonic` derives
+    //    `ZeroizeOnDrop`, so when `blob` drops at the end of this
+    //    block the phrase's heap allocation is wiped.
+    //
+    // 2. `serde_json::to_vec` returns a plain `Vec<u8>` containing
+    //    the JSON-serialised mnemonic — i.e. a second copy of the
+    //    phrase bytes. Wrapping in `Zeroizing<Vec<u8>>` ensures those
+    //    bytes are also wiped on drop. Without this wrap the JSON
+    //    copy would linger on the heap past the end of this scope.
+    //    `recovery::encrypt` takes `&[u8]` and `Zeroizing<Vec<u8>>`
+    //    derefs cleanly.
     let seed_ct = if include_seed {
         let words = mnemonic.as_ref().unwrap();
-        let phrase = words.join(" ");
         let blob = SeedBlob {
             version: BLOB_VERSION,
             cube: cube_meta.clone(),
             mnemonic: SeedBlobMnemonic {
-                phrase,
+                phrase: words.join(" "),
                 language: "en".to_string(),
             },
         };
-        let bytes = serde_json::to_vec(&blob).map_err(|e| format!("serialize seed: {}", e))?;
+        let bytes: Zeroizing<Vec<u8>> = Zeroizing::new(
+            serde_json::to_vec(&blob).map_err(|e| format!("serialize seed: {}", e))?,
+        );
         Some(
             recovery::encrypt(&bytes, &password, KdfParams::DEFAULT_V1)
                 .map_err(|e| format!("encrypt seed: {}", e))?,
@@ -926,6 +1028,96 @@ mod tests {
             created_at: None,
             updated_at: None,
         }
+    }
+
+    // Regression tests for the delete-is-idempotent behaviour: a
+    // second delete of a already-removed kit (or any race where the
+    // server no longer has the kit) should count as success so the
+    // local-fingerprint cache gets cleared and the card refreshes —
+    // not dead-end on an error screen that would leave a stale cache.
+
+    #[test]
+    fn normalize_delete_ok_stays_ok() {
+        assert!(matches!(normalize_delete_result(Ok(())), Ok(())));
+    }
+
+    #[test]
+    fn normalize_delete_not_found_becomes_ok() {
+        // Second-delete / race case — treat as the desired end state.
+        assert!(matches!(
+            normalize_delete_result(Err(CoincubeError::NotFound)),
+            Ok(())
+        ));
+    }
+
+    #[test]
+    fn normalize_delete_rate_limited_propagates() {
+        // Server is asking us to back off — not idempotent success.
+        let err = normalize_delete_result(Err(CoincubeError::RateLimited {
+            retry_after: std::time::Duration::from_secs(30),
+        }));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn normalize_delete_api_error_propagates() {
+        let err = normalize_delete_result(Err(CoincubeError::Api("boom".to_string())));
+        assert!(matches!(err, Err(ref msg) if msg.contains("boom")));
+    }
+
+    // Regression tests for the upload-error-preserves-password-entry
+    // flow: a transient upload failure must restore the user's
+    // `PasswordEntry` screen with inputs intact, not drop them on
+    // the floor and force a full PIN + password re-type.
+
+    fn sample_pending() -> PasswordEntryPending {
+        PasswordEntryPending {
+            mode: RecoveryKitMode::Create,
+            mnemonic: Some(Zeroizing::new(vec!["abandon".to_string(); 12])),
+            password: Zeroizing::new("correct-horse-battery-staple".to_string()),
+            confirm: Zeroizing::new("correct-horse-battery-staple".to_string()),
+            acknowledged: true,
+        }
+    }
+
+    #[test]
+    fn upload_error_restores_password_entry_from_uploading_snapshot() {
+        let mut flow = RecoveryKitState::Uploading {
+            pending: sample_pending(),
+        };
+        restore_entry_on_upload_error(&mut flow, "Connect timed out");
+        match flow {
+            RecoveryKitState::PasswordEntry {
+                mode,
+                mnemonic,
+                password,
+                confirm,
+                acknowledged,
+                error,
+            } => {
+                assert_eq!(mode, RecoveryKitMode::Create);
+                assert!(mnemonic.is_some(), "mnemonic must survive the round-trip");
+                assert_eq!(mnemonic.as_ref().unwrap().len(), 12);
+                assert_eq!(password.as_str(), "correct-horse-battery-staple");
+                assert_eq!(confirm.as_str(), "correct-horse-battery-staple");
+                assert!(acknowledged);
+                assert_eq!(error.as_deref(), Some("Connect timed out"));
+            }
+            other => panic!("expected PasswordEntry, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn upload_error_from_non_uploading_state_falls_back_to_error() {
+        // State drift — e.g. a stale `UploadResult` arrives after
+        // the user hit Cancel and the flow is already `None`.
+        // Don't crash or silently revert; surface the error.
+        let mut flow = RecoveryKitState::None;
+        restore_entry_on_upload_error(&mut flow, "stale upload result");
+        assert!(matches!(
+            flow,
+            RecoveryKitState::Error { ref message } if message == "stale upload result"
+        ));
     }
 
     // Regression tests for the Start-handler auth gate: the wizard
@@ -1151,5 +1343,86 @@ mod tests {
         blob.vault.descriptor = "different".into();
         let after = descriptor_blob_fingerprint(&blob).unwrap();
         assert_ne!(before, after);
+    }
+
+    // Regression test for the HashSet-order determinism bug:
+    // `Wallet::descriptor_keys()` returns a `HashSet<Fingerprint>`
+    // whose iteration order is randomised per-process. If
+    // `descriptor_blob_from_wallet` had serialised signers in
+    // HashSet order, each App tick would compute a different
+    // fingerprint and fire spurious W12 drift banners every time
+    // the live fingerprint was re-hashed. The fix is to sort the
+    // fingerprints by lowercase hex before building the signer
+    // list; this test pins the underlying invariant that justifies
+    // that sort.
+    fn signer(fp_hex: &str) -> DescriptorBlobSigner {
+        DescriptorBlobSigner {
+            name: "Signer".into(),
+            fingerprint: fp_hex.to_string(),
+            xpub: String::new(),
+        }
+    }
+
+    #[test]
+    fn descriptor_fingerprint_depends_on_signer_order() {
+        // Two blobs with identical signer *sets* but different
+        // orderings must produce different fingerprints — this is
+        // precisely why `descriptor_blob_from_wallet` sorts before
+        // building the list.
+        let base_vault = DescriptorBlobVault {
+            name: "n".into(),
+            descriptor: "d".into(),
+            change_descriptor: None,
+            signers: vec![signer("aaaaaaaa"), signer("bbbbbbbb")],
+        };
+        let a = DescriptorBlob {
+            version: BLOB_VERSION,
+            cube: DescriptorBlobCube {
+                uuid: "u".into(),
+                network: "bitcoin".into(),
+            },
+            vault: base_vault.clone(),
+        };
+        let mut b = a.clone();
+        b.vault.signers.reverse();
+        assert_ne!(
+            descriptor_blob_fingerprint(&a).unwrap(),
+            descriptor_blob_fingerprint(&b).unwrap(),
+            "signer order changes the fingerprint — production must sort before hashing",
+        );
+    }
+
+    #[test]
+    fn descriptor_fingerprint_stable_when_signers_are_presented_in_sorted_order() {
+        // Two independent Vec<DescriptorBlobSigner> constructions
+        // that both follow the "sort by lowercase hex" convention
+        // produce identical fingerprints — confirms the sort
+        // strategy used by `descriptor_blob_from_wallet`.
+        fn build_sorted(fps: &[&str]) -> DescriptorBlob {
+            let mut v: Vec<&str> = fps.to_vec();
+            v.sort_by_key(|s| s.to_lowercase());
+            DescriptorBlob {
+                version: BLOB_VERSION,
+                cube: DescriptorBlobCube {
+                    uuid: "u".into(),
+                    network: "bitcoin".into(),
+                },
+                vault: DescriptorBlobVault {
+                    name: "n".into(),
+                    descriptor: "d".into(),
+                    change_descriptor: None,
+                    signers: v.into_iter().map(signer).collect(),
+                },
+            }
+        }
+        // Two callers pass fingerprints in different "observed"
+        // orderings (simulating two HashSet iteration orders), but
+        // both sort before building — fingerprints must match.
+        let a = build_sorted(&["cafebabe", "deadbeef", "aabbccdd"]);
+        let b = build_sorted(&["aabbccdd", "deadbeef", "cafebabe"]);
+        assert_eq!(
+            descriptor_blob_fingerprint(&a).unwrap(),
+            descriptor_blob_fingerprint(&b).unwrap(),
+        );
     }
 }

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -51,7 +51,12 @@ pub enum SeedSource {
 /// failure can restore the entry screen without making the user
 /// re-type their password (and, for mnemonic cubes, re-enter their
 /// PIN to re-decrypt the mnemonic).
-#[derive(Debug)]
+///
+/// `Debug` is manual — the derived version would deref through
+/// `Zeroizing<String>` / `Zeroizing<Vec<String>>` and print the
+/// password and mnemonic words in plaintext to any `{:?}` site,
+/// which defeats the whole reason those fields are Zeroizing-wrapped
+/// in the first place. Keep the manual impl in sync with the fields.
 pub struct PasswordEntryPending {
     pub mode: RecoveryKitMode,
     pub mnemonic: Option<Zeroizing<Vec<String>>>,
@@ -60,9 +65,27 @@ pub struct PasswordEntryPending {
     pub acknowledged: bool,
 }
 
+impl std::fmt::Debug for PasswordEntryPending {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PasswordEntryPending")
+            .field("mode", &self.mode)
+            .field("mnemonic", &self.mnemonic.as_ref().map(|_| "<redacted>"))
+            .field("password", &"<redacted>")
+            .field("confirm", &"<redacted>")
+            .field("acknowledged", &self.acknowledged)
+            .finish()
+    }
+}
+
 /// The actual UI state of the wizard. `None` = card view; any other
 /// variant = wizard is taking over the settings page.
-#[derive(Debug)]
+///
+/// `Debug` is manual — the `PasswordEntry` variant holds the live
+/// password/confirm inputs and (for mnemonic cubes) the decrypted
+/// mnemonic; a derived `Debug` would print all three in plaintext.
+/// `Uploading` is also manual because it carries `PasswordEntryPending`
+/// which has its own redacting impl we want to delegate to. Other
+/// variants are non-sensitive and get straightforward formatting.
 pub enum RecoveryKitState {
     None,
     PinEntry {
@@ -96,6 +119,57 @@ pub enum RecoveryKitState {
     Error {
         message: String,
     },
+}
+
+impl std::fmt::Debug for RecoveryKitState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "None"),
+            Self::PinEntry { mode, error } => f
+                .debug_struct("PinEntry")
+                .field("mode", mode)
+                .field("error", error)
+                .finish(),
+            Self::PasswordEntry {
+                mode,
+                mnemonic,
+                acknowledged,
+                error,
+                // `password` and `confirm` intentionally omitted
+                // from the Debug output — printing them would
+                // leak the live recovery password. The `..`
+                // pattern keeps this impl compilable if fields
+                // are added later, but the "add new field" path
+                // should deliberately decide whether to expose it.
+                ..
+            } => f
+                .debug_struct("PasswordEntry")
+                .field("mode", mode)
+                .field("mnemonic", &mnemonic.as_ref().map(|_| "<redacted>"))
+                .field("password", &"<redacted>")
+                .field("confirm", &"<redacted>")
+                .field("acknowledged", acknowledged)
+                .field("error", error)
+                .finish(),
+            Self::Uploading { pending } => f
+                .debug_struct("Uploading")
+                // `pending`'s own Debug is redacting — delegate.
+                .field("pending", pending)
+                .finish(),
+            Self::Completed {
+                updated_at,
+                now_has_seed,
+                now_has_descriptor,
+            } => f
+                .debug_struct("Completed")
+                .field("updated_at", updated_at)
+                .field("now_has_seed", now_has_seed)
+                .field("now_has_descriptor", now_has_descriptor)
+                .finish(),
+            Self::Removing => write!(f, "Removing"),
+            Self::Error { message } => f.debug_struct("Error").field("message", message).finish(),
+        }
+    }
 }
 
 /// Top-level container held on `GeneralSettingsState`. Separates the
@@ -328,7 +402,10 @@ pub fn update(
                 password, error, ..
             } = &mut rk.flow
             {
-                *password = Zeroizing::new(value);
+                // `value` is already `Zeroizing<String>` from the
+                // message payload — move it straight in. The
+                // previous `password` drops here, wiping its heap.
+                *password = value;
                 *error = None;
             }
             Task::none()
@@ -336,7 +413,7 @@ pub fn update(
 
         RecoveryKitMessage::ConfirmChanged(value) => {
             if let RecoveryKitState::PasswordEntry { confirm, error, .. } = &mut rk.flow {
-                *confirm = Zeroizing::new(value);
+                *confirm = value;
                 *error = None;
             }
             Task::none()
@@ -934,10 +1011,18 @@ async fn encrypt_and_upload(
         None
     };
 
-    // Descriptor blob.
+    // Descriptor blob. Wrapping the serialised JSON in `Zeroizing<Vec<u8>>`
+    // mirrors the seed-blob site above and ensures the plaintext bytes —
+    // which embed the wallet's xpubs — are wiped when `bytes` drops at
+    // the end of this block. The descriptor halves aren't as sensitive
+    // as the mnemonic, but xpubs give watch-only spend access to every
+    // address on the wallet and match the privacy discipline applied
+    // to `DescriptorBlob`'s redacting Debug impl.
     let (desc_ct, desc_fp) = if include_descriptor {
         let blob = descriptor_blob.as_ref().unwrap();
-        let bytes = serde_json::to_vec(blob).map_err(|e| format!("serialize descriptor: {}", e))?;
+        let bytes: Zeroizing<Vec<u8>> = Zeroizing::new(
+            serde_json::to_vec(blob).map_err(|e| format!("serialize descriptor: {}", e))?,
+        );
         let ct = recovery::encrypt(&bytes, &password, KdfParams::DEFAULT_V1)
             .map_err(|e| format!("encrypt descriptor: {}", e))?;
         let fp = descriptor_blob_fingerprint(blob);
@@ -1079,6 +1164,92 @@ mod tests {
             confirm: Zeroizing::new("correct-horse-battery-staple".to_string()),
             acknowledged: true,
         }
+    }
+
+    // Regression tests for the Debug redaction on
+    // `PasswordEntryPending` and `RecoveryKitState`. Without manual
+    // impls, the derived versions would deref through `Zeroizing`
+    // and print the password + mnemonic words to any `{:?}` site,
+    // defeating the whole reason those fields are Zeroizing-wrapped.
+    // Canary strings are unlikely to collide with `<redacted>` or
+    // field names.
+
+    const PASSWORD_CANARY: &str = "pwd-canary-XYZZY-XYZZY-XYZZY";
+    const MNEMONIC_CANARY: &str = "mnemonic-canary-word-XYZZY";
+
+    fn pending_with_canaries() -> PasswordEntryPending {
+        PasswordEntryPending {
+            mode: RecoveryKitMode::Create,
+            mnemonic: Some(Zeroizing::new(vec![MNEMONIC_CANARY.to_string(); 12])),
+            password: Zeroizing::new(PASSWORD_CANARY.to_string()),
+            confirm: Zeroizing::new(PASSWORD_CANARY.to_string()),
+            acknowledged: true,
+        }
+    }
+
+    #[test]
+    fn password_entry_pending_debug_redacts_secrets() {
+        let p = pending_with_canaries();
+        let r = format!("{:?}", p);
+        assert!(
+            !r.contains(PASSWORD_CANARY),
+            "password leaked through PasswordEntryPending Debug: {}",
+            r
+        );
+        assert!(
+            !r.contains(MNEMONIC_CANARY),
+            "mnemonic leaked through PasswordEntryPending Debug: {}",
+            r
+        );
+        // Non-sensitive metadata is preserved for diagnostics.
+        assert!(r.contains("Create"), "mode should be visible: {}", r);
+        assert!(
+            r.contains("acknowledged: true"),
+            "acknowledged should be visible: {}",
+            r
+        );
+    }
+
+    #[test]
+    fn recovery_kit_state_password_entry_debug_redacts_secrets() {
+        let state = RecoveryKitState::PasswordEntry {
+            mode: RecoveryKitMode::Create,
+            mnemonic: Some(Zeroizing::new(vec![MNEMONIC_CANARY.to_string(); 12])),
+            password: Zeroizing::new(PASSWORD_CANARY.to_string()),
+            confirm: Zeroizing::new(PASSWORD_CANARY.to_string()),
+            acknowledged: false,
+            error: Some("wrong password".to_string()),
+        };
+        let r = format!("{:?}", state);
+        assert!(
+            !r.contains(PASSWORD_CANARY),
+            "password leaked through PasswordEntry Debug: {}",
+            r
+        );
+        assert!(
+            !r.contains(MNEMONIC_CANARY),
+            "mnemonic leaked through PasswordEntry Debug: {}",
+            r
+        );
+        // Error messages are diagnostic and non-secret; surface them.
+        assert!(
+            r.contains("wrong password"),
+            "error field should be visible: {}",
+            r
+        );
+    }
+
+    #[test]
+    fn recovery_kit_state_uploading_debug_redacts_via_pending() {
+        // The `Uploading { pending }` branch delegates to
+        // `PasswordEntryPending`'s redacting Debug; verify the
+        // composite doesn't re-expose the secrets.
+        let state = RecoveryKitState::Uploading {
+            pending: pending_with_canaries(),
+        };
+        let r = format!("{:?}", state);
+        assert!(!r.contains(PASSWORD_CANARY), "pwd leaked: {}", r);
+        assert!(!r.contains(MNEMONIC_CANARY), "mnemonic leaked: {}", r);
     }
 
     #[test]

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -96,6 +96,14 @@ pub struct RecoveryKit {
     /// they won't be, but keeping them isolated avoids accidental
     /// coupling).
     pub pin: PinInput,
+    /// One-shot flag: when the next `StatusLoaded` message resolves
+    /// (regardless of which code path fired the corresponding
+    /// `LoadStatus`), emit the post-vault-creation nudge toast iff
+    /// the loaded status indicates the user doesn't yet have a
+    /// descriptor backed up. Set by the W10 code path in
+    /// `App::update`; cleared on handle so subsequent Settings-page
+    /// entries don't re-nag.
+    pub nudge_on_next_status_load: bool,
 }
 
 impl RecoveryKit {
@@ -105,6 +113,7 @@ impl RecoveryKit {
             status_loading: false,
             flow: RecoveryKitState::None,
             pin: PinInput::new(),
+            nudge_on_next_status_load: false,
         }
     }
 
@@ -163,11 +172,29 @@ pub fn update(
                     tracing::warn!("get_recovery_kit_status failed: {}", e);
                     // Keep the prior cached status (if any) so the
                     // card doesn't flicker; surface a toast only —
-                    // no state transition.
+                    // no state transition. Also clear the nudge
+                    // flag — we don't want to defer the toast
+                    // indefinitely because of a transient error.
+                    rk.nudge_on_next_status_load = false;
                     return Task::done(Message::View(view::Message::ShowError(format!(
                         "Couldn't load Recovery Kit status: {}",
                         e
                     ))));
+                }
+            }
+            // W10 post-vault-creation nudge: fires only against a
+            // freshly-loaded status so we don't nag users whose kit
+            // already has a descriptor backed up. One-shot flag is
+            // cleared here regardless of outcome.
+            if rk.nudge_on_next_status_load {
+                rk.nudge_on_next_status_load = false;
+                if should_nudge_for_status(rk.status.as_ref()) {
+                    return Task::done(Message::View(view::Message::ShowToast(
+                        log::Level::Info,
+                        "Your new Vault is ready — back up your Wallet Descriptor in \
+                         Settings → General → Cube Recovery Kit."
+                            .to_string(),
+                    )));
                 }
             }
             Task::none()
@@ -175,6 +202,31 @@ pub fn update(
 
         RecoveryKitMessage::Start(mode) => {
             rk.pin.clear();
+            // Gate the whole wizard on Connect auth + cube
+            // registration *before* we collect anything sensitive
+            // (PIN, password). Without those, the final upload in
+            // `submit_password` would always fail — and the user
+            // would've re-entered their PIN and typed a password
+            // for nothing. Fail fast and point them at sign-in.
+            match start_guard(client.as_ref(), server_cube_id) {
+                StartGuard::Ok => {}
+                StartGuard::NotSignedIn => {
+                    rk.flow = RecoveryKitState::Error {
+                        message: "Sign in to Connect to back up your Recovery Kit. \
+                                  You can sign in from Settings → Connect."
+                            .to_string(),
+                    };
+                    return Task::none();
+                }
+                StartGuard::CubeNotRegistered => {
+                    rk.flow = RecoveryKitState::Error {
+                        message: "This Cube isn't registered with Connect yet. \
+                                  Open the Connect panel to finish setup, then try again."
+                            .to_string(),
+                    };
+                    return Task::none();
+                }
+            }
             match seed_source {
                 SeedSource::Mnemonic => {
                     rk.flow = RecoveryKitState::PinEntry { mode, error: None };
@@ -285,17 +337,25 @@ pub fn update(
                     let updated_at = outcome.updated_at.clone();
                     let now_has_seed = outcome.now_has_seed;
                     let now_has_descriptor = outcome.now_has_descriptor;
-                    let persist_fp_task = persist_descriptor_fingerprint(
-                        cache,
-                        local_cube_id,
-                        outcome.descriptor_fingerprint,
-                    );
+                    // Only refresh the cached drift fingerprint when
+                    // *this* upload actually included a descriptor half.
+                    // Passing through `None` would wipe a previously-
+                    // stored fingerprint on a seed-only upload (e.g.
+                    // `AddSeed`), which then silently disables drift
+                    // detection for the descriptor that's still on
+                    // the server. The `Remove` path clears the
+                    // fingerprint through its own dedicated call.
+                    let fp_to_persist = next_fingerprint_to_persist(&outcome);
                     rk.flow = RecoveryKitState::Completed {
                         updated_at,
                         now_has_seed,
                         now_has_descriptor,
                     };
-                    persist_fp_task
+                    if let Some(fp) = fp_to_persist {
+                        persist_descriptor_fingerprint(cache, local_cube_id, Some(fp))
+                    } else {
+                        Task::none()
+                    }
                 }
                 Err(e) => {
                     // Preserve any already-entered password so the user
@@ -476,20 +536,10 @@ fn submit_password(
     server_cube_id: Option<u64>,
     wallet: Option<Arc<Wallet>>,
 ) -> Task<Message> {
-    // Destructure without moving fields out of the state — we'll set
-    // rk.flow to `Uploading` if all validation passes.
-    let (
-        mode,
-        mnemonic_opt,
-        password_copy,
-        mnemonic_clone_opt,
-        cube_uuid,
-        cube_name,
-        network,
-        lightning_address,
-        created_at_str,
-    );
-    match &rk.flow {
+    // Pull validation + cloneable inputs out of the state without
+    // moving fields — we'll set `rk.flow = Uploading` once all checks
+    // pass and the task is on its way.
+    let (mode, password_copy, mnemonic_clone_opt) = match &rk.flow {
         RecoveryKitState::PasswordEntry {
             mode: m,
             mnemonic,
@@ -498,7 +548,6 @@ fn submit_password(
             acknowledged,
             ..
         } => {
-            // Validate.
             if password.as_str() != confirm.as_str() {
                 set_pw_error(rk, "Passwords don't match.");
                 return Task::none();
@@ -525,15 +574,10 @@ fn submit_password(
                 set_pw_error(rk, "Please confirm that you've written down this password.");
                 return Task::none();
             }
-
-            mode = *m;
-            mnemonic_opt = mnemonic.as_ref().map(|z| z.to_vec());
-            mnemonic_clone_opt = mnemonic.clone();
-            password_copy = Zeroizing::new(password.to_string());
+            (*m, Zeroizing::new(password.to_string()), mnemonic.clone())
         }
         _ => return Task::none(),
-    }
-    let _ = mnemonic_opt; // silence unused warning before shadowing below
+    };
 
     // Pull cube-scoped metadata from settings so the blob is complete.
     let network_dir = cache.datadir_path.network_directory(cache.network);
@@ -545,11 +589,11 @@ fn submit_password(
         set_pw_error(rk, "Cube not found in settings.");
         return Task::none();
     };
-    cube_uuid = cube.id.clone();
-    cube_name = cube.name.clone();
-    network = network_str(cube.network);
-    lightning_address = cache.lightning_address.clone();
-    created_at_str = chrono::DateTime::<chrono::Utc>::from_timestamp(cube.created_at, 0)
+    let cube_uuid = cube.id.clone();
+    let cube_name = cube.name.clone();
+    let network = network_str(cube.network);
+    let lightning_address = cache.lightning_address.clone();
+    let created_at_str = chrono::DateTime::<chrono::Utc>::from_timestamp(cube.created_at, 0)
         .map(|t| t.to_rfc3339())
         .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string());
 
@@ -603,15 +647,70 @@ fn set_pw_error(rk: &mut RecoveryKit, msg: &str) {
     }
 }
 
+/// Network string used inside `SeedBlob`/`DescriptorBlob`. Routed
+/// through the canonical `settings::network_to_api_string` so blobs
+/// written here agree with the Connect API's convention (`"mainnet"`
+/// for Bitcoin mainnet). A mismatch would leak into `DescriptorBlob.
+/// cube.network`, the fingerprint hash, and the restore-side
+/// network-filter — and silently break cross-client interop.
 fn network_str(n: Network) -> String {
-    match n {
-        Network::Bitcoin => "bitcoin",
-        Network::Testnet => "testnet",
-        Network::Signet => "signet",
-        Network::Regtest => "regtest",
-        _ => "unknown",
+    settings::network_to_api_string(n)
+}
+
+/// Result of the pre-flight check run at the top of
+/// `RecoveryKitMessage::Start`. Split out so the branch table is
+/// unit-testable without an authenticated Connect client or a full
+/// `App` instance.
+#[derive(Debug, PartialEq, Eq)]
+enum StartGuard {
+    /// User is signed in and the cube is registered with Connect —
+    /// proceed into the PIN/password wizard.
+    Ok,
+    /// No authenticated client available. Before we collect any
+    /// secrets (PIN, password), route the user to sign in.
+    NotSignedIn,
+    /// User is signed in but this Cube hasn't been registered with
+    /// Connect yet (missing `server_cube_id`). Rare — happens when
+    /// the `register_cube` call is still pending at the time the
+    /// user hits the Recovery-Kit CTA.
+    CubeNotRegistered,
+}
+
+fn start_guard(client: Option<&CoincubeClient>, server_cube_id: Option<u64>) -> StartGuard {
+    if client.is_none() {
+        return StartGuard::NotSignedIn;
     }
-    .to_string()
+    if server_cube_id.is_none() {
+        return StartGuard::CubeNotRegistered;
+    }
+    StartGuard::Ok
+}
+
+/// After a successful upload, what fingerprint (if any) should be
+/// written to the local drift cache? `None` means "leave the existing
+/// cache untouched" — the key distinction from "clear it", which the
+/// Remove path handles explicitly via `persist_descriptor_fingerprint(
+/// ..., None)`. Seed-only uploads don't compute a descriptor
+/// fingerprint, so they must not overwrite the previously-stored one
+/// — otherwise the still-on-server descriptor would become invisible
+/// to drift detection.
+fn next_fingerprint_to_persist(outcome: &RecoveryKitUploadOutcome) -> Option<String> {
+    outcome.descriptor_fingerprint.clone()
+}
+
+/// Should the post-vault-creation nudge toast be shown, given a
+/// `RecoveryKitStatus` loaded fresh from Connect?
+///
+/// Returns `true` when the user clearly needs to back up a descriptor:
+/// no kit at all, or a kit without the descriptor half. `None` is
+/// treated as "needs nudge" — the only way to reach `None` after a
+/// successful `StatusLoaded(Ok(...))` is if the in-memory slot was
+/// never populated, which means the 404 fallback also didn't fire,
+/// and nudging is the conservative choice.
+fn should_nudge_for_status(status: Option<&RecoveryKitStatus>) -> bool {
+    status
+        .map(|s| !s.has_recovery_kit || !s.has_encrypted_wallet_descriptor)
+        .unwrap_or(true)
 }
 
 fn descriptor_blob_from_wallet(wallet: &Wallet, cube_uuid: &str, network: &str) -> DescriptorBlob {
@@ -795,6 +894,144 @@ mod tests {
     use crate::services::recovery::{
         DescriptorBlob, DescriptorBlobCube, DescriptorBlobSigner, DescriptorBlobVault,
     };
+
+    fn status_complete() -> RecoveryKitStatus {
+        RecoveryKitStatus {
+            has_recovery_kit: true,
+            has_encrypted_seed: true,
+            has_encrypted_wallet_descriptor: true,
+            encryption_scheme: "aes-256-gcm".into(),
+            created_at: Some("2026-04-23T00:00:00Z".into()),
+            updated_at: Some("2026-04-23T00:00:00Z".into()),
+        }
+    }
+
+    fn status_seed_only() -> RecoveryKitStatus {
+        RecoveryKitStatus {
+            has_recovery_kit: true,
+            has_encrypted_seed: true,
+            has_encrypted_wallet_descriptor: false,
+            encryption_scheme: "aes-256-gcm".into(),
+            created_at: Some("2026-04-23T00:00:00Z".into()),
+            updated_at: Some("2026-04-23T00:00:00Z".into()),
+        }
+    }
+
+    fn status_absent() -> RecoveryKitStatus {
+        RecoveryKitStatus {
+            has_recovery_kit: false,
+            has_encrypted_seed: false,
+            has_encrypted_wallet_descriptor: false,
+            encryption_scheme: String::new(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    // Regression tests for the Start-handler auth gate: the wizard
+    // must not push the user into PIN/password entry when the
+    // upload is guaranteed to fail at the end (not signed in, or
+    // the Cube isn't registered yet). Without these, users waste
+    // re-entering their PIN + typing a password only to hit "Sign
+    // in to Connect" on Submit.
+
+    #[test]
+    fn start_guard_fails_without_client() {
+        assert_eq!(start_guard(None, Some(42)), StartGuard::NotSignedIn);
+        assert_eq!(start_guard(None, None), StartGuard::NotSignedIn);
+    }
+
+    #[test]
+    fn start_guard_fails_without_cube_id() {
+        let client = CoincubeClient::for_test("http://localhost");
+        assert_eq!(
+            start_guard(Some(&client), None),
+            StartGuard::CubeNotRegistered
+        );
+    }
+
+    #[test]
+    fn start_guard_ok_when_authed_and_registered() {
+        let client = CoincubeClient::for_test("http://localhost");
+        assert_eq!(start_guard(Some(&client), Some(42)), StartGuard::Ok);
+    }
+
+    // Regression tests for the seed-only-upload fingerprint-clobber
+    // bug: a seed-only upload (AddSeed mode on a mnemonic cube) must
+    // not wipe a previously-stored drift fingerprint. Otherwise the
+    // descriptor that's still on the server becomes invisible to
+    // W12 drift detection.
+
+    #[test]
+    fn next_fingerprint_none_on_seed_only_upload() {
+        let outcome = RecoveryKitUploadOutcome {
+            updated_at: "2026-04-23T00:00:00Z".into(),
+            now_has_seed: true,
+            now_has_descriptor: false,
+            descriptor_fingerprint: None,
+        };
+        assert!(
+            next_fingerprint_to_persist(&outcome).is_none(),
+            "seed-only upload must signal 'skip persist' so the \
+             previously-stored fingerprint is preserved",
+        );
+    }
+
+    #[test]
+    fn next_fingerprint_some_when_descriptor_uploaded() {
+        let outcome = RecoveryKitUploadOutcome {
+            updated_at: "2026-04-23T00:00:00Z".into(),
+            now_has_seed: true,
+            now_has_descriptor: true,
+            descriptor_fingerprint: Some("a".repeat(64)),
+        };
+        assert_eq!(next_fingerprint_to_persist(&outcome), Some("a".repeat(64)));
+    }
+
+    // Regression tests for the W10 post-vault-creation nudge: the
+    // decision must be based on a *freshly-loaded* status, not the
+    // in-memory cache at the moment the vault transition fires. A
+    // pre-fetch `None` used to produce a spurious nudge for users
+    // with a complete kit.
+
+    #[test]
+    fn nudge_when_no_kit_on_server() {
+        assert!(should_nudge_for_status(Some(&status_absent())));
+    }
+
+    #[test]
+    fn nudge_when_kit_has_seed_but_no_descriptor() {
+        assert!(should_nudge_for_status(Some(&status_seed_only())));
+    }
+
+    #[test]
+    fn no_nudge_when_kit_already_has_descriptor() {
+        assert!(!should_nudge_for_status(Some(&status_complete())));
+    }
+
+    #[test]
+    fn nudge_when_status_is_none_defensively() {
+        // `None` should not normally reach this function after a
+        // successful `StatusLoaded(Ok(_))` (the handler assigns
+        // `rk.status` before calling). Defensive default is to
+        // nudge rather than silently drop.
+        assert!(should_nudge_for_status(None));
+    }
+
+    // Regression test for the Bitcoin-mainnet restore bug: the local
+    // network string used by the restore step's cube-picker filter
+    // (and by blob content) must match the Connect API's canonical
+    // form — otherwise mainnet users see zero matching cubes when
+    // trying to restore.
+    #[test]
+    fn network_str_matches_api_for_all_networks() {
+        use coincube_core::miniscript::bitcoin::Network as BtcNet;
+        assert_eq!(network_str(BtcNet::Bitcoin), "mainnet");
+        assert_eq!(network_str(BtcNet::Testnet), "testnet");
+        assert_eq!(network_str(BtcNet::Testnet4), "testnet4");
+        assert_eq!(network_str(BtcNet::Signet), "signet");
+        assert_eq!(network_str(BtcNet::Regtest), "regtest");
+    }
 
     #[test]
     fn descriptor_fingerprint_is_deterministic() {

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -1,0 +1,822 @@
+//! Cube Recovery Kit state machine + message handler.
+//!
+//! The state is held as a sub-struct on `GeneralSettingsState` so that
+//! the existing local-paper-backup flow (`BackupSeedState`) coexists
+//! untouched — the two features live side-by-side per the plan (§1).
+//!
+//! Dispatch uses the same pattern as `state::connect::cube_members`:
+//! the handler is a free function, and the parent (App-level) injects
+//! the authenticated `CoincubeClient`, the Connect-numeric cube id,
+//! and the live `Wallet` because those are not reachable from the
+//! generic `State::update` trait signature.
+//!
+//! See `plans/PLAN-cube-recovery-kit-desktop.md` §2.3 (state machine)
+//! and §2.4 (card rendering).
+
+use std::sync::Arc;
+
+use coincube_core::miniscript::bitcoin::Network;
+use coincube_core::signer::MasterSigner;
+use iced::Task;
+use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
+
+use crate::app::cache::Cache;
+use crate::app::message::Message;
+use crate::app::settings::{self, update_settings_file};
+use crate::app::view;
+use crate::app::view::{RecoveryKitMessage, RecoveryKitMode, RecoveryKitUploadOutcome};
+use crate::app::wallet::Wallet;
+use crate::pin_input::PinInput;
+use crate::services::coincube::{
+    CoincubeClient, CoincubeError, RecoveryKit as ApiRecoveryKit, RecoveryKitStatus,
+    RECOVERY_KIT_SCHEME_AES_256_GCM,
+};
+use crate::services::recovery::{
+    self, DescriptorBlob, DescriptorBlobCube, DescriptorBlobSigner, DescriptorBlobVault, KdfParams,
+    SeedBlob, SeedBlobCube, SeedBlobMnemonic, BLOB_VERSION, MIN_PASSWORD_LEN,
+};
+
+/// Whether this cube's seed is extractable on-device (mnemonic cubes
+/// can extract via PIN; passkey cubes cannot — their seed derives from
+/// a WebAuthn PRF re-ceremony). Drives whether PIN entry is part of
+/// the flow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeedSource {
+    Mnemonic,
+    Passkey,
+}
+
+/// The actual UI state of the wizard. `None` = card view; any other
+/// variant = wizard is taking over the settings page.
+#[derive(Debug)]
+pub enum RecoveryKitState {
+    None,
+    PinEntry {
+        mode: RecoveryKitMode,
+        error: Option<String>,
+    },
+    PasswordEntry {
+        mode: RecoveryKitMode,
+        /// Present for mnemonic cubes once PIN has been verified. `None`
+        /// for passkey cubes (descriptor-only upload).
+        mnemonic: Option<Zeroizing<Vec<String>>>,
+        password: Zeroizing<String>,
+        confirm: Zeroizing<String>,
+        /// "I've written this down" gate — Submit is inert until true.
+        acknowledged: bool,
+        error: Option<String>,
+    },
+    Uploading,
+    Completed {
+        updated_at: String,
+        now_has_seed: bool,
+        now_has_descriptor: bool,
+    },
+    Removing,
+    Error {
+        message: String,
+    },
+}
+
+/// Top-level container held on `GeneralSettingsState`. Separates the
+/// Recovery-Kit concern from the local-paper-backup state so each has
+/// its own independent lifecycle.
+pub struct RecoveryKit {
+    /// Last-known status from Connect. Drives the card copy. `None`
+    /// until the first `LoadStatus` fires and resolves.
+    pub status: Option<RecoveryKitStatus>,
+    /// True while a `LoadStatus` round-trip is in flight. Card can
+    /// show a skeleton while this is set.
+    pub status_loading: bool,
+    /// Wizard state; `None` when the card is visible.
+    pub flow: RecoveryKitState,
+    /// PIN widget — separate from `backup_pin` so the two flows can
+    /// be active at once without stepping on each other (in practice
+    /// they won't be, but keeping them isolated avoids accidental
+    /// coupling).
+    pub pin: PinInput,
+}
+
+impl RecoveryKit {
+    pub fn new() -> Self {
+        Self {
+            status: None,
+            status_loading: false,
+            flow: RecoveryKitState::None,
+            pin: PinInput::new(),
+        }
+    }
+
+    /// Drop any in-flight flow state (PIN, password, decrypted
+    /// mnemonic). Called on Cancel and on wizard completion.
+    pub fn reset_flow(&mut self) {
+        self.flow = RecoveryKitState::None;
+        self.pin.clear();
+    }
+}
+
+impl Default for RecoveryKit {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Entry point. Intended to be called from `App::update` for every
+/// `SettingsMessage::RecoveryKit(_)` it sees. The caller injects the
+/// authenticated Connect client, the numeric cube id, and the current
+/// Wallet (if any) — these aren't reachable from the generic
+/// `State::update` trait signature.
+#[allow(clippy::too_many_arguments)]
+pub fn update(
+    rk: &mut RecoveryKit,
+    msg: RecoveryKitMessage,
+    cache: &Cache,
+    local_cube_id: &str,
+    seed_source: SeedSource,
+    client: Option<CoincubeClient>,
+    server_cube_id: Option<u64>,
+    wallet: Option<Arc<Wallet>>,
+) -> Task<Message> {
+    match msg {
+        RecoveryKitMessage::LoadStatus => load_status(rk, client, server_cube_id),
+
+        RecoveryKitMessage::StatusLoaded(res) => {
+            rk.status_loading = false;
+            match res {
+                Ok(Some(s)) => {
+                    rk.status = Some(s);
+                }
+                Ok(None) => {
+                    // 404 — no kit on the server; render card in
+                    // "Create" state.
+                    rk.status = Some(RecoveryKitStatus {
+                        has_recovery_kit: false,
+                        has_encrypted_seed: false,
+                        has_encrypted_wallet_descriptor: false,
+                        encryption_scheme: String::new(),
+                        created_at: None,
+                        updated_at: None,
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!("get_recovery_kit_status failed: {}", e);
+                    // Keep the prior cached status (if any) so the
+                    // card doesn't flicker; surface a toast only —
+                    // no state transition.
+                    return Task::done(Message::View(view::Message::ShowError(format!(
+                        "Couldn't load Recovery Kit status: {}",
+                        e
+                    ))));
+                }
+            }
+            Task::none()
+        }
+
+        RecoveryKitMessage::Start(mode) => {
+            rk.pin.clear();
+            match seed_source {
+                SeedSource::Mnemonic => {
+                    rk.flow = RecoveryKitState::PinEntry { mode, error: None };
+                }
+                SeedSource::Passkey => {
+                    // Passkey cubes skip PIN entry — the seed is not
+                    // extractable on-device; we can only upload the
+                    // descriptor blob. Guard: a descriptor must exist.
+                    if wallet.is_none() {
+                        rk.flow = RecoveryKitState::Error {
+                            message: "Create a Vault first — a passkey Cube can only back up its \
+                                      Wallet Descriptor, and there's no Vault yet."
+                                .to_string(),
+                        };
+                        return Task::none();
+                    }
+                    rk.flow = RecoveryKitState::PasswordEntry {
+                        mode,
+                        mnemonic: None,
+                        password: Zeroizing::new(String::new()),
+                        confirm: Zeroizing::new(String::new()),
+                        acknowledged: false,
+                        error: None,
+                    };
+                }
+            }
+            Task::none()
+        }
+
+        RecoveryKitMessage::Cancel => {
+            rk.reset_flow();
+            Task::none()
+        }
+
+        RecoveryKitMessage::PinInput(pin_msg) => {
+            if let RecoveryKitState::PinEntry { error, .. } = &mut rk.flow {
+                *error = None;
+            }
+            rk.pin.update(pin_msg).map(|m| {
+                Message::View(view::Message::Settings(view::SettingsMessage::RecoveryKit(
+                    RecoveryKitMessage::PinInput(m),
+                )))
+            })
+        }
+
+        RecoveryKitMessage::VerifyPin => verify_pin(rk, cache, local_cube_id),
+
+        RecoveryKitMessage::PinVerified(res) => {
+            rk.pin.clear();
+            let mode = match &rk.flow {
+                RecoveryKitState::PinEntry { mode, .. } => *mode,
+                _ => return Task::none(),
+            };
+            match res {
+                Ok(words) => {
+                    rk.flow = RecoveryKitState::PasswordEntry {
+                        mode,
+                        mnemonic: Some(Zeroizing::new(words)),
+                        password: Zeroizing::new(String::new()),
+                        confirm: Zeroizing::new(String::new()),
+                        acknowledged: false,
+                        error: None,
+                    };
+                }
+                Err(e) => {
+                    rk.flow = RecoveryKitState::PinEntry {
+                        mode,
+                        error: Some(e),
+                    };
+                }
+            }
+            Task::none()
+        }
+
+        RecoveryKitMessage::PasswordChanged(value) => {
+            if let RecoveryKitState::PasswordEntry {
+                password, error, ..
+            } = &mut rk.flow
+            {
+                *password = Zeroizing::new(value);
+                *error = None;
+            }
+            Task::none()
+        }
+
+        RecoveryKitMessage::ConfirmChanged(value) => {
+            if let RecoveryKitState::PasswordEntry {
+                confirm, error, ..
+            } = &mut rk.flow
+            {
+                *confirm = Zeroizing::new(value);
+                *error = None;
+            }
+            Task::none()
+        }
+
+        RecoveryKitMessage::AcknowledgeToggled(checked) => {
+            if let RecoveryKitState::PasswordEntry { acknowledged, .. } = &mut rk.flow {
+                *acknowledged = checked;
+            }
+            Task::none()
+        }
+
+        RecoveryKitMessage::SubmitPassword => submit_password(rk, cache, client, server_cube_id, wallet),
+
+        RecoveryKitMessage::UploadResult(res) => {
+            match res {
+                Ok(outcome) => {
+                    let updated_at = outcome.updated_at.clone();
+                    let now_has_seed = outcome.now_has_seed;
+                    let now_has_descriptor = outcome.now_has_descriptor;
+                    let persist_fp_task = persist_descriptor_fingerprint(
+                        cache,
+                        local_cube_id,
+                        outcome.descriptor_fingerprint,
+                    );
+                    rk.flow = RecoveryKitState::Completed {
+                        updated_at,
+                        now_has_seed,
+                        now_has_descriptor,
+                    };
+                    persist_fp_task
+                }
+                Err(e) => {
+                    // Preserve any already-entered password so the user
+                    // doesn't have to retype it. Error shows inline.
+                    if let RecoveryKitState::PasswordEntry { error, .. } = &mut rk.flow {
+                        *error = Some(e.clone());
+                    } else {
+                        // Mid-flight cancel or state drift — fall back
+                        // to the Error screen.
+                        rk.flow = RecoveryKitState::Error { message: e.clone() };
+                    }
+                    Task::done(Message::View(view::Message::ShowError(e)))
+                }
+            }
+        }
+
+        RecoveryKitMessage::DismissCompleted => {
+            rk.reset_flow();
+            // Re-fetch status so the card shows the new state.
+            load_status(rk, client, server_cube_id)
+        }
+
+        RecoveryKitMessage::Remove => {
+            let Some(client) = client else {
+                return Task::done(Message::View(view::Message::ShowError(
+                    "Sign in to Connect to remove your Recovery Kit.".to_string(),
+                )));
+            };
+            let Some(cube_id) = server_cube_id else {
+                return Task::done(Message::View(view::Message::ShowError(
+                    "This Cube isn't registered with Connect yet.".to_string(),
+                )));
+            };
+            rk.flow = RecoveryKitState::Removing;
+            Task::perform(
+                async move { client.delete_recovery_kit(cube_id).await.map_err(|e| e.to_string()) },
+                |res| {
+                    Message::View(view::Message::Settings(view::SettingsMessage::RecoveryKit(
+                        RecoveryKitMessage::RemoveResult(res),
+                    )))
+                },
+            )
+        }
+
+        RecoveryKitMessage::RemoveResult(res) => {
+            match res {
+                Ok(()) => {
+                    rk.reset_flow();
+                    // Clear local drift fingerprint cache — there's
+                    // nothing backed up to compare against any more.
+                    let persist = persist_descriptor_fingerprint(cache, local_cube_id, None);
+                    let reload = load_status(rk, client, server_cube_id);
+                    Task::batch([persist, reload])
+                }
+                Err(e) => {
+                    rk.flow = RecoveryKitState::Error { message: e.clone() };
+                    Task::done(Message::View(view::Message::ShowError(e)))
+                }
+            }
+        }
+    }
+}
+
+fn load_status(
+    rk: &mut RecoveryKit,
+    client: Option<CoincubeClient>,
+    server_cube_id: Option<u64>,
+) -> Task<Message> {
+    let Some(client) = client else {
+        return Task::none();
+    };
+    let Some(cube_id) = server_cube_id else {
+        return Task::none();
+    };
+    if rk.status_loading {
+        return Task::none();
+    }
+    rk.status_loading = true;
+    Task::perform(
+        async move {
+            match client.get_recovery_kit_status(cube_id).await {
+                Ok(s) => Ok(Some(s)),
+                // 404 is the "no kit yet" signal — not an error for
+                // our card logic. Collapse it to Ok(None).
+                Err(CoincubeError::NotFound) => Ok(None),
+                Err(e) => Err(e.to_string()),
+            }
+        },
+        |res| {
+            Message::View(view::Message::Settings(view::SettingsMessage::RecoveryKit(
+                RecoveryKitMessage::StatusLoaded(res),
+            )))
+        },
+    )
+}
+
+fn verify_pin(rk: &mut RecoveryKit, cache: &Cache, local_cube_id: &str) -> Task<Message> {
+    let mode = match &rk.flow {
+        RecoveryKitState::PinEntry { mode, .. } => *mode,
+        _ => return Task::none(),
+    };
+    if !rk.pin.is_complete() {
+        rk.flow = RecoveryKitState::PinEntry {
+            mode,
+            error: Some("Please enter all 4 PIN digits".to_string()),
+        };
+        return Task::none();
+    }
+    let pin = rk.pin.value();
+
+    // Reach into the on-disk settings for this cube to get the
+    // fingerprint + PIN hash. Matches `handle_backup_message`.
+    let network_dir = cache.datadir_path.network_directory(cache.network);
+    let Ok(s) = settings::Settings::from_file(&network_dir) else {
+        rk.flow = RecoveryKitState::PinEntry {
+            mode,
+            error: Some("Failed to read settings file".to_string()),
+        };
+        return Task::none();
+    };
+    let Some(cube) = s.cubes.iter().find(|c| c.id == local_cube_id).cloned() else {
+        rk.flow = RecoveryKitState::PinEntry {
+            mode,
+            error: Some("Cube not found in settings".to_string()),
+        };
+        return Task::none();
+    };
+    let Some(fingerprint) = cube.master_signer_fingerprint else {
+        rk.flow = RecoveryKitState::PinEntry {
+            mode,
+            error: Some("This Cube has no master signer.".to_string()),
+        };
+        return Task::none();
+    };
+    let datadir = cache.datadir_path.path().to_path_buf();
+    let network = cache.network;
+
+    Task::perform(
+        async move {
+            tokio::task::spawn_blocking(move || {
+                if !cube.verify_pin(&pin) {
+                    return Err("Incorrect PIN. Please try again.".to_string());
+                }
+                load_mnemonic_words(&datadir, network, fingerprint, &pin)
+            })
+            .await
+            .map_err(|e| format!("PIN verification task failed: {}", e))?
+        },
+        |res| {
+            Message::View(view::Message::Settings(view::SettingsMessage::RecoveryKit(
+                RecoveryKitMessage::PinVerified(res),
+            )))
+        },
+    )
+}
+
+fn load_mnemonic_words(
+    datadir: &std::path::Path,
+    network: Network,
+    fingerprint: coincube_core::miniscript::bitcoin::bip32::Fingerprint,
+    pin: &str,
+) -> Result<Vec<String>, String> {
+    let signer =
+        MasterSigner::from_datadir_by_fingerprint(datadir, network, fingerprint, Some(pin))
+            .map_err(|e| e.to_string())?;
+    Ok(signer.words().iter().map(|w| (*w).to_string()).collect())
+}
+
+fn submit_password(
+    rk: &mut RecoveryKit,
+    cache: &Cache,
+    client: Option<CoincubeClient>,
+    server_cube_id: Option<u64>,
+    wallet: Option<Arc<Wallet>>,
+) -> Task<Message> {
+    // Destructure without moving fields out of the state — we'll set
+    // rk.flow to `Uploading` if all validation passes.
+    let (
+        mode,
+        mnemonic_opt,
+        password_copy,
+        mnemonic_clone_opt,
+        cube_uuid,
+        cube_name,
+        network,
+        lightning_address,
+        created_at_str,
+    );
+    match &rk.flow {
+        RecoveryKitState::PasswordEntry {
+            mode: m,
+            mnemonic,
+            password,
+            confirm,
+            acknowledged,
+            ..
+        } => {
+            // Validate.
+            if password.as_str() != confirm.as_str() {
+                set_pw_error(rk, "Passwords don't match.");
+                return Task::none();
+            }
+            if password.len() < MIN_PASSWORD_LEN {
+                set_pw_error(
+                    rk,
+                    &format!("Password must be at least {} characters.", MIN_PASSWORD_LEN),
+                );
+                return Task::none();
+            }
+            let (strength, _) = recovery::score_password(password, &[]);
+            if !strength.is_acceptable() {
+                set_pw_error(
+                    rk,
+                    &format!(
+                        "Password is too weak ({}). Try a longer passphrase or add complexity.",
+                        strength.label()
+                    ),
+                );
+                return Task::none();
+            }
+            if !*acknowledged {
+                set_pw_error(
+                    rk,
+                    "Please confirm that you've written down this password.",
+                );
+                return Task::none();
+            }
+
+            mode = *m;
+            mnemonic_opt = mnemonic.as_ref().map(|z| z.to_vec());
+            mnemonic_clone_opt = mnemonic.clone();
+            password_copy = Zeroizing::new(password.to_string());
+        }
+        _ => return Task::none(),
+    }
+    let _ = mnemonic_opt; // silence unused warning before shadowing below
+
+    // Pull cube-scoped metadata from settings so the blob is complete.
+    let network_dir = cache.datadir_path.network_directory(cache.network);
+    let Ok(s) = settings::Settings::from_file(&network_dir) else {
+        set_pw_error(rk, "Failed to read settings file.");
+        return Task::none();
+    };
+    let Some(cube) = s.cubes.iter().find(|c| c.id == cache.cube_id).cloned() else {
+        set_pw_error(rk, "Cube not found in settings.");
+        return Task::none();
+    };
+    cube_uuid = cube.id.clone();
+    cube_name = cube.name.clone();
+    network = network_str(cube.network);
+    lightning_address = cache.lightning_address.clone();
+    created_at_str = chrono::DateTime::<chrono::Utc>::from_timestamp(cube.created_at, 0)
+        .map(|t| t.to_rfc3339())
+        .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string());
+
+    let Some(client) = client else {
+        set_pw_error(rk, "Sign in to Connect to back up your Recovery Kit.");
+        return Task::none();
+    };
+    let Some(cube_id_num) = server_cube_id else {
+        set_pw_error(rk, "This Cube isn't registered with Connect yet.");
+        return Task::none();
+    };
+
+    // Build descriptor blob when we have a live wallet.
+    let descriptor_blob = wallet.as_ref().map(|w| descriptor_blob_from_wallet(w, &cube_uuid, &network));
+
+    rk.flow = RecoveryKitState::Uploading;
+
+    let mnemonic = mnemonic_clone_opt;
+    Task::perform(
+        async move {
+            encrypt_and_upload(
+                client,
+                cube_id_num,
+                mode,
+                mnemonic,
+                descriptor_blob,
+                SeedBlobCube {
+                    uuid: cube_uuid,
+                    name: cube_name,
+                    network,
+                    created_at: created_at_str,
+                    lightning_address,
+                },
+                password_copy,
+            )
+            .await
+        },
+        |res| {
+            Message::View(view::Message::Settings(view::SettingsMessage::RecoveryKit(
+                RecoveryKitMessage::UploadResult(res),
+            )))
+        },
+    )
+}
+
+fn set_pw_error(rk: &mut RecoveryKit, msg: &str) {
+    if let RecoveryKitState::PasswordEntry { error, .. } = &mut rk.flow {
+        *error = Some(msg.to_string());
+    }
+}
+
+fn network_str(n: Network) -> String {
+    match n {
+        Network::Bitcoin => "bitcoin",
+        Network::Testnet => "testnet",
+        Network::Signet => "signet",
+        Network::Regtest => "regtest",
+        _ => "unknown",
+    }
+    .to_string()
+}
+
+fn descriptor_blob_from_wallet(wallet: &Wallet, cube_uuid: &str, network: &str) -> DescriptorBlob {
+    // The descriptor string embeds the full signer xpubs inline, so
+    // restore is self-contained from `vault.descriptor` alone. The
+    // separate `signers` array is metadata the UI can show pre-restore
+    // (fingerprint, friendly name) — xpubs are extracted by the
+    // restorer from the descriptor itself. Leaving `xpub` empty here
+    // is deliberate: we'd need a miniscript-level traversal to pull
+    // per-fingerprint xpubs out cleanly, which is a larger change.
+    let signers: Vec<DescriptorBlobSigner> = wallet
+        .descriptor_keys()
+        .into_iter()
+        .map(|fp| DescriptorBlobSigner {
+            name: wallet
+                .keys_aliases
+                .get(&fp)
+                .cloned()
+                .unwrap_or_else(|| "Signer".to_string()),
+            fingerprint: format!("{}", fp).to_lowercase(),
+            xpub: String::new(),
+        })
+        .collect();
+    DescriptorBlob {
+        version: BLOB_VERSION,
+        cube: DescriptorBlobCube {
+            uuid: cube_uuid.to_string(),
+            network: network.to_string(),
+        },
+        vault: DescriptorBlobVault {
+            name: wallet.name.clone(),
+            descriptor: wallet.main_descriptor.to_string(),
+            change_descriptor: None,
+            signers,
+        },
+    }
+}
+
+/// SHA-256 over the canonical JSON of the descriptor blob. Used as
+/// the drift fingerprint cached on `CubeSettings`. Deterministic so
+/// long as `serde_json::to_vec` is called consistently.
+pub fn descriptor_blob_fingerprint(blob: &DescriptorBlob) -> Option<String> {
+    let bytes = serde_json::to_vec(blob).ok()?;
+    let digest = Sha256::digest(&bytes);
+    Some(hex::encode(digest))
+}
+
+/// Compute the live descriptor fingerprint for a wallet. Used by
+/// `App::update` to populate `cache.current_descriptor_fingerprint`
+/// each tick, which the Settings card compares against the last-
+/// backed-up fingerprint to surface the drift banner (W12).
+pub fn live_descriptor_fingerprint(
+    wallet: &Wallet,
+    cube_uuid: &str,
+    network: &str,
+) -> Option<String> {
+    let blob = descriptor_blob_from_wallet(wallet, cube_uuid, network);
+    descriptor_blob_fingerprint(&blob)
+}
+
+async fn encrypt_and_upload(
+    client: CoincubeClient,
+    cube_id_num: u64,
+    mode: RecoveryKitMode,
+    mnemonic: Option<Zeroizing<Vec<String>>>,
+    descriptor_blob: Option<DescriptorBlob>,
+    cube_meta: SeedBlobCube,
+    password: Zeroizing<String>,
+) -> Result<RecoveryKitUploadOutcome, String> {
+    // Decide which halves to include based on mode + available data.
+    let include_seed = matches!(
+        mode,
+        RecoveryKitMode::Create | RecoveryKitMode::AddSeed | RecoveryKitMode::Rotate
+    ) && mnemonic.is_some();
+    let include_descriptor = descriptor_blob.is_some()
+        && !matches!(mode, RecoveryKitMode::AddSeed);
+
+    if !include_seed && !include_descriptor {
+        return Err(
+            "Nothing to back up — mnemonic cubes need a PIN, passkey cubes need a Vault."
+                .to_string(),
+        );
+    }
+
+    // Seed blob.
+    let seed_ct = if include_seed {
+        let words = mnemonic.as_ref().unwrap();
+        let phrase = words.join(" ");
+        let blob = SeedBlob {
+            version: BLOB_VERSION,
+            cube: cube_meta.clone(),
+            mnemonic: SeedBlobMnemonic {
+                phrase,
+                language: "en".to_string(),
+            },
+        };
+        let bytes = serde_json::to_vec(&blob).map_err(|e| format!("serialize seed: {}", e))?;
+        Some(
+            recovery::encrypt(&bytes, &password, KdfParams::DEFAULT_V1)
+                .map_err(|e| format!("encrypt seed: {}", e))?,
+        )
+    } else {
+        None
+    };
+
+    // Descriptor blob.
+    let (desc_ct, desc_fp) = if include_descriptor {
+        let blob = descriptor_blob.as_ref().unwrap();
+        let bytes =
+            serde_json::to_vec(blob).map_err(|e| format!("serialize descriptor: {}", e))?;
+        let ct = recovery::encrypt(&bytes, &password, KdfParams::DEFAULT_V1)
+            .map_err(|e| format!("encrypt descriptor: {}", e))?;
+        let fp = descriptor_blob_fingerprint(blob);
+        (Some(ct), fp)
+    } else {
+        (None, None)
+    };
+
+    let seed_ref = seed_ct.as_deref();
+    let desc_ref = desc_ct.as_deref();
+    let kit: ApiRecoveryKit = client
+        .put_recovery_kit(cube_id_num, seed_ref, desc_ref, RECOVERY_KIT_SCHEME_AES_256_GCM)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(RecoveryKitUploadOutcome {
+        updated_at: kit.updated_at,
+        now_has_seed: !kit.encrypted_cube_seed.is_empty(),
+        now_has_descriptor: !kit.encrypted_wallet_descriptor.is_empty(),
+        descriptor_fingerprint: desc_fp,
+    })
+}
+
+fn persist_descriptor_fingerprint(
+    cache: &Cache,
+    local_cube_id: &str,
+    fingerprint: Option<String>,
+) -> Task<Message> {
+    let network_dir = cache.datadir_path.network_directory(cache.network);
+    let cube_id = local_cube_id.to_string();
+    Task::perform(
+        async move {
+            update_settings_file(&network_dir, |mut s| {
+                if let Some(cube) = s.cubes.iter_mut().find(|c| c.id == cube_id) {
+                    cube.recovery_kit_last_backed_up_descriptor_fingerprint = fingerprint.clone();
+                }
+                Some(s)
+            })
+            .await
+            .map_err(|e| format!("Failed to update settings: {}", e))
+        },
+        |res: Result<(), String>| match res {
+            Ok(()) => Message::SettingsSaved,
+            Err(e) => Message::View(view::Message::ShowError(e)),
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::recovery::{
+        DescriptorBlob, DescriptorBlobCube, DescriptorBlobSigner, DescriptorBlobVault,
+    };
+
+    #[test]
+    fn descriptor_fingerprint_is_deterministic() {
+        let blob = DescriptorBlob {
+            version: BLOB_VERSION,
+            cube: DescriptorBlobCube {
+                uuid: "u".into(),
+                network: "bitcoin".into(),
+            },
+            vault: DescriptorBlobVault {
+                name: "n".into(),
+                descriptor: "d".into(),
+                change_descriptor: None,
+                signers: vec![DescriptorBlobSigner {
+                    name: "s".into(),
+                    fingerprint: "deadbeef".into(),
+                    xpub: String::new(),
+                }],
+            },
+        };
+        let a = descriptor_blob_fingerprint(&blob).unwrap();
+        let b = descriptor_blob_fingerprint(&blob).unwrap();
+        assert_eq!(a, b, "fingerprint must be deterministic");
+        assert_eq!(a.len(), 64, "SHA-256 hex is 64 chars");
+    }
+
+    #[test]
+    fn descriptor_fingerprint_differs_on_content_change() {
+        let mut blob = DescriptorBlob {
+            version: BLOB_VERSION,
+            cube: DescriptorBlobCube {
+                uuid: "u".into(),
+                network: "bitcoin".into(),
+            },
+            vault: DescriptorBlobVault {
+                name: "n".into(),
+                descriptor: "d".into(),
+                change_descriptor: None,
+                signers: vec![],
+            },
+        };
+        let before = descriptor_blob_fingerprint(&blob).unwrap();
+        blob.vault.descriptor = "different".into();
+        let after = descriptor_blob_fingerprint(&blob).unwrap();
+        assert_ne!(before, after);
+    }
+}

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -427,7 +427,7 @@ pub fn update(
         }
 
         RecoveryKitMessage::SubmitPassword => {
-            submit_password(rk, cache, client, server_cube_id, wallet)
+            submit_password(rk, cache, local_cube_id, client, server_cube_id, wallet)
         }
 
         RecoveryKitMessage::UploadResult(res) => {
@@ -622,6 +622,15 @@ fn verify_pin(rk: &mut RecoveryKit, cache: &Cache, local_cube_id: &str) -> Task<
 fn submit_password(
     rk: &mut RecoveryKit,
     cache: &Cache,
+    // Use the dispatcher-injected local cube id rather than
+    // `cache.cube_id`. Both come from `self.cube_settings.id` today,
+    // but they refresh on different cadences — routing everything in
+    // this module through the same `local_cube_id` parameter keeps
+    // `verify_pin`, `submit_password`, and the UploadResult
+    // `persist_descriptor_fingerprint` call all pointing at the same
+    // cube even if a mid-session settings reload ever desynchronizes
+    // the two sources.
+    local_cube_id: &str,
     client: Option<CoincubeClient>,
     server_cube_id: Option<u64>,
     wallet: Option<Arc<Wallet>>,
@@ -691,7 +700,7 @@ fn submit_password(
         set_pw_error(rk, "Failed to read settings file.");
         return Task::none();
     };
-    let Some(cube) = s.cubes.iter().find(|c| c.id == cache.cube_id).cloned() else {
+    let Some(cube) = s.cubes.iter().find(|c| c.id == local_cube_id).cloned() else {
         set_pw_error(rk, "Cube not found in settings.");
         return Task::none();
     };

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -16,7 +16,6 @@
 use std::sync::Arc;
 
 use coincube_core::miniscript::bitcoin::Network;
-use coincube_core::signer::MasterSigner;
 use iced::Task;
 use sha2::{Digest, Sha256};
 use zeroize::Zeroizing;
@@ -302,9 +301,12 @@ pub fn update(
             };
             match res {
                 Ok(words) => {
+                    // `words: Zeroizing<Vec<String>>` — the wrap
+                    // already happened at the async boundary in
+                    // `verify_pin`'s task. Just move it into state.
                     rk.flow = RecoveryKitState::PasswordEntry {
                         mode,
-                        mnemonic: Some(Zeroizing::new(words)),
+                        mnemonic: Some(words),
                         password: Zeroizing::new(String::new()),
                         confirm: Zeroizing::new(String::new()),
                         acknowledged: false,
@@ -512,11 +514,22 @@ fn verify_pin(rk: &mut RecoveryKit, cache: &Cache, local_cube_id: &str) -> Task<
 
     Task::perform(
         async move {
+            // Wrap the decrypted mnemonic in `Zeroizing` at the
+            // async boundary — before the value enters the message
+            // queue — so every in-flight copy of the subsequent
+            // `PinVerified` message gets wiped on drop, not just
+            // the final one stashed in state. `load_mnemonic_words`
+            // returns a plain `Vec<String>` because the local
+            // paper-backup flow doesn't need Zeroizing wrapping
+            // (its final consumer is a `Zeroizing<Vec<String>>`
+            // state field); here we promote at the earliest
+            // reachable point.
             tokio::task::spawn_blocking(move || {
                 if !cube.verify_pin(&pin) {
                     return Err("Incorrect PIN. Please try again.".to_string());
                 }
-                load_mnemonic_words(&datadir, network, fingerprint, &pin)
+                super::general::load_mnemonic_words(&datadir, network, fingerprint, &pin)
+                    .map(Zeroizing::new)
             })
             .await
             .map_err(|e| format!("PIN verification task failed: {}", e))?
@@ -527,18 +540,6 @@ fn verify_pin(rk: &mut RecoveryKit, cache: &Cache, local_cube_id: &str) -> Task<
             )))
         },
     )
-}
-
-fn load_mnemonic_words(
-    datadir: &std::path::Path,
-    network: Network,
-    fingerprint: coincube_core::miniscript::bitcoin::bip32::Fingerprint,
-    pin: &str,
-) -> Result<Vec<String>, String> {
-    let signer =
-        MasterSigner::from_datadir_by_fingerprint(datadir, network, fingerprint, Some(pin))
-            .map_err(|e| e.to_string())?;
-    Ok(signer.words().iter().map(|w| (*w).to_string()).collect())
 }
 
 fn submit_password(

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -642,7 +642,7 @@ fn submit_password(
     // fails, so a transient network error doesn't force the user to
     // re-type their password (and re-enter their PIN to unlock the
     // mnemonic again).
-    let (mode, password_copy, mnemonic_clone_opt, pending) = match &rk.flow {
+    let (password_copy, mnemonic_clone_opt, pending) = match &rk.flow {
         RecoveryKitState::PasswordEntry {
             mode: m,
             mnemonic,
@@ -685,7 +685,6 @@ fn submit_password(
                 acknowledged: *acknowledged,
             };
             (
-                *m,
                 Zeroizing::new(password.to_string()),
                 mnemonic.clone(),
                 pending,
@@ -734,7 +733,6 @@ fn submit_password(
             encrypt_and_upload(
                 client,
                 cube_id_num,
-                mode,
                 mnemonic,
                 descriptor_blob,
                 SeedBlobCube {
@@ -969,7 +967,6 @@ fn restore_entry_on_upload_error(flow: &mut RecoveryKitState, err: &str) {
 async fn encrypt_and_upload(
     client: CoincubeClient,
     cube_id_num: u64,
-    _mode: RecoveryKitMode,
     mnemonic: Option<Zeroizing<Vec<String>>>,
     descriptor_blob: Option<DescriptorBlob>,
     cube_meta: SeedBlobCube,

--- a/coincube-gui/src/app/view/global_home.rs
+++ b/coincube-gui/src/app/view/global_home.rs
@@ -262,8 +262,14 @@ fn wallet_card<'a>(
                 .push(text("Vault").size(14))
                 .push(
                     Row::new()
+                        .spacing(10)
                         .align_y(Alignment::Center)
                         .push(Space::new().width(Length::Fill))
+                        .push(
+                            button::secondary(None, "Restore from Connect")
+                                .width(Length::Fixed(200.0))
+                                .on_press(Message::SetupVaultRestoreFromKit),
+                        )
                         .push(
                             button::primary(None, "Create Vault")
                                 .width(Length::Fixed(160.0))

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -259,6 +259,11 @@ pub enum SettingsMessage {
     /// Master seed backup flow (moved from Liquid Settings to Cube/General Settings).
     BackupMasterSeed(BackupWalletMessage),
     BackupMasterSeedUpdated,
+    /// Cube Recovery Kit — Connect-hosted encrypted backup of the seed
+    /// and/or wallet descriptor. See `PLAN-cube-recovery-kit-desktop.md`.
+    /// Coexists with `BackupMasterSeed` above (the local paper-phrase
+    /// backup), it does not replace it.
+    RecoveryKit(RecoveryKitMessage),
 }
 
 #[derive(Debug, Clone)]
@@ -691,6 +696,144 @@ impl std::fmt::Debug for BackupWalletMessage {
                 .field(&Err::<(), _>(e))
                 .finish(),
             Self::BackupSaveResult(res) => f.debug_tuple("BackupSaveResult").field(res).finish(),
+        }
+    }
+}
+
+/// Which Recovery-Kit mode the user entered the wizard under. Carried
+/// inside `RecoveryKitMessage::Start` so the wizard knows whether to
+/// prompt for the PIN (mnemonic cubes uploading the seed half) or
+/// skip straight to the password screen (passkey cubes, which can
+/// only back up the wallet descriptor). Mirrors the plan §2.3 mode
+/// matrix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryKitMode {
+    /// No server-side kit yet — create the first one. For mnemonic
+    /// cubes this uploads the seed blob plus (when a Vault exists)
+    /// the descriptor blob. For passkey cubes it's descriptor-only.
+    Create,
+    /// An existing kit has a seed but no descriptor; add the
+    /// descriptor half (and re-encrypt the seed with the new
+    /// password, per plan §5).
+    AddDescriptor,
+    /// An existing kit has a descriptor but no seed; add the seed
+    /// half. Not reachable for passkey cubes.
+    AddSeed,
+    /// Re-encrypt the existing kit under a new password. Keeps both
+    /// halves that are present; doesn't add missing halves.
+    Rotate,
+}
+
+/// Messages driving the Cube Recovery Kit flow. Mirrors the shape of
+/// `BackupWalletMessage` — a Debug impl below redacts every variant
+/// that carries key material (mnemonic, password, ciphertext) so the
+/// tracing subscriber can still dump messages without leaking.
+#[derive(Clone)]
+pub enum RecoveryKitMessage {
+    /// Fire a `get_recovery_kit_status` request to refresh the cached
+    /// status used to render the Settings card. Emitted on page entry
+    /// and after any local change that could invalidate the cache
+    /// (rotate/remove).
+    LoadStatus,
+    /// Async result of `LoadStatus`. `Ok(None)` means the backend
+    /// returned 404 (no kit on this cube yet).
+    StatusLoaded(Result<Option<crate::services::coincube::RecoveryKitStatus>, String>),
+    /// User clicked the card CTA — enter the wizard in the given
+    /// mode. Kicks off PIN entry for mnemonic cubes or jumps
+    /// straight to password entry for passkey cubes.
+    Start(RecoveryKitMode),
+    /// User hit "Cancel" or back-arrow inside the wizard — drop
+    /// transient state (PIN, password, decrypted mnemonic) and
+    /// return to the card view.
+    Cancel,
+    /// Digit entry in the PIN re-verification gate (mnemonic cubes
+    /// only — the PIN unlocks the on-disk encrypted mnemonic so the
+    /// seed blob can be built).
+    PinInput(crate::pin_input::Message),
+    /// User submitted the PIN.
+    VerifyPin,
+    /// Async result: `Ok(words)` on correct PIN + successful
+    /// decryption; `Err(msg)` on wrong PIN or disk error.
+    PinVerified(Result<Vec<String>, String>),
+    /// Recovery password input changed.
+    PasswordChanged(String),
+    /// "Confirm recovery password" input changed.
+    ConfirmChanged(String),
+    /// User toggled the "I've written this down" gate on the password
+    /// screen. Submit is inert until this is true.
+    AcknowledgeToggled(bool),
+    /// User clicked Submit on the password screen. Triggers the
+    /// build-blob → encrypt → upload async task.
+    SubmitPassword,
+    /// Async result of the encrypt+upload round-trip. The payload is
+    /// the `(updated_at, descriptor_fingerprint_hex)` tuple the
+    /// settings state needs to cache.
+    UploadResult(Result<RecoveryKitUploadOutcome, String>),
+    /// User dismissed the Completed screen — return to card view and
+    /// trigger a fresh `LoadStatus`.
+    DismissCompleted,
+    /// User clicked Remove. Fires `delete_recovery_kit`.
+    Remove,
+    /// Async result of Remove.
+    RemoveResult(Result<(), String>),
+}
+
+/// What the upload handler hands back to the state machine on success.
+/// We only carry the fields the state needs to render the Completed
+/// screen and persist the drift-fingerprint cache.
+#[derive(Debug, Clone)]
+pub struct RecoveryKitUploadOutcome {
+    /// RFC 3339 timestamp from the server's `updatedAt` field. Shown
+    /// in the Completed screen's "Last updated" line.
+    pub updated_at: String,
+    /// `has_encrypted_seed` per the server's response (so the card
+    /// can pick the right next-state copy without a second round-trip).
+    pub now_has_seed: bool,
+    /// `has_encrypted_wallet_descriptor` per the server's response.
+    pub now_has_descriptor: bool,
+    /// SHA-256 (hex) over the `DescriptorBlob` plaintext we just
+    /// uploaded. `None` when the upload didn't include a descriptor
+    /// blob. Settings state persists this into
+    /// `CubeSettings::recovery_kit_last_backed_up_descriptor_fingerprint`
+    /// for drift detection (W12).
+    pub descriptor_fingerprint: Option<String>,
+}
+
+// Manual Debug: every variant that could carry mnemonic, password,
+// or ciphertext bytes is redacted. Matches `BackupWalletMessage`'s
+// pattern above — losing a tracing snapshot must not leak the kit.
+impl std::fmt::Debug for RecoveryKitMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LoadStatus => write!(f, "LoadStatus"),
+            Self::StatusLoaded(r) => f.debug_tuple("StatusLoaded").field(r).finish(),
+            Self::Start(m) => f.debug_tuple("Start").field(m).finish(),
+            Self::Cancel => write!(f, "Cancel"),
+            Self::PinInput(_) => f.debug_tuple("PinInput").field(&"<redacted>").finish(),
+            Self::VerifyPin => write!(f, "VerifyPin"),
+            Self::PinVerified(Ok(_)) => write!(f, "PinVerified(Ok(<redacted>))"),
+            Self::PinVerified(Err(e)) => f
+                .debug_tuple("PinVerified")
+                .field(&Err::<(), _>(e))
+                .finish(),
+            Self::PasswordChanged(_) => f
+                .debug_tuple("PasswordChanged")
+                .field(&"<redacted>")
+                .finish(),
+            Self::ConfirmChanged(_) => f
+                .debug_tuple("ConfirmChanged")
+                .field(&"<redacted>")
+                .finish(),
+            Self::AcknowledgeToggled(b) => f.debug_tuple("AcknowledgeToggled").field(b).finish(),
+            Self::SubmitPassword => write!(f, "SubmitPassword"),
+            Self::UploadResult(Ok(o)) => f.debug_tuple("UploadResult(Ok)").field(o).finish(),
+            Self::UploadResult(Err(e)) => f
+                .debug_tuple("UploadResult")
+                .field(&Err::<(), _>(e))
+                .finish(),
+            Self::DismissCompleted => write!(f, "DismissCompleted"),
+            Self::Remove => write!(f, "Remove"),
+            Self::RemoveResult(r) => f.debug_tuple("RemoveResult").field(r).finish(),
         }
     }
 }

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -59,6 +59,12 @@ pub enum Message {
     Clipboard(String),
     Menu(Menu),
     SetupVault,
+    /// W15 — launch the vault installer in "restore from Connect
+    /// Recovery Kit" mode. Branches off the same button the default
+    /// `SetupVault` goes through, but flags the installer to use
+    /// `UserFlow::RestoreVaultFromRecoveryKit` instead of
+    /// `CreateWallet`.
+    SetupVaultRestoreFromKit,
     Close,
     Select(usize),
     SelectRefundable(usize),

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -759,8 +759,13 @@ pub enum RecoveryKitMessage {
     /// User submitted the PIN.
     VerifyPin,
     /// Async result: `Ok(words)` on correct PIN + successful
-    /// decryption; `Err(msg)` on wrong PIN or disk error.
-    PinVerified(Result<Vec<String>, String>),
+    /// decryption; `Err(msg)` on wrong PIN or disk error. The
+    /// mnemonic is wrapped in `Zeroizing` so every in-flight copy
+    /// of this message (Iced's runtime may clone between the
+    /// update handler, task, and view) is wiped on drop. Without
+    /// the wrap, a plain `Vec<String>` with the phrase bytes would
+    /// linger on the heap past the message cycle.
+    PinVerified(Result<zeroize::Zeroizing<Vec<String>>, String>),
     /// Recovery password input changed.
     PasswordChanged(String),
     /// "Confirm recovery password" input changed.

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -766,10 +766,17 @@ pub enum RecoveryKitMessage {
     /// the wrap, a plain `Vec<String>` with the phrase bytes would
     /// linger on the heap past the message cycle.
     PinVerified(Result<zeroize::Zeroizing<Vec<String>>, String>),
-    /// Recovery password input changed.
-    PasswordChanged(String),
-    /// "Confirm recovery password" input changed.
-    ConfirmChanged(String),
+    /// Recovery password input changed. Wrapped in `Zeroizing` at
+    /// the message level (not just on the state field) because
+    /// Iced's runtime clones messages between update/task/view —
+    /// plain `String` copies would linger on the heap past the
+    /// flow's completion. Matches the installer's
+    /// `RecoveryKitRestoreMsg::PasswordEdited` discipline.
+    PasswordChanged(zeroize::Zeroizing<String>),
+    /// "Confirm recovery password" input changed. Same
+    /// `Zeroizing`-at-message-level discipline as
+    /// `PasswordChanged` above.
+    ConfirmChanged(zeroize::Zeroizing<String>),
     /// User toggled the "I've written this down" gate on the password
     /// screen. Submit is inert until this is true.
     AcknowledgeToggled(bool),
@@ -792,7 +799,14 @@ pub enum RecoveryKitMessage {
 /// What the upload handler hands back to the state machine on success.
 /// We only carry the fields the state needs to render the Completed
 /// screen and persist the drift-fingerprint cache.
-#[derive(Debug, Clone)]
+///
+/// `Debug` is manual below — the `descriptor_fingerprint` hex is a
+/// stable identifier correlatable across sessions and against the
+/// server-side record, so it's redacted from any `{:?}` site.
+/// Tracing dumps see `Some(<redacted>)` / `None` while still
+/// revealing whether an upload produced a fingerprint at all (a
+/// non-sensitive signal useful for diagnostics).
+#[derive(Clone)]
 pub struct RecoveryKitUploadOutcome {
     /// RFC 3339 timestamp from the server's `updatedAt` field. Shown
     /// in the Completed screen's "Last updated" line.
@@ -808,6 +822,22 @@ pub struct RecoveryKitUploadOutcome {
     /// `CubeSettings::recovery_kit_last_backed_up_descriptor_fingerprint`
     /// for drift detection (W12).
     pub descriptor_fingerprint: Option<String>,
+}
+
+impl std::fmt::Debug for RecoveryKitUploadOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RecoveryKitUploadOutcome")
+            .field("updated_at", &self.updated_at)
+            .field("now_has_seed", &self.now_has_seed)
+            .field("now_has_descriptor", &self.now_has_descriptor)
+            .field(
+                "descriptor_fingerprint",
+                // Preserve presence/absence for diagnostics while
+                // hiding the hex itself.
+                &self.descriptor_fingerprint.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
 }
 
 // Manual Debug: every variant that could carry mnemonic, password,
@@ -1337,4 +1367,71 @@ pub enum P2PMessage {
     FileSaved(Result<(), String>),
     // Stream-level errors (relay connection, subscription, restore failures)
     StreamError(String),
+}
+
+#[cfg(test)]
+mod recovery_kit_upload_outcome_debug_tests {
+    use super::{RecoveryKitMessage, RecoveryKitUploadOutcome};
+
+    /// Canary string embedded into the fingerprint. If it ever appears in
+    /// a Debug render we know the redaction regressed.
+    const CANARY_FP: &str = "canary-fp-XYZZY-do-not-leak";
+
+    fn outcome_with_fp(fp: Option<String>) -> RecoveryKitUploadOutcome {
+        RecoveryKitUploadOutcome {
+            updated_at: "2026-04-22T00:00:00Z".to_string(),
+            now_has_seed: true,
+            now_has_descriptor: true,
+            descriptor_fingerprint: fp,
+        }
+    }
+
+    #[test]
+    fn debug_redacts_some_fingerprint_but_preserves_presence() {
+        let outcome = outcome_with_fp(Some(CANARY_FP.to_string()));
+        let rendered = format!("{:?}", outcome);
+        assert!(
+            !rendered.contains(CANARY_FP),
+            "fingerprint hex leaked through Debug: {}",
+            rendered
+        );
+        assert!(
+            rendered.contains("<redacted>"),
+            "redaction marker missing: {}",
+            rendered
+        );
+        assert!(
+            rendered.contains("Some"),
+            "presence of Some() should remain visible: {}",
+            rendered
+        );
+        assert!(rendered.contains("updated_at"));
+        assert!(rendered.contains("now_has_seed"));
+        assert!(rendered.contains("now_has_descriptor"));
+    }
+
+    #[test]
+    fn debug_renders_none_when_fingerprint_absent() {
+        let outcome = outcome_with_fp(None);
+        let rendered = format!("{:?}", outcome);
+        assert!(
+            rendered.contains("None"),
+            "absent case lost signal: {}",
+            rendered
+        );
+        assert!(!rendered.contains(CANARY_FP));
+    }
+
+    #[test]
+    fn upload_result_ok_debug_does_not_leak_fingerprint() {
+        let msg =
+            RecoveryKitMessage::UploadResult(Ok(outcome_with_fp(Some(CANARY_FP.to_string()))));
+        let rendered = format!("{:?}", msg);
+        assert!(
+            !rendered.contains(CANARY_FP),
+            "Debug(RecoveryKitMessage::UploadResult(Ok(..))) leaked fingerprint: {}",
+            rendered
+        );
+        assert!(rendered.contains("<redacted>"));
+    }
 }

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -11,8 +11,10 @@ use crate::app::menu::Menu;
 use crate::app::settings::display::DisplayMode;
 use crate::app::settings::fiat::PriceSetting;
 use crate::app::settings::unit::{BitcoinDisplayUnit, UnitSetting};
+use crate::app::state::settings::recovery_kit::RecoveryKit;
 use crate::app::view::dashboard;
 use crate::app::view::message::*;
+use crate::services::coincube::RecoveryKitStatus;
 use crate::services::fiat::{Currency, ALL_PRICE_SOURCES};
 
 #[allow(clippy::too_many_arguments)]
@@ -27,6 +29,7 @@ pub fn general_section<'a>(
     backup_state: &'a crate::app::state::settings::general::BackupSeedState,
     backup_pin: &'a crate::pin_input::PinInput,
     backup_mnemonic: Option<&'a [String]>,
+    recovery_kit: Option<&'a RecoveryKit>,
 ) -> Element<'a, Message> {
     use crate::app::state::settings::general::BackupSeedState;
 
@@ -49,6 +52,39 @@ pub fn general_section<'a>(
         .push(direction_badges_toggle(show_direction_badges))
         .push(fiat_price(new_price_setting, currencies_list))
         .push(backup_master_seed_card(cache.current_cube_backed_up));
+
+    // Connect-hosted Recovery Kit card. Render only when the outer
+    // SettingsState had a `RecoveryKit` on hand — i.e. when the
+    // downcasting wrapper invoked `view_with_recovery_kit`. Falling
+    // back to no-card when `None` keeps the trait-based `view`
+    // callers harmless.
+    if let Some(rk) = recovery_kit {
+        // W12 drift: compute on the fly by comparing the cached live
+        // fingerprint (refreshed every App tick) with the last-backed-up
+        // fingerprint (persisted on `CubeSettings`). Only meaningful
+        // when a descriptor has actually been backed up — otherwise
+        // the card's "incomplete" copy already prompts the user.
+        let server_has_descriptor = rk
+            .status
+            .as_ref()
+            .map(|s| s.has_encrypted_wallet_descriptor)
+            .unwrap_or(false);
+        let drift = server_has_descriptor
+            && match (
+                &cache.current_descriptor_fingerprint,
+                &cache.recovery_kit_last_backed_up_descriptor_fingerprint,
+            ) {
+                (Some(live), Some(cached)) => live != cached,
+                _ => false,
+            };
+        col = col.push(recovery_kit_card(
+            cache.current_cube_is_passkey,
+            cache.has_vault,
+            rk.status.as_ref(),
+            rk.status_loading,
+            drift,
+        ));
+    }
 
     if developer_mode {
         col = col.push(toast_testing());
@@ -91,6 +127,167 @@ fn backup_master_seed_card<'a>(backed_up: bool) -> Element<'a, Message> {
                     .width(Length::Fixed(160.0))
                     .on_press(SettingsMessage::BackupMasterSeed(BackupWalletMessage::Start).into()),
             ),
+    )
+    .width(Length::Fill)
+    .into()
+}
+
+/// Cube Recovery Kit card — rendered below the local paper-phrase
+/// backup card. Shows copy + a primary action that drives the
+/// `RecoveryKitMessage` flow. States mirror the plan §6.3 matrix.
+///
+/// - `is_passkey`: when true, the seed is unextractable on-device and
+///   only the descriptor can be backed up; the card has a reduced
+///   two-state variant and is suppressed entirely on passkey cubes
+///   without a Vault (nothing to back up).
+/// - `has_vault`: gates the "complete" copy on mnemonic cubes — a
+///   seed-only kit on a vaultless cube is already "complete" from the
+///   user's perspective, so the CTA becomes "Update" rather than
+///   "Add Wallet Descriptor".
+fn recovery_kit_card<'a>(
+    is_passkey: bool,
+    has_vault: bool,
+    status: Option<&RecoveryKitStatus>,
+    loading: bool,
+    drift: bool,
+) -> Element<'a, Message> {
+    // Passkey + no vault => nothing to back up yet. Render a thin
+    // informational card rather than the regular flow.
+    if is_passkey && !has_vault {
+        return card::simple(
+            Column::new()
+                .spacing(4)
+                .push(text("Back up your Wallet Descriptor").bold())
+                .push(
+                    text(
+                        "Passkey Cubes back up the Wallet Descriptor only — create a Vault \
+                         to enable Recovery-Kit backup.",
+                    )
+                    .size(14),
+                ),
+        )
+        .width(Length::Fill)
+        .into();
+    }
+
+    let (title, subtitle, primary_label, primary_mode) = if is_passkey {
+        // Passkey variant — descriptor-only. Two states.
+        match status {
+            Some(s) if s.has_encrypted_wallet_descriptor => (
+                "Wallet Descriptor backed up",
+                format!(
+                    "Last updated {}.",
+                    s.updated_at.as_deref().unwrap_or("—")
+                ),
+                "Update",
+                RecoveryKitMode::Rotate,
+            ),
+            _ => (
+                "Back up your Wallet Descriptor",
+                "Your Master Seed Phrase is protected by your passkey and isn't included \
+                 in the Recovery Kit — we back up the Wallet Descriptor only."
+                    .to_string(),
+                "Create Recovery Kit",
+                RecoveryKitMode::Create,
+            ),
+        }
+    } else {
+        // Mnemonic variant — full four-state matrix per plan §6.3.
+        match status {
+            Some(s) if !s.has_recovery_kit => (
+                "Back up your Cube Recovery Kit",
+                "Back up your Master Seed Phrase and Wallet Descriptor to your Connect \
+                 account so you can restore your Cube if you lose this device."
+                    .to_string(),
+                "Create Recovery Kit",
+                RecoveryKitMode::Create,
+            ),
+            Some(s) if s.has_encrypted_seed && !s.has_encrypted_wallet_descriptor && has_vault => (
+                "Finish backing up your Recovery Kit",
+                "Your Master Seed Phrase is backed up, but your Wallet Descriptor isn't."
+                    .to_string(),
+                "Add Wallet Descriptor",
+                RecoveryKitMode::AddDescriptor,
+            ),
+            Some(s) if !s.has_encrypted_seed && s.has_encrypted_wallet_descriptor => (
+                "Finish backing up your Recovery Kit",
+                "Your Wallet Descriptor is backed up, but your Master Seed Phrase isn't."
+                    .to_string(),
+                "Add Master Seed Phrase",
+                RecoveryKitMode::AddSeed,
+            ),
+            Some(s) => (
+                "Recovery Kit backed up",
+                format!(
+                    "Last updated {}.",
+                    s.updated_at.as_deref().unwrap_or("—")
+                ),
+                "Update",
+                RecoveryKitMode::Rotate,
+            ),
+            None => (
+                "Cube Recovery Kit",
+                if loading {
+                    "Checking your Connect account…".to_string()
+                } else {
+                    "Sign in to Connect to back up your Cube Recovery Kit.".to_string()
+                },
+                "Create Recovery Kit",
+                RecoveryKitMode::Create,
+            ),
+        }
+    };
+
+    // Drift overrides the "complete" state: primary CTA becomes
+    // "Update now" and the subtitle swaps to the drift warning.
+    let (subtitle, primary_label, primary_mode) = if drift {
+        (
+            "Your Wallet Descriptor changed since your last backup — update now.".to_string(),
+            "Update now",
+            RecoveryKitMode::Rotate,
+        )
+    } else {
+        (subtitle, primary_label, primary_mode)
+    };
+
+    // Render with Remove button when a kit exists.
+    let has_kit = status.map(|s| s.has_recovery_kit).unwrap_or(false);
+    let mut actions = Row::new().spacing(10).align_y(Alignment::Center).push(
+        button::primary(None, primary_label)
+            .padding([8, 16])
+            .width(Length::Fixed(220.0))
+            .on_press(
+                SettingsMessage::RecoveryKit(RecoveryKitMessage::Start(primary_mode)).into(),
+            ),
+    );
+    if has_kit {
+        actions = actions.push(
+            button::secondary(None, "Remove")
+                .padding([8, 16])
+                .width(Length::Fixed(120.0))
+                .on_press(SettingsMessage::RecoveryKit(RecoveryKitMessage::Remove).into()),
+        );
+    }
+
+    let mut body = Column::new()
+        .spacing(4)
+        .width(Length::Fill)
+        .push(text(title).bold())
+        .push(text(subtitle).size(14));
+    if drift {
+        body = body.push(
+            text("⚠ Descriptor out of sync with your Connect backup.")
+                .size(12)
+                .style(coincube_ui::theme::text::warning),
+        );
+    }
+
+    card::simple(
+        Row::new()
+            .spacing(20)
+            .align_y(Alignment::Center)
+            .push(body)
+            .push(actions),
     )
     .width(Length::Fill)
     .into()

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -490,18 +490,24 @@ fn descriptor_drift(server_has_descriptor: bool, live: Option<&str>, cached: Opt
         return false;
     }
     match (live, cached) {
-        // Both present — direct comparison.
+        // Both present — direct comparison. This is the only branch
+        // with positive evidence of drift; everything else is
+        // absence-of-evidence and must not fire the banner.
         (Some(live), Some(cached)) => live != cached,
-        // Live wallet descriptor loaded but no local fingerprint to
-        // compare against (cache cleared, restored from a different
-        // install, descriptor uploaded from another device). The
-        // server says a descriptor is backed up; we can't verify it
-        // matches what this device would now upload, so nudge the
-        // user to resync.
-        (Some(_), None) => true,
-        // Any case where the live fingerprint isn't computable (no
-        // Vault loaded yet) can't produce a meaningful comparison;
-        // avoid a false positive.
+        // Live descriptor known, no cached hash. This happens for:
+        // kit restored onto this device (we never re-uploaded so
+        // never populated the cache), kit uploaded from a different
+        // device, and installs that pre-date the cache field. In
+        // all three, the server's `has_encrypted_wallet_descriptor`
+        // flag already tells us a backup exists — firing the banner
+        // here produces a *permanent* false positive that stays up
+        // until the user manually re-uploads, training them to
+        // ignore the signal entirely (banner blindness). The
+        // always-visible "Update" CTA on the card is the right
+        // affordance for users who want to force a refresh; the
+        // banner is reserved for confirmed drift.
+        (Some(_), None) => false,
+        // No live fingerprint (no Vault loaded yet) → can't compare.
         _ => false,
     }
 }
@@ -530,12 +536,16 @@ mod tests {
     }
 
     #[test]
-    fn drift_when_cached_missing_but_live_present() {
-        // Regression: previously swallowed by `_ => false`. Server
-        // reports a descriptor, live wallet is loaded, but we have
-        // no local cache to compare against — the conservative call
-        // is to flag drift so the user resyncs.
-        assert!(descriptor_drift(true, Some("a"), None));
+    fn no_drift_when_cached_missing_but_live_present() {
+        // The drift banner must fire only on *positive evidence* of
+        // drift (cached hash known + different). Absence of a local
+        // cached fingerprint is the normal state after a kit is
+        // restored to this device, uploaded from another device, or
+        // created by a client version predating the cache field.
+        // The server's `has_encrypted_wallet_descriptor=true` is the
+        // authoritative signal that a backup exists; firing a
+        // permanent banner here would train users to tune it out.
+        assert!(!descriptor_drift(true, Some("a"), None));
     }
 
     #[test]

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -175,10 +175,7 @@ fn recovery_kit_card<'a>(
         match status {
             Some(s) if s.has_encrypted_wallet_descriptor => (
                 "Wallet Descriptor backed up",
-                format!(
-                    "Last updated {}.",
-                    s.updated_at.as_deref().unwrap_or("—")
-                ),
+                format!("Last updated {}.", s.updated_at.as_deref().unwrap_or("—")),
                 "Update",
                 RecoveryKitMode::Rotate,
             ),
@@ -218,10 +215,7 @@ fn recovery_kit_card<'a>(
             ),
             Some(s) => (
                 "Recovery Kit backed up",
-                format!(
-                    "Last updated {}.",
-                    s.updated_at.as_deref().unwrap_or("—")
-                ),
+                format!("Last updated {}.", s.updated_at.as_deref().unwrap_or("—")),
                 "Update",
                 RecoveryKitMode::Rotate,
             ),
@@ -256,9 +250,7 @@ fn recovery_kit_card<'a>(
         button::primary(None, primary_label)
             .padding([8, 16])
             .width(Length::Fixed(220.0))
-            .on_press(
-                SettingsMessage::RecoveryKit(RecoveryKitMessage::Start(primary_mode)).into(),
-            ),
+            .on_press(SettingsMessage::RecoveryKit(RecoveryKitMessage::Start(primary_mode)).into()),
     );
     if has_kit {
         actions = actions.push(

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -69,14 +69,13 @@ pub fn general_section<'a>(
             .as_ref()
             .map(|s| s.has_encrypted_wallet_descriptor)
             .unwrap_or(false);
-        let drift = server_has_descriptor
-            && match (
-                &cache.current_descriptor_fingerprint,
-                &cache.recovery_kit_last_backed_up_descriptor_fingerprint,
-            ) {
-                (Some(live), Some(cached)) => live != cached,
-                _ => false,
-            };
+        let drift = descriptor_drift(
+            server_has_descriptor,
+            cache.current_descriptor_fingerprint.as_deref(),
+            cache
+                .recovery_kit_last_backed_up_descriptor_fingerprint
+                .as_deref(),
+        );
         col = col.push(recovery_kit_card(
             cache.current_cube_is_passkey,
             cache.has_vault,
@@ -472,4 +471,80 @@ pub fn fiat_price<'a>(
     )
     .width(Length::Fill)
     .into()
+}
+
+/// Decide whether the Recovery-Kit card should flag "descriptor
+/// drift". Split out of `general_section` so the branch table is
+/// testable without standing up a full `Cache`.
+///
+/// - `server_has_descriptor`: the Connect-side `RecoveryKitStatus`
+///   reports a descriptor half is backed up.
+/// - `live`: SHA-256 of what the live wallet would currently upload
+///   (`None` when no Vault is loaded).
+/// - `cached`: SHA-256 of what this device last uploaded
+///   (`None` when the local cache was cleared, the kit was made from
+///   a different install, or the backup happened before the cache
+///   field existed).
+fn descriptor_drift(server_has_descriptor: bool, live: Option<&str>, cached: Option<&str>) -> bool {
+    if !server_has_descriptor {
+        return false;
+    }
+    match (live, cached) {
+        // Both present — direct comparison.
+        (Some(live), Some(cached)) => live != cached,
+        // Live wallet descriptor loaded but no local fingerprint to
+        // compare against (cache cleared, restored from a different
+        // install, descriptor uploaded from another device). The
+        // server says a descriptor is backed up; we can't verify it
+        // matches what this device would now upload, so nudge the
+        // user to resync.
+        (Some(_), None) => true,
+        // Any case where the live fingerprint isn't computable (no
+        // Vault loaded yet) can't produce a meaningful comparison;
+        // avoid a false positive.
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_drift_when_server_has_no_descriptor() {
+        // Card's "incomplete" copy already covers this case; drift
+        // must not double up the signal.
+        assert!(!descriptor_drift(false, Some("a"), Some("b")));
+        assert!(!descriptor_drift(false, Some("a"), None));
+        assert!(!descriptor_drift(false, None, Some("b")));
+    }
+
+    #[test]
+    fn drift_when_live_and_cached_differ() {
+        assert!(descriptor_drift(true, Some("a"), Some("b")));
+    }
+
+    #[test]
+    fn no_drift_when_live_and_cached_match() {
+        assert!(!descriptor_drift(true, Some("a"), Some("a")));
+    }
+
+    #[test]
+    fn drift_when_cached_missing_but_live_present() {
+        // Regression: previously swallowed by `_ => false`. Server
+        // reports a descriptor, live wallet is loaded, but we have
+        // no local cache to compare against — the conservative call
+        // is to flag drift so the user resyncs.
+        assert!(descriptor_drift(true, Some("a"), None));
+    }
+
+    #[test]
+    fn no_drift_when_live_missing() {
+        // No Vault loaded yet — can't compute a comparison.
+        // `server_has_descriptor` being true here means another
+        // device backed up the descriptor; we can't usefully flag
+        // drift until this device has a wallet to diff against.
+        assert!(!descriptor_drift(true, None, Some("b")));
+        assert!(!descriptor_drift(true, None, None));
+    }
 }

--- a/coincube-gui/src/app/view/settings/mod.rs
+++ b/coincube-gui/src/app/view/settings/mod.rs
@@ -3,6 +3,7 @@ pub mod backup;
 pub mod general;
 pub mod install_stats;
 pub mod lightning;
+pub mod recovery_kit;
 
 use coincube_ui::{component::text::*, widget::*};
 

--- a/coincube-gui/src/app/view/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/view/settings/recovery_kit.rs
@@ -1,0 +1,438 @@
+//! Views for the Cube Recovery Kit wizard.
+//!
+//! Rendered as a full-page takeover of the General Settings view when
+//! `RecoveryKitState != None` (see `general.rs::general_section`). The
+//! Settings card itself (shown when the wizard is inactive) lives in
+//! `general.rs::recovery_kit_card`.
+//!
+//! Flow for a mnemonic cube in Create mode:
+//!   PinEntry → PasswordEntry → Uploading → Completed
+//! A passkey cube (descriptor-only) skips PinEntry.
+
+use coincube_ui::{
+    color,
+    component::{button as ui_button, text::*},
+    icon, theme,
+    widget::{CheckBox, Container, Element, TextInput},
+};
+use iced::widget::{progress_bar, Column, Row, Space};
+use iced::{Alignment, Length};
+
+use crate::app::state::settings::recovery_kit::RecoveryKitState;
+use crate::app::view::message::{Message, RecoveryKitMessage, SettingsMessage};
+use crate::pin_input::PinInput;
+use crate::services::recovery::{score_password, PasswordStrength};
+use zeroize::Zeroizing;
+
+fn wrap(msg: RecoveryKitMessage) -> Message {
+    Message::Settings(SettingsMessage::RecoveryKit(msg))
+}
+
+/// Single "< Back" button row — mirrors backup.rs::header.
+fn header<'a>() -> Element<'a, Message> {
+    Row::new()
+        .spacing(10)
+        .align_y(Alignment::Center)
+        .push(
+            ui_button::secondary(None, "< Back")
+                .on_press(wrap(RecoveryKitMessage::Cancel))
+                .padding([8, 16])
+                .width(Length::Fixed(150.0)),
+        )
+        .into()
+}
+
+/// PIN gate — mnemonic cubes only. Unlocks the on-disk encrypted
+/// mnemonic so the seed blob can be built.
+pub fn pin_entry_view<'a>(pin: &'a PinInput, error: Option<&'a str>) -> Element<'a, Message> {
+    let mut col = Column::new()
+        .spacing(20)
+        .width(Length::Fill)
+        .push(header())
+        .push(Space::new().height(Length::Fixed(16.0)))
+        .push(
+            Row::new()
+                .width(Length::Fill)
+                .align_y(Alignment::Center)
+                .push(Space::new().width(Length::Fill))
+                .push(icon::lock_icon().size(100).color(color::ORANGE))
+                .push(Space::new().width(Length::Fill)),
+        )
+        .push(Space::new().height(Length::Fixed(16.0)))
+        .push(
+            Row::new()
+                .width(Length::Fill)
+                .align_y(Alignment::Center)
+                .push(Space::new().width(Length::Fill))
+                .push(
+                    Container::new(
+                        text(
+                            "Enter your Cube PIN to unlock your Master Seed Phrase. \
+                             We'll encrypt it with your recovery password on-device \
+                             before uploading.",
+                        )
+                        .size(18)
+                        .align_x(iced::alignment::Horizontal::Center),
+                    )
+                    .width(Length::Fixed(600.0))
+                    .align_x(iced::alignment::Horizontal::Center),
+                )
+                .push(Space::new().width(Length::Fill)),
+        )
+        .push(Space::new().height(Length::Fixed(24.0)))
+        .push(
+            Row::new()
+                .width(Length::Fill)
+                .align_y(Alignment::Center)
+                .push(Space::new().width(Length::Fill))
+                .push(pin.view().map(|m| wrap(RecoveryKitMessage::PinInput(m))))
+                .push(Space::new().width(Length::Fill)),
+        );
+
+    col = col.push(Space::new().height(Length::Fixed(16.0)));
+
+    if let Some(err) = error {
+        col = col.push(
+            Row::new()
+                .width(Length::Fill)
+                .align_y(Alignment::Center)
+                .push(Space::new().width(Length::Fill))
+                .push(text(err).size(16).color(color::RED))
+                .push(Space::new().width(Length::Fill)),
+        );
+        col = col.push(Space::new().height(Length::Fixed(8.0)));
+    }
+
+    col = col.push(
+        Row::new()
+            .spacing(20)
+            .width(Length::Fill)
+            .align_y(Alignment::Center)
+            .push(Space::new().width(Length::Fill))
+            .push(
+                ui_button::secondary(None, "Cancel")
+                    .on_press(wrap(RecoveryKitMessage::Cancel))
+                    .padding([8, 16])
+                    .width(Length::Fixed(150.0)),
+            )
+            .push({
+                let btn = ui_button::primary(None, "Unlock")
+                    .padding([8, 16])
+                    .width(Length::Fixed(200.0));
+                if pin.is_complete() {
+                    btn.on_press(wrap(RecoveryKitMessage::VerifyPin))
+                } else {
+                    btn
+                }
+            })
+            .push(Space::new().width(Length::Fill)),
+    );
+
+    col.into()
+}
+
+/// Password entry. Two inputs (password + confirm), live strength
+/// meter, acknowledge checkbox, Submit button gated on all three.
+pub fn password_entry_view<'a>(
+    password: &'a Zeroizing<String>,
+    confirm: &'a Zeroizing<String>,
+    acknowledged: bool,
+    error: Option<&'a str>,
+) -> Element<'a, Message> {
+    let (strength, hint) = score_password(password, &[]);
+    let strength_label = strength.label();
+    let strength_fraction = strength.fraction();
+    let can_submit = !password.is_empty()
+        && password.as_str() == confirm.as_str()
+        && strength.is_acceptable()
+        && acknowledged;
+
+    let mut col = Column::new()
+        .spacing(20)
+        .width(Length::Fill)
+        .push(header())
+        .push(Space::new().height(Length::Fixed(16.0)))
+        .push(
+            Row::new()
+                .width(Length::Fill)
+                .align_y(Alignment::Center)
+                .push(Space::new().width(Length::Fill))
+                .push(icon::key_icon().size(100).color(color::ORANGE))
+                .push(Space::new().width(Length::Fill)),
+        )
+        .push(Space::new().height(Length::Fixed(16.0)))
+        .push(
+            Row::new()
+                .width(Length::Fill)
+                .align_y(Alignment::Center)
+                .push(Space::new().width(Length::Fill))
+                .push(
+                    Container::new(
+                        text(
+                            "Choose a recovery password. This is separate from your \
+                             Cube PIN — write it down somewhere safe. COINCUBE cannot \
+                             recover it for you.",
+                        )
+                        .size(18)
+                        .align_x(iced::alignment::Horizontal::Center),
+                    )
+                    .width(Length::Fixed(600.0))
+                    .align_x(iced::alignment::Horizontal::Center),
+                )
+                .push(Space::new().width(Length::Fill)),
+        )
+        .push(Space::new().height(Length::Fixed(24.0)));
+
+    // Password inputs — centred 600px column.
+    let inputs = Column::new()
+        .spacing(12)
+        .width(Length::Fixed(600.0))
+        .push(caption("Recovery password"))
+        .push(
+            TextInput::new("Choose a password", password.as_str())
+                .on_input(|v| wrap(RecoveryKitMessage::PasswordChanged(v)))
+                .secure(true)
+                .size(16)
+                .padding(12)
+                .width(Length::Fill),
+        )
+        .push(Space::new().height(Length::Fixed(8.0)))
+        .push(
+            progress_bar(0.0..=1.0, strength_fraction)
+                .style(theme::progress_bar::primary),
+        )
+        .push({
+            let mut r = Row::new()
+                .width(Length::Fill)
+                .push(text(format!("Strength: {}", strength_label)).size(14))
+                .push(Space::new().width(Length::Fill));
+            if let Some(h) = hint {
+                r = r.push(text(h).size(12).style(theme::text::warning));
+            }
+            r
+        })
+        .push(Space::new().height(Length::Fixed(8.0)))
+        .push(caption("Confirm recovery password"))
+        .push(
+            TextInput::new("Re-enter password", confirm.as_str())
+                .on_input(|v| wrap(RecoveryKitMessage::ConfirmChanged(v)))
+                .secure(true)
+                .size(16)
+                .padding(12)
+                .width(Length::Fill),
+        );
+
+    col = col.push(
+        Row::new()
+            .width(Length::Fill)
+            .align_y(Alignment::Center)
+            .push(Space::new().width(Length::Fill))
+            .push(inputs)
+            .push(Space::new().width(Length::Fill)),
+    );
+
+    // Mismatch warning if confirm diverges.
+    if !confirm.is_empty() && password.as_str() != confirm.as_str() {
+        col = col.push(
+            Row::new()
+                .width(Length::Fill)
+                .align_y(Alignment::Center)
+                .push(Space::new().width(Length::Fill))
+                .push(text("Passwords don't match.").size(14).color(color::RED))
+                .push(Space::new().width(Length::Fill)),
+        );
+    }
+
+    col = col.push(Space::new().height(Length::Fixed(16.0)));
+
+    // Acknowledge checkbox.
+    col = col.push(
+        Row::new()
+            .width(Length::Fill)
+            .align_y(Alignment::Center)
+            .push(Space::new().width(Length::Fill))
+            .push(
+                Container::new(
+                    CheckBox::new(acknowledged)
+                        .label("I've written this password down somewhere I can find it")
+                        .on_toggle(|v| wrap(RecoveryKitMessage::AcknowledgeToggled(v)))
+                        .style(theme::checkbox::primary),
+                )
+                .width(Length::Fixed(600.0)),
+            )
+            .push(Space::new().width(Length::Fill)),
+    );
+
+    if let Some(err) = error {
+        col = col.push(
+            Row::new()
+                .width(Length::Fill)
+                .align_y(Alignment::Center)
+                .push(Space::new().width(Length::Fill))
+                .push(text(err).size(16).color(color::RED))
+                .push(Space::new().width(Length::Fill)),
+        );
+    }
+
+    col = col.push(Space::new().height(Length::Fixed(16.0)));
+
+    col = col.push(
+        Row::new()
+            .spacing(20)
+            .width(Length::Fill)
+            .align_y(Alignment::Center)
+            .push(Space::new().width(Length::Fill))
+            .push(
+                ui_button::secondary(None, "Cancel")
+                    .on_press(wrap(RecoveryKitMessage::Cancel))
+                    .padding([8, 16])
+                    .width(Length::Fixed(150.0)),
+            )
+            .push({
+                let btn = ui_button::primary(None, "Back up Recovery Kit")
+                    .padding([8, 16])
+                    .width(Length::Fixed(300.0));
+                if can_submit {
+                    btn.on_press(wrap(RecoveryKitMessage::SubmitPassword))
+                } else {
+                    btn
+                }
+            })
+            .push(Space::new().width(Length::Fill)),
+    );
+
+    let _ = PasswordStrength::VeryStrong; // silence unused import warning if strength bands shift
+    col.into()
+}
+
+/// Indeterminate "uploading" state. Kept simple — the upload is
+/// usually sub-second so a full spinner widget is overkill.
+pub fn uploading_view() -> Element<'static, Message> {
+    Column::new()
+        .spacing(20)
+        .width(Length::Fill)
+        .align_x(Alignment::Center)
+        .push(Space::new().height(Length::Fixed(80.0)))
+        .push(icon::backup_icon().size(100).color(color::ORANGE))
+        .push(Space::new().height(Length::Fixed(16.0)))
+        .push(text("Encrypting and uploading…").size(20))
+        .push(
+            text("This takes a moment — Argon2id key derivation is intentionally slow.")
+                .size(14),
+        )
+        .into()
+}
+
+/// "Removing" placeholder while `delete_recovery_kit` is in flight.
+pub fn removing_view() -> Element<'static, Message> {
+    Column::new()
+        .spacing(20)
+        .width(Length::Fill)
+        .align_x(Alignment::Center)
+        .push(Space::new().height(Length::Fixed(80.0)))
+        .push(icon::trash_icon().size(100).color(color::RED))
+        .push(Space::new().height(Length::Fixed(16.0)))
+        .push(text("Removing Recovery Kit from Connect…").size(20))
+        .into()
+}
+
+/// Success screen. Shown after a successful upload; user dismisses
+/// via the button which fires `DismissCompleted` and reloads status.
+pub fn completed_view(
+    updated_at: &str,
+    has_seed: bool,
+    has_descriptor: bool,
+) -> Element<'static, Message> {
+    let subtitle = match (has_seed, has_descriptor) {
+        (true, true) => "Both your Master Seed Phrase and Wallet Descriptor are backed up.",
+        (true, false) => {
+            "Your Master Seed Phrase is backed up. Add your Wallet Descriptor once you \
+             have a Vault."
+        }
+        (false, true) => "Your Wallet Descriptor is backed up.",
+        (false, false) => "Nothing is currently backed up.",
+    };
+    Column::new()
+        .spacing(20)
+        .width(Length::Fill)
+        .align_x(Alignment::Center)
+        .push(Space::new().height(Length::Fixed(40.0)))
+        .push(icon::check_icon().size(100).color(color::GREEN))
+        .push(Space::new().height(Length::Fixed(16.0)))
+        .push(text("Recovery Kit backed up").size(24).bold())
+        .push(
+            Container::new(text(subtitle).size(16).align_x(iced::alignment::Horizontal::Center))
+                .width(Length::Fixed(600.0)),
+        )
+        .push(Space::new().height(Length::Fixed(8.0)))
+        .push(text(format!("Last updated: {}", updated_at)).size(14))
+        .push(Space::new().height(Length::Fixed(24.0)))
+        .push(
+            ui_button::primary(None, "Back to Settings")
+                .on_press(wrap(RecoveryKitMessage::DismissCompleted))
+                .padding([8, 16])
+                .width(Length::Fixed(300.0)),
+        )
+        .into()
+}
+
+pub fn error_view(message: &str) -> Element<'static, Message> {
+    Column::new()
+        .spacing(20)
+        .width(Length::Fill)
+        .align_x(Alignment::Center)
+        .push(Space::new().height(Length::Fixed(40.0)))
+        .push(icon::warning_icon().size(80).color(color::RED))
+        .push(Space::new().height(Length::Fixed(16.0)))
+        .push(text("Couldn't complete Recovery Kit action").size(20).bold())
+        .push(
+            Container::new(
+                text(message.to_string())
+                    .size(16)
+                    .align_x(iced::alignment::Horizontal::Center),
+            )
+            .width(Length::Fixed(600.0)),
+        )
+        .push(Space::new().height(Length::Fixed(24.0)))
+        .push(
+            ui_button::primary(None, "Back to Settings")
+                .on_press(wrap(RecoveryKitMessage::Cancel))
+                .padding([8, 16])
+                .width(Length::Fixed(300.0)),
+        )
+        .into()
+}
+
+/// Returns `Some(wizard)` when the flow is active and should take
+/// over the settings page, `None` when the card should render inline.
+pub fn dispatch<'a>(
+    state: &'a RecoveryKitState,
+    pin: &'a PinInput,
+) -> Option<Element<'a, Message>> {
+    match state {
+        RecoveryKitState::None => None,
+        RecoveryKitState::PinEntry { error, .. } => {
+            Some(pin_entry_view(pin, error.as_deref()))
+        }
+        RecoveryKitState::PasswordEntry {
+            password,
+            confirm,
+            acknowledged,
+            error,
+            ..
+        } => Some(password_entry_view(
+            password,
+            confirm,
+            *acknowledged,
+            error.as_deref(),
+        )),
+        RecoveryKitState::Uploading => Some(uploading_view()),
+        RecoveryKitState::Removing => Some(removing_view()),
+        RecoveryKitState::Completed {
+            updated_at,
+            now_has_seed,
+            now_has_descriptor,
+        } => Some(completed_view(updated_at, *now_has_seed, *now_has_descriptor)),
+        RecoveryKitState::Error { message } => Some(error_view(message)),
+    }
+}

--- a/coincube-gui/src/app/view/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/view/settings/recovery_kit.rs
@@ -197,10 +197,7 @@ pub fn password_entry_view<'a>(
                 .width(Length::Fill),
         )
         .push(Space::new().height(Length::Fixed(8.0)))
-        .push(
-            progress_bar(0.0..=1.0, strength_fraction)
-                .style(theme::progress_bar::primary),
-        )
+        .push(progress_bar(0.0..=1.0, strength_fraction).style(theme::progress_bar::primary))
         .push({
             let mut r = Row::new()
                 .width(Length::Fill)
@@ -316,10 +313,7 @@ pub fn uploading_view() -> Element<'static, Message> {
         .push(icon::backup_icon().size(100).color(color::ORANGE))
         .push(Space::new().height(Length::Fixed(16.0)))
         .push(text("Encrypting and uploading…").size(20))
-        .push(
-            text("This takes a moment — Argon2id key derivation is intentionally slow.")
-                .size(14),
-        )
+        .push(text("This takes a moment — Argon2id key derivation is intentionally slow.").size(14))
         .into()
 }
 
@@ -361,8 +355,12 @@ pub fn completed_view(
         .push(Space::new().height(Length::Fixed(16.0)))
         .push(text("Recovery Kit backed up").size(24).bold())
         .push(
-            Container::new(text(subtitle).size(16).align_x(iced::alignment::Horizontal::Center))
-                .width(Length::Fixed(600.0)),
+            Container::new(
+                text(subtitle)
+                    .size(16)
+                    .align_x(iced::alignment::Horizontal::Center),
+            )
+            .width(Length::Fixed(600.0)),
         )
         .push(Space::new().height(Length::Fixed(8.0)))
         .push(text(format!("Last updated: {}", updated_at)).size(14))
@@ -384,7 +382,11 @@ pub fn error_view(message: &str) -> Element<'static, Message> {
         .push(Space::new().height(Length::Fixed(40.0)))
         .push(icon::warning_icon().size(80).color(color::RED))
         .push(Space::new().height(Length::Fixed(16.0)))
-        .push(text("Couldn't complete Recovery Kit action").size(20).bold())
+        .push(
+            text("Couldn't complete Recovery Kit action")
+                .size(20)
+                .bold(),
+        )
         .push(
             Container::new(
                 text(message.to_string())
@@ -411,9 +413,7 @@ pub fn dispatch<'a>(
 ) -> Option<Element<'a, Message>> {
     match state {
         RecoveryKitState::None => None,
-        RecoveryKitState::PinEntry { error, .. } => {
-            Some(pin_entry_view(pin, error.as_deref()))
-        }
+        RecoveryKitState::PinEntry { error, .. } => Some(pin_entry_view(pin, error.as_deref())),
         RecoveryKitState::PasswordEntry {
             password,
             confirm,
@@ -432,7 +432,11 @@ pub fn dispatch<'a>(
             updated_at,
             now_has_seed,
             now_has_descriptor,
-        } => Some(completed_view(updated_at, *now_has_seed, *now_has_descriptor)),
+        } => Some(completed_view(
+            updated_at,
+            *now_has_seed,
+            *now_has_descriptor,
+        )),
         RecoveryKitState::Error { message } => Some(error_view(message)),
     }
 }

--- a/coincube-gui/src/app/view/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/view/settings/recovery_kit.rs
@@ -426,7 +426,7 @@ pub fn dispatch<'a>(
             *acknowledged,
             error.as_deref(),
         )),
-        RecoveryKitState::Uploading => Some(uploading_view()),
+        RecoveryKitState::Uploading { .. } => Some(uploading_view()),
         RecoveryKitState::Removing => Some(removing_view()),
         RecoveryKitState::Completed {
             updated_at,

--- a/coincube-gui/src/app/view/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/view/settings/recovery_kit.rs
@@ -198,7 +198,14 @@ pub fn password_entry_view<'a>(
         .push(caption("Recovery password"))
         .push(
             TextInput::new("Choose a password", password.as_str())
-                .on_input(|v| wrap(RecoveryKitMessage::PasswordChanged(v)))
+                .on_input(|v| {
+                    // Wrap at the message boundary — the `String`
+                    // from iced's callback is the last unprotected
+                    // copy in our code path; every in-flight clone
+                    // from here on is in a `Zeroizing` wrapper that
+                    // wipes on drop.
+                    wrap(RecoveryKitMessage::PasswordChanged(Zeroizing::new(v)))
+                })
                 .secure(true)
                 .size(16)
                 .padding(12)
@@ -220,7 +227,7 @@ pub fn password_entry_view<'a>(
         .push(caption("Confirm recovery password"))
         .push(
             TextInput::new("Re-enter password", confirm.as_str())
-                .on_input(|v| wrap(RecoveryKitMessage::ConfirmChanged(v)))
+                .on_input(|v| wrap(RecoveryKitMessage::ConfirmChanged(Zeroizing::new(v))))
                 .secure(true)
                 .size(16)
                 .padding(12)

--- a/coincube-gui/src/app/view/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/view/settings/recovery_kit.rs
@@ -21,7 +21,7 @@ use iced::{Alignment, Length};
 use crate::app::state::settings::recovery_kit::RecoveryKitState;
 use crate::app::view::message::{Message, RecoveryKitMessage, SettingsMessage};
 use crate::pin_input::PinInput;
-use crate::services::recovery::{score_password, PasswordStrength};
+use crate::services::recovery::{score_password, MIN_PASSWORD_LEN};
 use zeroize::Zeroizing;
 
 fn wrap(msg: RecoveryKitMessage) -> Message {
@@ -142,7 +142,15 @@ pub fn password_entry_view<'a>(
     let (strength, hint) = score_password(password, &[]);
     let strength_label = strength.label();
     let strength_fraction = strength.fraction();
-    let can_submit = !password.is_empty()
+    // Mirror the gates that `submit_password` enforces server-side
+    // (state/settings/recovery_kit.rs), in the same order. A short
+    // but otherwise-varied password can clear `is_acceptable()`
+    // (zxcvbn rates complexity, not length) while still failing the
+    // `MIN_PASSWORD_LEN` floor — without the explicit length check
+    // here, the Submit button would light up and then the handler
+    // would bounce the user back with "Password must be at least
+    // 12 characters", which reads as a bug.
+    let can_submit = password.len() >= MIN_PASSWORD_LEN
         && password.as_str() == confirm.as_str()
         && strength.is_acceptable()
         && acknowledged;
@@ -298,7 +306,6 @@ pub fn password_entry_view<'a>(
             .push(Space::new().width(Length::Fill)),
     );
 
-    let _ = PasswordStrength::VeryStrong; // silence unused import warning if strength bands shift
     col.into()
 }
 

--- a/coincube-gui/src/app/view/vault/settings/mod.rs
+++ b/coincube-gui/src/app/view/vault/settings/mod.rs
@@ -29,7 +29,7 @@ use coincube_ui::{
 use crate::{
     app::{
         cache::Cache,
-        menu::{Menu, VaultSubMenu},
+        menu::{HomeSettingsOption, HomeSubMenu, Menu, VaultSubMenu},
         settings::ProviderKey,
         view::vault::hw,
     },
@@ -142,20 +142,19 @@ pub fn import_export<'a>(menu: &'a Menu, cache: &'a Cache) -> Element<'a, Messag
         ))
         .push(Space::new().width(Length::Fill));
 
-    // Nudges users toward Connect-hosted backup first — this is the
-    // disaster-recovery path the product pushes new users onto. Firing
-    // `Start(Create)` is safe regardless of current kit state because
-    // `put_recovery_kit` is a status-first upsert under the hood (POST
-    // vs PUT decided at dispatch time), and the wizard's password
-    // screen re-encrypts all present halves, which is equivalent to
-    // Rotate / AddDescriptor / AddSeed for a completed kit.
+    // Nudge to Cube → Settings → General, where the Recovery Kit card
+    // lives. Can't fire `Start(Create)` here: the wizard is only
+    // rendered inside `SettingsState::view` on the global settings
+    // panel, so starting the flow from Vault leaves it running on an
+    // unrendered panel and the state persists into the next General
+    // visit.
     let backup_to_connect = export_section(
         "Connect Recovery Kit",
         "Back up your Wallet Descriptor (and Master Seed Phrase) to your Connect account. \
          Encrypted on-device with a password you choose.",
         icon::backup_icon(),
-        Message::Settings(SettingsMessage::RecoveryKit(RecoveryKitMessage::Start(
-            RecoveryKitMode::Create,
+        Message::Menu(Menu::Home(HomeSubMenu::Settings(
+            HomeSettingsOption::General,
         ))),
     );
 

--- a/coincube-gui/src/app/view/vault/settings/mod.rs
+++ b/coincube-gui/src/app/view/vault/settings/mod.rs
@@ -142,6 +142,23 @@ pub fn import_export<'a>(menu: &'a Menu, cache: &'a Cache) -> Element<'a, Messag
         ))
         .push(Space::new().width(Length::Fill));
 
+    // Nudges users toward Connect-hosted backup first — this is the
+    // disaster-recovery path the product pushes new users onto. Firing
+    // `Start(Create)` is safe regardless of current kit state because
+    // `put_recovery_kit` is a status-first upsert under the hood (POST
+    // vs PUT decided at dispatch time), and the wizard's password
+    // screen re-encrypts all present halves, which is equivalent to
+    // Rotate / AddDescriptor / AddSeed for a completed kit.
+    let backup_to_connect = export_section(
+        "Connect Recovery Kit",
+        "Back up your Wallet Descriptor (and Master Seed Phrase) to your Connect account. \
+         Encrypted on-device with a password you choose.",
+        icon::backup_icon(),
+        Message::Settings(SettingsMessage::RecoveryKit(RecoveryKitMessage::Start(
+            RecoveryKitMode::Create,
+        ))),
+    );
+
     let export_encrypted_descriptor = export_section(
         "Encrypted descriptor",
         ".bed file, can be decrypted with one of your signing devices or xpubs.",
@@ -199,6 +216,7 @@ pub fn import_export<'a>(menu: &'a Menu, cache: &'a Cache) -> Element<'a, Messag
             .spacing(20)
             .push(header)
             .push(description)
+            .push(backup_to_connect)
             .push(export_encrypted_descriptor)
             .push(export_wallet)
             .push(import_wallet)

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -1156,22 +1156,15 @@ async fn find_or_create_cube(
             {
                 let mut empty_cube = settings_data.cubes[empty_idx].clone();
                 empty_cube.vault_wallet_id = Some(wallet_id.clone());
-                if let Some(seed) = restore_seed {
-                    empty_cube.master_signer_fingerprint = Some(seed.master_signer_fingerprint);
-                    // `with_pin` is the sanctioned path for setting
-                    // the Argon2id hash; go through it even when the
-                    // Cube already exists so the restored Cube has a
-                    // usable PIN hash. If the Cube had its own
-                    // `security_pin_hash`, this replaces it with one
-                    // derived from the PIN the user just chose —
-                    // consistent with the newly-encrypted mnemonic on
-                    // disk (otherwise PIN entry against the old hash
-                    // would silently succeed but fail to decrypt the
-                    // mnemonic).
-                    empty_cube = empty_cube
-                        .with_pin(seed.pin.as_str())
-                        .map_err(|e| format!("Failed to set PIN on restored cube: {}", e))?;
-                }
+                // Reuse `decorate_new` so the fingerprint + PIN-hash
+                // path matches the brand-new-Cube branches below. If
+                // the Cube had its own `security_pin_hash`, `with_pin`
+                // replaces it with one derived from the PIN the user
+                // just chose — consistent with the newly-encrypted
+                // mnemonic on disk (otherwise PIN entry against the
+                // old hash would silently succeed but fail to decrypt
+                // the mnemonic).
+                let empty_cube = decorate_new(empty_cube)?;
                 settings_data.cubes[empty_idx] = empty_cube.clone();
                 let cube_name = empty_cube.name.clone();
 

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -380,12 +380,14 @@ impl Tab {
                             // Only the restore path needs to build a
                             // BreezClient up-front — fresh-install +
                             // remote-backend flows build it at PIN
-                            // entry / login. Also gate on the network
-                            // actually being supported; `load_breez_client`
-                            // returns `NetworkNotSupported` on
-                            // testnet/signet which we want to treat as
-                            // a legit "no client" rather than a hard
-                            // error.
+                            // entry / login. On `NetworkNotSupported`
+                            // (testnet/signet) we mirror the PIN-entry
+                            // branch (`BreezClientLoadedAfterPin`
+                            // handler) and hand back a disconnected
+                            // client: the Loader's Synced/App arms
+                            // treat a `None` BreezClient as an
+                            // architectural bug and error out, so
+                            // pre-loaded-must-exist is the contract.
                             let breez_client = if let Some(seed) = &restore_seed {
                                 match breez_liquid::load_breez_client(
                                     datadir.path(),
@@ -399,10 +401,13 @@ impl Tab {
                                     Err(breez_liquid::BreezError::NetworkNotSupported(n)) => {
                                         info!(
                                             "BreezClient not loaded for restored Cube: \
-                                             network {} is not supported by Breez SDK",
+                                             network {} is not supported by Breez SDK; \
+                                             using disconnected client",
                                             n
                                         );
-                                        None
+                                        Some(Arc::new(breez_liquid::BreezClient::disconnected(
+                                            network,
+                                        )))
                                     }
                                     Err(e) => {
                                         // A non-network failure here
@@ -423,7 +428,42 @@ impl Tab {
                                 None
                             };
 
-                            Ok((cube, breez_client))
+                            // Mirror the PIN-entry path (tab.rs Spark
+                            // load near line 781): spawn the bridge
+                            // subprocess against the just-encrypted
+                            // mnemonic so the Loader can hand a live
+                            // SparkBackend to App. Failures here are
+                            // non-fatal — without this, the first
+                            // boot after restore landed in the app
+                            // with `spark_backend = None` and the
+                            // Spark panels only populated after the
+                            // user closed + re-opened the Cube.
+                            let spark_backend = if let Some(seed) = &restore_seed {
+                                match app::breez_spark::load_spark_client(
+                                    datadir.path(),
+                                    network,
+                                    seed.master_signer_fingerprint,
+                                    seed.pin.as_str(),
+                                )
+                                .await
+                                {
+                                    Ok(client) => {
+                                        Some(Arc::new(app::wallets::SparkBackend::new(client)))
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            "Spark bridge unavailable after restore, \
+                                             continuing without Spark: {}",
+                                            e
+                                        );
+                                        None
+                                    }
+                                }
+                            } else {
+                                None
+                            };
+
+                            Ok((cube, breez_client, spark_backend))
                         },
                         move |result| {
                             Message::Install(installer::Message::CubeSaved(
@@ -437,8 +477,8 @@ impl Tab {
                     msg
                 {
                     // Handle cube save failure
-                    let (cube, restored_breez_client) = match result {
-                        Ok(pair) => pair,
+                    let (cube, restored_breez_client, restored_spark_backend) = match result {
+                        Ok(triple) => triple,
                         Err(err) => {
                             error!("Aborting loader transition due to cube save failure");
                             return i
@@ -481,7 +521,13 @@ impl Tab {
                             // the user's new PIN) wins over the
                             // installer-launched one.
                             restored_breez_client.or_else(|| i.breez_client.clone()),
-                            None, // Installer path doesn't plumb Spark yet — follow-up
+                            // Spark backend built against the user's
+                            // new PIN during the restore async block.
+                            // Falling back to the installer's existing
+                            // handle covers the non-restore flows that
+                            // already had Spark wired in before this
+                            // Message arm widened.
+                            restored_spark_backend.or_else(|| i.spark_backend.clone()),
                         );
                         self.state = State::Loader(loader);
                         command.map(Message::Load)

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -1140,6 +1140,11 @@ pub fn create_app_with_remote_backend(
             show_direction_badges: true,
             lightning_address: None,
             cube_id: cube_settings.id.clone(),
+            current_cube_server_id: None,
+            current_descriptor_fingerprint: None,
+            recovery_kit_last_backed_up_descriptor_fingerprint: cube_settings
+                .recovery_kit_last_backed_up_descriptor_fingerprint
+                .clone(),
             default_lightning_backend: cube_settings.default_lightning_backend,
         },
         Arc::new(

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -172,7 +172,7 @@ impl Tab {
         use crate::app::settings::global::GlobalSettings;
         let result = match (&mut self.state, message) {
             (State::Launcher(l), Message::Launch(msg)) => match msg {
-                launcher::Message::Install(datadir, network, init) => {
+                launcher::Message::Install(datadir, network, init, coincube_client) => {
                     if !datadir.exists() {
                         // datadir is created right before launching the installer
                         // so logs can go in <datadir_path>/installer.log
@@ -185,9 +185,23 @@ impl Tab {
                             );
                         }
                     }
+                    // `coincube_client` is populated when the launcher
+                    // already holds an authenticated Connect session (today
+                    // the Recovery-Kit restore path forwards it so the
+                    // installer step can skip a redundant email+OTP). Other
+                    // launcher entry points pass `None` and the relevant
+                    // installer step runs its own auth form as before.
                     let (install, command) = Installer::new(
-                        datadir, network, None, init, false, None, None, None, false,
-                        None, // No coincube_client from launcher
+                        datadir,
+                        network,
+                        None,
+                        init,
+                        false,
+                        None,
+                        None,
+                        None,
+                        false,
+                        coincube_client,
                     );
                     self.state = State::Installer(install);
                     command.map(Message::Install)
@@ -325,16 +339,91 @@ impl Tab {
             },
             (State::Installer(i), Message::Install(msg)) => {
                 if let installer::Message::Exit(settings, internal_bitcoind) = msg {
-                    // Associate wallet with cube
+                    // Associate wallet with cube, and — for the Recovery
+                    // Kit restore flow specifically — build the
+                    // BreezClient in the same async task so the loader
+                    // doesn't hit the "missing pre-loaded BreezClient"
+                    // error path and hang on "Starting daemon…".
                     let network_dir = i.datadir.network_directory(i.network);
+                    let datadir = i.datadir.clone();
                     let wallet_id = settings.wallet_id();
                     let wallet_alias = settings.alias.clone();
                     let network = i.network;
 
+                    // Capture restore-flow state up-front. Cloning the
+                    // `Zeroizing<String>` here means the PIN copy
+                    // carried into the Task is its own heap-zeroing
+                    // value — it's dropped (and zeroed) once the task
+                    // completes.
+                    let restore_seed = match (
+                        i.context.restore_pin.clone(),
+                        i.context.recovered_signer.as_ref().map(|s| s.fingerprint()),
+                    ) {
+                        (Some(pin), Some(fp)) => Some(RestoreCubeSeed {
+                            pin,
+                            master_signer_fingerprint: fp,
+                        }),
+                        _ => None,
+                    };
+
                     Task::perform(
                         async move {
-                            find_or_create_cube(&network_dir, &wallet_id, &wallet_alias, network)
+                            let cube = find_or_create_cube(
+                                &network_dir,
+                                &wallet_id,
+                                &wallet_alias,
+                                network,
+                                restore_seed.as_ref(),
+                            )
+                            .await?;
+
+                            // Only the restore path needs to build a
+                            // BreezClient up-front — fresh-install +
+                            // remote-backend flows build it at PIN
+                            // entry / login. Also gate on the network
+                            // actually being supported; `load_breez_client`
+                            // returns `NetworkNotSupported` on
+                            // testnet/signet which we want to treat as
+                            // a legit "no client" rather than a hard
+                            // error.
+                            let breez_client = if let Some(seed) = &restore_seed {
+                                match breez_liquid::load_breez_client(
+                                    datadir.path(),
+                                    network,
+                                    seed.master_signer_fingerprint,
+                                    seed.pin.as_str(),
+                                )
                                 .await
+                                {
+                                    Ok(c) => Some(c),
+                                    Err(breez_liquid::BreezError::NetworkNotSupported(n)) => {
+                                        info!(
+                                            "BreezClient not loaded for restored Cube: \
+                                             network {} is not supported by Breez SDK",
+                                            n
+                                        );
+                                        None
+                                    }
+                                    Err(e) => {
+                                        // A non-network failure here
+                                        // means the mnemonic is on disk
+                                        // but we can't decrypt/connect.
+                                        // Roll the whole post-install
+                                        // into an error so the user
+                                        // sees something actionable
+                                        // rather than silently landing
+                                        // on a broken Loader.
+                                        return Err(format!(
+                                            "Failed to load BreezClient after restore: {}",
+                                            e
+                                        ));
+                                    }
+                                }
+                            } else {
+                                None
+                            };
+
+                            Ok((cube, breez_client))
                         },
                         move |result| {
                             Message::Install(installer::Message::CubeSaved(
@@ -348,8 +437,8 @@ impl Tab {
                     msg
                 {
                     // Handle cube save failure
-                    let cube = match result {
-                        Ok(c) => c,
+                    let (cube, restored_breez_client) = match result {
+                        Ok(pair) => pair,
                         Err(err) => {
                             error!("Aborting loader transition due to cube save failure");
                             return i
@@ -363,7 +452,10 @@ impl Tab {
                             i.datadir.clone(),
                             i.network,
                             *settings,
-                            i.breez_client.clone(),
+                            // Prefer the just-loaded BreezClient from
+                            // the restore path; fall back to whatever
+                            // the installer was launched with.
+                            restored_breez_client.or_else(|| i.breez_client.clone()),
                         );
                         self.state = State::Login(login);
                         command.map(Message::Login)
@@ -384,7 +476,11 @@ impl Tab {
                             i.context.backup.clone(),
                             Some(*settings),
                             cube.clone(),
-                            i.breez_client.clone(), // Pass pre-loaded BreezClient from installer
+                            // Same preference chain as the Login arm —
+                            // the restored BreezClient (built against
+                            // the user's new PIN) wins over the
+                            // installer-launched one.
+                            restored_breez_client.or_else(|| i.breez_client.clone()),
                             None, // Installer path doesn't plumb Spark yet — follow-up
                         );
                         self.state = State::Loader(loader);
@@ -955,15 +1051,45 @@ async fn save_cube_settings(
     }
 }
 
+/// Bundle of restore-flow context that lets `find_or_create_cube`
+/// mint a `CubeSettings` with the same shape a fresh-install Cube
+/// produces: a PIN hash + master-signer fingerprint. Populated only
+/// for `UserFlow::RestoreFromRecoveryKit` after `RestorePinSetupStep`;
+/// `None` for every other flow preserves the previous behaviour.
+struct RestoreCubeSeed {
+    pin: zeroize::Zeroizing<String>,
+    master_signer_fingerprint: bitcoin::bip32::Fingerprint,
+}
+
 async fn find_or_create_cube(
     network_dir: &NetworkDirectory,
     wallet_id: &WalletId,
     wallet_alias: &Option<String>,
     network: bitcoin::Network,
+    restore_seed: Option<&RestoreCubeSeed>,
 ) -> Result<app::settings::CubeSettings, String> {
+    // Helper: decorate a freshly-minted CubeSettings with
+    // PIN + master-signer-fingerprint when we're on the restore path.
+    // Pulled out so the three "new cube" branches share one code path.
+    let decorate_new =
+        |mut cube: app::settings::CubeSettings| -> Result<app::settings::CubeSettings, String> {
+            if let Some(seed) = restore_seed {
+                cube = cube.with_master_signer(seed.master_signer_fingerprint);
+                cube = cube
+                    .with_pin(seed.pin.as_str())
+                    .map_err(|e| format!("Failed to set PIN on restored cube: {}", e))?;
+            }
+            Ok(cube)
+        };
+
     match app::settings::Settings::from_file(network_dir) {
         Ok(mut settings_data) => {
-            // First, check if a cube already has this wallet
+            // First, check if a cube already has this wallet.
+            // We don't decorate existing cubes with the restore PIN —
+            // if the cube already has a PIN hash / fingerprint those
+            // are its source of truth. The restore flow only overwrites
+            // Cube-level credentials when we're actually minting a new
+            // Cube for the restored wallet.
             if let Some(existing_cube) = settings_data
                 .cubes
                 .iter()
@@ -972,14 +1098,35 @@ async fn find_or_create_cube(
                 return Ok(existing_cube.clone());
             }
 
-            // Second, find a cube without a vault and associate this wallet with it
-            if let Some(empty_cube) = settings_data
+            // Second, find a cube without a vault and associate this wallet with it.
+            // Find by index so we can overwrite with a decorated clone without
+            // fighting the borrow checker over a mutable reference that would
+            // otherwise need `mem::take` (and `CubeSettings` doesn't implement
+            // `Default`).
+            if let Some(empty_idx) = settings_data
                 .cubes
-                .iter_mut()
-                .find(|c| c.vault_wallet_id.is_none())
+                .iter()
+                .position(|c| c.vault_wallet_id.is_none())
             {
+                let mut empty_cube = settings_data.cubes[empty_idx].clone();
                 empty_cube.vault_wallet_id = Some(wallet_id.clone());
-                let cube_clone = empty_cube.clone();
+                if let Some(seed) = restore_seed {
+                    empty_cube.master_signer_fingerprint = Some(seed.master_signer_fingerprint);
+                    // `with_pin` is the sanctioned path for setting
+                    // the Argon2id hash; go through it even when the
+                    // Cube already exists so the restored Cube has a
+                    // usable PIN hash. If the Cube had its own
+                    // `security_pin_hash`, this replaces it with one
+                    // derived from the PIN the user just chose —
+                    // consistent with the newly-encrypted mnemonic on
+                    // disk (otherwise PIN entry against the old hash
+                    // would silently succeed but fail to decrypt the
+                    // mnemonic).
+                    empty_cube = empty_cube
+                        .with_pin(seed.pin.as_str())
+                        .map_err(|e| format!("Failed to set PIN on restored cube: {}", e))?;
+                }
+                settings_data.cubes[empty_idx] = empty_cube.clone();
                 let cube_name = empty_cube.name.clone();
 
                 info!(
@@ -987,17 +1134,19 @@ async fn find_or_create_cube(
                     wallet_id, cube_name, network
                 );
 
-                return save_cube_settings(network_dir, cube_clone, network, settings_data).await;
+                return save_cube_settings(network_dir, empty_cube, network, settings_data).await;
             }
 
             // Third, create a new cube for this wallet
-            let cube = app::settings::CubeSettings::new(
-                wallet_alias
-                    .clone()
-                    .unwrap_or_else(|| format!("My {} Cube", network)),
-                network,
-            )
-            .with_vault(wallet_id.clone());
+            let cube = decorate_new(
+                app::settings::CubeSettings::new(
+                    wallet_alias
+                        .clone()
+                        .unwrap_or_else(|| format!("My {} Cube", network)),
+                    network,
+                )
+                .with_vault(wallet_id.clone()),
+            )?;
             let cube_name = cube.name.clone();
 
             info!(
@@ -1010,13 +1159,15 @@ async fn find_or_create_cube(
         }
         Err(_) => {
             // No settings file yet, create first cube
-            let cube = app::settings::CubeSettings::new(
-                wallet_alias
-                    .clone()
-                    .unwrap_or_else(|| format!("My {} Cube", network)),
-                network,
-            )
-            .with_vault(wallet_id.clone());
+            let cube = decorate_new(
+                app::settings::CubeSettings::new(
+                    wallet_alias
+                        .clone()
+                        .unwrap_or_else(|| format!("My {} Cube", network)),
+                    network,
+                )
+                .with_vault(wallet_id.clone()),
+            )?;
             let cube_name = cube.name.clone();
 
             info!(

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -603,6 +603,27 @@ impl Tab {
                         self.state = State::Installer(install);
                         command.map(Message::Install)
                     }
+                    app::Message::View(app::view::Message::SetupVaultRestoreFromKit) => {
+                        // W15 — same installer launch path as SetupVault,
+                        // but starts in the Recovery-Kit restore flow
+                        // instead of the new-vault descriptor editor.
+                        let (install, command) = Installer::new(
+                            app.datadir().clone(),
+                            app.cache().network,
+                            None,
+                            UserFlow::RestoreVaultFromRecoveryKit,
+                            true,
+                            Some(app.cube_settings().clone()),
+                            Some(app.breez_client()),
+                            app.spark_backend(),
+                            GlobalSettings::load_developer_mode(&GlobalSettings::path(
+                                app.datadir(),
+                            )),
+                            app.authenticated_coincube_client(),
+                        );
+                        self.state = State::Installer(install);
+                        command.map(Message::Install)
+                    }
                     app::Message::View(app::view::Message::ToggleTheme) => {
                         Task::done(Message::ToggleTheme)
                     }

--- a/coincube-gui/src/installer/context.rs
+++ b/coincube-gui/src/installer/context.rs
@@ -130,6 +130,24 @@ pub struct Context {
     /// with an "approximate" caveat in the Final step's success caption.
     /// `None` when the descriptor has no recovery paths.
     pub connect_vault_timelock_days: Option<i32>,
+    /// PIN chosen by the user during a Recovery Kit restore. Populated
+    /// by `RestorePinSetupStep` (between `RecoveryKitRestoreStep` and
+    /// the node-setup step in `UserFlow::RestoreFromRecoveryKit`).
+    ///
+    /// Downstream consumers:
+    /// - `install_local_wallet` branches on this to call
+    ///   `Signer::store_encrypted(..., &pin)` rather than the
+    ///   unencrypted `store(...)` so the Liquid/Spark BreezClient can
+    ///   decrypt the mnemonic on subsequent Cube opens.
+    /// - `gui::tab::find_or_create_cube` / the `CubeSaved` handler use
+    ///   the value to populate `CubeSettings.security_pin_hash` and
+    ///   `CubeSettings.master_signer_fingerprint`, matching what a
+    ///   fresh-install Cube stores.
+    ///
+    /// Wrapped in `Zeroizing<String>` so the heap allocation is zeroed
+    /// when the `Context` clone held by `Task::perform` drops after
+    /// the install completes. `None` for non-restore flows.
+    pub restore_pin: Option<zeroize::Zeroizing<String>>,
 }
 
 impl Context {
@@ -169,6 +187,7 @@ impl Context {
             cube_name: cube_settings.map(|cs| cs.name.clone()),
             connect_vault_members: Vec::new(),
             connect_vault_timelock_days: None,
+            restore_pin: None,
         }
     }
 }

--- a/coincube-gui/src/installer/context.rs
+++ b/coincube-gui/src/installer/context.rs
@@ -96,7 +96,13 @@ pub struct Context {
     pub recovered_signer: Option<Arc<Signer>>,
     pub bitcoind_is_external: bool,
     pub use_coincube_connect: bool,
-    pub connect_jwt: Option<String>,
+    /// Connect JWT threaded across installer steps. Wrapped in
+    /// `Zeroizing<String>` so the heap allocation is scrubbed when the
+    /// `Context` (and any `Task::perform` clone of it) drops — keeps
+    /// the token off the residual heap between the step that writes it
+    /// (`CoincubeConnectStep` or `RecoveryKitRestoreStep`) and the
+    /// downstream step that copies it into `EsploraConfig.token`.
+    pub connect_jwt: Option<zeroize::Zeroizing<String>>,
     pub install_node_alongside_connect: bool,
     pub internal_bitcoind_config: Option<InternalBitcoindConfig>,
     pub internal_bitcoind: Option<Bitcoind>,
@@ -189,5 +195,21 @@ impl Context {
             connect_vault_timelock_days: None,
             restore_pin: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Context;
+
+    /// Compile-time pin: if anyone reverts `Context.connect_jwt` to a
+    /// plain `Option<String>`, this type-level assertion stops
+    /// compiling. Keeps the JWT's scrub-on-drop guarantee intact
+    /// across the installer → Esplora handoff.
+    #[test]
+    fn connect_jwt_is_zeroizing_wrapped() {
+        #[allow(dead_code)]
+        const _: fn(&Context) -> Option<&zeroize::Zeroizing<String>> =
+            |ctx| ctx.connect_jwt.as_ref();
     }
 }

--- a/coincube-gui/src/installer/message.rs
+++ b/coincube-gui/src/installer/message.rs
@@ -306,7 +306,7 @@ pub enum RecoveryKitRestoreMsg {
 impl std::fmt::Debug for RecoveryKitRestoreMsg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::EmailEdited(_) => f.debug_tuple("EmailEdited").field(&"<redacted>").finish(),
+            Self::EmailEdited(s) => f.debug_tuple("EmailEdited").field(s).finish(),
             Self::RequestOtp => write!(f, "RequestOtp"),
             Self::OtpSent(r) => f.debug_tuple("OtpSent").field(r).finish(),
             Self::OtpEdited(_) => f.debug_tuple("OtpEdited").field(&"<redacted>").finish(),

--- a/coincube-gui/src/installer/message.rs
+++ b/coincube-gui/src/installer/message.rs
@@ -92,6 +92,8 @@ pub enum Message {
         Result<super::connect_vault::ConnectVaultOutcome, super::connect_vault::ConnectVaultError>,
     ),
     CoincubeConnect(CoincubeConnectMsg),
+    /// Cube Recovery Kit restore step (W13 / W14 / W15).
+    RecoveryKitRestore(RecoveryKitRestoreMsg),
     BorderWalletWizard(
         super::step::descriptor::editor::border_wallet_wizard::BorderWalletWizardMessage,
     ),
@@ -195,6 +197,63 @@ pub enum CoincubeConnectMsg {
     ResendOtp,
     OtpResent(Result<(), String>),
     Skip,
+}
+
+/// Messages driving the Cube Recovery Kit restore step. Manual
+/// `Debug` redacts every variant that carries password, OTP, or
+/// mnemonic material — tracing dumps don't leak the kit.
+#[derive(Clone)]
+pub enum RecoveryKitRestoreMsg {
+    EmailEdited(String),
+    RequestOtp,
+    OtpSent(Result<(), String>),
+    OtpEdited(String),
+    OtpVerified(Result<String, String>),
+    CubesLoaded(Result<Vec<super::step::recovery_kit_restore::RestoreCubeCandidate>, String>),
+    SelectCube(u64),
+    PasswordEdited(String),
+    SubmitPassword,
+    DecryptResult(
+        Result<
+            (
+                Option<crate::services::recovery::SeedBlob>,
+                Option<crate::services::recovery::DescriptorBlob>,
+            ),
+            String,
+        >,
+    ),
+    RetryFromStart,
+    Skip,
+}
+
+impl std::fmt::Debug for RecoveryKitRestoreMsg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmailEdited(_) => f.debug_tuple("EmailEdited").field(&"<redacted>").finish(),
+            Self::RequestOtp => write!(f, "RequestOtp"),
+            Self::OtpSent(r) => f.debug_tuple("OtpSent").field(r).finish(),
+            Self::OtpEdited(_) => f.debug_tuple("OtpEdited").field(&"<redacted>").finish(),
+            Self::OtpVerified(Ok(_)) => write!(f, "OtpVerified(Ok(<redacted>))"),
+            Self::OtpVerified(Err(e)) => f
+                .debug_tuple("OtpVerified")
+                .field(&Err::<(), _>(e))
+                .finish(),
+            Self::CubesLoaded(r) => f.debug_tuple("CubesLoaded").field(r).finish(),
+            Self::SelectCube(id) => f.debug_tuple("SelectCube").field(id).finish(),
+            Self::PasswordEdited(_) => f
+                .debug_tuple("PasswordEdited")
+                .field(&"<redacted>")
+                .finish(),
+            Self::SubmitPassword => write!(f, "SubmitPassword"),
+            Self::DecryptResult(Ok(_)) => write!(f, "DecryptResult(Ok(<redacted>))"),
+            Self::DecryptResult(Err(e)) => f
+                .debug_tuple("DecryptResult")
+                .field(&Err::<(), _>(e))
+                .finish(),
+            Self::RetryFromStart => write!(f, "RetryFromStart"),
+            Self::Skip => write!(f, "Skip"),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/coincube-gui/src/installer/message.rs
+++ b/coincube-gui/src/installer/message.rs
@@ -202,16 +202,27 @@ pub enum CoincubeConnectMsg {
 /// Messages driving the Cube Recovery Kit restore step. Manual
 /// `Debug` redacts every variant that carries password, OTP, or
 /// mnemonic material — tracing dumps don't leak the kit.
+///
+/// Sensitive payloads (`OtpEdited`, `OtpVerified` JWT,
+/// `PasswordEdited`) are wrapped in `Zeroizing<String>` so each
+/// in-flight copy zeroes its heap allocation on drop, not just the
+/// copy stored on the step's state. Iced's runtime may hold several
+/// message copies simultaneously (update → task → view round-trip),
+/// so wrapping at the message level — not just at the state field —
+/// is what prevents key material from lingering after the flow
+/// completes. `EmailEdited` stays as plain `String`: the email is
+/// already surfaced elsewhere in the UI (header caption) and isn't
+/// a credential.
 #[derive(Clone)]
 pub enum RecoveryKitRestoreMsg {
     EmailEdited(String),
     RequestOtp,
     OtpSent(Result<(), String>),
-    OtpEdited(String),
-    OtpVerified(Result<String, String>),
+    OtpEdited(zeroize::Zeroizing<String>),
+    OtpVerified(Result<zeroize::Zeroizing<String>, String>),
     CubesLoaded(Result<Vec<super::step::recovery_kit_restore::RestoreCubeCandidate>, String>),
     SelectCube(u64),
-    PasswordEdited(String),
+    PasswordEdited(zeroize::Zeroizing<String>),
     SubmitPassword,
     DecryptResult(
         Result<

--- a/coincube-gui/src/installer/message.rs
+++ b/coincube-gui/src/installer/message.rs
@@ -78,8 +78,25 @@ pub enum Message {
     SelectKeySource(SelectKeySourceMessage),
     EditKeyAlias(EditKeyAliasMessage),
     Decrypt(Decrypt),
+    /// Post-install orchestration completed. The first field pairs the
+    /// saved/found `CubeSettings` with an optional pre-loaded
+    /// `BreezClient`.
+    ///
+    /// The BreezClient slot is populated only for the Recovery Kit
+    /// restore flow, where the new PIN-setup step lets us build the
+    /// client up-front against the just-encrypted mnemonic — matching
+    /// what fresh-install + pre-existing-Cube opens already do. For
+    /// every other flow (fresh install, remote backend, etc.) the
+    /// client is built downstream (PIN entry, login) and this slot
+    /// stays `None`.
     CubeSaved(
-        Result<CubeSettings, String>,
+        Result<
+            (
+                CubeSettings,
+                Option<std::sync::Arc<crate::app::breez_liquid::BreezClient>>,
+            ),
+            String,
+        >,
         Box<settings::WalletSettings>,
         Option<Bitcoind>,
     ),
@@ -92,6 +109,13 @@ pub enum Message {
         Result<super::connect_vault::ConnectVaultOutcome, super::connect_vault::ConnectVaultError>,
     ),
     CoincubeConnect(CoincubeConnectMsg),
+    /// PIN-setup step that runs after a full Recovery Kit restore
+    /// (`UserFlow::RestoreFromRecoveryKit`). Collects a 4-digit PIN
+    /// used to AES-encrypt the restored mnemonic on disk and to seed
+    /// `CubeSettings.security_pin_hash`, bringing the restore flow in
+    /// line with fresh-install Cubes so the Liquid/Spark BreezClient
+    /// can decrypt the mnemonic on later opens.
+    RestorePinSetup(RestorePinSetupMsg),
     /// Cube Recovery Kit restore step (W13 / W14 / W15).
     RecoveryKitRestore(RecoveryKitRestoreMsg),
     BorderWalletWizard(
@@ -224,13 +248,20 @@ pub enum RecoveryKitRestoreMsg {
     SelectCube(u64),
     PasswordEdited(zeroize::Zeroizing<String>),
     SubmitPassword,
+    /// Carries the typed `RestoreError` rather than a flattened
+    /// `String` so the UI can branch on variants — `BadPasswordOrCorrupt`
+    /// keeps the user on `PasswordEntry` for a retry, while
+    /// `RateLimited` / `NotFound` / `BlobParse` / `Api` are terminal
+    /// and route to `Phase::Error`. A stringified error here would
+    /// collapse those cases and produce wrong UX (e.g. rate-limit
+    /// cooldowns treated as retryable password errors).
     DecryptResult(
         Result<
             (
                 Option<crate::services::recovery::SeedBlob>,
                 Option<crate::services::recovery::DescriptorBlob>,
             ),
-            String,
+            crate::services::recovery::restore::RestoreError,
         >,
     ),
     RetryFromStart,
@@ -263,6 +294,46 @@ impl std::fmt::Debug for RecoveryKitRestoreMsg {
                 .finish(),
             Self::RetryFromStart => write!(f, "RetryFromStart"),
             Self::Skip => write!(f, "Skip"),
+        }
+    }
+}
+
+/// Messages driving the PIN-setup step that runs in between the
+/// Recovery Kit restore step and the node-setup steps in
+/// `UserFlow::RestoreFromRecoveryKit`. Manual `Debug` redacts the PIN
+/// payloads so tracing dumps don't leak them — see the analogous
+/// pattern on `RecoveryKitRestoreMsg`.
+///
+/// The step holds *two* `PinInput` widgets (entry + confirmation), so
+/// the digit/toggle variants carry a `PinField` discriminator rather
+/// than threading separate message trees through the view.
+#[derive(Clone)]
+pub enum RestorePinSetupMsg {
+    /// A digit was typed in one of the PIN fields. `pin_input::Message`
+    /// uses the derived `Debug` which includes the typed digit — our
+    /// outer `Debug` impl below replaces the inner message with
+    /// `<redacted>` so tracing dumps don't reveal keystrokes.
+    Pin(PinField, crate::pin_input::Message),
+    Submit,
+}
+
+/// Identifier for which `PinInput` widget a `RestorePinSetupMsg::Pin`
+/// refers to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinField {
+    Entry,
+    Confirm,
+}
+
+impl std::fmt::Debug for RestorePinSetupMsg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pin(field, _) => f
+                .debug_tuple("Pin")
+                .field(field)
+                .field(&"<redacted>")
+                .finish(),
+            Self::Submit => write!(f, "Submit"),
         }
     }
 }

--- a/coincube-gui/src/installer/message.rs
+++ b/coincube-gui/src/installer/message.rs
@@ -34,6 +34,19 @@ use crate::{
     },
 };
 
+/// Result handed to `Message::CubeSaved` after post-install
+/// orchestration finishes. Extracted as an alias because the
+/// inlined form trips `clippy::type_complexity`; the name also
+/// documents the intent at call sites.
+pub type CubeSaveResult = Result<
+    (
+        CubeSettings,
+        Option<std::sync::Arc<crate::app::breez_liquid::BreezClient>>,
+        Option<std::sync::Arc<crate::app::wallets::SparkBackend>>,
+    ),
+    String,
+>;
+
 #[derive(Debug, Clone)]
 pub enum Message {
     UserActionDone(bool),
@@ -80,23 +93,20 @@ pub enum Message {
     Decrypt(Decrypt),
     /// Post-install orchestration completed. The first field pairs the
     /// saved/found `CubeSettings` with an optional pre-loaded
-    /// `BreezClient`.
+    /// `BreezClient` and `SparkBackend`.
     ///
-    /// The BreezClient slot is populated only for the Recovery Kit
+    /// Both wallet-client slots are populated only for the Recovery Kit
     /// restore flow, where the new PIN-setup step lets us build the
-    /// client up-front against the just-encrypted mnemonic — matching
-    /// what fresh-install + pre-existing-Cube opens already do. For
-    /// every other flow (fresh install, remote backend, etc.) the
-    /// client is built downstream (PIN entry, login) and this slot
-    /// stays `None`.
+    /// clients up-front against the just-encrypted mnemonic — matching
+    /// what fresh-install + pre-existing-Cube opens already do. Without
+    /// this, the Loader landed on the post-install screen with
+    /// `spark_backend = None` and the Spark panels stayed empty until
+    /// the user closed and re-opened the Cube (at which point the
+    /// normal PIN-entry path loads Spark correctly). For every other
+    /// flow (fresh install, remote backend, etc.) the clients are
+    /// built downstream (PIN entry, login) and these slots stay `None`.
     CubeSaved(
-        Result<
-            (
-                CubeSettings,
-                Option<std::sync::Arc<crate::app::breez_liquid::BreezClient>>,
-            ),
-            String,
-        >,
+        CubeSaveResult,
         Box<settings::WalletSettings>,
         Option<Bitcoind>,
     ),

--- a/coincube-gui/src/installer/message.rs
+++ b/coincube-gui/src/installer/message.rs
@@ -220,17 +220,42 @@ pub enum SelectBitcoindTypeMsg {
     UseConnect,
 }
 
-#[derive(Debug, Clone)]
+/// Manual `Debug` redacts the OTP-verify JWT payload. The `Ok` arm of
+/// `OtpVerified` carries a `Zeroizing<String>` whose heap allocation is
+/// scrubbed on drop — but `Zeroizing<T>` delegates `Debug` to the inner
+/// `String`, so without the manual impl the token would leak into any
+/// tracing snapshot of a parent message (notably `Message::Install`).
+#[derive(Clone)]
 pub enum CoincubeConnectMsg {
     EmailEdited(String),
     ToggleMode,
     RequestOtp,
     OtpRequested(Result<(), String>),
     OtpEdited(String),
-    OtpVerified(Result<String, String>),
+    OtpVerified(Result<zeroize::Zeroizing<String>, String>),
     ResendOtp,
     OtpResent(Result<(), String>),
     Skip,
+}
+
+impl std::fmt::Debug for CoincubeConnectMsg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmailEdited(s) => f.debug_tuple("EmailEdited").field(s).finish(),
+            Self::ToggleMode => write!(f, "ToggleMode"),
+            Self::RequestOtp => write!(f, "RequestOtp"),
+            Self::OtpRequested(r) => f.debug_tuple("OtpRequested").field(r).finish(),
+            Self::OtpEdited(s) => f.debug_tuple("OtpEdited").field(s).finish(),
+            Self::OtpVerified(Ok(_)) => write!(f, "OtpVerified(Ok(<redacted>))"),
+            Self::OtpVerified(Err(e)) => f
+                .debug_tuple("OtpVerified")
+                .field(&Err::<(), _>(e))
+                .finish(),
+            Self::ResendOtp => write!(f, "ResendOtp"),
+            Self::OtpResent(r) => f.debug_tuple("OtpResent").field(r).finish(),
+            Self::Skip => write!(f, "Skip"),
+        }
+    }
 }
 
 /// Messages driving the Cube Recovery Kit restore step. Manual
@@ -409,4 +434,33 @@ pub enum ThresholdSequenceModal {
     ThresholdEdited(usize),
     SequenceEdited(String),
     Confirm,
+}
+
+#[cfg(test)]
+mod coincube_connect_msg_debug_tests {
+    use super::CoincubeConnectMsg;
+    use zeroize::Zeroizing;
+
+    /// Canary: appears in the Debug render only if redaction regressed.
+    const CANARY_JWT: &str = "eyCANARY.cc-jwt.XYZZY-do-not-leak";
+
+    #[test]
+    fn otp_verified_ok_is_redacted() {
+        let msg = CoincubeConnectMsg::OtpVerified(Ok(Zeroizing::new(CANARY_JWT.to_string())));
+        let rendered = format!("{:?}", msg);
+        assert!(
+            !rendered.contains(CANARY_JWT),
+            "JWT leaked through CoincubeConnectMsg::OtpVerified Debug: {}",
+            rendered
+        );
+        assert!(rendered.contains("<redacted>"));
+    }
+
+    #[test]
+    fn otp_verified_err_preserves_error_message() {
+        let msg = CoincubeConnectMsg::OtpVerified(Err("bad otp".to_string()));
+        let rendered = format!("{:?}", msg);
+        assert!(rendered.contains("bad otp"));
+        assert!(!rendered.contains(CANARY_JWT));
+    }
 }

--- a/coincube-gui/src/installer/mod.rs
+++ b/coincube-gui/src/installer/mod.rs
@@ -213,16 +213,12 @@ impl Installer {
             spark_backend,
             steps: {
                 // Network string used as a filter by the restore step's
-                // cube-picker. The backend accepts the canonical lowercase
-                // names rather than `Network::Display`'s output.
-                let network_str = match network {
-                    Network::Bitcoin => "bitcoin",
-                    Network::Testnet => "testnet",
-                    Network::Signet => "signet",
-                    Network::Regtest => "regtest",
-                    _ => "bitcoin",
-                }
-                .to_string();
+                // cube-picker. Must match the Connect API's canonical
+                // form (`"mainnet"` for Bitcoin mainnet) — `CubeResponse.network`
+                // comes straight from the backend which uses that shape.
+                // Using any other form here silently filters out every
+                // server-side cube on mainnet.
+                let network_str = crate::app::settings::network_to_api_string(network);
                 match user_flow {
                     UserFlow::CreateWallet => vec![
                         ChooseDescriptorTemplate::default().into(),

--- a/coincube-gui/src/installer/mod.rs
+++ b/coincube-gui/src/installer/mod.rs
@@ -64,8 +64,9 @@ pub use message::Message;
 use step::{
     BackupDescriptor, BackupMnemonic, ChooseBackend, ChooseDescriptorTemplate, CoincubeConnectStep,
     DefineDescriptor, DefineNode, DescriptorTemplateDescription, Final, ImportDescriptor,
-    ImportRemoteWallet, InternalBitcoindStep, RecoverMnemonic, RegisterDescriptor,
-    RemoteBackendLogin, SelectBitcoindTypeStep, ShareXpubs, Step, WalletAlias,
+    ImportRemoteWallet, InternalBitcoindStep, RecoverMnemonic, RecoveryKitRestoreStep,
+    RegisterDescriptor, RemoteBackendLogin, RestoreScope, SelectBitcoindTypeStep, ShareXpubs, Step,
+    WalletAlias,
 };
 
 #[derive(Debug, Clone)]
@@ -73,6 +74,18 @@ pub enum UserFlow {
     CreateWallet,
     AddWallet,
     ShareXpubs,
+    /// W13 — full install restore from a Connect Recovery Kit.
+    /// Skips the descriptor-editor, backup-mnemonic, and register-
+    /// descriptor steps because the kit provides both the seed and
+    /// the descriptor. The flow is: RecoveryKitRestore(Full) →
+    /// CoincubeConnect (noop — already authed) → Node setup →
+    /// WalletAlias → Final.
+    RestoreFromRecoveryKit,
+    /// W15 — restore the Wallet Descriptor only, from a running
+    /// Cube. Assumes the Cube's seed is already on disk (the user
+    /// just needs to rehydrate the vault). Launched from the
+    /// running app's "Create Vault" menu.
+    RestoreVaultFromRecoveryKit,
 }
 
 pub struct Installer {
@@ -198,37 +211,94 @@ impl Installer {
             cube_settings,
             breez_client,
             spark_backend,
-            steps: match user_flow {
-                UserFlow::CreateWallet => vec![
-                    ChooseDescriptorTemplate::default().into(),
-                    DescriptorTemplateDescription::default().into(),
-                    DefineDescriptor::new(network, signer.clone()).into(),
-                    BackupMnemonic::new(signer.clone()).into(),
-                    BackupDescriptor::default().into(),
-                    RegisterDescriptor::new_create_wallet().into(),
-                    CoincubeConnectStep::new().into(),
-                    SelectBitcoindTypeStep::new().into(),
-                    InternalBitcoindStep::new(&context.coincube_directory).into(),
-                    DefineNode::new(crate::node::NodeType::Esplora).into(),
-                    WalletAlias::default().into(),
-                    Final::new().into(),
-                ],
-                UserFlow::ShareXpubs => vec![ShareXpubs::new(network, signer.clone()).into()],
-                UserFlow::AddWallet => vec![
-                    ChooseBackend::new(network).into(),
-                    RemoteBackendLogin::new(network, destination_path.network_directory(network))
+            steps: {
+                // Network string used as a filter by the restore step's
+                // cube-picker. The backend accepts the canonical lowercase
+                // names rather than `Network::Display`'s output.
+                let network_str = match network {
+                    Network::Bitcoin => "bitcoin",
+                    Network::Testnet => "testnet",
+                    Network::Signet => "signet",
+                    Network::Regtest => "regtest",
+                    _ => "bitcoin",
+                }
+                .to_string();
+                match user_flow {
+                    UserFlow::CreateWallet => vec![
+                        ChooseDescriptorTemplate::default().into(),
+                        DescriptorTemplateDescription::default().into(),
+                        DefineDescriptor::new(network, signer.clone()).into(),
+                        BackupMnemonic::new(signer.clone()).into(),
+                        BackupDescriptor::default().into(),
+                        RegisterDescriptor::new_create_wallet().into(),
+                        CoincubeConnectStep::new().into(),
+                        SelectBitcoindTypeStep::new().into(),
+                        InternalBitcoindStep::new(&context.coincube_directory).into(),
+                        DefineNode::new(crate::node::NodeType::Esplora).into(),
+                        WalletAlias::default().into(),
+                        Final::new().into(),
+                    ],
+                    UserFlow::ShareXpubs => vec![ShareXpubs::new(network, signer.clone()).into()],
+                    UserFlow::AddWallet => vec![
+                        ChooseBackend::new(network).into(),
+                        RemoteBackendLogin::new(
+                            network,
+                            destination_path.network_directory(network),
+                        )
                         .into(),
-                    ImportRemoteWallet::new(network).into(),
-                    ImportDescriptor::new(network).into(),
-                    RecoverMnemonic::default().into(),
-                    RegisterDescriptor::new_import_wallet().into(),
-                    CoincubeConnectStep::new().into(),
-                    SelectBitcoindTypeStep::new().into(),
-                    InternalBitcoindStep::new(&context.coincube_directory).into(),
-                    DefineNode::default().into(),
-                    WalletAlias::default().into(),
-                    Final::new().into(),
-                ],
+                        ImportRemoteWallet::new(network).into(),
+                        ImportDescriptor::new(network).into(),
+                        RecoverMnemonic::default().into(),
+                        // W14 — offer to pull the descriptor from Connect
+                        // after the user confirms their mnemonic. The step
+                        // is skippable; `apply(skipped)` leaves the
+                        // context alone so the file-imported descriptor
+                        // (from `ImportDescriptor` above) stays in place.
+                        RecoveryKitRestoreStep::new(
+                            RestoreScope::DescriptorOnly,
+                            network_str.clone(),
+                        )
+                        .into(),
+                        RegisterDescriptor::new_import_wallet().into(),
+                        CoincubeConnectStep::new().into(),
+                        SelectBitcoindTypeStep::new().into(),
+                        InternalBitcoindStep::new(&context.coincube_directory).into(),
+                        DefineNode::default().into(),
+                        WalletAlias::default().into(),
+                        Final::new().into(),
+                    ],
+                    // W13 — full restore: the kit carries both the seed
+                    // and the descriptor, so the flow skips the editor +
+                    // register-descriptor + backup-mnemonic steps that
+                    // only make sense for a fresh install.
+                    UserFlow::RestoreFromRecoveryKit => vec![
+                        RecoveryKitRestoreStep::new(RestoreScope::Full, network_str.clone()).into(),
+                        CoincubeConnectStep::new().into(),
+                        SelectBitcoindTypeStep::new().into(),
+                        InternalBitcoindStep::new(&context.coincube_directory).into(),
+                        DefineNode::new(crate::node::NodeType::Esplora).into(),
+                        WalletAlias::default().into(),
+                        Final::new().into(),
+                    ],
+                    // W15 — running-app Vault restore: the current Cube
+                    // already has its seed on disk, we just need the
+                    // descriptor. Launched with `launched_from_app = true`
+                    // so `previous()` at step 0 returns to App rather
+                    // than exiting the installer.
+                    UserFlow::RestoreVaultFromRecoveryKit => vec![
+                        RecoveryKitRestoreStep::new(
+                            RestoreScope::DescriptorOnly,
+                            network_str.clone(),
+                        )
+                        .into(),
+                        RegisterDescriptor::new_import_wallet().into(),
+                        SelectBitcoindTypeStep::new().into(),
+                        InternalBitcoindStep::new(&context.coincube_directory).into(),
+                        DefineNode::default().into(),
+                        WalletAlias::default().into(),
+                        Final::new().into(),
+                    ],
+                }
             },
             context,
             signer,

--- a/coincube-gui/src/installer/mod.rs
+++ b/coincube-gui/src/installer/mod.rs
@@ -65,8 +65,8 @@ use step::{
     BackupDescriptor, BackupMnemonic, ChooseBackend, ChooseDescriptorTemplate, CoincubeConnectStep,
     DefineDescriptor, DefineNode, DescriptorTemplateDescription, Final, ImportDescriptor,
     ImportRemoteWallet, InternalBitcoindStep, RecoverMnemonic, RecoveryKitRestoreStep,
-    RegisterDescriptor, RemoteBackendLogin, RestoreScope, SelectBitcoindTypeStep, ShareXpubs, Step,
-    WalletAlias,
+    RegisterDescriptor, RemoteBackendLogin, RestorePinSetupStep, RestoreScope,
+    SelectBitcoindTypeStep, ShareXpubs, Step, WalletAlias,
 };
 
 #[derive(Debug, Clone)]
@@ -193,6 +193,17 @@ impl Installer {
                     match (&user_flow, network) {
                         // CreateWallet no longer has a ChooseBackend step; always local.
                         (UserFlow::CreateWallet, _) => RemoteBackend::None,
+                        // Restore flows also have no ChooseBackend step — the
+                        // user is restoring a descriptor (and optionally a
+                        // seed) into a fresh local install. Connect auth still
+                        // happens via the `CoincubeConnectStep` further down
+                        // the flow, which sets `ctx.connect_jwt` and lets
+                        // Final idempotently re-register the Cube. Without
+                        // this match arm `ctx.remote_backend` stays at
+                        // `Undefined` and the `Message::Install` match panics
+                        // with `unreachable!("Must be defined at this point")`.
+                        (UserFlow::RestoreFromRecoveryKit, _)
+                        | (UserFlow::RestoreVaultFromRecoveryKit, _) => RemoteBackend::None,
                         // AddWallet still has ChooseBackend which transitions away from Undefined.
                         (_, Network::Bitcoin | Network::Signet) => RemoteBackend::Undefined,
                         // Non-mainnet/signet AddWallet skips backend choice.
@@ -269,6 +280,17 @@ impl Installer {
                     // only make sense for a fresh install.
                     UserFlow::RestoreFromRecoveryKit => vec![
                         RecoveryKitRestoreStep::new(RestoreScope::Full, network_str.clone()).into(),
+                        // Collect a PIN *after* the kit is decrypted
+                        // (so `ctx.recovered_signer` is populated and
+                        // the step's `skip()` doesn't short-circuit)
+                        // but *before* node setup — the PIN ends up
+                        // encrypting the restored mnemonic in
+                        // `install_local_wallet` and seeding
+                        // `CubeSettings.security_pin_hash` in the
+                        // tab-level `CubeSaved` handler, matching the
+                        // fresh-install Cube layout so BreezClient
+                        // decrypt-on-open works.
+                        RestorePinSetupStep::new().into(),
                         CoincubeConnectStep::new().into(),
                         SelectBitcoindTypeStep::new().into(),
                         InternalBitcoindStep::new(&context.coincube_directory).into(),
@@ -624,18 +646,40 @@ pub async fn install_local_wallet(
     }
 
     if let Some(signer) = &ctx.recovered_signer {
-        signer
-            .store(
-                &ctx.coincube_directory,
-                cfg.bitcoin_config.network,
-                &wallet_id.descriptor_checksum,
-                wallet_id
-                    .timestamp
-                    .expect("Every new wallet have now a timestamp"),
-            )
-            .map_err(|e| Error::Unexpected(format!("Failed to store mnemonic: {}", e)))?;
-
-        info!("Recovered signer mnemonic stored");
+        let timestamp = wallet_id
+            .timestamp
+            .expect("Every new wallet have now a timestamp");
+        // Recovery Kit restore: encrypt the mnemonic with the PIN the
+        // user chose in `RestorePinSetupStep` so the on-disk layout
+        // matches what a fresh-install Cube produces. If `restore_pin`
+        // is absent (e.g. `RestoreVaultFromRecoveryKit` or an older
+        // flow) fall back to the unencrypted path — that path keeps
+        // the legacy AddWallet recovery behaviour working, where the
+        // user's existing Cube already holds its PIN-encrypted seed.
+        if let Some(pin) = ctx.restore_pin.as_ref() {
+            signer
+                .store_encrypted(
+                    &ctx.coincube_directory,
+                    cfg.bitcoin_config.network,
+                    &wallet_id.descriptor_checksum,
+                    timestamp,
+                    pin.as_str(),
+                )
+                .map_err(|e| {
+                    Error::Unexpected(format!("Failed to store encrypted mnemonic: {}", e))
+                })?;
+            info!("Recovered signer mnemonic stored (PIN-encrypted)");
+        } else {
+            signer
+                .store(
+                    &ctx.coincube_directory,
+                    cfg.bitcoin_config.network,
+                    &wallet_id.descriptor_checksum,
+                    timestamp,
+                )
+                .map_err(|e| Error::Unexpected(format!("Failed to store mnemonic: {}", e)))?;
+            info!("Recovered signer mnemonic stored");
+        }
     }
 
     // create coincube GUI configuration file

--- a/coincube-gui/src/installer/step/coincube_connect.rs
+++ b/coincube-gui/src/installer/step/coincube_connect.rs
@@ -89,7 +89,12 @@ impl Step for CoincubeConnectStep {
         }
         if let Some(token) = &self.jwt {
             ctx.use_coincube_connect = true;
-            ctx.connect_jwt = Some(token.clone());
+            // Wrap into `Zeroizing<String>` at the Context handoff so
+            // the JWT heap allocation is scrubbed on Context drop.
+            // `self.jwt` is a plain `Option<String>` today; promoting
+            // it to `Zeroizing` end-to-end would be a broader refactor
+            // (OTP-verify plumbing), tracked separately.
+            ctx.connect_jwt = Some(zeroize::Zeroizing::new(token.clone()));
             true
         } else {
             false

--- a/coincube-gui/src/installer/step/coincube_connect.rs
+++ b/coincube-gui/src/installer/step/coincube_connect.rs
@@ -71,6 +71,14 @@ impl Step for CoincubeConnectStep {
     fn skip(&self, ctx: &Context) -> bool {
         ctx.network == coincube_core::miniscript::bitcoin::Network::Regtest
             || ctx.remote_backend.is_some()
+            // An earlier step (today: `RecoveryKitRestoreStep`) has
+            // already collected the user's JWT for the same Connect
+            // account, so re-authenticating here would just be a
+            // second email + OTP round on the same session. Honor the
+            // existing token and move on. Revert paths upstream clear
+            // `connect_jwt` back to `None`, so navigating backward
+            // through this step won't strand a stale token.
+            || ctx.connect_jwt.is_some()
     }
 
     fn apply(&mut self, ctx: &mut Context) -> bool {

--- a/coincube-gui/src/installer/step/coincube_connect.rs
+++ b/coincube-gui/src/installer/step/coincube_connect.rs
@@ -1,5 +1,6 @@
 use coincube_ui::{component::form, widget::*};
 use iced::Task;
+use zeroize::Zeroizing;
 
 use crate::{
     hw::HardwareWallets,
@@ -19,7 +20,14 @@ pub struct CoincubeConnectStep {
     otp: form::Value<String>,
     otp_sent: bool,
     is_signup: bool,
-    jwt: Option<String>,
+    /// JWT captured from the OTP-verify response, held on the step
+    /// between `update(OtpVerified)` and the next `apply()`. Wrapped in
+    /// `Zeroizing` so the heap allocation is scrubbed on drop; `apply`
+    /// moves the value into `Context` with `take()` so no plaintext
+    /// copy lingers on the step after hand-off. Navigating back past
+    /// this step can't re-trigger `apply` — `skip()` short-circuits
+    /// while `ctx.connect_jwt.is_some()` — so `take` is safe.
+    jwt: Option<Zeroizing<String>>,
     processing: bool,
     error: Option<String>,
     skipped: bool,
@@ -87,14 +95,13 @@ impl Step for CoincubeConnectStep {
             ctx.connect_jwt = None;
             return true;
         }
-        if let Some(token) = &self.jwt {
+        // Move the JWT out of the step into `Context`. The step won't
+        // be re-entered while `ctx.connect_jwt.is_some()` (see
+        // `skip()`), so consuming the token here is safe and avoids
+        // keeping a duplicate `Zeroizing<String>` alive on the step.
+        if let Some(token) = self.jwt.take() {
             ctx.use_coincube_connect = true;
-            // Wrap into `Zeroizing<String>` at the Context handoff so
-            // the JWT heap allocation is scrubbed on Context drop.
-            // `self.jwt` is a plain `Option<String>` today; promoting
-            // it to `Zeroizing` end-to-end would be a broader refactor
-            // (OTP-verify plumbing), tracked separately.
-            ctx.connect_jwt = Some(zeroize::Zeroizing::new(token.clone()));
+            ctx.connect_jwt = Some(token);
             true
         } else {
             false
@@ -182,7 +189,14 @@ impl Step for CoincubeConnectStep {
                                 } else {
                                     client.login_verify_otp(req).await
                                 }
-                                .map(|resp| resp.token)
+                                // Wrap into `Zeroizing<String>` at the
+                                // async boundary — before the token
+                                // enters the message queue — so every
+                                // in-flight copy of the subsequent
+                                // `OtpVerified` message scrubs its
+                                // heap on drop, not just the copy
+                                // stashed on the step's state.
+                                .map(|resp| Zeroizing::new(resp.token))
                                 .map_err(|e| e.to_string())
                             },
                             |res| Message::CoincubeConnect(CoincubeConnectMsg::OtpVerified(res)),

--- a/coincube-gui/src/installer/step/mod.rs
+++ b/coincube-gui/src/installer/step/mod.rs
@@ -5,6 +5,7 @@ mod backend;
 mod coincube_connect;
 mod mnemonic;
 pub(crate) mod node;
+pub mod recovery_kit_restore;
 mod share_xpubs;
 mod wallet_alias;
 
@@ -24,6 +25,7 @@ pub use descriptor::{
 pub use backend::{ChooseBackend, ImportRemoteWallet, RemoteBackendLogin};
 pub use coincube_connect::CoincubeConnectStep;
 pub use mnemonic::{BackupMnemonic, RecoverMnemonic};
+pub use recovery_kit_restore::{RecoveryKitRestoreStep, RestoreScope};
 pub use share_xpubs::ShareXpubs;
 use tracing::warn;
 pub use wallet_alias::WalletAlias;

--- a/coincube-gui/src/installer/step/mod.rs
+++ b/coincube-gui/src/installer/step/mod.rs
@@ -6,6 +6,7 @@ mod coincube_connect;
 mod mnemonic;
 pub(crate) mod node;
 pub mod recovery_kit_restore;
+pub mod restore_pin_setup;
 mod share_xpubs;
 mod wallet_alias;
 
@@ -26,6 +27,7 @@ pub use backend::{ChooseBackend, ImportRemoteWallet, RemoteBackendLogin};
 pub use coincube_connect::CoincubeConnectStep;
 pub use mnemonic::{BackupMnemonic, RecoverMnemonic};
 pub use recovery_kit_restore::{RecoveryKitRestoreStep, RestoreScope};
+pub use restore_pin_setup::RestorePinSetupStep;
 pub use share_xpubs::ShareXpubs;
 use tracing::warn;
 pub use wallet_alias::WalletAlias;

--- a/coincube-gui/src/installer/step/node/bitcoind.rs
+++ b/coincube-gui/src/installer/step/node/bitcoind.rs
@@ -379,9 +379,12 @@ impl Step for SelectBitcoindTypeStep {
                 let Some(token) = &ctx.connect_jwt else {
                     return false;
                 };
+                // `EsploraConfig.token` is a plain `String` (serialized
+                // to disk in `coincubed` config), so we copy the inner
+                // string out of the `Zeroizing<String>` wrapper here.
                 ctx.bitcoin_backend = Some(BitcoinBackend::Esplora(EsploraConfig {
                     addr: crate::installer::connect_url(ctx.network),
-                    token: Some(token.clone()),
+                    token: Some(token.as_str().to_owned()),
                 }));
                 ctx.internal_bitcoind_config = None;
                 ctx.pending_bitcoind_config = None;
@@ -867,9 +870,13 @@ impl Step for InternalBitcoindStep {
                 let Some(token) = &ctx.connect_jwt else {
                     return false;
                 };
+                // Inner `String` copy: `EsploraConfig.token` is a plain
+                // `String` (persisted to disk), so extract it from the
+                // `Zeroizing<String>` wrapper rather than cloning the
+                // wrapper itself.
                 ctx.bitcoin_backend = Some(BitcoinBackend::Esplora(EsploraConfig {
                     addr: crate::installer::connect_url(ctx.network),
-                    token: Some(token.clone()),
+                    token: Some(token.as_str().to_owned()),
                 }));
             } else {
                 ctx.bitcoin_backend = bitcoind_config.map(BitcoinBackend::Bitcoind);

--- a/coincube-gui/src/installer/step/recovery_kit_restore.rs
+++ b/coincube-gui/src/installer/step/recovery_kit_restore.rs
@@ -36,7 +36,10 @@ use crate::{
         view,
     },
     services::{
-        coincube::{CoincubeClient, CubeResponse, OtpRequest, OtpVerifyRequest, RecoveryKitStatus},
+        coincube::{
+            CoincubeClient, CoincubeError, CubeResponse, OtpRequest, OtpVerifyRequest,
+            RecoveryKitStatus,
+        },
         recovery::{
             restore::{fetch_and_decrypt_kit, DecryptedKit, RestoreError},
             score_password, DescriptorBlob, PasswordStrength, SeedBlob,
@@ -214,8 +217,20 @@ impl RecoveryKitRestoreStep {
                     all.into_iter().filter(|c| c.network == network).collect();
                 let mut out = Vec::with_capacity(matches.len());
                 for cube in matches {
-                    let status = client.get_recovery_kit_status(cube.id).await.unwrap_or(
-                        RecoveryKitStatus {
+                    // Only NotFound is a signal that this particular
+                    // cube has no kit yet — that's a legitimate state
+                    // and we render it as a disabled row in the picker.
+                    // Auth / rate-limit / 5xx / network errors are
+                    // *probe failures*, not "no kit"; silently
+                    // mapping them to `has_recovery_kit: false` would
+                    // mislead the user into thinking they need to
+                    // back up on a different device when the real
+                    // issue is transient. Surface those instead so
+                    // the picker's error path (`Phase::Error`) can
+                    // show the cause and let the user retry.
+                    let status = match client.get_recovery_kit_status(cube.id).await {
+                        Ok(s) => s,
+                        Err(CoincubeError::NotFound) => RecoveryKitStatus {
                             has_recovery_kit: false,
                             has_encrypted_seed: false,
                             has_encrypted_wallet_descriptor: false,
@@ -223,7 +238,13 @@ impl RecoveryKitRestoreStep {
                             created_at: None,
                             updated_at: None,
                         },
-                    );
+                        Err(e) => {
+                            return Err(format!(
+                                "Couldn't load Recovery Kit status for \"{}\": {}",
+                                cube.name, e
+                            ));
+                        }
+                    };
                     out.push(RestoreCubeCandidate {
                         id: cube.id,
                         uuid: cube.uuid,
@@ -245,22 +266,81 @@ impl RecoveryKitRestoreStep {
         let password = Zeroizing::new(self.password.to_string());
         Task::perform(
             async move {
+                // Pass the typed `RestoreError` through unchanged so
+                // the handler (see `DecryptResult` arm in `update`)
+                // can branch on `BadPasswordOrCorrupt` vs. terminal
+                // variants like `RateLimited` / `Api` / `NotFound` /
+                // `BlobParse`. Stringifying here would collapse them
+                // into an untyped bag and force the wrong UX.
                 fetch_and_decrypt_kit(&client, cube_id, &password)
                     .await
                     .map(|DecryptedKit { seed, descriptor }| (seed, descriptor))
-                    .map_err(map_restore_error)
             },
             |res| Message::RecoveryKitRestore(RecoveryKitRestoreMsg::DecryptResult(res)),
         )
     }
 }
 
-fn map_restore_error(e: RestoreError) -> String {
-    // `RestoreError` already formats cleanly — just stringify. The
-    // UI uses the string for the inline banner; typed branching on
-    // specific errors (retry_after, bad password) happens at the
-    // message dispatch level if we want to add it later.
-    e.to_string()
+/// Classify a decrypt error for UI routing. Returns `true` iff the
+/// error is one the user can fix by retyping the password — i.e.,
+/// `BadPasswordOrCorrupt`, the only variant where keeping the user
+/// on the `PasswordEntry` screen with an inline banner is the right
+/// UX. Every other variant (`RateLimited`, `Api`, `NotFound`,
+/// `BlobParse`, `HalfMissing`) is terminal for this attempt and
+/// routes to `Phase::Error`, because retyping the password won't
+/// help.
+fn is_retryable_on_password_screen(e: &RestoreError) -> bool {
+    matches!(e, RestoreError::BadPasswordOrCorrupt)
+}
+
+/// After decrypting a kit, verify that any blobs we got back are
+/// actually for the cube the user picked. The blob plaintexts carry
+/// their own `cube.uuid` + `cube.network` identifiers — if either
+/// disagrees with `selected`, something upstream is misrouted
+/// (wrong kit served for a cube id, cross-device mix-up) and we
+/// should refuse to apply the payload.
+///
+/// Returns `Ok(())` when every present blob matches, `Err(message)`
+/// with a user-visible string otherwise.
+fn validate_blobs_match_selected(
+    seed: Option<&SeedBlob>,
+    descriptor: Option<&DescriptorBlob>,
+    selected: &RestoreCubeCandidate,
+) -> Result<(), String> {
+    let mismatch_msg = || {
+        "This Recovery Kit contains data for a different Cube or network. \
+         Sign out and retry — or contact support if the problem persists."
+            .to_string()
+    };
+    if let Some(s) = seed {
+        if s.cube.uuid != selected.uuid || s.cube.network != selected.network {
+            return Err(mismatch_msg());
+        }
+    }
+    if let Some(d) = descriptor {
+        if d.cube.uuid != selected.uuid || d.cube.network != selected.network {
+            return Err(mismatch_msg());
+        }
+    }
+    Ok(())
+}
+
+/// Does `c` carry the specific encrypted half this restore flow
+/// needs? `has_recovery_kit` alone isn't enough — a cube can have
+/// a seed-only kit (mnemonic cube without a Vault when the backup
+/// was made) or a descriptor-only kit (passkey cube, or the
+/// descriptor half uploaded first). Routing a Full restore to a
+/// descriptor-only kit, or a DescriptorOnly restore to a seed-only
+/// kit, would decrypt successfully and then hit the post-decrypt
+/// `missing_half` guard — making the user enter their password
+/// only to be told the kit can't satisfy this flow. Gating at
+/// selection time catches it up front.
+fn has_required_half(scope: RestoreScope, c: &RestoreCubeCandidate) -> bool {
+    c.status.has_recovery_kit
+        && match scope {
+            RestoreScope::Full => c.status.has_encrypted_seed,
+            RestoreScope::DescriptorOnly => c.status.has_encrypted_wallet_descriptor,
+        }
 }
 
 /// Transition function called after `list_cubes` + per-cube status
@@ -269,29 +349,43 @@ fn map_restore_error(e: RestoreError) -> String {
 /// without standing up the whole installer step.
 ///
 /// Branches:
-/// - Exactly one cube with a kit → auto-select it (common restore path)
-/// - Exactly one cube **without** a kit → `Phase::Error` with a
-///   specific message; the picker's "no kit (disabled)" affordance
-///   doesn't help when there's only one row
+/// - Exactly one cube with the required half → auto-select it
+///   (common restore path)
+/// - Exactly one cube **without** the required half → `Phase::Error`
+///   with a specific message naming the missing half; the picker's
+///   disabled-row affordance doesn't help when there's only one row
 /// - Zero or 2+ cubes → `Phase::CubePicker` (the picker view already
-///   handles the empty-list and mixed-kit cases cleanly)
-fn phase_after_cubes_loaded(cubes: Vec<RestoreCubeCandidate>) -> Phase {
+///   handles the empty-list and mixed-kit cases cleanly, and the
+///   picker's per-row availability label narrates scope mismatches)
+fn phase_after_cubes_loaded(scope: RestoreScope, cubes: Vec<RestoreCubeCandidate>) -> Phase {
     if cubes.len() == 1 {
         // Can't `into_iter().next().unwrap()` inside the `if` guard
         // without moving; handle with `match` on length-1 form.
         let c = cubes.into_iter().next().expect("len == 1");
-        if c.status.has_recovery_kit {
+        if has_required_half(scope, &c) {
             Phase::PasswordEntry {
                 selected: c,
                 attempts: 0,
             }
         } else {
+            let (needed, hint) = match scope {
+                RestoreScope::Full => (
+                    "a Master Seed Phrase",
+                    "the kit was backed up without the seed half (passkey Cubes can't \
+                     include it), and Full restore needs it",
+                ),
+                RestoreScope::DescriptorOnly => (
+                    "a Wallet Descriptor",
+                    "the kit was backed up seed-only (the Cube had no Vault at backup \
+                     time)",
+                ),
+            };
             Phase::Error {
                 message: format!(
-                    "\"{}\" doesn't have a Recovery Kit backed up on Connect. Back up \
-                     the kit first from a device where the Cube is already installed, \
-                     then return here to restore.",
-                    c.name
+                    "\"{}\" doesn't have {} backed up on Connect — {}. Finish the \
+                     backup from a device where the Cube is already installed, then \
+                     return here to restore.",
+                    c.name, needed, hint,
                 ),
             }
         }
@@ -310,6 +404,63 @@ impl From<RecoveryKitRestoreStep> for Box<dyn Step> {
 }
 
 impl Step for RecoveryKitRestoreStep {
+    /// Pick up an already-authenticated Connect session from
+    /// `Context` the first time this step becomes active.
+    ///
+    /// Today the Recovery-Kit restore flow is typically launched from
+    /// a launcher row whose "remote cubes" list only exists because
+    /// the user already signed into Connect. That session lives on
+    /// the launcher's `ConnectAccountPanel` and gets forwarded into
+    /// the installer as `ctx.coincube_client`. Without this hook the
+    /// step would start at `Phase::Email` and ask the user to retype
+    /// their email + OTP for the same account — the "two sign-ins"
+    /// bug reported in the app.
+    ///
+    /// Guards:
+    ///   * Only triggers on the *initial* `Phase::Email` and when we
+    ///     haven't captured our own JWT yet (i.e. the user hasn't
+    ///     already completed the in-step auth form). That means a
+    ///     late `load_context` — e.g. after the user hit
+    ///     `RetryFromStart`, which re-enters `Phase::Email` on
+    ///     purpose — won't silently teleport them back into
+    ///     `LoadingCubes` with whatever stale client `ctx` still
+    ///     carries.
+    ///   * Requires `client.token().is_some()` because an
+    ///     unauthenticated `CoincubeClient` is useless for
+    ///     `list_cubes` and would just surface as a 401 further down.
+    fn load_context(&mut self, ctx: &Context) {
+        if !matches!(self.phase, Phase::Email) || self.jwt.is_some() {
+            return;
+        }
+        let Some(client) = &ctx.coincube_client else {
+            return;
+        };
+        let Some(token) = client.token() else {
+            return;
+        };
+        // Clone the client (not just the token) so we inherit whatever
+        // base URL / HTTP plumbing the launcher has already configured.
+        // Stash the JWT in `Zeroizing` so it gets scrubbed from the
+        // heap when the step drops — matches the handling of tokens
+        // captured via the in-step OTP path.
+        self.client = client.clone();
+        self.jwt = Some(Zeroizing::new(token.to_string()));
+        self.set_phase(Phase::LoadingCubes);
+    }
+
+    /// Kick off the cube-list fetch as soon as we've been promoted
+    /// into `Phase::LoadingCubes` by `load_context`. Without this the
+    /// UI would sit on a loading spinner indefinitely — the step
+    /// machine otherwise relies on user-driven messages to fire tasks
+    /// (OTP submit etc.), which this pre-authed path skips entirely.
+    fn load(&self) -> Task<Message> {
+        if matches!(self.phase, Phase::LoadingCubes) {
+            self.list_cubes_task()
+        } else {
+            Task::none()
+        }
+    }
+
     fn update(&mut self, _hws: &mut HardwareWallets, message: Message) -> Task<Message> {
         let Message::RecoveryKitRestore(msg) = message else {
             return Task::none();
@@ -376,7 +527,7 @@ impl Step for RecoveryKitRestoreStep {
             }
             RecoveryKitRestoreMsg::CubesLoaded(res) => {
                 match res {
-                    Ok(cubes) => self.set_phase(phase_after_cubes_loaded(cubes)),
+                    Ok(cubes) => self.set_phase(phase_after_cubes_loaded(self.scope, cubes)),
                     Err(e) => {
                         self.set_phase(Phase::Error {
                             message: format!("Couldn't load cubes: {}", e),
@@ -387,7 +538,16 @@ impl Step for RecoveryKitRestoreStep {
             }
             RecoveryKitRestoreMsg::SelectCube(id) => {
                 if let Phase::CubePicker { cubes, .. } = &self.phase {
-                    if let Some(c) = cubes.iter().find(|c| c.id == id).cloned() {
+                    // Re-check `has_required_half` in case the view's
+                    // disabled-row rendering ever falls out of sync
+                    // with the state-machine gate. Defensive — the
+                    // picker's `on_press` is gated on the same
+                    // predicate.
+                    if let Some(c) = cubes
+                        .iter()
+                        .find(|c| c.id == id && has_required_half(self.scope, c))
+                        .cloned()
+                    {
                         self.set_phase(Phase::PasswordEntry {
                             selected: c,
                             attempts: 0,
@@ -452,6 +612,24 @@ impl Step for RecoveryKitRestoreStep {
                             });
                             return Task::none();
                         }
+                        // Cross-check the decrypted blob(s) against the
+                        // cube the user picked: the blob carries its
+                        // own `cube.uuid` + `cube.network` in plaintext,
+                        // and either mismatching those would mean we're
+                        // about to restore data belonging to a different
+                        // Cube/network. AES-GCM authentication already
+                        // ruled out tampering of *our* blob, but a
+                        // backend routing bug (wrong kit served for a
+                        // cube id) could still ship us the wrong payload;
+                        // the defensive identity check costs ~nothing.
+                        if let Err(msg) = validate_blobs_match_selected(
+                            seed.as_ref(),
+                            descriptor.as_ref(),
+                            &selected,
+                        ) {
+                            self.set_phase(Phase::Error { message: msg });
+                            return Task::none();
+                        }
                         self.set_phase(Phase::Ready {
                             selected,
                             seed,
@@ -463,13 +641,17 @@ impl Step for RecoveryKitRestoreStep {
                         Task::done(Message::Next)
                     }
                     Err(e) => {
-                        // Wrong password / corrupt envelope — keep the
-                        // user on PasswordEntry with an inline banner.
-                        self.set_phase(Phase::PasswordEntry {
-                            selected,
-                            attempts: 1, // TODO wire backoff counter
-                        });
-                        self.error = Some(e);
+                        if is_retryable_on_password_screen(&e) {
+                            self.set_phase(Phase::PasswordEntry {
+                                selected,
+                                attempts: 1, // TODO wire backoff counter
+                            });
+                            self.error = Some(e.to_string());
+                        } else {
+                            self.set_phase(Phase::Error {
+                                message: e.to_string(),
+                            });
+                        }
                         Task::none()
                     }
                 }
@@ -517,15 +699,17 @@ impl Step for RecoveryKitRestoreStep {
             return false;
         };
 
-        // Apply the descriptor blob. The blob carries the full
-        // descriptor string including inline xpubs, so parsing it
-        // rebuilds a live `CoincubeDescriptor` without needing the
-        // signer set yet.
-        if let Some(desc_blob) = descriptor {
-            match desc_blob.vault.descriptor.parse::<CoincubeDescriptor>() {
-                Ok(parsed) => {
-                    ctx.descriptor = Some(parsed);
-                }
+        // Stage 1 — parse the descriptor into a local. If this fails
+        // we transition to `Phase::Error` and bail without touching
+        // `ctx`. Keeping the parse result in a local instead of
+        // writing it straight through to `ctx.descriptor` means a
+        // subsequent seed-derivation failure won't leave a partially-
+        // applied context behind, which would survive until the user
+        // re-enters the step and could be picked up by a downstream
+        // step that wasn't expecting a populated `ctx.descriptor`.
+        let staged_descriptor: Option<CoincubeDescriptor> = match descriptor {
+            Some(desc_blob) => match desc_blob.vault.descriptor.parse::<CoincubeDescriptor>() {
+                Ok(parsed) => Some(parsed),
                 Err(e) => {
                     self.set_phase(Phase::Error {
                         message: format!(
@@ -536,13 +720,13 @@ impl Step for RecoveryKitRestoreStep {
                     });
                     return false;
                 }
-            }
-        }
+            },
+            None => None,
+        };
 
-        // Apply the seed blob (W13 only). We install the mnemonic into
-        // a fresh `MasterSigner` and stash it on the context the same
-        // way `RecoverMnemonic::apply` does for a typed-in mnemonic.
-        if matches!(self.scope, RestoreScope::Full) {
+        // Stage 2 — derive the seed signer into a local (W13 only).
+        // Same all-or-nothing discipline as stage 1.
+        let staged_signer: Option<Signer> = if matches!(self.scope, RestoreScope::Full) {
             let Some(seed_blob) = seed else {
                 // `Ready` phase should have had the seed already —
                 // defensive check in case the phase was populated
@@ -553,10 +737,7 @@ impl Step for RecoveryKitRestoreStep {
                 return false;
             };
             match MasterSigner::from_str(ctx.bitcoin_config.network, &seed_blob.mnemonic.phrase) {
-                Ok(master) => {
-                    let signer = Signer::new(master);
-                    ctx.recovered_signer = Some(Arc::new(signer));
-                }
+                Ok(master) => Some(Signer::new(master)),
                 Err(e) => {
                     self.set_phase(Phase::Error {
                         message: format!("Restored mnemonic failed to derive a signer: {}", e),
@@ -564,6 +745,37 @@ impl Step for RecoveryKitRestoreStep {
                     return false;
                 }
             }
+        } else {
+            None
+        };
+
+        // Stage 3 — commit both results atomically. We only reach
+        // here after every fallible step above succeeded, so `ctx`
+        // transitions from "nothing applied" to "fully applied" in
+        // one go. `Arc::new` happens here rather than at staging so
+        // we don't allocate the refcounted handle for a signer that
+        // ultimately gets dropped on the error path.
+        if let Some(d) = staged_descriptor {
+            ctx.descriptor = Some(d);
+        }
+        if let Some(s) = staged_signer {
+            ctx.recovered_signer = Some(Arc::new(s));
+        }
+
+        // Thread the JWT we captured during the OTP step into the
+        // context so the downstream `CoincubeConnectStep` can skip
+        // re-authentication. Without this, the user has to type their
+        // email + OTP a second time — same account, same session —
+        // which is both confusing and a soft footgun (users can
+        // accidentally auth as a different account and register the
+        // restored Cube under the wrong Connect user).
+        //
+        // JWT is only present when we went through the successful
+        // `Phase::Ready` path above; the `skipped` branch short-circuits
+        // before reaching here so we never push a stale/empty JWT.
+        if let Some(jwt) = &self.jwt {
+            ctx.connect_jwt = Some(jwt.to_string());
+            ctx.use_coincube_connect = true;
         }
 
         true
@@ -579,6 +791,14 @@ impl Step for RecoveryKitRestoreStep {
         // later step through this one, keeping a stale descriptor would
         // leak into a subsequent decision.
         ctx.descriptor = None;
+        // Also drop the Connect auth bits we pushed in `apply`.
+        // `CoincubeConnectStep` skips itself when `connect_jwt` is
+        // `Some`, so failing to clear here would "teleport" the user
+        // past the auth step on a subsequent forward pass with a stale
+        // token. Clearing is harmless when this step never populated
+        // them (idempotent).
+        ctx.connect_jwt = None;
+        ctx.use_coincube_connect = false;
     }
 
     fn view<'a>(
@@ -640,6 +860,27 @@ mod tests {
         }
     }
 
+    /// Fine-grained variant of `candidate` that lets tests control
+    /// each half independently — needed to exercise the scope-aware
+    /// gating where `has_recovery_kit` is true but only one half is
+    /// present.
+    fn candidate_halves(name: &str, has_seed: bool, has_descriptor: bool) -> RestoreCubeCandidate {
+        RestoreCubeCandidate {
+            id: 1,
+            uuid: "uuid".to_string(),
+            name: name.to_string(),
+            network: "mainnet".to_string(),
+            status: RecoveryKitStatus {
+                has_recovery_kit: has_seed || has_descriptor,
+                has_encrypted_seed: has_seed,
+                has_encrypted_wallet_descriptor: has_descriptor,
+                encryption_scheme: "aes-256-gcm".to_string(),
+                created_at: None,
+                updated_at: None,
+            },
+        }
+    }
+
     // Regression tests for the auto-select-skips-kit-check bug. Before
     // this fix, a single cube without a kit would land the user on
     // the password screen, which would then 404 at decrypt time —
@@ -647,7 +888,7 @@ mod tests {
 
     #[test]
     fn single_cube_with_kit_auto_advances_to_password() {
-        let phase = phase_after_cubes_loaded(vec![candidate("My Cube", true)]);
+        let phase = phase_after_cubes_loaded(RestoreScope::Full, vec![candidate("My Cube", true)]);
         match phase {
             Phase::PasswordEntry { selected, attempts } => {
                 assert_eq!(selected.name, "My Cube");
@@ -659,7 +900,7 @@ mod tests {
 
     #[test]
     fn single_cube_without_kit_surfaces_error_not_password_screen() {
-        let phase = phase_after_cubes_loaded(vec![candidate("My Cube", false)]);
+        let phase = phase_after_cubes_loaded(RestoreScope::Full, vec![candidate("My Cube", false)]);
         match phase {
             Phase::Error { message } => {
                 assert!(
@@ -668,7 +909,7 @@ mod tests {
                     message
                 );
                 assert!(
-                    message.contains("doesn't have a Recovery Kit"),
+                    message.contains("doesn't have"),
                     "error message should explain the cause, got: {}",
                     message
                 );
@@ -677,13 +918,231 @@ mod tests {
         }
     }
 
+    // Regression tests for the scope-aware half-gating: a kit that
+    // exists but lacks the required half must NOT advance to the
+    // password screen. Without this gate, a Full-scope restore
+    // against a descriptor-only kit (or DescriptorOnly against a
+    // seed-only kit) would silently decrypt, land on `Ready`, and
+    // only then hit the post-decrypt `missing_half` error — making
+    // the user re-enter their password for nothing.
+
+    #[test]
+    fn full_scope_on_descriptor_only_kit_routes_to_error() {
+        // Kit has descriptor but not seed; Full restore needs seed.
+        let phase = phase_after_cubes_loaded(
+            RestoreScope::Full,
+            vec![candidate_halves("Passkey Cube", false, true)],
+        );
+        match phase {
+            Phase::Error { message } => {
+                assert!(message.contains("Passkey Cube"));
+                assert!(
+                    message.contains("Master Seed"),
+                    "error should name the missing half (seed): {}",
+                    message
+                );
+            }
+            other => panic!("expected Error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn descriptor_only_scope_on_seed_only_kit_routes_to_error() {
+        // Kit has seed but no descriptor; DescriptorOnly needs descriptor.
+        let phase = phase_after_cubes_loaded(
+            RestoreScope::DescriptorOnly,
+            vec![candidate_halves("No-Vault Cube", true, false)],
+        );
+        match phase {
+            Phase::Error { message } => {
+                assert!(message.contains("No-Vault Cube"));
+                assert!(
+                    message.contains("Wallet Descriptor"),
+                    "error should name the missing half (descriptor): {}",
+                    message
+                );
+            }
+            other => panic!("expected Error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn has_required_half_matches_scope() {
+        let seed_only = candidate_halves("s", true, false);
+        let desc_only = candidate_halves("d", false, true);
+        let both = candidate_halves("b", true, true);
+        let none = candidate_halves("n", false, false);
+
+        assert!(has_required_half(RestoreScope::Full, &seed_only));
+        assert!(!has_required_half(RestoreScope::Full, &desc_only));
+        assert!(has_required_half(RestoreScope::Full, &both));
+        assert!(!has_required_half(RestoreScope::Full, &none));
+
+        assert!(!has_required_half(RestoreScope::DescriptorOnly, &seed_only));
+        assert!(has_required_half(RestoreScope::DescriptorOnly, &desc_only));
+        assert!(has_required_half(RestoreScope::DescriptorOnly, &both));
+        assert!(!has_required_half(RestoreScope::DescriptorOnly, &none));
+    }
+
+    // Regression tests for the decrypt-error branching: the
+    // handler must route `BadPasswordOrCorrupt` back to the
+    // password screen (retryable) but every other variant to
+    // `Phase::Error` (terminal for this attempt). Before this
+    // fix the handler stringified all errors and treated them
+    // uniformly as "keep the user on PasswordEntry", which made
+    // rate limits / NotFound / BlobParse read as wrong-password
+    // errors that retyping couldn't fix.
+
+    #[test]
+    fn bad_password_is_retryable_on_password_screen() {
+        assert!(is_retryable_on_password_screen(
+            &RestoreError::BadPasswordOrCorrupt
+        ));
+    }
+
+    #[test]
+    fn rate_limited_is_not_retryable_on_password_screen() {
+        assert!(!is_retryable_on_password_screen(
+            &RestoreError::RateLimited {
+                retry_after: std::time::Duration::from_secs(30)
+            }
+        ));
+    }
+
+    #[test]
+    fn not_found_is_not_retryable_on_password_screen() {
+        assert!(!is_retryable_on_password_screen(&RestoreError::NotFound));
+    }
+
+    #[test]
+    fn api_error_is_not_retryable_on_password_screen() {
+        assert!(!is_retryable_on_password_screen(&RestoreError::Api(
+            "5xx".to_string()
+        )));
+    }
+
+    #[test]
+    fn blob_parse_is_not_retryable_on_password_screen() {
+        assert!(!is_retryable_on_password_screen(&RestoreError::BlobParse(
+            "future version".to_string()
+        )));
+    }
+
+    #[test]
+    fn half_missing_is_not_retryable_on_password_screen() {
+        // HalfMissing gets its own dedicated pre-check elsewhere
+        // (the `missing_half` guard) so it shouldn't normally reach
+        // this branch; pinning the non-retryable classification
+        // here guards against a future refactor that collapses the
+        // two sites.
+        assert!(!is_retryable_on_password_screen(&RestoreError::HalfMissing));
+    }
+
+    // Regression tests for the cube-identity cross-check performed
+    // after decrypt. The blob plaintext carries `cube.uuid` +
+    // `cube.network`; if those disagree with the cube the user
+    // picked, we refuse to restore — this catches backend
+    // misrouting and any future class of "wrong kit served for
+    // this cube id" bugs before on-disk state gets corrupted.
+
+    fn seed_blob_for(uuid: &str, network: &str) -> crate::services::recovery::SeedBlob {
+        use crate::services::recovery::{
+            plaintext::BLOB_VERSION, SeedBlob, SeedBlobCube, SeedBlobMnemonic,
+        };
+        SeedBlob {
+            version: BLOB_VERSION,
+            cube: SeedBlobCube {
+                uuid: uuid.to_string(),
+                name: "name".to_string(),
+                network: network.to_string(),
+                created_at: "2026-04-23T00:00:00Z".to_string(),
+                lightning_address: None,
+            },
+            mnemonic: SeedBlobMnemonic {
+                phrase: "word ".repeat(12).trim().to_string(),
+                language: "en".to_string(),
+            },
+        }
+    }
+
+    fn descriptor_blob_for(uuid: &str, network: &str) -> crate::services::recovery::DescriptorBlob {
+        use crate::services::recovery::{
+            plaintext::BLOB_VERSION, DescriptorBlob, DescriptorBlobCube, DescriptorBlobVault,
+        };
+        DescriptorBlob {
+            version: BLOB_VERSION,
+            cube: DescriptorBlobCube {
+                uuid: uuid.to_string(),
+                network: network.to_string(),
+            },
+            vault: DescriptorBlobVault {
+                name: "v".into(),
+                descriptor: "d".into(),
+                change_descriptor: None,
+                signers: vec![],
+            },
+        }
+    }
+
+    #[test]
+    fn validate_passes_when_both_blobs_match_selected() {
+        let sel = candidate("My Cube", true);
+        let s = seed_blob_for(&sel.uuid, &sel.network);
+        let d = descriptor_blob_for(&sel.uuid, &sel.network);
+        assert!(validate_blobs_match_selected(Some(&s), Some(&d), &sel).is_ok());
+    }
+
+    #[test]
+    fn validate_passes_when_only_one_blob_present_and_matches() {
+        let sel = candidate("My Cube", true);
+        let d = descriptor_blob_for(&sel.uuid, &sel.network);
+        assert!(validate_blobs_match_selected(None, Some(&d), &sel).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_seed_blob_with_wrong_uuid() {
+        let sel = candidate("My Cube", true);
+        let s = seed_blob_for("some-other-uuid", &sel.network);
+        let err = validate_blobs_match_selected(Some(&s), None, &sel)
+            .expect_err("expected mismatch error");
+        assert!(err.contains("different Cube"), "got: {}", err);
+    }
+
+    #[test]
+    fn validate_rejects_descriptor_blob_with_wrong_network() {
+        let sel = candidate("My Cube", true);
+        // selected is "mainnet"; blob is on testnet — legitimate
+        // cross-cube mixup we must refuse (e.g. the cube-picker
+        // filter failed upstream, or backend misrouted).
+        let d = descriptor_blob_for(&sel.uuid, "testnet");
+        assert!(validate_blobs_match_selected(None, Some(&d), &sel).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_when_either_blob_mismatches() {
+        let sel = candidate("My Cube", true);
+        // Seed matches but descriptor doesn't — still a reject.
+        let s = seed_blob_for(&sel.uuid, &sel.network);
+        let d = descriptor_blob_for("different-uuid", &sel.network);
+        assert!(validate_blobs_match_selected(Some(&s), Some(&d), &sel).is_err());
+    }
+
+    #[test]
+    fn validate_passes_when_both_blobs_absent() {
+        // Trivial case — no blobs to mismatch against.
+        let sel = candidate("My Cube", true);
+        assert!(validate_blobs_match_selected(None, None, &sel).is_ok());
+    }
+
     #[test]
     fn multiple_cubes_route_to_picker_regardless_of_kit_status() {
         // The picker view itself disables no-kit rows; we hand the
         // whole list through so the user can see context (e.g.
         // "that one's the one without a kit").
-        let phase =
-            phase_after_cubes_loaded(vec![candidate("Alice", true), candidate("Bob", false)]);
+        let phase = phase_after_cubes_loaded(
+            RestoreScope::Full,
+            vec![candidate("Alice", true), candidate("Bob", false)],
+        );
         match phase {
             Phase::CubePicker { cubes, selected } => {
                 assert_eq!(cubes.len(), 2);
@@ -698,7 +1157,7 @@ mod tests {
         // Empty picker is the right surface — the picker view
         // renders "No Cubes found on this Connect account..." which
         // is more actionable than a generic error.
-        let phase = phase_after_cubes_loaded(vec![]);
+        let phase = phase_after_cubes_loaded(RestoreScope::Full, vec![]);
         match phase {
             Phase::CubePicker { cubes, .. } => assert!(cubes.is_empty()),
             other => panic!("expected CubePicker, got {:?}", other),

--- a/coincube-gui/src/installer/step/recovery_kit_restore.rs
+++ b/coincube-gui/src/installer/step/recovery_kit_restore.rs
@@ -263,6 +263,46 @@ fn map_restore_error(e: RestoreError) -> String {
     e.to_string()
 }
 
+/// Transition function called after `list_cubes` + per-cube status
+/// probes resolve. Extracted as a pure function over the Phase enum
+/// so the auto-select vs picker vs error decision is unit-testable
+/// without standing up the whole installer step.
+///
+/// Branches:
+/// - Exactly one cube with a kit → auto-select it (common restore path)
+/// - Exactly one cube **without** a kit → `Phase::Error` with a
+///   specific message; the picker's "no kit (disabled)" affordance
+///   doesn't help when there's only one row
+/// - Zero or 2+ cubes → `Phase::CubePicker` (the picker view already
+///   handles the empty-list and mixed-kit cases cleanly)
+fn phase_after_cubes_loaded(cubes: Vec<RestoreCubeCandidate>) -> Phase {
+    if cubes.len() == 1 {
+        // Can't `into_iter().next().unwrap()` inside the `if` guard
+        // without moving; handle with `match` on length-1 form.
+        let c = cubes.into_iter().next().expect("len == 1");
+        if c.status.has_recovery_kit {
+            Phase::PasswordEntry {
+                selected: c,
+                attempts: 0,
+            }
+        } else {
+            Phase::Error {
+                message: format!(
+                    "\"{}\" doesn't have a Recovery Kit backed up on Connect. Back up \
+                     the kit first from a device where the Cube is already installed, \
+                     then return here to restore.",
+                    c.name
+                ),
+            }
+        }
+    } else {
+        Phase::CubePicker {
+            cubes,
+            selected: None,
+        }
+    }
+}
+
 impl From<RecoveryKitRestoreStep> for Box<dyn Step> {
     fn from(s: RecoveryKitRestoreStep) -> Box<dyn Step> {
         Box::new(s)
@@ -336,22 +376,7 @@ impl Step for RecoveryKitRestoreStep {
             }
             RecoveryKitRestoreMsg::CubesLoaded(res) => {
                 match res {
-                    Ok(cubes) => {
-                        if cubes.len() == 1 {
-                            // Auto-select the unambiguous case and
-                            // immediately advance to password entry.
-                            let c = cubes.into_iter().next().unwrap();
-                            self.set_phase(Phase::PasswordEntry {
-                                selected: c,
-                                attempts: 0,
-                            });
-                        } else {
-                            self.set_phase(Phase::CubePicker {
-                                cubes,
-                                selected: None,
-                            });
-                        }
-                    }
+                    Ok(cubes) => self.set_phase(phase_after_cubes_loaded(cubes)),
                     Err(e) => {
                         self.set_phase(Phase::Error {
                             message: format!("Couldn't load cubes: {}", e),
@@ -592,4 +617,91 @@ pub use self::Phase as RestorePhase;
 pub fn classify_password(password: &str) -> PasswordStrength {
     let z = Zeroizing::new(password.to_string());
     score_password(&z, &[]).0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(name: &str, has_kit: bool) -> RestoreCubeCandidate {
+        RestoreCubeCandidate {
+            id: 1,
+            uuid: "uuid".to_string(),
+            name: name.to_string(),
+            network: "mainnet".to_string(),
+            status: RecoveryKitStatus {
+                has_recovery_kit: has_kit,
+                has_encrypted_seed: has_kit,
+                has_encrypted_wallet_descriptor: has_kit,
+                encryption_scheme: "aes-256-gcm".to_string(),
+                created_at: None,
+                updated_at: None,
+            },
+        }
+    }
+
+    // Regression tests for the auto-select-skips-kit-check bug. Before
+    // this fix, a single cube without a kit would land the user on
+    // the password screen, which would then 404 at decrypt time —
+    // a worse UX than a direct "no kit yet" message up front.
+
+    #[test]
+    fn single_cube_with_kit_auto_advances_to_password() {
+        let phase = phase_after_cubes_loaded(vec![candidate("My Cube", true)]);
+        match phase {
+            Phase::PasswordEntry { selected, attempts } => {
+                assert_eq!(selected.name, "My Cube");
+                assert_eq!(attempts, 0);
+            }
+            other => panic!("expected PasswordEntry, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn single_cube_without_kit_surfaces_error_not_password_screen() {
+        let phase = phase_after_cubes_loaded(vec![candidate("My Cube", false)]);
+        match phase {
+            Phase::Error { message } => {
+                assert!(
+                    message.contains("My Cube"),
+                    "error message should name the cube, got: {}",
+                    message
+                );
+                assert!(
+                    message.contains("doesn't have a Recovery Kit"),
+                    "error message should explain the cause, got: {}",
+                    message
+                );
+            }
+            other => panic!("expected Error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn multiple_cubes_route_to_picker_regardless_of_kit_status() {
+        // The picker view itself disables no-kit rows; we hand the
+        // whole list through so the user can see context (e.g.
+        // "that one's the one without a kit").
+        let phase =
+            phase_after_cubes_loaded(vec![candidate("Alice", true), candidate("Bob", false)]);
+        match phase {
+            Phase::CubePicker { cubes, selected } => {
+                assert_eq!(cubes.len(), 2);
+                assert!(selected.is_none());
+            }
+            other => panic!("expected CubePicker, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn zero_cubes_route_to_picker_which_renders_empty_state() {
+        // Empty picker is the right surface — the picker view
+        // renders "No Cubes found on this Connect account..." which
+        // is more actionable than a generic error.
+        let phase = phase_after_cubes_loaded(vec![]);
+        match phase {
+            Phase::CubePicker { cubes, .. } => assert!(cubes.is_empty()),
+            other => panic!("expected CubePicker, got {:?}", other),
+        }
+    }
 }

--- a/coincube-gui/src/installer/step/recovery_kit_restore.rs
+++ b/coincube-gui/src/installer/step/recovery_kit_restore.rs
@@ -1,0 +1,580 @@
+//! Installer step: restore a Cube from its Connect-hosted Recovery Kit.
+//!
+//! Mounts into three entry points:
+//!   * W13 — full restore from scratch (fresh install, no local state).
+//!           The step populates `ctx.recovered_signer` + `ctx.descriptor`
+//!           from the decrypted blobs. Runs inside
+//!           `UserFlow::RestoreFromRecoveryKit`.
+//!   * W14 — after the user enters a mnemonic in `AddWallet`, offer to
+//!           fetch the wallet descriptor from Connect instead of (or in
+//!           addition to) importing from a file. Only the descriptor
+//!           half is applied; the seed half is ignored because the user
+//!           just retyped their mnemonic.
+//!   * W15 — running-app "Restore Vault from Connect". Same shape as
+//!           W14 but without an accompanying mnemonic entry — the
+//!           current Cube already has its seed on disk; we just need
+//!           the descriptor.
+//!
+//! The step is a single Iced `Step` with an internal state machine
+//! (`Phase`). It reuses the reusable restore helpers in
+//! `services::recovery::restore` so the crypto + API sequencing is
+//! audited in one place.
+
+use std::sync::Arc;
+
+use coincube_core::{descriptors::CoincubeDescriptor, signer::MasterSigner};
+use coincube_ui::{component::form, widget::Element};
+use iced::Task;
+use zeroize::Zeroizing;
+
+use crate::{
+    hw::HardwareWallets,
+    installer::{
+        context::Context,
+        message::{Message, RecoveryKitRestoreMsg},
+        step::Step,
+        view,
+    },
+    services::{
+        coincube::{CoincubeClient, CubeResponse, OtpRequest, OtpVerifyRequest, RecoveryKitStatus},
+        recovery::{
+            restore::{fetch_and_decrypt_kit, DecryptedKit, RestoreError},
+            score_password, DescriptorBlob, PasswordStrength, SeedBlob, MIN_PASSWORD_LEN,
+        },
+    },
+    signer::Signer,
+};
+
+/// Scope controls which halves the step tries to apply to `Context`
+/// and determines the user-visible copy. A mode mismatch with the
+/// server-side kit surfaces as `RestoreError::HalfMissing` at decrypt
+/// time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RestoreScope {
+    /// W13 — full installer restore: populate both `recovered_signer`
+    /// and `descriptor` from the kit.
+    Full,
+    /// W14 / W15 — descriptor-only: populate `descriptor` only, ignore
+    /// any seed half on the server (the user already has a seed).
+    DescriptorOnly,
+}
+
+#[derive(Debug)]
+pub enum Phase {
+    /// Collect email + send OTP (reuses the shape of CoincubeConnectStep).
+    Email,
+    /// OTP sent; user types the 6-digit code.
+    OtpEntry,
+    /// Fetching the cube list to let the user pick.
+    LoadingCubes,
+    /// Show cubes; user selects one to restore from. `selected` is
+    /// reserved for a future "highlight-then-confirm" UX; today the
+    /// picker advances on click, so it's always `None` in practice.
+    #[allow(dead_code)]
+    CubePicker {
+        cubes: Vec<RestoreCubeCandidate>,
+        selected: Option<u64>,
+    },
+    /// Selected; prompting for the recovery password.
+    PasswordEntry {
+        selected: RestoreCubeCandidate,
+        /// Attempts since last server fetch. Drives the client-side
+        /// backoff hint (plan §2.8).
+        attempts: u8,
+    },
+    /// Fetch + decrypt in flight.
+    Decrypting { selected: RestoreCubeCandidate },
+    /// Decrypted cleanly; waiting for the user to click Next to
+    /// advance the installer flow. `apply` pulls these out into
+    /// `Context`.
+    Ready {
+        selected: RestoreCubeCandidate,
+        seed: Option<SeedBlob>,
+        descriptor: Option<DescriptorBlob>,
+    },
+    /// Terminal error state. User can either retry (back to Email) or
+    /// Skip to proceed without restoration.
+    Error { message: String },
+}
+
+/// What we remember about each cube the user can pick from. Carries
+/// `status` so we can disable entries that don't have the half we're
+/// trying to restore.
+#[derive(Debug, Clone)]
+pub struct RestoreCubeCandidate {
+    pub id: u64,
+    pub uuid: String,
+    pub name: String,
+    pub network: String,
+    pub status: RecoveryKitStatus,
+}
+
+/// The step itself — self-contained with its own internal state.
+pub struct RecoveryKitRestoreStep {
+    scope: RestoreScope,
+    /// Network filter applied to the cube picker. The user can only
+    /// restore into the same network they're installing for.
+    network_filter: String,
+    client: CoincubeClient,
+    phase: Phase,
+    // Transient UI inputs held outside Phase so typing during an
+    // async transition (unlikely but possible) doesn't crash.
+    email: form::Value<String>,
+    otp: form::Value<String>,
+    password: Zeroizing<String>,
+    /// `true` when the user hit Skip; `apply` returns `true` without
+    /// touching `Context`. Cleared on re-entry (e.g. going Back).
+    skipped: bool,
+    processing: bool,
+    error: Option<String>,
+    jwt: Option<String>,
+}
+
+impl RecoveryKitRestoreStep {
+    pub fn new(scope: RestoreScope, network_filter: String) -> Self {
+        Self {
+            scope,
+            network_filter,
+            client: CoincubeClient::new(),
+            phase: Phase::Email,
+            email: form::Value {
+                valid: false,
+                ..form::Value::default()
+            },
+            otp: form::Value::default(),
+            password: Zeroizing::new(String::new()),
+            skipped: false,
+            processing: false,
+            error: None,
+            jwt: None,
+        }
+    }
+
+    /// Observable scope — the parent installer uses this to decide
+    /// whether to let the user skip (W14/W15 allow skip; W13 does not,
+    /// since the whole point of W13 is the restore).
+    pub fn scope(&self) -> RestoreScope {
+        self.scope
+    }
+
+    fn set_phase(&mut self, phase: Phase) {
+        self.phase = phase;
+        self.error = None;
+    }
+
+    fn send_otp_task(&self) -> Task<Message> {
+        let client = self.client.clone();
+        let email = self.email.value.clone();
+        self.processing_task(Task::perform(
+            async move {
+                client
+                    .login_send_otp(OtpRequest { email })
+                    .await
+                    .map_err(|e| e.to_string())
+            },
+            |res| Message::RecoveryKitRestore(RecoveryKitRestoreMsg::OtpSent(res)),
+        ))
+    }
+
+    fn processing_task(&self, task: Task<Message>) -> Task<Message> {
+        task
+    }
+
+    fn verify_otp_task(&self) -> Task<Message> {
+        let client = self.client.clone();
+        let email = self.email.value.clone();
+        let otp = self.otp.value.clone();
+        Task::perform(
+            async move {
+                client
+                    .login_verify_otp(OtpVerifyRequest { email, otp })
+                    .await
+                    .map(|r| r.token)
+                    .map_err(|e| e.to_string())
+            },
+            |res| Message::RecoveryKitRestore(RecoveryKitRestoreMsg::OtpVerified(res)),
+        )
+    }
+
+    fn list_cubes_task(&self) -> Task<Message> {
+        let client = self.client.clone();
+        let network = self.network_filter.clone();
+        Task::perform(
+            async move {
+                let all = client.list_cubes().await.map_err(|e| e.to_string())?;
+                // Filter to cubes on the requested network. We don't
+                // filter by `has_recovery_kit` at list time because the
+                // kit status lives on a separate endpoint — fetch
+                // status in parallel.
+                let matches: Vec<CubeResponse> =
+                    all.into_iter().filter(|c| c.network == network).collect();
+                let mut out = Vec::with_capacity(matches.len());
+                for cube in matches {
+                    let status = client.get_recovery_kit_status(cube.id).await.unwrap_or(
+                        RecoveryKitStatus {
+                            has_recovery_kit: false,
+                            has_encrypted_seed: false,
+                            has_encrypted_wallet_descriptor: false,
+                            encryption_scheme: String::new(),
+                            created_at: None,
+                            updated_at: None,
+                        },
+                    );
+                    out.push(RestoreCubeCandidate {
+                        id: cube.id,
+                        uuid: cube.uuid,
+                        name: cube.name,
+                        network: cube.network,
+                        status,
+                    });
+                }
+                Ok(out)
+            },
+            |res: Result<Vec<RestoreCubeCandidate>, String>| {
+                Message::RecoveryKitRestore(RecoveryKitRestoreMsg::CubesLoaded(res))
+            },
+        )
+    }
+
+    fn decrypt_task(&self, cube_id: u64) -> Task<Message> {
+        let client = self.client.clone();
+        let password = Zeroizing::new(self.password.to_string());
+        Task::perform(
+            async move {
+                fetch_and_decrypt_kit(&client, cube_id, &password)
+                    .await
+                    .map(|DecryptedKit { seed, descriptor }| (seed, descriptor))
+                    .map_err(|e| map_restore_error(e))
+            },
+            |res| Message::RecoveryKitRestore(RecoveryKitRestoreMsg::DecryptResult(res)),
+        )
+    }
+}
+
+fn map_restore_error(e: RestoreError) -> String {
+    // `RestoreError` already formats cleanly — just stringify. The
+    // UI uses the string for the inline banner; typed branching on
+    // specific errors (retry_after, bad password) happens at the
+    // message dispatch level if we want to add it later.
+    e.to_string()
+}
+
+impl From<RecoveryKitRestoreStep> for Box<dyn Step> {
+    fn from(s: RecoveryKitRestoreStep) -> Box<dyn Step> {
+        Box::new(s)
+    }
+}
+
+impl Step for RecoveryKitRestoreStep {
+    fn update(&mut self, _hws: &mut HardwareWallets, message: Message) -> Task<Message> {
+        let Message::RecoveryKitRestore(msg) = message else {
+            return Task::none();
+        };
+        match msg {
+            RecoveryKitRestoreMsg::EmailEdited(value) => {
+                self.email.value = value;
+                self.email.valid = !self.email.value.is_empty() && self.email.value.contains('@');
+                Task::none()
+            }
+            RecoveryKitRestoreMsg::RequestOtp => {
+                if !self.email.valid || self.processing {
+                    return Task::none();
+                }
+                self.processing = true;
+                self.send_otp_task()
+            }
+            RecoveryKitRestoreMsg::OtpSent(res) => {
+                self.processing = false;
+                match res {
+                    Ok(()) => {
+                        self.otp = form::Value::default();
+                        self.set_phase(Phase::OtpEntry);
+                    }
+                    Err(e) => self.error = Some(e),
+                }
+                Task::none()
+            }
+            RecoveryKitRestoreMsg::OtpEdited(value) => {
+                self.otp.value = value.trim().to_string();
+                self.otp.valid = self.otp.value.len() == 6;
+                // Auto-submit when 6 digits — matches
+                // CoincubeConnectStep UX.
+                if self.otp.valid && !self.processing {
+                    self.processing = true;
+                    self.verify_otp_task()
+                } else {
+                    Task::none()
+                }
+            }
+            RecoveryKitRestoreMsg::OtpVerified(res) => {
+                self.processing = false;
+                match res {
+                    Ok(token) => {
+                        self.client.set_token(&token);
+                        self.jwt = Some(token);
+                        self.set_phase(Phase::LoadingCubes);
+                        self.list_cubes_task()
+                    }
+                    Err(e) => {
+                        self.otp.valid = false;
+                        self.error = Some(e);
+                        Task::none()
+                    }
+                }
+            }
+            RecoveryKitRestoreMsg::CubesLoaded(res) => {
+                match res {
+                    Ok(cubes) => {
+                        if cubes.len() == 1 {
+                            // Auto-select the unambiguous case and
+                            // immediately advance to password entry.
+                            let c = cubes.into_iter().next().unwrap();
+                            self.set_phase(Phase::PasswordEntry {
+                                selected: c,
+                                attempts: 0,
+                            });
+                        } else {
+                            self.set_phase(Phase::CubePicker {
+                                cubes,
+                                selected: None,
+                            });
+                        }
+                    }
+                    Err(e) => {
+                        self.set_phase(Phase::Error {
+                            message: format!("Couldn't load cubes: {}", e),
+                        });
+                    }
+                }
+                Task::none()
+            }
+            RecoveryKitRestoreMsg::SelectCube(id) => {
+                if let Phase::CubePicker { cubes, .. } = &self.phase {
+                    if let Some(c) = cubes.iter().find(|c| c.id == id).cloned() {
+                        self.set_phase(Phase::PasswordEntry {
+                            selected: c,
+                            attempts: 0,
+                        });
+                    }
+                }
+                Task::none()
+            }
+            RecoveryKitRestoreMsg::PasswordEdited(v) => {
+                self.password = Zeroizing::new(v);
+                Task::none()
+            }
+            RecoveryKitRestoreMsg::SubmitPassword => {
+                if self.processing {
+                    return Task::none();
+                }
+                // Basic client-side sanity: a recovery password can't
+                // be shorter than the minimum we enforce on backup.
+                // Avoids a round-trip for an obvious typo.
+                if self.password.len() < MIN_PASSWORD_LEN {
+                    self.error = Some(format!(
+                        "Password must be at least {} characters.",
+                        MIN_PASSWORD_LEN
+                    ));
+                    return Task::none();
+                }
+                let Phase::PasswordEntry { selected, attempts } = &self.phase else {
+                    return Task::none();
+                };
+                let cube_id = selected.id;
+                let selected = selected.clone();
+                let _ = attempts; // reserved for future backoff UI
+                self.processing = true;
+                self.set_phase(Phase::Decrypting { selected });
+                self.processing = true;
+                self.decrypt_task(cube_id)
+            }
+            RecoveryKitRestoreMsg::DecryptResult(res) => {
+                self.processing = false;
+                let Phase::Decrypting { selected } = &self.phase else {
+                    // Message arrived after the user navigated away —
+                    // drop it.
+                    return Task::none();
+                };
+                let selected = selected.clone();
+                match res {
+                    Ok((seed, descriptor)) => {
+                        // Validate we actually got the half we need.
+                        let missing_half = match self.scope {
+                            RestoreScope::Full => seed.is_none(),
+                            RestoreScope::DescriptorOnly => descriptor.is_none(),
+                        };
+                        if missing_half {
+                            self.set_phase(Phase::Error {
+                                message:
+                                    "This Cube's Recovery Kit doesn't include the data needed \
+                                     for this restore."
+                                        .to_string(),
+                            });
+                            return Task::none();
+                        }
+                        self.set_phase(Phase::Ready {
+                            selected,
+                            seed,
+                            descriptor,
+                        });
+                        // Auto-advance — the user clicked Submit and the
+                        // decrypt succeeded; no reason to make them
+                        // click Next again.
+                        Task::done(Message::Next)
+                    }
+                    Err(e) => {
+                        // Wrong password / corrupt envelope — keep the
+                        // user on PasswordEntry with an inline banner.
+                        self.set_phase(Phase::PasswordEntry {
+                            selected,
+                            attempts: 1, // TODO wire backoff counter
+                        });
+                        self.error = Some(e);
+                        Task::none()
+                    }
+                }
+            }
+            RecoveryKitRestoreMsg::RetryFromStart => {
+                // Full reset: drop JWT, clear transient inputs, back to
+                // email entry.
+                self.client = CoincubeClient::new();
+                self.jwt = None;
+                self.email.value.clear();
+                self.email.valid = false;
+                self.otp = form::Value::default();
+                self.password = Zeroizing::new(String::new());
+                self.skipped = false;
+                self.set_phase(Phase::Email);
+                Task::none()
+            }
+            RecoveryKitRestoreMsg::Skip => {
+                // Only makes sense for DescriptorOnly (W14/W15); the
+                // full-restore W13 step should hide this in the view.
+                if matches!(self.scope, RestoreScope::DescriptorOnly) {
+                    self.skipped = true;
+                    Task::done(Message::Next)
+                } else {
+                    Task::none()
+                }
+            }
+        }
+    }
+
+    fn apply(&mut self, ctx: &mut Context) -> bool {
+        // Skip path: the user opted out (W14/W15 only). Leave `ctx`
+        // alone and let the installer proceed.
+        if self.skipped {
+            self.skipped = false;
+            return true;
+        }
+        // Must have a `Ready` phase to apply. Otherwise the user is
+        // trying to advance before the decrypt resolved — keep them
+        // where they are.
+        let Phase::Ready {
+            seed, descriptor, ..
+        } = &self.phase
+        else {
+            return false;
+        };
+
+        // Apply the descriptor blob. The blob carries the full
+        // descriptor string including inline xpubs, so parsing it
+        // rebuilds a live `CoincubeDescriptor` without needing the
+        // signer set yet.
+        if let Some(desc_blob) = descriptor {
+            match desc_blob.vault.descriptor.parse::<CoincubeDescriptor>() {
+                Ok(parsed) => {
+                    ctx.descriptor = Some(parsed);
+                }
+                Err(e) => {
+                    self.set_phase(Phase::Error {
+                        message: format!(
+                            "Recovery Kit descriptor failed to parse: {}. Kit may be from a \
+                             newer client version.",
+                            e
+                        ),
+                    });
+                    return false;
+                }
+            }
+        }
+
+        // Apply the seed blob (W13 only). We install the mnemonic into
+        // a fresh `MasterSigner` and stash it on the context the same
+        // way `RecoverMnemonic::apply` does for a typed-in mnemonic.
+        if matches!(self.scope, RestoreScope::Full) {
+            let Some(seed_blob) = seed else {
+                // `Ready` phase should have had the seed already —
+                // defensive check in case the phase was populated
+                // with a DescriptorOnly kit.
+                self.set_phase(Phase::Error {
+                    message: "Seed blob missing from decrypted kit.".to_string(),
+                });
+                return false;
+            };
+            match MasterSigner::from_str(ctx.bitcoin_config.network, &seed_blob.mnemonic.phrase) {
+                Ok(master) => {
+                    let signer = Signer::new(master);
+                    ctx.recovered_signer = Some(Arc::new(signer));
+                }
+                Err(e) => {
+                    self.set_phase(Phase::Error {
+                        message: format!("Restored mnemonic failed to derive a signer: {}", e),
+                    });
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    fn revert(&self, ctx: &mut Context) {
+        // Back-out: drop anything this step wrote to context so the
+        // user can re-do the restore cleanly.
+        if matches!(self.scope, RestoreScope::Full) {
+            ctx.recovered_signer = None;
+        }
+        // Always clear descriptor — if the user navigates back from a
+        // later step through this one, keeping a stale descriptor would
+        // leak into a subsequent decision.
+        ctx.descriptor = None;
+    }
+
+    fn view<'a>(
+        &'a self,
+        _hws: &'a HardwareWallets,
+        progress: (usize, usize),
+        _email: Option<&'a str>,
+    ) -> Element<'a, Message> {
+        // Placeholder view — re-uses existing installer text layout.
+        // A polished design pass is a follow-up; what matters here is
+        // that each Phase has a reachable interaction so the flow
+        // progresses.
+        view::recovery_kit_restore(
+            progress,
+            self.scope,
+            &self.phase,
+            &self.email,
+            &self.otp,
+            self.password.as_str(),
+            self.processing,
+            self.error.as_deref(),
+        )
+    }
+}
+
+// Public re-exports for the view module — `Phase` and
+// `RestoreCubeCandidate` are consumed there when rendering.
+pub use self::Phase as RestorePhase;
+
+/// Strength hint (for the password-entry sub-screen) — forwarded from
+/// the recovery-kit password module so the view module doesn't have to
+/// import two namespaces. Currently unused by the placeholder view but
+/// kept here so a follow-up UI pass can surface the meter without
+/// reaching across crates.
+#[allow(dead_code)]
+pub fn classify_password(password: &str) -> PasswordStrength {
+    let z = Zeroizing::new(password.to_string());
+    score_password(&z, &[]).0
+}

--- a/coincube-gui/src/installer/step/recovery_kit_restore.rs
+++ b/coincube-gui/src/installer/step/recovery_kit_restore.rs
@@ -774,7 +774,10 @@ impl Step for RecoveryKitRestoreStep {
         // `Phase::Ready` path above; the `skipped` branch short-circuits
         // before reaching here so we never push a stale/empty JWT.
         if let Some(jwt) = &self.jwt {
-            ctx.connect_jwt = Some(jwt.to_string());
+            // `self.jwt: Option<Zeroizing<String>>` — cloning preserves
+            // the wrapper so `Context` carries the scrub-on-drop
+            // guarantee all the way to the Esplora-config copy.
+            ctx.connect_jwt = Some(jwt.clone());
             ctx.use_coincube_connect = true;
         }
 

--- a/coincube-gui/src/installer/step/recovery_kit_restore.rs
+++ b/coincube-gui/src/installer/step/recovery_kit_restore.rs
@@ -2,18 +2,18 @@
 //!
 //! Mounts into three entry points:
 //!   * W13 — full restore from scratch (fresh install, no local state).
-//!           The step populates `ctx.recovered_signer` + `ctx.descriptor`
-//!           from the decrypted blobs. Runs inside
-//!           `UserFlow::RestoreFromRecoveryKit`.
+//!     The step populates `ctx.recovered_signer` + `ctx.descriptor`
+//!     from the decrypted blobs. Runs inside
+//!     `UserFlow::RestoreFromRecoveryKit`.
 //!   * W14 — after the user enters a mnemonic in `AddWallet`, offer to
-//!           fetch the wallet descriptor from Connect instead of (or in
-//!           addition to) importing from a file. Only the descriptor
-//!           half is applied; the seed half is ignored because the user
-//!           just retyped their mnemonic.
+//!     fetch the wallet descriptor from Connect instead of (or in
+//!     addition to) importing from a file. Only the descriptor
+//!     half is applied; the seed half is ignored because the user
+//!     just retyped their mnemonic.
 //!   * W15 — running-app "Restore Vault from Connect". Same shape as
-//!           W14 but without an accompanying mnemonic entry — the
-//!           current Cube already has its seed on disk; we just need
-//!           the descriptor.
+//!     W14 but without an accompanying mnemonic entry — the
+//!     current Cube already has its seed on disk; we just need
+//!     the descriptor.
 //!
 //! The step is a single Iced `Step` with an internal state machine
 //! (`Phase`). It reuses the reusable restore helpers in
@@ -127,7 +127,11 @@ pub struct RecoveryKitRestoreStep {
     skipped: bool,
     processing: bool,
     error: Option<String>,
-    jwt: Option<String>,
+    /// JWT bearer token captured on successful OTP verify. Stays
+    /// valid for the session, so wrapping it in `Zeroizing` is the
+    /// difference between key material lingering on the heap after
+    /// this step drops versus being scrubbed on drop.
+    jwt: Option<Zeroizing<String>>,
 }
 
 impl RecoveryKitRestoreStep {
@@ -189,7 +193,7 @@ impl RecoveryKitRestoreStep {
                 client
                     .login_verify_otp(OtpVerifyRequest { email, otp })
                     .await
-                    .map(|r| r.token)
+                    .map(|r| Zeroizing::new(r.token))
                     .map_err(|e| e.to_string())
             },
             |res| Message::RecoveryKitRestore(RecoveryKitRestoreMsg::OtpVerified(res)),
@@ -244,7 +248,7 @@ impl RecoveryKitRestoreStep {
                 fetch_and_decrypt_kit(&client, cube_id, &password)
                     .await
                     .map(|DecryptedKit { seed, descriptor }| (seed, descriptor))
-                    .map_err(|e| map_restore_error(e))
+                    .map_err(map_restore_error)
             },
             |res| Message::RecoveryKitRestore(RecoveryKitRestoreMsg::DecryptResult(res)),
         )
@@ -295,6 +299,10 @@ impl Step for RecoveryKitRestoreStep {
                 Task::none()
             }
             RecoveryKitRestoreMsg::OtpEdited(value) => {
+                // Trim-and-store at the form level. The message-level
+                // Zeroizing wrapper protected the in-flight copies;
+                // the step state holds only the trimmed value briefly
+                // until auto-submit or clear-on-verify.
                 self.otp.value = value.trim().to_string();
                 self.otp.valid = self.otp.value.len() == 6;
                 // Auto-submit when 6 digits — matches
@@ -310,7 +318,11 @@ impl Step for RecoveryKitRestoreStep {
                 self.processing = false;
                 match res {
                     Ok(token) => {
-                        self.client.set_token(&token);
+                        // `token` is `Zeroizing<String>` — deref to
+                        // `&str` for `set_token`, then stash the
+                        // Zeroizing wrapper so the JWT heap bytes are
+                        // wiped when the step drops or re-auths.
+                        self.client.set_token(token.as_str());
                         self.jwt = Some(token);
                         self.set_phase(Phase::LoadingCubes);
                         self.list_cubes_task()
@@ -360,7 +372,10 @@ impl Step for RecoveryKitRestoreStep {
                 Task::none()
             }
             RecoveryKitRestoreMsg::PasswordEdited(v) => {
-                self.password = Zeroizing::new(v);
+                // Move the `Zeroizing<String>` wrapper straight into
+                // state; the old `self.password` is dropped here
+                // (its heap zeroes via Zeroizing's Drop).
+                self.password = v;
                 Task::none()
             }
             RecoveryKitRestoreMsg::SubmitPassword => {

--- a/coincube-gui/src/installer/step/recovery_kit_restore.rs
+++ b/coincube-gui/src/installer/step/recovery_kit_restore.rs
@@ -39,7 +39,7 @@ use crate::{
         coincube::{CoincubeClient, CubeResponse, OtpRequest, OtpVerifyRequest, RecoveryKitStatus},
         recovery::{
             restore::{fetch_and_decrypt_kit, DecryptedKit, RestoreError},
-            score_password, DescriptorBlob, PasswordStrength, SeedBlob, MIN_PASSWORD_LEN,
+            score_password, DescriptorBlob, PasswordStrength, SeedBlob,
         },
     },
     signer::Signer,
@@ -382,16 +382,17 @@ impl Step for RecoveryKitRestoreStep {
                 if self.processing {
                     return Task::none();
                 }
-                // Basic client-side sanity: a recovery password can't
-                // be shorter than the minimum we enforce on backup.
-                // Avoids a round-trip for an obvious typo.
-                if self.password.len() < MIN_PASSWORD_LEN {
-                    self.error = Some(format!(
-                        "Password must be at least {} characters.",
-                        MIN_PASSWORD_LEN
-                    ));
-                    return Task::none();
-                }
+                // Do NOT enforce `MIN_PASSWORD_LEN` here. That floor
+                // belongs on the backup side — it's about picking a
+                // strong password. On restore the user enters what
+                // they chose at backup time, which may pre-date this
+                // client's minimum (or come from another client with
+                // different rules). A hardcoded gate here silently
+                // blocks a correct password from ever reaching the
+                // AES-GCM tag check, which is the only authoritative
+                // validator of "is this the right password". The
+                // view disables Submit when the input is empty, so
+                // no input-required guard is needed here either.
                 let Phase::PasswordEntry { selected, attempts } = &self.phase else {
                     return Task::none();
                 };
@@ -400,7 +401,6 @@ impl Step for RecoveryKitRestoreStep {
                 let _ = attempts; // reserved for future backoff UI
                 self.processing = true;
                 self.set_phase(Phase::Decrypting { selected });
-                self.processing = true;
                 self.decrypt_task(cube_id)
             }
             RecoveryKitRestoreMsg::DecryptResult(res) => {

--- a/coincube-gui/src/installer/step/restore_pin_setup.rs
+++ b/coincube-gui/src/installer/step/restore_pin_setup.rs
@@ -1,0 +1,165 @@
+//! PIN-setup step for the full Recovery Kit restore flow
+//! (`UserFlow::RestoreFromRecoveryKit`).
+//!
+//! # Why this step exists
+//!
+//! Fresh-install Cubes always persist their master mnemonic in the
+//! AES-encrypted, password-protected layout (see `MasterSigner::
+//! store_encrypted`). The Liquid / Spark BreezClient then decrypts the
+//! blob via the user's PIN at Cube-open time. Before this step
+//! existed, the restore flow wrote the restored mnemonic **unencrypted**,
+//! then tried to boot the app without constructing a BreezClient at
+//! all — the app hung on "Starting daemon…" because the loader's
+//! `Synced` branch expects a pre-loaded BreezClient.
+//!
+//! Inserting this step between `RecoveryKitRestoreStep` and the
+//! node-setup steps gives the user an explicit PIN-creation pad and
+//! lets `install_local_wallet` store the mnemonic in the same shape a
+//! fresh-install Cube uses. Downstream, the tab-level `CubeSaved`
+//! handler can load a BreezClient against that blob before handing
+//! off to the Loader.
+//!
+//! # Scope note
+//!
+//! This step only runs in `RestoreFromRecoveryKit`. The
+//! `RestoreVaultFromRecoveryKit` flow (W15) restores a descriptor
+//! into an existing Cube whose mnemonic + PIN are already on disk, so
+//! re-prompting there would be wrong. The `skip()` hook checks for
+//! `ctx.recovered_signer.is_some()` — if there's no new seed to
+//! persist, we skip ahead.
+
+use iced::Task;
+use zeroize::Zeroizing;
+
+use coincube_ui::widget::*;
+
+use crate::{
+    hw::HardwareWallets,
+    installer::{
+        context::Context,
+        message::{Message, PinField, RestorePinSetupMsg},
+        step::Step,
+        view,
+    },
+    pin_input::PinInput,
+};
+
+pub struct RestorePinSetupStep {
+    entry: PinInput,
+    confirm: PinInput,
+    /// Validation error displayed under the confirm pad — currently
+    /// only "PINs do not match", but typed so it's easy to surface
+    /// future validations (e.g. "PIN too weak").
+    error: Option<&'static str>,
+}
+
+impl Default for RestorePinSetupStep {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RestorePinSetupStep {
+    pub fn new() -> Self {
+        Self {
+            entry: PinInput::new(),
+            confirm: PinInput::new(),
+            error: None,
+        }
+    }
+
+    /// Both pads full *and* matching — the only shape that unlocks the
+    /// Next button and a viable `apply()`.
+    fn is_ready(&self) -> bool {
+        self.entry.is_complete()
+            && self.confirm.is_complete()
+            && self.entry.value() == self.confirm.value()
+    }
+}
+
+impl Step for RestorePinSetupStep {
+    fn skip(&self, ctx: &Context) -> bool {
+        // Only run when we actually have a freshly-restored mnemonic
+        // to persist. If `recovered_signer` is absent, this is either
+        // W15 (descriptor-only restore into an existing Cube) or a
+        // misconfigured flow — either way, a PIN prompt doesn't belong.
+        ctx.recovered_signer.is_none()
+    }
+
+    fn update(&mut self, _hws: &mut HardwareWallets, message: Message) -> Task<Message> {
+        let Message::RestorePinSetup(msg) = message else {
+            return Task::none();
+        };
+        match msg {
+            RestorePinSetupMsg::Pin(PinField::Entry, pin_msg) => {
+                // Reset the mismatch error as soon as the user edits
+                // either pad — it'll be recomputed on Submit /
+                // is_ready, and leaving it visible while the user is
+                // still typing is misleading.
+                self.error = None;
+                self.entry.update(pin_msg).map(move |m| {
+                    Message::RestorePinSetup(RestorePinSetupMsg::Pin(PinField::Entry, m))
+                })
+            }
+            RestorePinSetupMsg::Pin(PinField::Confirm, pin_msg) => {
+                self.error = None;
+                self.confirm.update(pin_msg).map(move |m| {
+                    Message::RestorePinSetup(RestorePinSetupMsg::Pin(PinField::Confirm, m))
+                })
+            }
+            RestorePinSetupMsg::Submit => {
+                // The view gates Next on `is_ready`, but handle
+                // Submit defensively in case the user hit Enter on a
+                // `pin_input` without the pads matching.
+                if self.is_ready() {
+                    Task::done(Message::Next)
+                } else {
+                    self.error = Some("PINs do not match.");
+                    Task::none()
+                }
+            }
+        }
+    }
+
+    fn view<'a>(
+        &'a self,
+        _hws: &'a HardwareWallets,
+        progress: (usize, usize),
+        email: Option<&'a str>,
+    ) -> Element<'a, Message> {
+        view::restore_pin_setup(
+            progress,
+            email,
+            &self.entry,
+            &self.confirm,
+            self.error,
+            self.is_ready(),
+        )
+    }
+
+    fn apply(&mut self, ctx: &mut Context) -> bool {
+        if !self.is_ready() {
+            self.error = Some("PINs do not match.");
+            return false;
+        }
+        // Store the PIN in the Context so `install_local_wallet` can
+        // use it as the encryption password for the restored mnemonic
+        // and the tab-level `CubeSaved` handler can mint
+        // `CubeSettings.security_pin_hash`.
+        ctx.restore_pin = Some(Zeroizing::new(self.entry.value()));
+        true
+    }
+
+    fn revert(&self, ctx: &mut Context) {
+        // Keep Context in a consistent state if the user navigates
+        // back past this step — otherwise a later step might still
+        // see a stale PIN from a prior pass of the wizard.
+        ctx.restore_pin = None;
+    }
+}
+
+impl From<RestorePinSetupStep> for Box<dyn Step> {
+    fn from(s: RestorePinSetupStep) -> Box<dyn Step> {
+        Box::new(s)
+    }
+}

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -2706,7 +2706,13 @@ pub fn recovery_kit_restore<'a>(
                 .push(text::text("Enter the 6-digit code we sent to your email."))
                 .push(
                     form::Form::new_trimmed("123456", otp, |v| {
-                        Message::RecoveryKitRestore(RecoveryKitRestoreMsg::OtpEdited(v))
+                        // Wrap immediately — the `String` from iced's
+                        // input callback is the last unprotected copy
+                        // in our code path; from here it lives inside
+                        // `Zeroizing` all the way to the async task.
+                        Message::RecoveryKitRestore(RecoveryKitRestoreMsg::OtpEdited(
+                            zeroize::Zeroizing::new(v),
+                        ))
                     })
                     .warning("Invalid code")
                     .size(16)
@@ -2757,7 +2763,15 @@ pub fn recovery_kit_restore<'a>(
                 .push(
                     TextInput::new("Recovery password", password)
                         .on_input(|v| {
-                            Message::RecoveryKitRestore(RecoveryKitRestoreMsg::PasswordEdited(v))
+                            // Wrap the password in `Zeroizing` before
+                            // it enters the message queue — see
+                            // `RecoveryKitRestoreMsg` doc. The `String`
+                            // from iced's callback is the last plain
+                            // copy; every subsequent clone is
+                            // auto-zeroed on drop.
+                            Message::RecoveryKitRestore(RecoveryKitRestoreMsg::PasswordEdited(
+                                zeroize::Zeroizing::new(v),
+                            ))
                         })
                         .secure(true)
                         .size(16)
@@ -2784,10 +2798,22 @@ pub fn recovery_kit_restore<'a>(
             ));
         }
         RestorePhase::Ready { selected, .. } => {
-            content = content.push(text::text(format!(
-                "Ready to restore from \"{}\". Click Next to continue.",
-                selected.name
-            )));
+            // The happy path after a successful decrypt fires
+            // `Message::Next` automatically, so the user rarely
+            // lingers on this screen. But a user can land here
+            // again by navigating back through the installer —
+            // without an explicit Next button they'd be stuck.
+            content = content
+                .push(text::text(format!(
+                    "Ready to restore from \"{}\". Click Next to continue.",
+                    selected.name
+                )))
+                .push(
+                    button::primary(None, "Next")
+                        .on_press(Message::Next)
+                        .width(Length::Fixed(220.0))
+                        .padding([10, 20]),
+                );
         }
         RestorePhase::Error { message } => {
             content = content

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -2644,3 +2644,185 @@ fn layout<'a>(
     .style(theme::container::background)
     .into()
 }
+
+/// Placeholder view for the Cube Recovery Kit restore step (W13/W14/W15).
+/// Renders a minimal but complete UI so every Phase has a reachable
+/// interaction. A design pass is expected as a follow-up.
+///
+/// The scope arg changes the headline copy and hides "Skip" when
+/// the flow is `Full` (W13 — the restore IS the point of the flow).
+#[allow(clippy::too_many_arguments)]
+pub fn recovery_kit_restore<'a>(
+    progress: (usize, usize),
+    scope: crate::installer::step::RestoreScope,
+    phase: &'a crate::installer::step::recovery_kit_restore::RestorePhase,
+    email: &'a form::Value<String>,
+    otp: &'a form::Value<String>,
+    password: &'a str,
+    processing: bool,
+    error: Option<&'a str>,
+) -> Element<'a, Message> {
+    use crate::installer::message::RecoveryKitRestoreMsg;
+    use crate::installer::step::recovery_kit_restore::RestorePhase;
+
+    let title = match scope {
+        crate::installer::step::RestoreScope::Full => "Restore from Connect Recovery Kit",
+        crate::installer::step::RestoreScope::DescriptorOnly => {
+            "Restore Wallet Descriptor from Connect"
+        }
+    };
+
+    let mut content: Column<'a, Message> = Column::new().spacing(20).width(Length::Fill);
+
+    match phase {
+        RestorePhase::Email => {
+            content = content
+                .push(text::text(
+                    "Sign in to your Connect account to fetch your Cube Recovery Kit.",
+                ))
+                .push(
+                    form::Form::new_trimmed("you@example.com", email, |v| {
+                        Message::RecoveryKitRestore(RecoveryKitRestoreMsg::EmailEdited(v))
+                    })
+                    .warning("Email is invalid")
+                    .size(16)
+                    .padding(10),
+                )
+                .push({
+                    let btn = button::primary(None, "Send code")
+                        .width(Length::Fixed(220.0))
+                        .padding([10, 20]);
+                    if email.valid && !processing {
+                        btn.on_press(Message::RecoveryKitRestore(
+                            RecoveryKitRestoreMsg::RequestOtp,
+                        ))
+                    } else {
+                        btn
+                    }
+                });
+        }
+        RestorePhase::OtpEntry => {
+            content = content
+                .push(text::text("Enter the 6-digit code we sent to your email."))
+                .push(
+                    form::Form::new_trimmed("123456", otp, |v| {
+                        Message::RecoveryKitRestore(RecoveryKitRestoreMsg::OtpEdited(v))
+                    })
+                    .warning("Invalid code")
+                    .size(16)
+                    .padding(10),
+                );
+        }
+        RestorePhase::LoadingCubes => {
+            content = content.push(text::text("Loading your Cubes from Connect…"));
+        }
+        RestorePhase::CubePicker { cubes, .. } => {
+            let mut col = Column::new().spacing(10);
+            if cubes.is_empty() {
+                col = col.push(text::text(
+                    "No Cubes found on this Connect account for the current network.",
+                ));
+            } else {
+                for c in cubes {
+                    let label = if c.status.has_recovery_kit {
+                        format!("{} — kit available", c.name)
+                    } else {
+                        format!("{} — no kit (disabled)", c.name)
+                    };
+                    let id = c.id;
+                    let has_kit = c.status.has_recovery_kit;
+                    // Raw `iced::widget::Button` because the labels are
+                    // built from dynamic `String`s — `button::secondary`
+                    // requires `&'static str`.
+                    let mut btn = Button::new(text::text(label))
+                        .width(Length::Fixed(360.0))
+                        .padding([8, 16])
+                        .style(theme::button::secondary);
+                    if has_kit {
+                        btn = btn.on_press(Message::RecoveryKitRestore(
+                            RecoveryKitRestoreMsg::SelectCube(id),
+                        ));
+                    }
+                    col = col.push(btn);
+                }
+            }
+            content = content.push(col);
+        }
+        RestorePhase::PasswordEntry { selected, .. } => {
+            content = content
+                .push(text::text(format!(
+                    "Enter the recovery password for \"{}\".",
+                    selected.name
+                )))
+                .push(
+                    TextInput::new("Recovery password", password)
+                        .on_input(|v| {
+                            Message::RecoveryKitRestore(RecoveryKitRestoreMsg::PasswordEdited(v))
+                        })
+                        .secure(true)
+                        .size(16)
+                        .padding(12)
+                        .width(Length::Fixed(400.0)),
+                )
+                .push({
+                    let btn = button::primary(None, "Restore")
+                        .width(Length::Fixed(220.0))
+                        .padding([10, 20]);
+                    if !password.is_empty() && !processing {
+                        btn.on_press(Message::RecoveryKitRestore(
+                            RecoveryKitRestoreMsg::SubmitPassword,
+                        ))
+                    } else {
+                        btn
+                    }
+                });
+        }
+        RestorePhase::Decrypting { .. } => {
+            content = content.push(text::text(
+                "Decrypting your Recovery Kit. This takes a moment — \
+                 Argon2id key derivation is intentionally slow.",
+            ));
+        }
+        RestorePhase::Ready { selected, .. } => {
+            content = content.push(text::text(format!(
+                "Ready to restore from \"{}\". Click Next to continue.",
+                selected.name
+            )));
+        }
+        RestorePhase::Error { message } => {
+            content = content
+                .push(text::text(message.clone()).style(theme::text::warning))
+                .push(
+                    button::secondary(None, "Try again")
+                        .on_press(Message::RecoveryKitRestore(
+                            RecoveryKitRestoreMsg::RetryFromStart,
+                        ))
+                        .width(Length::Fixed(220.0))
+                        .padding([10, 20]),
+                );
+        }
+    }
+
+    if let Some(e) = error {
+        content = content.push(text::text(e.to_string()).style(theme::text::warning));
+    }
+
+    // Skip button — only for DescriptorOnly scopes.
+    if matches!(scope, crate::installer::step::RestoreScope::DescriptorOnly) {
+        content = content.push(
+            button::secondary(None, "Skip — restore later")
+                .on_press(Message::RecoveryKitRestore(RecoveryKitRestoreMsg::Skip))
+                .width(Length::Fixed(220.0))
+                .padding([10, 20]),
+        );
+    }
+
+    layout(
+        progress,
+        None,
+        title,
+        content,
+        true,
+        Some(Message::Previous),
+    )
+}

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -2539,6 +2539,63 @@ pub const REMOTE_BACKEND_DESC: &str = "Use Wizardsardine service to instantly be
 
 pub const LOCAL_WALLET_DESC: &str = "Use your already existing Bitcoin node or automatically install one. The Vault wallet will not connect to any external server.\n\nThis is the most private option, but the data is locally stored on this computer, only. You must perform your own backups, and share the descriptor with other people you want to be able to access the wallet.";
 
+/// View for `RestorePinSetupStep`. Two `PinInput` pads stacked
+/// vertically, an optional inline error under the confirm pad, and a
+/// Next button gated on both pads being complete + matching.
+///
+/// The `ready` flag is computed in the step (not here) so the view
+/// stays dumb — the caller owns the matching rule.
+pub fn restore_pin_setup<'a>(
+    progress: (usize, usize),
+    email: Option<&'a str>,
+    entry: &'a crate::pin_input::PinInput,
+    confirm: &'a crate::pin_input::PinInput,
+    error: Option<&'static str>,
+    ready: bool,
+) -> Element<'a, Message> {
+    use message::{PinField, RestorePinSetupMsg};
+
+    let entry_view = entry
+        .view()
+        .map(|m| Message::RestorePinSetup(RestorePinSetupMsg::Pin(PinField::Entry, m)));
+    let confirm_view = confirm
+        .view()
+        .map(|m| Message::RestorePinSetup(RestorePinSetupMsg::Pin(PinField::Confirm, m)));
+
+    layout(
+        progress,
+        email,
+        "Create a PIN to secure your restored Cube",
+        Column::new()
+            .spacing(40)
+            .push(p2_regular(
+                "Your Cube's mnemonic will be encrypted with this PIN on disk. \
+                 You'll enter it every time you open this Cube — the PIN is \
+                 what lets the Liquid and Spark wallets decrypt your keys.",
+            ))
+            .push(
+                Column::new()
+                    .spacing(15)
+                    .push(p1_bold("Enter a 4-digit PIN:"))
+                    .push(entry_view),
+            )
+            .push(
+                Column::new()
+                    .spacing(15)
+                    .push(p1_bold("Confirm PIN:"))
+                    .push(confirm_view)
+                    .push(error.map(|e| p2_regular(e).style(theme::text::error))),
+            )
+            .push(
+                button::secondary(None, "Next")
+                    .width(Length::Fixed(200.0))
+                    .on_press_maybe(if ready { Some(Message::Next) } else { None }),
+            ),
+        true,
+        Some(Message::Previous),
+    )
+}
+
 pub fn wallet_alias<'a>(
     progress: (usize, usize),
     email: Option<&'a str>,
@@ -2730,13 +2787,36 @@ pub fn recovery_kit_restore<'a>(
                 ));
             } else {
                 for c in cubes {
-                    let label = if c.status.has_recovery_kit {
+                    // Scope-aware availability: a descriptor-only
+                    // kit can't satisfy a Full restore, and a
+                    // seed-only kit can't satisfy DescriptorOnly.
+                    // Disable the row (and say why) rather than
+                    // let the user click through to a post-decrypt
+                    // "missing half" error.
+                    let available = c.status.has_recovery_kit
+                        && match scope {
+                            crate::installer::step::RestoreScope::Full => {
+                                c.status.has_encrypted_seed
+                            }
+                            crate::installer::step::RestoreScope::DescriptorOnly => {
+                                c.status.has_encrypted_wallet_descriptor
+                            }
+                        };
+                    let label = if available {
                         format!("{} — kit available", c.name)
-                    } else {
+                    } else if !c.status.has_recovery_kit {
                         format!("{} — no kit (disabled)", c.name)
+                    } else {
+                        match scope {
+                            crate::installer::step::RestoreScope::Full => {
+                                format!("{} — no seed in kit (disabled)", c.name)
+                            }
+                            crate::installer::step::RestoreScope::DescriptorOnly => {
+                                format!("{} — no descriptor in kit (disabled)", c.name)
+                            }
+                        }
                     };
                     let id = c.id;
-                    let has_kit = c.status.has_recovery_kit;
                     // Raw `iced::widget::Button` because the labels are
                     // built from dynamic `String`s — `button::secondary`
                     // requires `&'static str`.
@@ -2744,7 +2824,7 @@ pub fn recovery_kit_restore<'a>(
                         .width(Length::Fixed(360.0))
                         .padding([8, 16])
                         .style(theme::button::secondary);
-                    if has_kit {
+                    if available {
                         btn = btn.on_press(Message::RecoveryKitRestore(
                             RecoveryKitRestoreMsg::SelectCube(id),
                         ));

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -294,6 +294,16 @@ impl Launcher {
                     Message::Install(d, n, UserFlow::CreateWallet)
                 })
             }
+            Message::View(ViewMessage::RestoreFromRecoveryKit) => {
+                // W13 — same launch shape as CreateWallet; the
+                // installer picks the Recovery-Kit step sequence off
+                // the UserFlow.
+                let datadir_path = self.datadir_path.clone();
+                let network = self.network;
+                Task::perform(async move { (datadir_path, network) }, |(d, n)| {
+                    Message::Install(d, n, UserFlow::RestoreFromRecoveryKit)
+                })
+            }
             Message::View(ViewMessage::ShareXpubs) => {
                 if !self.developer_mode {
                     tracing::debug!(
@@ -2660,6 +2670,10 @@ pub enum Message {
 pub enum ViewMessage {
     ImportWallet,
     CreateWallet,
+    /// W13 — launch the installer in "restore from Connect Recovery
+    /// Kit" mode. Sibling to `CreateWallet` / `ImportWallet` in the
+    /// cube-setup menu.
+    RestoreFromRecoveryKit,
     ShowCreateCube(bool),
     CubeNameEdited(String),
     CreateCube,

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -2398,9 +2398,16 @@ fn remote_cube_list_item<'a>(cube: &'a RemoteCube) -> Element<'a, ViewMessage> {
                 .style(theme::card::simple),
             )
             .push(
+                // W13 entry point on the launcher: clicking
+                // cloud-arrow-down on a remote-only cube kicks off
+                // the Connect-Recovery-Kit restore flow. The flow's
+                // cube picker (`RecoveryKitRestoreStep`) lets the
+                // user confirm which cube to restore; pre-selecting
+                // by `cube.uuid` here is a future refinement.
                 Button::new(icon::cloud_arrow_down_icon())
                     .style(theme::button::secondary)
-                    .padding(10),
+                    .padding(10)
+                    .on_press(ViewMessage::RestoreFromRecoveryKit),
             )
             .push(
                 Button::new(icon::trash_icon())

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -1,12 +1,11 @@
 use iced::{
     alignment::Horizontal,
-    widget::{pick_list, scrollable, Button, Space, Stack, Toggler},
+    widget::{pick_list, scrollable, tooltip as iced_tooltip, Button, Space, Stack, Toggler},
     Alignment, Length, Subscription, Task,
 };
 
 use coincube_core::{bip39, miniscript::bitcoin::Network};
 use coincube_ui::{
-    color,
     component::{button, card, network_banner, notification, spinner, text::*},
     icon, image, theme,
     widget::{modal::Modal, CheckBox, Column, Container, Element, Row},
@@ -2379,36 +2378,43 @@ fn cubes_list_item<'a>(cube: &'a CubeSettings, i: usize) -> Element<'a, ViewMess
 }
 
 fn remote_cube_list_item<'a>(cube: &'a RemoteCube) -> Element<'a, ViewMessage> {
-    let disabled_style = |_t: &theme::Theme| theme::text::custom(color::GREY_3);
+    // Render the cube-name area as a plain card, NOT a Button. Using a
+    // Button without `.on_press` makes Iced render it in
+    // `Status::Disabled` (alpha 0.2 on the text), which made the whole
+    // row read as "disabled" to users and obscured the fact that the
+    // cloud-download icon on the right is an active restore trigger.
+    let card = Container::new(
+        Column::new().spacing(4).push(p1_bold(&cube.name)).push(
+            p1_regular("On another device — click the download icon to restore")
+                .style(theme::text::secondary),
+        ),
+    )
+    .padding(15)
+    .width(Length::Fixed(500.0))
+    .style(theme::card::simple);
+
+    // W13 entry point on the launcher: clicking cloud-arrow-down on a
+    // remote-only cube kicks off the Connect-Recovery-Kit restore flow.
+    // The flow's cube picker (`RecoveryKitRestoreStep`) lets the user
+    // confirm which cube to restore; pre-selecting by `cube.uuid` here
+    // is a future refinement.
+    let restore_button = iced_tooltip::Tooltip::new(
+        Button::new(icon::cloud_arrow_down_icon())
+            .style(theme::button::secondary)
+            .padding(10)
+            .on_press(ViewMessage::RestoreFromRecoveryKit),
+        Container::new(p1_regular("Restore this Cube from your Recovery Kit"))
+            .padding(8)
+            .style(theme::card::simple),
+        iced_tooltip::Position::Bottom,
+    );
+
     Container::new(
         Row::new()
             .align_y(Alignment::Center)
             .spacing(20)
-            .push(
-                Container::new(
-                    Button::new(
-                        Column::new()
-                            .push(p1_bold(&cube.name).style(disabled_style))
-                            .push(p1_regular("On another device").style(disabled_style)),
-                    )
-                    .padding(15)
-                    .style(theme::button::container_border)
-                    .width(Length::Fixed(500.0)),
-                )
-                .style(theme::card::simple),
-            )
-            .push(
-                // W13 entry point on the launcher: clicking
-                // cloud-arrow-down on a remote-only cube kicks off
-                // the Connect-Recovery-Kit restore flow. The flow's
-                // cube picker (`RecoveryKitRestoreStep`) lets the
-                // user confirm which cube to restore; pre-selecting
-                // by `cube.uuid` here is a future refinement.
-                Button::new(icon::cloud_arrow_down_icon())
-                    .style(theme::button::secondary)
-                    .padding(10)
-                    .on_press(ViewMessage::RestoreFromRecoveryKit),
-            )
+            .push(card)
+            .push(restore_button)
             .push(
                 Button::new(icon::trash_icon())
                     .style(theme::button::secondary)

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -16,7 +16,7 @@ use tokio::runtime::Handle;
 use crate::feature_flags;
 use crate::pin_input;
 use crate::services::coincube::{
-    CubeLimitsResponse, CubeResponse, RegisterCubeRequest, UpdateCubeRequest,
+    CoincubeClient, CubeLimitsResponse, CubeResponse, RegisterCubeRequest, UpdateCubeRequest,
 };
 #[cfg(not(target_os = "macos"))]
 use crate::services::passkey::CeremonyMode;
@@ -283,25 +283,38 @@ impl Launcher {
                 let datadir_path = self.datadir_path.clone();
                 let network = self.network;
                 Task::perform(async move { (datadir_path, network) }, |(d, n)| {
-                    Message::Install(d, n, UserFlow::AddWallet)
+                    Message::Install(d, n, UserFlow::AddWallet, None)
                 })
             }
             Message::View(ViewMessage::CreateWallet) => {
                 let datadir_path = self.datadir_path.clone();
                 let network = self.network;
                 Task::perform(async move { (datadir_path, network) }, |(d, n)| {
-                    Message::Install(d, n, UserFlow::CreateWallet)
+                    Message::Install(d, n, UserFlow::CreateWallet, None)
                 })
             }
             Message::View(ViewMessage::RestoreFromRecoveryKit) => {
                 // W13 — same launch shape as CreateWallet; the
                 // installer picks the Recovery-Kit step sequence off
                 // the UserFlow.
+                //
+                // Forward the launcher's already-authenticated Connect
+                // client so `RecoveryKitRestoreStep` can skip its own
+                // email + OTP form (the user already signed in to see
+                // the list of remote cubes on this very screen —
+                // re-prompting them for the same credentials right
+                // after they clicked "restore this one" is pure churn).
+                // Falls back to `None` when the session isn't active
+                // yet (developer-mode path, or stale cached launcher
+                // state), in which case the step's own auth form
+                // kicks in.
                 let datadir_path = self.datadir_path.clone();
                 let network = self.network;
-                Task::perform(async move { (datadir_path, network) }, |(d, n)| {
-                    Message::Install(d, n, UserFlow::RestoreFromRecoveryKit)
-                })
+                let client = self.connect_account.authenticated_client();
+                Task::perform(
+                    async move { (datadir_path, network, client) },
+                    |(d, n, c)| Message::Install(d, n, UserFlow::RestoreFromRecoveryKit, c),
+                )
             }
             Message::View(ViewMessage::ShareXpubs) => {
                 if !self.developer_mode {
@@ -313,7 +326,7 @@ impl Launcher {
                 let datadir_path = self.datadir_path.clone();
                 let network = self.network;
                 Task::perform(async move { (datadir_path, network) }, |(d, n)| {
-                    Message::Install(d, n, UserFlow::ShareXpubs)
+                    Message::Install(d, n, UserFlow::ShareXpubs, None)
                 })
             }
             Message::View(ViewMessage::ShowCreateCube(show)) => {
@@ -2635,7 +2648,13 @@ fn map_connect_task(task: Task<app::message::Message>) -> Task<Message> {
 #[derive(Debug, Clone)]
 pub enum Message {
     View(ViewMessage),
-    Install(CoincubeDirectory, Network, UserFlow),
+    /// Launch the installer. The trailing `Option<CoincubeClient>`
+    /// forwards the launcher's already-authenticated Connect session
+    /// into the installer so steps like `RecoveryKitRestoreStep` don't
+    /// demand the user retype email + OTP a second time. `None` means
+    /// "launcher had no Connect session" — the relevant installer step
+    /// then falls back to its own auth form.
+    Install(CoincubeDirectory, Network, UserFlow, Option<CoincubeClient>),
     Checked(Result<State, String>),
     Run(
         CoincubeDirectory,

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -2409,14 +2409,18 @@ fn remote_cube_list_item<'a>(cube: &'a RemoteCube) -> Element<'a, ViewMessage> {
     // W13 entry point on the launcher: clicking cloud-arrow-down on a
     // remote-only cube kicks off the Connect-Recovery-Kit restore flow.
     // The flow's cube picker (`RecoveryKitRestoreStep`) lets the user
-    // confirm which cube to restore; pre-selecting by `cube.uuid` here
+    // choose which cube on their Connect account to restore — clicking
+    // this specific row doesn't preselect `cube.uuid`, so the tooltip
+    // is deliberately generic to avoid implying otherwise. Threading
+    // the clicked uuid through `ViewMessage::RestoreFromRecoveryKit`
+    // → `UserFlow::RestoreFromRecoveryKit` → the step's cube picker
     // is a future refinement.
     let restore_button = iced_tooltip::Tooltip::new(
         Button::new(icon::cloud_arrow_down_icon())
             .style(theme::button::secondary)
             .padding(10)
             .on_press(ViewMessage::RestoreFromRecoveryKit),
-        Container::new(p1_regular("Restore this Cube from your Recovery Kit"))
+        Container::new(p1_regular("Choose a Recovery Kit to restore"))
             .padding(8)
             .style(theme::card::simple),
         iced_tooltip::Position::Bottom,

--- a/coincube-gui/src/loader.rs
+++ b/coincube-gui/src/loader.rs
@@ -624,6 +624,12 @@ pub async fn load_application(
         show_direction_badges: true,
         lightning_address: None,
         cube_id: config.cube_settings.id.clone(),
+        current_cube_server_id: None,
+        current_descriptor_fingerprint: None,
+        recovery_kit_last_backed_up_descriptor_fingerprint: config
+            .cube_settings
+            .recovery_kit_last_backed_up_descriptor_fingerprint
+            .clone(),
         default_lightning_backend: config.cube_settings.default_lightning_backend,
     };
 

--- a/coincube-gui/src/pin_input.rs
+++ b/coincube-gui/src/pin_input.rs
@@ -57,20 +57,45 @@ impl PinInput {
         }
     }
 
+    /// Overwrite `self.digits[i]` with `new`, scrubbing the previous
+    /// String's heap bytes first. Needed because plain assignment
+    /// (`self.digits[i] = new`) drops the old `String` without
+    /// zeroizing, leaving the digit on the heap until the allocator
+    /// reuses that region. Callers with a digit character in hand use
+    /// this instead of direct assignment.
+    fn replace_digit(&mut self, i: usize, new: String) {
+        if i >= self.digits.len() {
+            return;
+        }
+        self.digits[i].zeroize();
+        self.digits[i] = new;
+    }
+
     pub fn update(&mut self, message: Message) -> Task<Message> {
         match message {
             Message::DigitChanged(index, value) => {
                 if index >= self.digits.len() {
                     return Task::none();
                 }
-                let old_value = self.digits[index].clone();
+                // Previous digit's state before we overwrite it. Capture
+                // just the booleans/lengths we need — cloning the String
+                // itself (the prior implementation did `old_value =
+                // self.digits[index].clone()`) would copy the plaintext
+                // digit onto a throwaway heap buffer that then dropped
+                // un-scrubbed at the end of this function.
+                let old_was_empty = self.digits[index].is_empty();
+                let old_len = self.digits[index].len();
                 if value.is_empty() {
-                    self.digits[index] = value;
+                    self.replace_digit(index, value);
                     if index > 0 {
                         // this deletes the number and also moves the cursor to the previous field
                         // If the field was already empty, also clear the previous field
-                        if old_value.is_empty() {
-                            self.digits[index - 1] = String::new();
+                        if old_was_empty {
+                            // Scrub the previous digit in place rather
+                            // than reassigning `String::new()`, which
+                            // would drop the old plaintext buffer
+                            // un-scrubbed.
+                            self.digits[index - 1].zeroize();
                         }
                         return focus_previous();
                     }
@@ -78,11 +103,11 @@ impl PinInput {
                     // Smart fill logic: determine which field to update
                     if value.len() == 1 {
                         // Simple case: typing in empty field
-                        self.digits[index] = value;
+                        self.replace_digit(index, value);
                         if index < 3 {
                             return focus_next();
                         }
-                    } else if value.len() > old_value.len() {
+                    } else if value.len() > old_len {
                         // User typed in a field that already has content
                         // Extract the newly typed character
                         if let Some(last_char) = value.chars().last() {
@@ -90,15 +115,13 @@ impl PinInput {
                                 let new_digit = last_char.to_string();
 
                                 // Smart fill: if current field has content and next field is empty, fill next
-                                if !old_value.is_empty()
-                                    && index < 3
-                                    && self.digits[index + 1].is_empty()
+                                if !old_was_empty && index < 3 && self.digits[index + 1].is_empty()
                                 {
-                                    self.digits[index + 1] = new_digit;
+                                    self.replace_digit(index + 1, new_digit);
                                     return focus_next();
                                 } else {
                                     // Otherwise replace current field
-                                    self.digits[index] = new_digit;
+                                    self.replace_digit(index, new_digit);
                                     if index < 3 {
                                         return focus_next();
                                     }
@@ -169,7 +192,7 @@ impl Drop for PinInput {
 
 #[cfg(test)]
 mod tests {
-    use super::PinInput;
+    use super::{Message, PinInput};
     use zeroize::Zeroize;
 
     #[test]
@@ -198,5 +221,61 @@ mod tests {
         let mut s = "9".to_string();
         s.zeroize();
         assert!(s.is_empty());
+    }
+
+    #[test]
+    fn replace_digit_scrubs_previous_buffer() {
+        let mut pin = PinInput::new();
+        pin.digits = ["7".to_string(), String::new(), String::new(), String::new()];
+        pin.replace_digit(0, "3".to_string());
+        // End state: only the new digit is visible.
+        assert_eq!(pin.digits[0], "3");
+        // The `zeroize::Zeroize for String` impl scrubs bytes then
+        // clears length before we drop the old allocation, so by the
+        // time `replace_digit` returns no plaintext "7" is reachable
+        // through `self.digits` — the only digit accessible is "3".
+        assert_eq!(pin.value(), "3");
+    }
+
+    #[test]
+    fn digit_changed_smart_fill_scrubs_previous_digit() {
+        // Reproduces the `update()` path where the user types into a
+        // field that already has a digit AND the next field is empty:
+        // the typed character goes into the next slot, leaving the
+        // current slot's previous digit in place. Nothing to scrub in
+        // this branch directly, but we must not panic or drop data.
+        let mut pin = PinInput::new();
+        pin.digits[0] = "5".to_string();
+        let _ = pin.update(Message::DigitChanged(0, "58".to_string()));
+        assert_eq!(pin.digits[0], "5");
+        assert_eq!(pin.digits[1], "8");
+    }
+
+    #[test]
+    fn digit_changed_replace_scrubs_overwritten_digit() {
+        // Path: `value.len() > old_len` with next-slot non-empty falls
+        // through to "replace current field". Old buffer must be
+        // scrubbed before the new one takes its place.
+        let mut pin = PinInput::new();
+        pin.digits[0] = "5".to_string();
+        pin.digits[1] = "9".to_string(); // occupies next slot → no smart-fill
+        let _ = pin.update(Message::DigitChanged(0, "52".to_string()));
+        // Slot 0 replaced with "2", previous "5" scrubbed before the
+        // replacement was assigned.
+        assert_eq!(pin.digits[0], "2");
+        assert_eq!(pin.digits[1], "9");
+    }
+
+    #[test]
+    fn digit_changed_backspace_on_empty_clears_prior_slot() {
+        // Path: `value.is_empty()` + `old_was_empty` → zeroize prior
+        // slot. Before this fix the prior slot was reassigned
+        // `String::new()`, dropping its plaintext buffer un-scrubbed.
+        let mut pin = PinInput::new();
+        pin.digits[0] = "4".to_string();
+        pin.digits[1] = String::new();
+        let _ = pin.update(Message::DigitChanged(1, String::new()));
+        assert!(pin.digits[0].is_empty(), "prior slot should be cleared");
+        assert!(pin.digits[1].is_empty());
     }
 }

--- a/coincube-gui/src/pin_input.rs
+++ b/coincube-gui/src/pin_input.rs
@@ -6,10 +6,18 @@ use iced::{
     widget::{operation::focus_next, operation::focus_previous},
     Alignment, Length, Task,
 };
+use zeroize::Zeroize;
 
 /// Reusable 4-digit PIN input component.
 ///
 /// Handles digit entry with auto-advance/retreat and show/hide toggle.
+///
+/// The `digits` buffers hold plaintext PIN characters while the user is
+/// entering them. `Drop` + `clear()` both `zeroize()` each digit so the
+/// heap allocations don't linger on the residual heap after the widget
+/// is destroyed or reset. Iced's internal render/event buffers may
+/// still hold short-lived copies — eliminating those is framework-side
+/// and out of this widget's control.
 #[derive(Default)]
 pub struct PinInput {
     pub digits: [String; 4],
@@ -41,9 +49,12 @@ impl PinInput {
         !self.digits.iter().any(|d| d.is_empty())
     }
 
-    /// Clear all digits.
+    /// Clear all digits, scrubbing each heap buffer before it's
+    /// reused. Leaves every digit as an empty `String`.
     pub fn clear(&mut self) {
-        self.digits = [String::new(), String::new(), String::new(), String::new()];
+        for d in &mut self.digits {
+            d.zeroize();
+        }
     }
 
     pub fn update(&mut self, message: Message) -> Task<Message> {
@@ -142,5 +153,50 @@ impl PinInput {
             .push(pin_inputs)
             .push(toggle_button)
             .into()
+    }
+}
+
+impl Drop for PinInput {
+    fn drop(&mut self) {
+        // Scrub every digit buffer before the heap allocations are
+        // handed back to the allocator, so a later allocation that
+        // reuses the same region can't read the PIN.
+        for d in &mut self.digits {
+            d.zeroize();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PinInput;
+    use zeroize::Zeroize;
+
+    #[test]
+    fn clear_empties_every_digit() {
+        let mut pin = PinInput::new();
+        pin.digits = [
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+        ];
+        assert_eq!(pin.value(), "1234");
+        pin.clear();
+        for d in &pin.digits {
+            assert!(d.is_empty(), "clear() left a digit non-empty: {:?}", d);
+        }
+        assert_eq!(pin.value(), "");
+    }
+
+    #[test]
+    fn zeroize_on_digit_clears_underlying_bytes() {
+        // Not a true "Drop observed memory" test (we can't look at
+        // freed allocations portably), but it pins the invariant that
+        // calling `zeroize()` on a digit leaves it empty — the same
+        // primitive the `Drop` impl relies on.
+        let mut s = "9".to_string();
+        s.zeroize();
+        assert!(s.is_empty());
     }
 }

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -6,12 +6,14 @@ use super::{
     ContactCube, Country, CreateConnectVaultRequest, CreateInviteRequest, CubeInviteOrAddResult,
     CubeKeyRaw, CubeLimitsResponse, CubeResponse, DownloadStats, FeaturesResponse, GetAvatarData,
     Invite, LightningAddress, LoginActivity, LoginResponse, OtpRequest, OtpVerifyRequest,
-    PublicAvatarData, RefreshTokenRequest, RegenerationData, RegisterCubeRequest, SaveQuoteRequest,
-    SaveQuoteResponse, StatsPeriod, TimeseriesResponse, TodayStats, UpdateCubeRequest, User,
-    VaultMemberResponse, VerifiedDevice,
+    PublicAvatarData, RecoveryKit, RecoveryKitStatus, RefreshTokenRequest, RegenerationData,
+    RegisterCubeRequest, SaveQuoteRequest, SaveQuoteResponse, StatsPeriod, TimeseriesResponse,
+    TodayStats, UpdateCubeRequest, UpsertRecoveryKitRequest, User, VaultMemberResponse,
+    VerifiedDevice,
 };
 use reqwest::{Client, Method};
 use serde::Deserialize;
+use std::time::Duration;
 
 use crate::services::http::ResponseExt;
 
@@ -822,6 +824,550 @@ impl CoincubeClient {
         let res = self.client.delete(&url).send().await?;
         res.check_success().await?;
         Ok(())
+    }
+}
+
+// =============================================================================
+// Cube Recovery Kit (W7)
+// =============================================================================
+//
+// Unlike the rest of the client, these methods intercept 404 / 429 before
+// `check_success` drains the response body, because:
+//
+// - 404 is not an error for the state machine driving the Settings card —
+//   a fresh cube legitimately has no kit yet, and the card uses that to
+//   pick the "Create Recovery Kit" copy. Surfacing it as the typed
+//   `CoincubeError::NotFound` lets callers match directly instead of
+//   pattern-matching on `Unsuccessful { status_code: 404, .. }`.
+//
+// - 429 carries a `Retry-After` header the UI needs to show a cooldown.
+//   `check_success` consumes the whole response, so the header is parsed
+//   before the body.
+//
+// Every other status follows the established flow (`check_success` →
+// `Unsuccessful` → existing error rendering).
+
+impl CoincubeClient {
+    /// Parses a recovery-kit response into either the expected success
+    /// body or one of the typed error variants (`NotFound`, `RateLimited`,
+    /// auth errors via `Unsuccessful`, etc.). Body is only read on the
+    /// non-NotFound failure paths.
+    async fn parse_recovery_response<T: serde::de::DeserializeOwned>(
+        res: reqwest::Response,
+    ) -> Result<T, CoincubeError> {
+        let status = res.status();
+        if status.is_success() {
+            let resp: ApiResponse<T> = res.json().await?;
+            return Ok(resp.data);
+        }
+        match status.as_u16() {
+            404 => Err(CoincubeError::NotFound),
+            429 => {
+                // Retry-After (seconds form). Falls back to 60s when the
+                // header is missing or malformed — the UI still gets a
+                // usable cooldown value instead of panicking.
+                let retry_after = res
+                    .headers()
+                    .get(reqwest::header::RETRY_AFTER)
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|s| s.trim().parse::<u64>().ok())
+                    .map(Duration::from_secs)
+                    .unwrap_or_else(|| Duration::from_secs(60));
+                Err(CoincubeError::RateLimited { retry_after })
+            }
+            _ => Err(CoincubeError::Unsuccessful(
+                crate::services::http::NotSuccessResponseInfo {
+                    status_code: status.as_u16(),
+                    text: res.text().await.unwrap_or_default(),
+                },
+            )),
+        }
+    }
+
+    /// GET /api/v1/connect/cubes/{cubeId}/recovery-kit/status — lightweight
+    /// existence/presence probe used to drive the Settings card copy. Never
+    /// returns the ciphertext.
+    pub async fn get_recovery_kit_status(
+        &self,
+        cube_id: u64,
+    ) -> Result<RecoveryKitStatus, CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/recovery-kit/status",
+            self.base_url, cube_id
+        );
+        let res = self.client.get(&url).send().await?;
+        Self::parse_recovery_response(res).await
+    }
+
+    /// GET /api/v1/connect/cubes/{cubeId}/recovery-kit — fetch the
+    /// ciphertext envelopes for restore. 404 → `CoincubeError::NotFound`;
+    /// 429 → `CoincubeError::RateLimited` with parsed `Retry-After`.
+    pub async fn get_recovery_kit(&self, cube_id: u64) -> Result<RecoveryKit, CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/recovery-kit",
+            self.base_url, cube_id
+        );
+        let res = self.client.get(&url).send().await?;
+        Self::parse_recovery_response(res).await
+    }
+
+    /// Upsert the kit: creates via POST when no kit exists on the server,
+    /// otherwise updates via PUT. The status-check is a separate cheap
+    /// round-trip; the state machine (§2.4) already has a cached status
+    /// by the time it reaches this call path.
+    ///
+    /// `encrypted_cube_seed` / `encrypted_wallet_descriptor` are opaque
+    /// base64 envelopes from `services::recovery::envelope::encrypt`; pass
+    /// `None` for a half that isn't being touched this call (e.g. a
+    /// passkey cube never uploads a seed envelope).
+    pub async fn put_recovery_kit(
+        &self,
+        cube_id: u64,
+        encrypted_cube_seed: Option<&str>,
+        encrypted_wallet_descriptor: Option<&str>,
+        encryption_scheme: &str,
+    ) -> Result<RecoveryKit, CoincubeError> {
+        let method = match self.get_recovery_kit_status(cube_id).await {
+            Ok(s) if s.has_recovery_kit => Method::PUT,
+            Ok(_) => Method::POST,
+            // Treat a missing status endpoint the same as "no kit" — the
+            // backend PR 1 relaxed-create allows POSTing partial fields.
+            Err(CoincubeError::NotFound) => Method::POST,
+            Err(e) => return Err(e),
+        };
+
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/recovery-kit",
+            self.base_url, cube_id
+        );
+        let body = UpsertRecoveryKitRequest {
+            encrypted_cube_seed,
+            encrypted_wallet_descriptor,
+            encryption_scheme,
+        };
+        let res = self.client.request(method, &url).json(&body).send().await?;
+        Self::parse_recovery_response(res).await
+    }
+
+    /// DELETE /api/v1/connect/cubes/{cubeId}/recovery-kit — tears down the
+    /// server-side kit. The caller is responsible for clearing any local
+    /// drift-fingerprint cache (§2.7) on success.
+    pub async fn delete_recovery_kit(&self, cube_id: u64) -> Result<(), CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/recovery-kit",
+            self.base_url, cube_id
+        );
+        let res = self.client.delete(&url).send().await?;
+        let status = res.status();
+        if status.is_success() {
+            return Ok(());
+        }
+        match status.as_u16() {
+            404 => Err(CoincubeError::NotFound),
+            429 => {
+                let retry_after = res
+                    .headers()
+                    .get(reqwest::header::RETRY_AFTER)
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|s| s.trim().parse::<u64>().ok())
+                    .map(Duration::from_secs)
+                    .unwrap_or_else(|| Duration::from_secs(60));
+                Err(CoincubeError::RateLimited { retry_after })
+            }
+            _ => Err(CoincubeError::Unsuccessful(
+                crate::services::http::NotSuccessResponseInfo {
+                    status_code: status.as_u16(),
+                    text: res.text().await.unwrap_or_default(),
+                },
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod recovery_kit_tests {
+    use super::*;
+    use crate::services::coincube::RECOVERY_KIT_SCHEME_AES_256_GCM;
+    use httpmock::{Method as MockMethod, MockServer};
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn get_recovery_kit_status_200_returns_flags() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/status");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "hasRecoveryKit": true,
+                        "hasEncryptedSeed": true,
+                        "hasEncryptedWalletDescriptor": false,
+                        "encryptionScheme": "aes-256-gcm",
+                        "createdAt": "2026-04-22T00:00:00Z",
+                        "updatedAt": "2026-04-22T00:00:00Z"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let status = client
+            .get_recovery_kit_status(42)
+            .await
+            .expect("status should succeed");
+        mock.assert();
+        assert!(status.has_recovery_kit);
+        assert!(status.has_encrypted_seed);
+        assert!(!status.has_encrypted_wallet_descriptor);
+        assert_eq!(status.encryption_scheme, "aes-256-gcm");
+    }
+
+    #[tokio::test]
+    async fn get_recovery_kit_status_404_maps_to_not_found() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/status");
+            then.status(404)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": false,
+                    "error": { "code": "CUBE_NOT_FOUND", "message": "no such cube" }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .get_recovery_kit_status(42)
+            .await
+            .expect_err("expected NotFound");
+        mock.assert();
+        assert!(err.is_not_found(), "expected is_not_found, got {:?}", err);
+    }
+
+    #[tokio::test]
+    async fn get_recovery_kit_status_403_maps_to_auth_error() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/status");
+            then.status(403)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": false,
+                    "error": { "code": "FORBIDDEN", "message": "not your cube" }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .get_recovery_kit_status(42)
+            .await
+            .expect_err("expected 403");
+        mock.assert();
+        assert!(err.is_auth_error(), "expected auth error, got {:?}", err);
+    }
+
+    #[tokio::test]
+    async fn get_recovery_kit_429_parses_retry_after() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("Retry-After", "90")
+                .json_body(json!({
+                    "success": false,
+                    "error": { "code": "RATE_LIMITED", "message": "slow down" }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client.get_recovery_kit(42).await.expect_err("expected 429");
+        mock.assert();
+
+        let retry = err
+            .rate_limit_retry_after()
+            .expect("expected RateLimited with Retry-After");
+        assert_eq!(retry, Duration::from_secs(90));
+    }
+
+    #[tokio::test]
+    async fn get_recovery_kit_429_without_header_falls_back_to_60s() {
+        // The server may omit `Retry-After` entirely; the client should
+        // still yield a typed RateLimited error rather than propagating
+        // `Unsuccessful`. This keeps the state-machine pattern match
+        // simple.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(429)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": false,
+                    "error": { "code": "RATE_LIMITED", "message": "slow down" }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client.get_recovery_kit(42).await.expect_err("expected 429");
+        mock.assert();
+        assert_eq!(
+            err.rate_limit_retry_after().unwrap(),
+            Duration::from_secs(60)
+        );
+    }
+
+    #[tokio::test]
+    async fn get_recovery_kit_200_returns_ciphertext() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 5,
+                        "cubeId": 42,
+                        "encryptedCubeSeed": "AAECAwQF...",
+                        "encryptedWalletDescriptor": "",
+                        "encryptionScheme": "aes-256-gcm",
+                        "createdAt": "2026-04-22T00:00:00Z",
+                        "updatedAt": "2026-04-22T00:00:00Z"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let kit = client
+            .get_recovery_kit(42)
+            .await
+            .expect("get_recovery_kit should succeed");
+        mock.assert();
+        assert_eq!(kit.id, 5);
+        assert_eq!(kit.cube_id, 42);
+        assert_eq!(kit.encrypted_cube_seed, "AAECAwQF...");
+        assert!(kit.encrypted_wallet_descriptor.is_empty());
+    }
+
+    #[tokio::test]
+    async fn put_recovery_kit_posts_when_no_existing_kit() {
+        // Status says `hasRecoveryKit: false` → upsert must POST, not PUT.
+        let server = MockServer::start();
+        let status_mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/status");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "hasRecoveryKit": false,
+                        "hasEncryptedSeed": false,
+                        "hasEncryptedWalletDescriptor": false,
+                        "encryptionScheme": ""
+                    }
+                }));
+        });
+        let post_mock = server.mock(|when, then| {
+            when.method(MockMethod::POST)
+                .path("/api/v1/connect/cubes/42/recovery-kit")
+                .json_body(json!({
+                    "encryptedCubeSeed": "CIPHER_A",
+                    "encryptionScheme": "aes-256-gcm"
+                }));
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 5,
+                        "cubeId": 42,
+                        "encryptedCubeSeed": "CIPHER_A",
+                        "encryptedWalletDescriptor": "",
+                        "encryptionScheme": "aes-256-gcm",
+                        "createdAt": "2026-04-22T00:00:00Z",
+                        "updatedAt": "2026-04-22T00:00:00Z"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let kit = client
+            .put_recovery_kit(42, Some("CIPHER_A"), None, RECOVERY_KIT_SCHEME_AES_256_GCM)
+            .await
+            .expect("upsert should succeed");
+        status_mock.assert();
+        post_mock.assert();
+        assert_eq!(kit.encrypted_cube_seed, "CIPHER_A");
+    }
+
+    #[tokio::test]
+    async fn put_recovery_kit_puts_when_kit_exists() {
+        let server = MockServer::start();
+        let status_mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/status");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "hasRecoveryKit": true,
+                        "hasEncryptedSeed": true,
+                        "hasEncryptedWalletDescriptor": false,
+                        "encryptionScheme": "aes-256-gcm",
+                        "createdAt": "2026-04-22T00:00:00Z",
+                        "updatedAt": "2026-04-22T00:00:00Z"
+                    }
+                }));
+        });
+        // Adding the wallet descriptor half. Seed field is omitted from
+        // the body (partial-field update, matches backend PR 1 behaviour).
+        let put_mock = server.mock(|when, then| {
+            when.method(MockMethod::PUT)
+                .path("/api/v1/connect/cubes/42/recovery-kit")
+                .json_body(json!({
+                    "encryptedWalletDescriptor": "CIPHER_D",
+                    "encryptionScheme": "aes-256-gcm"
+                }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 5,
+                        "cubeId": 42,
+                        "encryptedCubeSeed": "CIPHER_A",
+                        "encryptedWalletDescriptor": "CIPHER_D",
+                        "encryptionScheme": "aes-256-gcm",
+                        "createdAt": "2026-04-22T00:00:00Z",
+                        "updatedAt": "2026-04-22T00:01:00Z"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let kit = client
+            .put_recovery_kit(42, None, Some("CIPHER_D"), RECOVERY_KIT_SCHEME_AES_256_GCM)
+            .await
+            .expect("upsert should succeed");
+        status_mock.assert();
+        put_mock.assert();
+        assert_eq!(kit.encrypted_wallet_descriptor, "CIPHER_D");
+    }
+
+    #[tokio::test]
+    async fn put_recovery_kit_propagates_status_429() {
+        let server = MockServer::start();
+        let status_mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/status");
+            then.status(429)
+                .header("content-type", "application/json")
+                .header("Retry-After", "15")
+                .json_body(json!({
+                    "success": false,
+                    "error": { "code": "RATE_LIMITED", "message": "" }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .put_recovery_kit(42, Some("X"), None, RECOVERY_KIT_SCHEME_AES_256_GCM)
+            .await
+            .expect_err("expected 429");
+        status_mock.assert();
+        assert_eq!(
+            err.rate_limit_retry_after().unwrap(),
+            Duration::from_secs(15)
+        );
+    }
+
+    #[tokio::test]
+    async fn put_recovery_kit_404_on_status_still_posts() {
+        // If the backend serves 404 on the status endpoint (e.g. the
+        // endpoint isn't deployed yet on this tenant), the client should
+        // optimistically treat it as "no kit" and try POST. That keeps
+        // the backend PR rollout ordering flexible.
+        let server = MockServer::start();
+        let status_mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/status");
+            then.status(404);
+        });
+        let post_mock = server.mock(|when, then| {
+            when.method(MockMethod::POST)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 1,
+                        "cubeId": 42,
+                        "encryptedCubeSeed": "X",
+                        "encryptedWalletDescriptor": "",
+                        "encryptionScheme": "aes-256-gcm",
+                        "createdAt": "2026-04-22T00:00:00Z",
+                        "updatedAt": "2026-04-22T00:00:00Z"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        client
+            .put_recovery_kit(42, Some("X"), None, RECOVERY_KIT_SCHEME_AES_256_GCM)
+            .await
+            .expect("upsert should succeed");
+        status_mock.assert();
+        post_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn delete_recovery_kit_ok_on_200() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "success": true, "data": { "status": "deleted" } }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        client
+            .delete_recovery_kit(42)
+            .await
+            .expect("delete should succeed");
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn delete_recovery_kit_404_maps_to_not_found() {
+        // A second DELETE should be idempotent from the caller's
+        // perspective — but the server is free to 404; we surface
+        // that typed so the UI can treat it as "already gone".
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(404);
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .delete_recovery_kit(42)
+            .await
+            .expect_err("expected NotFound");
+        mock.assert();
+        assert!(err.is_not_found());
     }
 }
 

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -14,6 +14,7 @@ use super::{
 use reqwest::{Client, Method};
 use serde::Deserialize;
 use std::time::Duration;
+use zeroize::Zeroizing;
 
 use crate::services::http::ResponseExt;
 
@@ -28,7 +29,15 @@ const _: () = {
 pub struct CoincubeClient {
     pub client: Client,
     pub base_url: String,
-    token: Option<String>,
+    /// JWT bearer token. Wrapped in `Zeroizing` so the heap
+    /// allocation is wiped when the token field is reassigned,
+    /// when the client is dropped, or when a `Clone`'d copy drops.
+    /// `Option<Zeroizing<String>>` rather than
+    /// `Zeroizing<Option<String>>` because `Zeroize` needs `T` to
+    /// implement `Zeroize` directly, and `Option<T>` doesn't —
+    /// but the outer `Option` is a wrapper we can freely reassign,
+    /// and the inner `Zeroizing<String>` does the zeroing.
+    token: Option<Zeroizing<String>>,
 }
 
 impl Default for CoincubeClient {
@@ -62,7 +71,10 @@ impl CoincubeClient {
 
     /// A JWT is needed for some authenticated endpoints, acquired after a user successfully logs in
     pub fn set_token(&mut self, token: &str) {
-        self.token = Some(token.to_string());
+        // Assigning a new `Some(...)` drops the previous
+        // `Zeroizing<String>` (if any), wiping the old token's heap
+        // allocation before the new value takes its place.
+        self.token = Some(Zeroizing::new(token.to_string()));
 
         let mut headers = reqwest::header::HeaderMap::new();
         headers.append(
@@ -79,8 +91,29 @@ impl CoincubeClient {
             .unwrap();
     }
 
+    /// Explicit logout helper: drops the token (the `Zeroizing`
+    /// wrapper wipes its heap bytes on drop) and rebuilds the
+    /// underlying `reqwest::Client` without the `Authorization`
+    /// default header, so subsequent requests don't leak the old
+    /// token in outbound traffic.
+    ///
+    /// Callers that replace the whole `CoincubeClient` with a
+    /// fresh `CoincubeClient::new()` already get the same
+    /// behaviour via `Drop` on the old client; this helper lets
+    /// call sites that want in-place clearing do it without
+    /// reallocating the whole struct.
+    pub fn clear_token(&mut self) {
+        self.token = None;
+        let https_only = !self.base_url.starts_with("http://");
+        self.client = reqwest::ClientBuilder::new()
+            .timeout(std::time::Duration::from_secs(20))
+            .https_only(https_only)
+            .build()
+            .unwrap();
+    }
+
     pub fn token(&self) -> Option<&str> {
-        self.token.as_deref()
+        self.token.as_ref().map(|t| t.as_str())
     }
 
     /// Save a Mavapay quote to coincube-api
@@ -429,7 +462,12 @@ impl CoincubeClient {
     fn auth_headers(&self) -> reqwest::header::HeaderMap {
         let mut map = reqwest::header::HeaderMap::new();
         if let Some(ref t) = self.token {
-            if let Ok(val) = reqwest::header::HeaderValue::from_str(&format!("Bearer {}", t)) {
+            // Deref through `Zeroizing<String>` to `&str` for the
+            // format — `Zeroizing` doesn't implement Display so a
+            // direct `{}` placeholder wouldn't compile.
+            if let Ok(val) =
+                reqwest::header::HeaderValue::from_str(&format!("Bearer {}", t.as_str()))
+            {
                 map.insert("Authorization", val);
             }
         }
@@ -1028,6 +1066,68 @@ pub(crate) fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Duratio
     // Unparseable — use the default cooldown rather than retrying
     // immediately and slamming the server again.
     Duration::from_secs(60)
+}
+
+#[cfg(test)]
+mod token_zeroization_tests {
+    //! Regression tests for the `Option<Zeroizing<String>>` token
+    //! field. The Zeroizing wrapper wipes the heap allocation on
+    //! drop (including when it's reassigned via `set_token` or
+    //! cleared via `clear_token`), so post-logout memory scans
+    //! can't recover the JWT.
+    use super::CoincubeClient;
+
+    #[test]
+    fn token_accessor_returns_plain_str_slice() {
+        let mut c = CoincubeClient::for_test("http://127.0.0.1:0");
+        assert!(c.token().is_none());
+        c.set_token("abc.def.ghi");
+        // The public `token()` API stays `Option<&str>` — the
+        // Zeroizing wrap is an implementation detail and must not
+        // leak into callers who iterate on `&str`.
+        assert_eq!(c.token(), Some("abc.def.ghi"));
+    }
+
+    #[test]
+    fn set_token_replaces_previous_value() {
+        // Setting a new token drops the old `Zeroizing<String>`,
+        // which wipes the previous heap bytes before the new token
+        // is stored. We can't directly observe memory zeroing in a
+        // unit test, but we can verify the replacement happened
+        // (the previous token is no longer what the accessor returns).
+        let mut c = CoincubeClient::for_test("http://127.0.0.1:0");
+        c.set_token("first-token");
+        c.set_token("second-token");
+        assert_eq!(c.token(), Some("second-token"));
+    }
+
+    #[test]
+    fn clear_token_drops_token_and_rebuilds_client() {
+        let mut c = CoincubeClient::for_test("http://127.0.0.1:0");
+        c.set_token("abc.def.ghi");
+        assert!(c.token().is_some());
+        c.clear_token();
+        assert!(c.token().is_none());
+        // The rebuilt client has no default Authorization header,
+        // so future requests can't leak the old token even if the
+        // caller forgets they cleared it.
+    }
+
+    #[test]
+    fn cloned_client_carries_independent_token_copy() {
+        // Each Clone has its own Zeroizing wrapper → each will
+        // zero its own copy on drop. Confirms Clone is still
+        // viable after the field-type change.
+        let mut c = CoincubeClient::for_test("http://127.0.0.1:0");
+        c.set_token("tok");
+        let c2 = c.clone();
+        assert_eq!(c2.token(), Some("tok"));
+        drop(c);
+        // After original drops, the clone still has its token —
+        // proves the Zeroizing wrapper inside Clone is independent,
+        // not a shared reference.
+        assert_eq!(c2.token(), Some("tok"));
+    }
 }
 
 #[cfg(test)]

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -25,7 +25,18 @@ const _: () = {
     }
 };
 
-#[derive(Debug, Clone)]
+/// HTTP client for the coincube-api backend.
+///
+/// `Debug` is implemented manually below so `{:?}` on a `CoincubeClient`
+/// — or anything that transitively contains one (notably
+/// `Message::Install` in `launcher.rs`, which derives `Debug` and logs
+/// through tracing snapshots) — redacts the JWT. The `Zeroizing` wrapper
+/// only scrubs the heap *on drop*; it does **not** hide the token from
+/// `{:?}` (`Zeroizing<T>` derefs to `T` for Debug), so without this impl
+/// the bearer token leaks into any log line that formats a parent
+/// message. Mirror of the `EsploraConfig` pattern in
+/// `coincubed/src/config.rs`.
+#[derive(Clone)]
 pub struct CoincubeClient {
     pub client: Client,
     pub base_url: String,
@@ -38,6 +49,26 @@ pub struct CoincubeClient {
     /// but the outer `Option` is a wrapper we can freely reassign,
     /// and the inner `Zeroizing<String>` does the zeroing.
     token: Option<Zeroizing<String>>,
+}
+
+impl std::fmt::Debug for CoincubeClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The inner `reqwest::Client` is printed opaquely because
+        // `set_token` bakes the JWT into its `default_headers`
+        // (`Authorization: Bearer ...`); deriving / forwarding to
+        // `reqwest::Client`'s Debug would leak the token through a
+        // second path even though the dedicated `token` field is
+        // redacted. Low diagnostic loss — request-level logs already
+        // carry the useful HTTP details.
+        f.debug_struct("CoincubeClient")
+            .field("client", &"<reqwest::Client>")
+            .field("base_url", &self.base_url)
+            // Preserve Some/None presence for diagnostics (helps
+            // distinguish "unauthenticated" from "token-but-rejected"
+            // states in logs) while hiding the JWT itself.
+            .field("token", &self.token.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
 }
 
 impl Default for CoincubeClient {
@@ -1127,6 +1158,39 @@ mod token_zeroization_tests {
         // proves the Zeroizing wrapper inside Clone is independent,
         // not a shared reference.
         assert_eq!(c2.token(), Some("tok"));
+    }
+
+    /// Canary-string test guarding the manual `Debug` impl. Without
+    /// the redaction, `Zeroizing<String>` derefs to `String` and the
+    /// JWT bytes end up in any `{:?}` render of a parent message
+    /// (e.g. `Message::Install(... Option<CoincubeClient>)`).
+    #[test]
+    fn debug_redacts_jwt_and_preserves_presence() {
+        const CANARY_JWT: &str = "eyCANARY.jwt.XYZZY-do-not-leak";
+        let mut c = CoincubeClient::for_test("http://127.0.0.1:0");
+        c.set_token(CANARY_JWT);
+        let rendered = format!("{:?}", c);
+        assert!(
+            !rendered.contains(CANARY_JWT),
+            "JWT leaked through Debug: {}",
+            rendered
+        );
+        assert!(
+            rendered.contains("<redacted>"),
+            "redaction marker missing: {}",
+            rendered
+        );
+        assert!(
+            rendered.contains("Some"),
+            "Some/None signal lost — harms diagnostics: {}",
+            rendered
+        );
+        // No-token path: still prints None so "unauthenticated" is
+        // visible in logs.
+        c.clear_token();
+        let rendered_empty = format!("{:?}", c);
+        assert!(rendered_empty.contains("None"));
+        assert!(!rendered_empty.contains(CANARY_JWT));
     }
 }
 

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -862,19 +862,9 @@ impl CoincubeClient {
         }
         match status.as_u16() {
             404 => Err(CoincubeError::NotFound),
-            429 => {
-                // Retry-After (seconds form). Falls back to 60s when the
-                // header is missing or malformed — the UI still gets a
-                // usable cooldown value instead of panicking.
-                let retry_after = res
-                    .headers()
-                    .get(reqwest::header::RETRY_AFTER)
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|s| s.trim().parse::<u64>().ok())
-                    .map(Duration::from_secs)
-                    .unwrap_or_else(|| Duration::from_secs(60));
-                Err(CoincubeError::RateLimited { retry_after })
-            }
+            429 => Err(CoincubeError::RateLimited {
+                retry_after: parse_retry_after(res.headers()),
+            }),
             _ => Err(CoincubeError::Unsuccessful(
                 crate::services::http::NotSuccessResponseInfo {
                     status_code: status.as_u16(),
@@ -927,15 +917,12 @@ impl CoincubeClient {
         encrypted_wallet_descriptor: Option<&str>,
         encryption_scheme: &str,
     ) -> Result<RecoveryKit, CoincubeError> {
-        let method = match self.get_recovery_kit_status(cube_id).await {
-            Ok(s) if s.has_recovery_kit => Method::PUT,
-            Ok(_) => Method::POST,
-            // Treat a missing status endpoint the same as "no kit" — the
-            // backend PR 1 relaxed-create allows POSTing partial fields.
-            Err(CoincubeError::NotFound) => Method::POST,
-            Err(e) => return Err(e),
-        };
-
+        // Try PUT first (the common case: users who back up a second
+        // time already have a kit on the server), then fall back to
+        // POST on 404. This skips the pre-upsert `status` probe —
+        // which cost an extra round-trip and opened a race window
+        // (kit could be deleted/created between probe and write) —
+        // without changing the outward-facing method signature.
         let url = format!(
             "{}/api/v1/connect/cubes/{}/recovery-kit",
             self.base_url, cube_id
@@ -945,8 +932,30 @@ impl CoincubeClient {
             encrypted_wallet_descriptor,
             encryption_scheme,
         };
-        let res = self.client.request(method, &url).json(&body).send().await?;
-        Self::parse_recovery_response(res).await
+
+        let put_res = self
+            .client
+            .request(Method::PUT, &url)
+            .json(&body)
+            .send()
+            .await?;
+        match Self::parse_recovery_response::<RecoveryKit>(put_res).await {
+            Ok(kit) => Ok(kit),
+            // 404 on PUT → no kit exists yet. Fall back to POST
+            // once to create it. Any other error (auth, 429, 5xx)
+            // propagates untouched so retries are the caller's
+            // decision.
+            Err(CoincubeError::NotFound) => {
+                let post_res = self
+                    .client
+                    .request(Method::POST, &url)
+                    .json(&body)
+                    .send()
+                    .await?;
+                Self::parse_recovery_response(post_res).await
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// DELETE /api/v1/connect/cubes/{cubeId}/recovery-kit — tears down the
@@ -964,16 +973,9 @@ impl CoincubeClient {
         }
         match status.as_u16() {
             404 => Err(CoincubeError::NotFound),
-            429 => {
-                let retry_after = res
-                    .headers()
-                    .get(reqwest::header::RETRY_AFTER)
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|s| s.trim().parse::<u64>().ok())
-                    .map(Duration::from_secs)
-                    .unwrap_or_else(|| Duration::from_secs(60));
-                Err(CoincubeError::RateLimited { retry_after })
-            }
+            429 => Err(CoincubeError::RateLimited {
+                retry_after: parse_retry_after(res.headers()),
+            }),
             _ => Err(CoincubeError::Unsuccessful(
                 crate::services::http::NotSuccessResponseInfo {
                     status_code: status.as_u16(),
@@ -981,6 +983,110 @@ impl CoincubeClient {
                 },
             )),
         }
+    }
+}
+
+/// Parses a response's `Retry-After` header per RFC 7231 §7.1.3.
+///
+/// Accepts both documented forms:
+///   - *delta-seconds*: e.g. `Retry-After: 60`
+///   - *HTTP-date* (IMF-fixdate): e.g.
+///     `Retry-After: Wed, 21 Oct 2026 07:28:00 GMT`. The returned
+///     `Duration` is `date - now()`, clamped to zero when the date
+///     has already passed (the server is saying "retry whenever").
+///
+/// Falls back to 60 seconds when the header is missing or doesn't
+/// parse either form, so the UI always has a usable cooldown to
+/// render rather than panicking or hanging.
+pub(crate) fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Duration {
+    let raw = match headers
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(s) => s.trim(),
+        None => return Duration::from_secs(60),
+    };
+
+    // Form 1: delta-seconds. The common case — every Cloudflare /
+    // nginx rate limiter emits this shape.
+    if let Ok(secs) = raw.parse::<u64>() {
+        return Duration::from_secs(secs);
+    }
+
+    // Form 2: HTTP-date (IMF-fixdate). `DateTime::parse_from_rfc2822`
+    // accepts the fixed-length IMF subset that RFC 7231 requires.
+    if let Ok(at) = chrono::DateTime::parse_from_rfc2822(raw) {
+        let now = chrono::Utc::now();
+        let delta = at.with_timezone(&chrono::Utc) - now;
+        // Negative or zero → the date is in the past or now.
+        // `std::time::Duration` is unsigned, so `to_std` errors on
+        // a negative `chrono::Duration`; that's the clamp-to-zero
+        // case.
+        return delta.to_std().unwrap_or_else(|_| Duration::from_secs(0));
+    }
+
+    // Unparseable — use the default cooldown rather than retrying
+    // immediately and slamming the server again.
+    Duration::from_secs(60)
+}
+
+#[cfg(test)]
+mod retry_after_tests {
+    use super::parse_retry_after;
+    use reqwest::header::{HeaderMap, HeaderValue, RETRY_AFTER};
+    use std::time::Duration;
+
+    fn hdr(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(RETRY_AFTER, HeaderValue::from_str(value).unwrap());
+        h
+    }
+
+    #[test]
+    fn delta_seconds_form() {
+        assert_eq!(parse_retry_after(&hdr("90")), Duration::from_secs(90));
+        // Whitespace permitted per HTTP header conventions.
+        assert_eq!(parse_retry_after(&hdr("  15  ")), Duration::from_secs(15));
+    }
+
+    #[test]
+    fn http_date_form_parses_future_date() {
+        // Regression test for the RFC 7231 IMF-fixdate branch that
+        // was previously unreachable — the old implementation only
+        // accepted delta-seconds. We build the header from "now + 30s"
+        // so the assertion is deterministic even though wall-clock
+        // time advances during the test.
+        let at = chrono::Utc::now() + chrono::Duration::seconds(30);
+        let hdr_value = at.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
+        let d = parse_retry_after(&hdr(&hdr_value));
+        // Allow a generous lower bound for test-runner scheduling
+        // jitter; the upper bound is our "now + 30s" ceiling.
+        assert!(
+            d >= Duration::from_secs(25) && d <= Duration::from_secs(30),
+            "expected ~30s, got {}s",
+            d.as_secs(),
+        );
+    }
+
+    #[test]
+    fn http_date_in_the_past_clamps_to_zero() {
+        let at = chrono::Utc::now() - chrono::Duration::seconds(60);
+        let hdr_value = at.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
+        assert_eq!(parse_retry_after(&hdr(&hdr_value)), Duration::from_secs(0));
+    }
+
+    #[test]
+    fn missing_header_falls_back_to_60s() {
+        assert_eq!(
+            parse_retry_after(&HeaderMap::new()),
+            Duration::from_secs(60)
+        );
+    }
+
+    #[test]
+    fn malformed_header_falls_back_to_60s() {
+        // Neither a valid delta-seconds nor an IMF-fixdate.
+        assert_eq!(parse_retry_after(&hdr("soon-ish")), Duration::from_secs(60));
     }
 }
 
@@ -1157,23 +1263,61 @@ mod recovery_kit_tests {
     }
 
     #[tokio::test]
-    async fn put_recovery_kit_posts_when_no_existing_kit() {
-        // Status says `hasRecoveryKit: false` → upsert must POST, not PUT.
+    async fn put_recovery_kit_put_returns_kit_without_fallback() {
+        // Common case — kit already exists on the server. A single
+        // PUT succeeds and no POST is issued. Race-free by design:
+        // no pre-upsert status probe.
         let server = MockServer::start();
-        let status_mock = server.mock(|when, then| {
-            when.method(MockMethod::GET)
-                .path("/api/v1/connect/cubes/42/recovery-kit/status");
+        let put_mock = server.mock(|when, then| {
+            when.method(MockMethod::PUT)
+                .path("/api/v1/connect/cubes/42/recovery-kit")
+                .json_body(json!({
+                    "encryptedWalletDescriptor": "CIPHER_D",
+                    "encryptionScheme": "aes-256-gcm"
+                }));
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
                     "success": true,
                     "data": {
-                        "hasRecoveryKit": false,
-                        "hasEncryptedSeed": false,
-                        "hasEncryptedWalletDescriptor": false,
-                        "encryptionScheme": ""
+                        "id": 5,
+                        "cubeId": 42,
+                        "encryptedCubeSeed": "CIPHER_A",
+                        "encryptedWalletDescriptor": "CIPHER_D",
+                        "encryptionScheme": "aes-256-gcm",
+                        "createdAt": "2026-04-22T00:00:00Z",
+                        "updatedAt": "2026-04-22T00:01:00Z"
                     }
                 }));
+        });
+        // POST mock with no matcher beyond path — if the code
+        // incorrectly fires POST, this will record a hit that we
+        // assert below = 0.
+        let post_mock = server.mock(|when, then| {
+            when.method(MockMethod::POST)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(500);
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let kit = client
+            .put_recovery_kit(42, None, Some("CIPHER_D"), RECOVERY_KIT_SCHEME_AES_256_GCM)
+            .await
+            .expect("upsert should succeed");
+        put_mock.assert();
+        assert_eq!(post_mock.hits(), 0, "should not fall back to POST");
+        assert_eq!(kit.encrypted_wallet_descriptor, "CIPHER_D");
+    }
+
+    #[tokio::test]
+    async fn put_recovery_kit_falls_back_to_post_on_put_404() {
+        // First-time backup: no kit on the server yet. PUT 404s;
+        // client falls back to POST to create it.
+        let server = MockServer::start();
+        let put_mock = server.mock(|when, then| {
+            when.method(MockMethod::PUT)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(404);
         });
         let post_mock = server.mock(|when, then| {
             when.method(MockMethod::POST)
@@ -1203,79 +1347,26 @@ mod recovery_kit_tests {
             .put_recovery_kit(42, Some("CIPHER_A"), None, RECOVERY_KIT_SCHEME_AES_256_GCM)
             .await
             .expect("upsert should succeed");
-        status_mock.assert();
+        put_mock.assert();
         post_mock.assert();
         assert_eq!(kit.encrypted_cube_seed, "CIPHER_A");
     }
 
     #[tokio::test]
-    async fn put_recovery_kit_puts_when_kit_exists() {
+    async fn put_recovery_kit_propagates_429_without_fallback() {
+        // A 429 on PUT is NOT a signal to fall back to POST — the
+        // server is asking us to back off, not telling us to change
+        // method. Propagate the typed `RateLimited` error intact.
         let server = MockServer::start();
-        let status_mock = server.mock(|when, then| {
-            when.method(MockMethod::GET)
-                .path("/api/v1/connect/cubes/42/recovery-kit/status");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!({
-                    "success": true,
-                    "data": {
-                        "hasRecoveryKit": true,
-                        "hasEncryptedSeed": true,
-                        "hasEncryptedWalletDescriptor": false,
-                        "encryptionScheme": "aes-256-gcm",
-                        "createdAt": "2026-04-22T00:00:00Z",
-                        "updatedAt": "2026-04-22T00:00:00Z"
-                    }
-                }));
-        });
-        // Adding the wallet descriptor half. Seed field is omitted from
-        // the body (partial-field update, matches backend PR 1 behaviour).
         let put_mock = server.mock(|when, then| {
             when.method(MockMethod::PUT)
-                .path("/api/v1/connect/cubes/42/recovery-kit")
-                .json_body(json!({
-                    "encryptedWalletDescriptor": "CIPHER_D",
-                    "encryptionScheme": "aes-256-gcm"
-                }));
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!({
-                    "success": true,
-                    "data": {
-                        "id": 5,
-                        "cubeId": 42,
-                        "encryptedCubeSeed": "CIPHER_A",
-                        "encryptedWalletDescriptor": "CIPHER_D",
-                        "encryptionScheme": "aes-256-gcm",
-                        "createdAt": "2026-04-22T00:00:00Z",
-                        "updatedAt": "2026-04-22T00:01:00Z"
-                    }
-                }));
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(429).header("Retry-After", "15");
         });
-
-        let client = CoincubeClient::for_test(server.base_url());
-        let kit = client
-            .put_recovery_kit(42, None, Some("CIPHER_D"), RECOVERY_KIT_SCHEME_AES_256_GCM)
-            .await
-            .expect("upsert should succeed");
-        status_mock.assert();
-        put_mock.assert();
-        assert_eq!(kit.encrypted_wallet_descriptor, "CIPHER_D");
-    }
-
-    #[tokio::test]
-    async fn put_recovery_kit_propagates_status_429() {
-        let server = MockServer::start();
-        let status_mock = server.mock(|when, then| {
-            when.method(MockMethod::GET)
-                .path("/api/v1/connect/cubes/42/recovery-kit/status");
-            then.status(429)
-                .header("content-type", "application/json")
-                .header("Retry-After", "15")
-                .json_body(json!({
-                    "success": false,
-                    "error": { "code": "RATE_LIMITED", "message": "" }
-                }));
+        let post_mock = server.mock(|when, then| {
+            when.method(MockMethod::POST)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(500);
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -1283,7 +1374,8 @@ mod recovery_kit_tests {
             .put_recovery_kit(42, Some("X"), None, RECOVERY_KIT_SCHEME_AES_256_GCM)
             .await
             .expect_err("expected 429");
-        status_mock.assert();
+        put_mock.assert();
+        assert_eq!(post_mock.hits(), 0, "429 must not trigger a POST fallback");
         assert_eq!(
             err.rate_limit_retry_after().unwrap(),
             Duration::from_secs(15)
@@ -1291,43 +1383,35 @@ mod recovery_kit_tests {
     }
 
     #[tokio::test]
-    async fn put_recovery_kit_404_on_status_still_posts() {
-        // If the backend serves 404 on the status endpoint (e.g. the
-        // endpoint isn't deployed yet on this tenant), the client should
-        // optimistically treat it as "no kit" and try POST. That keeps
-        // the backend PR rollout ordering flexible.
+    async fn put_recovery_kit_propagates_post_errors_after_put_404() {
+        // If the fallback POST fails, surface *that* error — not the
+        // PUT 404. Simulates a bad-request from the backend's
+        // partial-field validator.
         let server = MockServer::start();
-        let status_mock = server.mock(|when, then| {
-            when.method(MockMethod::GET)
-                .path("/api/v1/connect/cubes/42/recovery-kit/status");
+        let put_mock = server.mock(|when, then| {
+            when.method(MockMethod::PUT)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
             then.status(404);
         });
         let post_mock = server.mock(|when, then| {
             when.method(MockMethod::POST)
                 .path("/api/v1/connect/cubes/42/recovery-kit");
-            then.status(201)
+            then.status(403)
                 .header("content-type", "application/json")
                 .json_body(json!({
-                    "success": true,
-                    "data": {
-                        "id": 1,
-                        "cubeId": 42,
-                        "encryptedCubeSeed": "X",
-                        "encryptedWalletDescriptor": "",
-                        "encryptionScheme": "aes-256-gcm",
-                        "createdAt": "2026-04-22T00:00:00Z",
-                        "updatedAt": "2026-04-22T00:00:00Z"
-                    }
+                    "success": false,
+                    "error": { "code": "FORBIDDEN", "message": "not your cube" }
                 }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
-        client
+        let err = client
             .put_recovery_kit(42, Some("X"), None, RECOVERY_KIT_SCHEME_AES_256_GCM)
             .await
-            .expect("upsert should succeed");
-        status_mock.assert();
+            .expect_err("expected 403");
+        put_mock.assert();
         post_mock.assert();
+        assert!(err.is_auth_error(), "expected auth error, got {:?}", err);
     }
 
     #[tokio::test]

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -36,9 +36,13 @@ pub enum CoincubeError {
     /// yet). Only the recovery-kit methods emit this variant today; other
     /// callers continue to route 404 through `Unsuccessful` as before.
     NotFound,
-    /// 429 from a rate-limited endpoint. `retry_after` is parsed from the
-    /// `Retry-After` response header (seconds form); falls back to 60s
-    /// when the header is missing or unparsable.
+    /// 429 from a rate-limited endpoint. `retry_after` is parsed from
+    /// the `Retry-After` response header per RFC 7231 §7.1.3 —
+    /// both *delta-seconds* (e.g. `60`) and *HTTP-date* (IMF-fixdate,
+    /// e.g. `Wed, 21 Oct 2026 07:28:00 GMT`) forms are accepted. An
+    /// HTTP-date that's already in the past is clamped to zero; a
+    /// missing or unparseable header falls back to 60s so the UI
+    /// always has a usable cooldown.
     RateLimited {
         retry_after: std::time::Duration,
     },
@@ -117,10 +121,12 @@ impl CoincubeError {
         matches!(self, CoincubeError::NotFound)
     }
 
-    /// When the error is a typed 429 rate-limit, returns the server's
-    /// `Retry-After` duration (falling back to 60s when the header was
-    /// missing). Callers can use this to delay a retry or to display a
-    /// cooldown counter to the user.
+    /// When the error is a typed 429 rate-limit, returns the cooldown
+    /// `Duration` computed from the server's `Retry-After` header.
+    /// Accepts both RFC 7231 forms (delta-seconds and HTTP-date);
+    /// past dates and missing/malformed headers are normalised to
+    /// safe defaults. Callers can use this to delay a retry or
+    /// display a countdown to the user.
     pub fn rate_limit_retry_after(&self) -> Option<std::time::Duration> {
         match self {
             CoincubeError::RateLimited { retry_after } => Some(*retry_after),
@@ -1267,17 +1273,42 @@ pub struct RecoveryKitStatus {
     pub updated_at: Option<String>,
 }
 
+/// Deserialize a field that may arrive as:
+///   - missing entirely (paired with `#[serde(default)]`),
+///   - explicit JSON `null`, or
+///   - a normal string.
+///
+/// All three reduce to the empty `String`, preserving the
+/// `.is_empty()` convention the rest of the codebase uses to
+/// detect "no half backed up". The current backend serialises
+/// absent halves as `""` and never emits null or omits the field,
+/// but `UpdateRecoveryKitRequest` already uses `*string` with
+/// `omitempty` on the request side — the response side may trend
+/// the same way, and this deserializer keeps the client robust
+/// across that evolution without an API break.
+fn null_as_empty_string<'de, D>(d: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<String>::deserialize(d)?.unwrap_or_default())
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RecoveryKit {
     pub id: u64,
     pub cube_id: u64,
-    /// May be the empty string when the kit is descriptor-only (e.g. a
-    /// passkey-seed cube backs up its wallet descriptor without the
-    /// seed, which it cannot extract).
+    /// Opaque base64 envelope for the seed half; the empty string
+    /// means "this half isn't backed up" (e.g. a passkey cube that
+    /// can't extract its seed). Tolerates `null` / missing on the
+    /// wire via `null_as_empty_string`; callers should continue to
+    /// check `.is_empty()` rather than `.is_some()`.
+    #[serde(default, deserialize_with = "null_as_empty_string")]
     pub encrypted_cube_seed: String,
-    /// May be the empty string when the kit is seed-only (no Vault
-    /// created yet, or the Vault wizard "skip" path).
+    /// Opaque base64 envelope for the descriptor half; empty when
+    /// the kit is seed-only (no Vault created yet, or the Vault
+    /// wizard "skip" path). Same wire-tolerance as `encrypted_cube_seed`.
+    #[serde(default, deserialize_with = "null_as_empty_string")]
     pub encrypted_wallet_descriptor: String,
     pub encryption_scheme: String,
     pub created_at: String,
@@ -1296,4 +1327,77 @@ pub struct UpsertRecoveryKitRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encrypted_wallet_descriptor: Option<&'a str>,
     pub encryption_scheme: &'a str,
+}
+
+#[cfg(test)]
+mod recovery_kit_response_tests {
+    //! Regression tests for `RecoveryKit` deserialisation tolerance.
+    //! The current backend always sends both ciphertext fields as
+    //! (possibly empty) strings, but the wire shape could evolve
+    //! toward nullable/omitted halves (request side already uses
+    //! `*string` with `omitempty`). Any of the four shapes below
+    //! must deserialise; `.is_empty()` is the caller's existing
+    //! "no half backed up" check.
+    use super::RecoveryKit;
+    use serde_json::json;
+
+    fn kit_with_halves(
+        seed: serde_json::Value,
+        descriptor: serde_json::Value,
+    ) -> serde_json::Value {
+        json!({
+            "id": 1,
+            "cubeId": 42,
+            "encryptedCubeSeed": seed,
+            "encryptedWalletDescriptor": descriptor,
+            "encryptionScheme": "aes-256-gcm",
+            "createdAt": "2026-04-23T00:00:00Z",
+            "updatedAt": "2026-04-23T00:00:00Z"
+        })
+    }
+
+    #[test]
+    fn deserialises_string_halves() {
+        let v = kit_with_halves(json!("CIPHER_A"), json!("CIPHER_D"));
+        let kit: RecoveryKit = serde_json::from_value(v).unwrap();
+        assert_eq!(kit.encrypted_cube_seed, "CIPHER_A");
+        assert_eq!(kit.encrypted_wallet_descriptor, "CIPHER_D");
+    }
+
+    #[test]
+    fn deserialises_empty_halves() {
+        // Current backend wire shape when one half isn't backed up.
+        let v = kit_with_halves(json!("CIPHER_A"), json!(""));
+        let kit: RecoveryKit = serde_json::from_value(v).unwrap();
+        assert_eq!(kit.encrypted_cube_seed, "CIPHER_A");
+        assert!(kit.encrypted_wallet_descriptor.is_empty());
+    }
+
+    #[test]
+    fn deserialises_null_halves() {
+        // Future-proofing: a server that serialises absent halves as
+        // JSON null instead of "" must not break the client.
+        let v = kit_with_halves(json!(null), json!(null));
+        let kit: RecoveryKit = serde_json::from_value(v).unwrap();
+        assert!(kit.encrypted_cube_seed.is_empty());
+        assert!(kit.encrypted_wallet_descriptor.is_empty());
+    }
+
+    #[test]
+    fn deserialises_missing_halves() {
+        // Future-proofing: a server with `omitempty` on the response
+        // (like `UpdateRecoveryKitRequest` already has on the request
+        // side) would omit the field entirely. `#[serde(default)]`
+        // handles that.
+        let v = json!({
+            "id": 1,
+            "cubeId": 42,
+            "encryptionScheme": "aes-256-gcm",
+            "createdAt": "2026-04-23T00:00:00Z",
+            "updatedAt": "2026-04-23T00:00:00Z"
+        });
+        let kit: RecoveryKit = serde_json::from_value(v).unwrap();
+        assert!(kit.encrypted_cube_seed.is_empty());
+        assert!(kit.encrypted_wallet_descriptor.is_empty());
+    }
 }

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -88,11 +88,9 @@ impl std::fmt::Display for CoincubeError {
                 vault_id
             ),
             CoincubeError::NotFound => write!(f, "Not found"),
-            CoincubeError::RateLimited { retry_after } => write!(
-                f,
-                "Rate limited — retry after {}s",
-                retry_after.as_secs()
-            ),
+            CoincubeError::RateLimited { retry_after } => {
+                write!(f, "Rate limited — retry after {}s", retry_after.as_secs())
+            }
         }
     }
 }

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -31,6 +31,17 @@ pub enum CoincubeError {
     VaultKeyholderLocked {
         vault_id: u64,
     },
+    /// 404 from an endpoint where the caller expects the resource may
+    /// legitimately be absent (e.g. `get_recovery_kit` when no kit exists
+    /// yet). Only the recovery-kit methods emit this variant today; other
+    /// callers continue to route 404 through `Unsuccessful` as before.
+    NotFound,
+    /// 429 from a rate-limited endpoint. `retry_after` is parsed from the
+    /// `Retry-After` response header (seconds form); falls back to 60s
+    /// when the header is missing or unparsable.
+    RateLimited {
+        retry_after: std::time::Duration,
+    },
 }
 
 impl From<serde_json::Error> for CoincubeError {
@@ -76,6 +87,12 @@ impl std::fmt::Display for CoincubeError {
                 "Can't add a keyholder to Vault #{} — the signing quorum is fixed at build time.",
                 vault_id
             ),
+            CoincubeError::NotFound => write!(f, "Not found"),
+            CoincubeError::RateLimited { retry_after } => write!(
+                f,
+                "Rate limited — retry after {}s",
+                retry_after.as_secs()
+            ),
         }
     }
 }
@@ -93,6 +110,24 @@ impl CoincubeError {
                 ..
             })
         )
+    }
+
+    /// True when the error is the typed 404 variant. Today only the
+    /// recovery-kit endpoints produce this; generic 404s still surface
+    /// as `Unsuccessful`.
+    pub fn is_not_found(&self) -> bool {
+        matches!(self, CoincubeError::NotFound)
+    }
+
+    /// When the error is a typed 429 rate-limit, returns the server's
+    /// `Retry-After` duration (falling back to 60s when the header was
+    /// missing). Callers can use this to delay a retry or to display a
+    /// cooldown counter to the user.
+    pub fn rate_limit_retry_after(&self) -> Option<std::time::Duration> {
+        match self {
+            CoincubeError::RateLimited { retry_after } => Some(*retry_after),
+            _ => None,
+        }
     }
 }
 
@@ -1203,4 +1238,64 @@ impl CoincubeError {
         }
         false
     }
+}
+
+// =============================================================================
+// Cube Recovery Kit (W7)
+// =============================================================================
+//
+// Backs the Settings → "Cube Recovery Kit" card and the installer restore
+// flow. See `plans/PLAN-cube-recovery-kit-desktop.md` §2.2.
+//
+// The `encrypted_*` fields are opaque base64 envelopes produced by
+// `services::recovery::envelope::encrypt`; the server stores and
+// returns them verbatim.
+
+/// Identifier for the only envelope scheme this client speaks today.
+/// Sent to the backend on upsert so the server can refuse kits it can't
+/// later hand back to older clients if the scheme ever changes.
+pub const RECOVERY_KIT_SCHEME_AES_256_GCM: &str = "aes-256-gcm";
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecoveryKitStatus {
+    pub has_recovery_kit: bool,
+    pub has_encrypted_seed: bool,
+    pub has_encrypted_wallet_descriptor: bool,
+    pub encryption_scheme: String,
+    #[serde(default)]
+    pub created_at: Option<String>,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecoveryKit {
+    pub id: u64,
+    pub cube_id: u64,
+    /// May be the empty string when the kit is descriptor-only (e.g. a
+    /// passkey-seed cube backs up its wallet descriptor without the
+    /// seed, which it cannot extract).
+    pub encrypted_cube_seed: String,
+    /// May be the empty string when the kit is seed-only (no Vault
+    /// created yet, or the Vault wizard "skip" path).
+    pub encrypted_wallet_descriptor: String,
+    pub encryption_scheme: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Body for POST / PUT `/api/v1/connect/cubes/{cubeId}/recovery-kit`. Omits
+/// `encryptedCubeSeed` / `encryptedWalletDescriptor` when `None`, which
+/// the backend's partial-field create path (backend PR 1) uses to decide
+/// which half of the kit the caller is touching.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpsertRecoveryKitRequest<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encrypted_cube_seed: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encrypted_wallet_descriptor: Option<&'a str>,
+    pub encryption_scheme: &'a str,
 }

--- a/coincube-gui/src/services/mavapay/api.rs
+++ b/coincube-gui/src/services/mavapay/api.rs
@@ -27,7 +27,9 @@ impl<T> From<coincube::CoincubeError> for MavapayApiResult<T> {
             coincube::CoincubeError::Api(msg) => msg.clone(),
             coincube::CoincubeError::Parse(e) => format!("Parse error: {e:?}"),
             coincube::CoincubeError::SseError(e) => format!("EventSource error: {:?}", e),
-            coincube::CoincubeError::VaultKeyholderLocked { .. } => e.to_string(),
+            coincube::CoincubeError::VaultKeyholderLocked { .. }
+            | coincube::CoincubeError::NotFound
+            | coincube::CoincubeError::RateLimited { .. } => e.to_string(),
         };
 
         MavapayApiResult::Error { message }

--- a/coincube-gui/src/services/mod.rs
+++ b/coincube-gui/src/services/mod.rs
@@ -10,6 +10,7 @@ pub mod lnurl;
 pub mod mavapay;
 pub mod meld;
 pub mod passkey;
+pub mod recovery;
 pub mod sideshift;
 
 /// Resolves the Coincube API base URL with this precedence:

--- a/coincube-gui/src/services/recovery/envelope.rs
+++ b/coincube-gui/src/services/recovery/envelope.rs
@@ -1,0 +1,376 @@
+//! AES-256-GCM + Argon2id envelope for the Cube Recovery Kit.
+//!
+//! Wire format (binary, then base64-encoded for transport):
+//!
+//! ```text
+//! version (1B=0x01) || kdf_id (1B=0x01) ||
+//! kdf_params (4B: memory_kib u16 BE || t_cost u8 || p_cost u8) ||
+//! salt (16B) || nonce (12B) || ciphertext || tag (16B)
+//! ```
+//!
+//! AAD bound into the GCM auth tag = `version || kdf_id || kdf_params`
+//! (the first 6 bytes). Salt and nonce are already GCM inputs and don't
+//! need separate integrity, but downgrading the version/kdf bytes must
+//! be rejected on decrypt.
+//!
+//! Aligned with `PLAN-cube-recovery-kit-desktop.md` §2.1.
+
+use aes_gcm::aead::{Aead, Payload};
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use argon2::{Algorithm, Argon2, Params, Version};
+use base64::Engine;
+use rand::RngCore;
+use zeroize::Zeroizing;
+
+use super::error::RecoveryError;
+
+/// Envelope version this client writes and is the only version it accepts.
+pub const ENVELOPE_VERSION: u8 = 0x01;
+
+/// KDF identifier for Argon2id-with-per-envelope-params. Adding a new KDF
+/// is a wire-format break and needs a new value here (and matching decrypt
+/// dispatch).
+pub const KDF_ID_ARGON2ID_V1: u8 = 0x01;
+
+const HEADER_LEN: usize = 6; // version + kdf_id + 4B params
+const SALT_LEN: usize = 16;
+const NONCE_LEN: usize = 12;
+const TAG_LEN: usize = 16;
+const KEY_LEN: usize = 32;
+const MIN_ENVELOPE_LEN: usize = HEADER_LEN + SALT_LEN + NONCE_LEN + TAG_LEN;
+
+/// Argon2id KDF cost parameters carried inside every envelope so that
+/// decrypt uses the exact same parameters that encrypt used — the caller
+/// never re-derives the wire params on decrypt.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct KdfParams {
+    pub memory_kib: u16,
+    pub t_cost: u8,
+    pub p_cost: u8,
+}
+
+impl KdfParams {
+    /// v1 defaults: matches the Argon2id params used for PIN hashing
+    /// (`coincube-gui/src/app/settings/mod.rs` — m=19456 KiB, t=2, p=1).
+    /// Carrying the params in the envelope means we can bump these later
+    /// without breaking existing backups.
+    pub const DEFAULT_V1: Self = Self {
+        memory_kib: 19456,
+        t_cost: 2,
+        p_cost: 1,
+    };
+}
+
+fn header_bytes(version: u8, kdf_id: u8, params: KdfParams) -> [u8; HEADER_LEN] {
+    let m = params.memory_kib.to_be_bytes();
+    [version, kdf_id, m[0], m[1], params.t_cost, params.p_cost]
+}
+
+fn parse_header(buf: &[u8]) -> Result<(u8, u8, KdfParams), RecoveryError> {
+    if buf.len() < HEADER_LEN {
+        return Err(RecoveryError::Truncated);
+    }
+    let version = buf[0];
+    let kdf_id = buf[1];
+    let memory_kib = u16::from_be_bytes([buf[2], buf[3]]);
+    let t_cost = buf[4];
+    let p_cost = buf[5];
+    Ok((
+        version,
+        kdf_id,
+        KdfParams {
+            memory_kib,
+            t_cost,
+            p_cost,
+        },
+    ))
+}
+
+fn derive_key(
+    password: &[u8],
+    salt: &[u8],
+    params: KdfParams,
+) -> Result<Zeroizing<[u8; KEY_LEN]>, RecoveryError> {
+    let argon_params = Params::new(
+        u32::from(params.memory_kib),
+        u32::from(params.t_cost),
+        u32::from(params.p_cost),
+        Some(KEY_LEN),
+    )
+    .map_err(RecoveryError::InvalidParams)?;
+    let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, argon_params);
+    let mut key = Zeroizing::new([0u8; KEY_LEN]);
+    argon2
+        .hash_password_into(password, salt, key.as_mut())
+        .map_err(RecoveryError::Kdf)?;
+    Ok(key)
+}
+
+/// Encrypts `plaintext` under `password` and returns a base64-encoded
+/// envelope. Generates a fresh 16-byte salt and 12-byte nonce per call.
+pub fn encrypt(
+    plaintext: &[u8],
+    password: &Zeroizing<String>,
+    params: KdfParams,
+) -> Result<String, RecoveryError> {
+    let mut salt = [0u8; SALT_LEN];
+    let mut nonce = [0u8; NONCE_LEN];
+    let mut rng = rand::thread_rng();
+    rng.fill_bytes(&mut salt);
+    rng.fill_bytes(&mut nonce);
+
+    encrypt_with(
+        plaintext,
+        password.as_bytes(),
+        &salt,
+        &nonce,
+        params,
+        ENVELOPE_VERSION,
+        KDF_ID_ARGON2ID_V1,
+    )
+}
+
+/// Internal encrypt that takes explicit salt/nonce/version/kdf_id so tests
+/// can pin known-answer vectors. Callers outside the crate should use
+/// `encrypt`.
+fn encrypt_with(
+    plaintext: &[u8],
+    password: &[u8],
+    salt: &[u8; SALT_LEN],
+    nonce: &[u8; NONCE_LEN],
+    params: KdfParams,
+    version: u8,
+    kdf_id: u8,
+) -> Result<String, RecoveryError> {
+    let key = derive_key(password, salt, params)?;
+    let cipher = Aes256Gcm::new_from_slice(key.as_ref()).map_err(RecoveryError::Cipher)?;
+    let header = header_bytes(version, kdf_id, params);
+
+    let ct = cipher
+        .encrypt(
+            Nonce::from_slice(nonce),
+            Payload {
+                msg: plaintext,
+                aad: &header,
+            },
+        )
+        .map_err(|_| RecoveryError::Seal)?;
+
+    let mut out = Vec::with_capacity(HEADER_LEN + SALT_LEN + NONCE_LEN + ct.len());
+    out.extend_from_slice(&header);
+    out.extend_from_slice(salt);
+    out.extend_from_slice(nonce);
+    out.extend_from_slice(&ct);
+    Ok(base64::engine::general_purpose::STANDARD.encode(out))
+}
+
+/// Decrypts a base64-encoded envelope. Returns the plaintext in a
+/// `Zeroizing<Vec<u8>>` so it's wiped on drop. A tag mismatch is reported
+/// as `BadPasswordOrCorrupt` — the caller cannot distinguish a wrong
+/// password from a tampered envelope, by design.
+pub fn decrypt(
+    envelope_b64: &str,
+    password: &Zeroizing<String>,
+) -> Result<Zeroizing<Vec<u8>>, RecoveryError> {
+    let raw = base64::engine::general_purpose::STANDARD.decode(envelope_b64)?;
+    if raw.len() < MIN_ENVELOPE_LEN {
+        return Err(RecoveryError::Truncated);
+    }
+
+    let (version, kdf_id, params) = parse_header(&raw)?;
+    if version != ENVELOPE_VERSION || kdf_id != KDF_ID_ARGON2ID_V1 {
+        return Err(RecoveryError::Unsupported { version, kdf_id });
+    }
+
+    let salt = &raw[HEADER_LEN..HEADER_LEN + SALT_LEN];
+    let nonce = &raw[HEADER_LEN + SALT_LEN..HEADER_LEN + SALT_LEN + NONCE_LEN];
+    let ct_and_tag = &raw[HEADER_LEN + SALT_LEN + NONCE_LEN..];
+
+    let key = derive_key(password.as_bytes(), salt, params)?;
+    let cipher = Aes256Gcm::new_from_slice(key.as_ref()).map_err(RecoveryError::Cipher)?;
+
+    let header = header_bytes(version, kdf_id, params);
+    let pt = cipher
+        .decrypt(
+            Nonce::from_slice(nonce),
+            Payload {
+                msg: ct_and_tag,
+                aad: &header,
+            },
+        )
+        .map_err(|_| RecoveryError::BadPasswordOrCorrupt)?;
+
+    Ok(Zeroizing::new(pt))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pw(s: &str) -> Zeroizing<String> {
+        Zeroizing::new(s.to_string())
+    }
+
+    // Deliberately reduced cost for fast tests. Production uses DEFAULT_V1.
+    const TEST_PARAMS: KdfParams = KdfParams {
+        memory_kib: 512,
+        t_cost: 1,
+        p_cost: 1,
+    };
+
+    #[test]
+    fn roundtrip_basic() {
+        let password = pw("correct horse battery staple");
+        let plaintext = b"hello cube recovery";
+        let env = encrypt(plaintext, &password, TEST_PARAMS).unwrap();
+        let got = decrypt(&env, &password).unwrap();
+        assert_eq!(got.as_slice(), plaintext);
+    }
+
+    #[test]
+    fn wrong_password_maps_to_bad_or_corrupt() {
+        let env = encrypt(b"secret", &pw("right password"), TEST_PARAMS).unwrap();
+        let err = decrypt(&env, &pw("wrong password")).unwrap_err();
+        assert!(matches!(err, RecoveryError::BadPasswordOrCorrupt));
+    }
+
+    #[test]
+    fn flipped_header_byte_rejected_by_aad() {
+        // Flip the kdf_params memory_kib bytes. The KDF-id check won't
+        // fire (we kept version=1, kdf=1); the AAD bind will.
+        let env = encrypt(b"hello", &pw("pw"), TEST_PARAMS).unwrap();
+        let mut raw = base64::engine::general_purpose::STANDARD
+            .decode(&env)
+            .unwrap();
+        raw[2] ^= 0x01; // mutate memory_kib MSB
+        let mutated = base64::engine::general_purpose::STANDARD.encode(raw);
+
+        // Tampered header either (a) changes the derived key via the
+        // params, or (b) breaks the AAD binding — either way, decrypt
+        // must fail. Both paths surface as `BadPasswordOrCorrupt`.
+        let err = decrypt(&mutated, &pw("pw")).unwrap_err();
+        assert!(
+            matches!(err, RecoveryError::BadPasswordOrCorrupt),
+            "expected BadPasswordOrCorrupt, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn flipped_ciphertext_byte_rejected_by_tag() {
+        let env = encrypt(b"hello", &pw("pw"), TEST_PARAMS).unwrap();
+        let mut raw = base64::engine::general_purpose::STANDARD
+            .decode(&env)
+            .unwrap();
+        // Flip a byte in the ciphertext region (past header + salt + nonce).
+        let ct_start = HEADER_LEN + SALT_LEN + NONCE_LEN;
+        raw[ct_start] ^= 0x01;
+        let mutated = base64::engine::general_purpose::STANDARD.encode(raw);
+
+        let err = decrypt(&mutated, &pw("pw")).unwrap_err();
+        assert!(matches!(err, RecoveryError::BadPasswordOrCorrupt));
+    }
+
+    #[test]
+    fn truncated_envelope_rejected() {
+        let env = encrypt(b"hello", &pw("pw"), TEST_PARAMS).unwrap();
+        let mut raw = base64::engine::general_purpose::STANDARD
+            .decode(&env)
+            .unwrap();
+        raw.truncate(MIN_ENVELOPE_LEN - 1);
+        let truncated = base64::engine::general_purpose::STANDARD.encode(raw);
+        let err = decrypt(&truncated, &pw("pw")).unwrap_err();
+        assert!(matches!(err, RecoveryError::Truncated));
+    }
+
+    #[test]
+    fn unsupported_version_rejected() {
+        let env = encrypt(b"hello", &pw("pw"), TEST_PARAMS).unwrap();
+        let mut raw = base64::engine::general_purpose::STANDARD
+            .decode(&env)
+            .unwrap();
+        raw[0] = 0x99;
+        let mutated = base64::engine::general_purpose::STANDARD.encode(raw);
+        let err = decrypt(&mutated, &pw("pw")).unwrap_err();
+        assert!(matches!(err, RecoveryError::Unsupported { version: 0x99, .. }));
+    }
+
+    #[test]
+    fn unsupported_kdf_id_rejected() {
+        let env = encrypt(b"hello", &pw("pw"), TEST_PARAMS).unwrap();
+        let mut raw = base64::engine::general_purpose::STANDARD
+            .decode(&env)
+            .unwrap();
+        raw[1] = 0xFE;
+        let mutated = base64::engine::general_purpose::STANDARD.encode(raw);
+        let err = decrypt(&mutated, &pw("pw")).unwrap_err();
+        assert!(matches!(err, RecoveryError::Unsupported { kdf_id: 0xFE, .. }));
+    }
+
+    #[test]
+    fn large_plaintext_roundtrips() {
+        // 1.5 MiB — exercises the Vec growth path and any AEAD buffer
+        // boundaries that would only show up at scale.
+        let password = pw("pw");
+        let plaintext = vec![0xA5u8; 1_500_000];
+        let env = encrypt(&plaintext, &password, TEST_PARAMS).unwrap();
+        let got = decrypt(&env, &password).unwrap();
+        assert_eq!(got.as_slice(), plaintext.as_slice());
+    }
+
+    #[test]
+    fn known_answer_pins_wire_format() {
+        // Fixed inputs → stable envelope. Guards against accidental wire
+        // format drift (field order, endianness, AAD contents). If this
+        // test changes, the wire format has changed and every backed-up
+        // kit in the wild would need re-encryption.
+        let password = b"known-answer-password";
+        let salt = [0x11u8; SALT_LEN];
+        let nonce = [0x22u8; NONCE_LEN];
+        let plaintext = b"KAT";
+        let env = encrypt_with(
+            plaintext,
+            password,
+            &salt,
+            &nonce,
+            TEST_PARAMS,
+            ENVELOPE_VERSION,
+            KDF_ID_ARGON2ID_V1,
+        )
+        .unwrap();
+
+        // Decode and assert the prefix bytes explicitly — byte-comparing
+        // the whole envelope as base64 would be fragile against any
+        // future implementation detail in aes-gcm / argon2. The ciphertext
+        // portion is covered by the roundtrip test.
+        let raw = base64::engine::general_purpose::STANDARD
+            .decode(&env)
+            .unwrap();
+        assert_eq!(raw[0], ENVELOPE_VERSION, "version byte");
+        assert_eq!(raw[1], KDF_ID_ARGON2ID_V1, "kdf_id byte");
+        let m = u16::from_be_bytes([raw[2], raw[3]]);
+        assert_eq!(m, TEST_PARAMS.memory_kib);
+        assert_eq!(raw[4], TEST_PARAMS.t_cost);
+        assert_eq!(raw[5], TEST_PARAMS.p_cost);
+        assert_eq!(&raw[HEADER_LEN..HEADER_LEN + SALT_LEN], &salt);
+        assert_eq!(
+            &raw[HEADER_LEN + SALT_LEN..HEADER_LEN + SALT_LEN + NONCE_LEN],
+            &nonce
+        );
+        assert_eq!(
+            raw.len(),
+            HEADER_LEN + SALT_LEN + NONCE_LEN + plaintext.len() + TAG_LEN
+        );
+    }
+
+    #[test]
+    fn distinct_salts_and_nonces_across_calls() {
+        // Two encrypts of the same plaintext under the same password must
+        // produce different envelopes — otherwise the PRNG wiring is
+        // broken or cached.
+        let password = pw("pw");
+        let a = encrypt(b"same", &password, TEST_PARAMS).unwrap();
+        let b = encrypt(b"same", &password, TEST_PARAMS).unwrap();
+        assert_ne!(a, b, "two sealings collided — RNG not feeding salt/nonce");
+    }
+}

--- a/coincube-gui/src/services/recovery/envelope.rs
+++ b/coincube-gui/src/services/recovery/envelope.rs
@@ -292,7 +292,10 @@ mod tests {
         raw[0] = 0x99;
         let mutated = base64::engine::general_purpose::STANDARD.encode(raw);
         let err = decrypt(&mutated, &pw("pw")).unwrap_err();
-        assert!(matches!(err, RecoveryError::Unsupported { version: 0x99, .. }));
+        assert!(matches!(
+            err,
+            RecoveryError::Unsupported { version: 0x99, .. }
+        ));
     }
 
     #[test]
@@ -304,7 +307,10 @@ mod tests {
         raw[1] = 0xFE;
         let mutated = base64::engine::general_purpose::STANDARD.encode(raw);
         let err = decrypt(&mutated, &pw("pw")).unwrap_err();
-        assert!(matches!(err, RecoveryError::Unsupported { kdf_id: 0xFE, .. }));
+        assert!(matches!(
+            err,
+            RecoveryError::Unsupported { kdf_id: 0xFE, .. }
+        ));
     }
 
     #[test]

--- a/coincube-gui/src/services/recovery/error.rs
+++ b/coincube-gui/src/services/recovery/error.rs
@@ -1,0 +1,73 @@
+use std::fmt;
+
+/// Errors produced by the Cube Recovery Kit envelope codec.
+///
+/// `BadPasswordOrCorrupt` intentionally collapses "wrong password" and
+/// "ciphertext mutated" into a single case — distinguishing them would
+/// leak a timing/oracle signal to an offline bruteforcer of the recovery
+/// password. See `PLAN-cube-recovery-kit-desktop.md` §2.1.
+#[derive(Debug)]
+pub enum RecoveryError {
+    /// Argon2id KDF failed to produce a key (bad params, OOM, etc).
+    Kdf(argon2::Error),
+    /// AES-GCM key init refused the key slice (should never happen at 32 bytes).
+    Cipher(aes_gcm::aes::cipher::InvalidLength),
+    /// AES-GCM seal/unseal returned an opaque error. For unseal this is
+    /// reported as `BadPasswordOrCorrupt` instead.
+    Seal,
+    /// Decrypt failed: either the password is wrong or the ciphertext /
+    /// AAD bytes have been tampered with.
+    BadPasswordOrCorrupt,
+    /// Base64 decoding of the outer envelope failed.
+    Base64(base64::DecodeError),
+    /// Envelope byte buffer is shorter than the fixed header + salt + nonce
+    /// + tag floor — the sender truncated or mis-encoded it.
+    Truncated,
+    /// Envelope header declares a version or kdf_id this client does not
+    /// know how to process. Future-proofs the wire format.
+    Unsupported { version: u8, kdf_id: u8 },
+    /// Argon2 `Params` rejected the per-envelope cost parameters (e.g. a
+    /// zero memory cost pulled from a malformed header). Separate from
+    /// `Kdf` so the UI can distinguish "your params don't load" from
+    /// "hashing ran but failed halfway".
+    InvalidParams(argon2::Error),
+}
+
+impl fmt::Display for RecoveryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Kdf(e) => write!(f, "key derivation failed: {}", e),
+            Self::Cipher(e) => write!(f, "AES-GCM key init failed: {}", e),
+            Self::Seal => write!(f, "AES-GCM seal failed"),
+            Self::BadPasswordOrCorrupt => write!(
+                f,
+                "recovery password is incorrect or the backup is corrupted"
+            ),
+            Self::Base64(e) => write!(f, "base64 decode failed: {}", e),
+            Self::Truncated => write!(f, "recovery envelope is truncated"),
+            Self::Unsupported { version, kdf_id } => write!(
+                f,
+                "recovery envelope version={} kdf_id={} is not supported by this client",
+                version, kdf_id
+            ),
+            Self::InvalidParams(e) => write!(f, "invalid KDF params in envelope: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for RecoveryError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Kdf(e) | Self::InvalidParams(e) => Some(e),
+            Self::Cipher(e) => Some(e),
+            Self::Base64(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<base64::DecodeError> for RecoveryError {
+    fn from(e: base64::DecodeError) -> Self {
+        Self::Base64(e)
+    }
+}

--- a/coincube-gui/src/services/recovery/mod.rs
+++ b/coincube-gui/src/services/recovery/mod.rs
@@ -1,0 +1,28 @@
+//! Cube Recovery Kit — on-device envelope codec and plaintext blob
+//! types that back up a Cube (seed + wallet descriptor) to the Connect
+//! account.
+//!
+//! This module is deliberately UI-free and network-free. The Connect
+//! client sits in `services::coincube`, and the UI state machine /
+//! views live in `app::`.
+//!
+//! See `plans/PLAN-cube-recovery-kit-desktop.md` for the end-to-end
+//! feature plan; this module is W6 (envelope codec + plaintext types).
+
+pub mod envelope;
+pub mod error;
+pub mod password;
+pub mod plaintext;
+pub mod restore;
+
+pub use envelope::{decrypt, encrypt, KdfParams, ENVELOPE_VERSION, KDF_ID_ARGON2ID_V1};
+pub use error::RecoveryError;
+pub use password::{score as score_password, PasswordStrength, MIN_PASSWORD_LEN};
+pub use plaintext::{
+    DescriptorBlob, DescriptorBlobCube, DescriptorBlobSigner, DescriptorBlobVault, SeedBlob,
+    SeedBlobCube, SeedBlobMnemonic, BLOB_VERSION,
+};
+pub use restore::{
+    decrypt_descriptor_blob, decrypt_seed_blob, fetch_and_decrypt_descriptor,
+    fetch_and_decrypt_for_install, fetch_and_decrypt_kit, DecryptedKit, RestoreError,
+};

--- a/coincube-gui/src/services/recovery/password.rs
+++ b/coincube-gui/src/services/recovery/password.rs
@@ -1,0 +1,156 @@
+//! Password-strength scoring for the Cube Recovery Kit password. The
+//! plan (§2.3) gates the `Submit` action on a minimum strength of
+//! `Fair`; this module produces a `PasswordStrength` enum plus a label
+//! for the UI bar.
+//!
+//! Under the hood this wraps `zxcvbn` — zxcvbn's native score is 0..=4
+//! so the enum mirrors that shape. We intentionally don't expose the
+//! raw zxcvbn estimates (guesses, crack-time) in the API surface
+//! because the UI only needs a coarse band.
+
+use zeroize::Zeroizing;
+
+/// Minimum password length enforced alongside strength. Set to the
+/// NIST-recommended floor of 12 chars; zxcvbn will also penalise short
+/// passwords in its score, but an explicit length gate keeps the
+/// failure message crisp ("at least 12 characters").
+pub const MIN_PASSWORD_LEN: usize = 12;
+
+/// Coarse strength band shown to the user. Ordered so comparisons
+/// (`strength >= PasswordStrength::Fair`) work as expected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PasswordStrength {
+    /// Too short, too common, or trivially guessable (zxcvbn score 0).
+    VeryWeak,
+    /// Bruteforceable in under an hour online (score 1).
+    Weak,
+    /// Resistant to online throttled attacks; a reasonable default floor
+    /// for a recovery password (score 2).
+    Fair,
+    /// Resistant to offline slow attacks (score 3).
+    Strong,
+    /// Resistant to offline fast-hardware attacks (score 4).
+    VeryStrong,
+}
+
+impl PasswordStrength {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::VeryWeak => "Very weak",
+            Self::Weak => "Weak",
+            Self::Fair => "Fair",
+            Self::Strong => "Strong",
+            Self::VeryStrong => "Very strong",
+        }
+    }
+
+    /// Progress-bar fill on a 0.0–1.0 scale. Kept here rather than in
+    /// the view module so the numeric mapping lives with the enum
+    /// definition.
+    pub fn fraction(self) -> f32 {
+        match self {
+            Self::VeryWeak => 0.1,
+            Self::Weak => 0.3,
+            Self::Fair => 0.5,
+            Self::Strong => 0.75,
+            Self::VeryStrong => 1.0,
+        }
+    }
+
+    /// True when the strength meets the submit floor set by the plan
+    /// (§2.3 — Submit gated on `strength >= medium`, which we interpret
+    /// as `Fair`).
+    pub fn is_acceptable(self) -> bool {
+        self >= Self::Fair
+    }
+}
+
+/// Scores `password` and returns the coarse band plus the first
+/// feedback suggestion from zxcvbn, if any. An empty password is
+/// treated as `VeryWeak` without invoking the full scorer.
+///
+/// The `user_inputs` slice is passed to zxcvbn so it can penalise
+/// passwords that reuse pieces of identity data the caller already
+/// knows (the user's email, the cube name). Callers should include
+/// anything an attacker could trivially guess — that's exactly what
+/// zxcvbn is designed to down-weight.
+pub fn score(password: &Zeroizing<String>, user_inputs: &[&str]) -> (PasswordStrength, Option<String>) {
+    if password.is_empty() {
+        return (PasswordStrength::VeryWeak, None);
+    }
+    let est = zxcvbn::zxcvbn(password, user_inputs);
+    let strength = match est.score() {
+        zxcvbn::Score::Zero => PasswordStrength::VeryWeak,
+        zxcvbn::Score::One => PasswordStrength::Weak,
+        zxcvbn::Score::Two => PasswordStrength::Fair,
+        zxcvbn::Score::Three => PasswordStrength::Strong,
+        zxcvbn::Score::Four => PasswordStrength::VeryStrong,
+        // zxcvbn::Score is #[non_exhaustive]; a future variant falls
+        // back to the strongest bucket we know about — safer than
+        // downgrading to VeryWeak on an upgrade.
+        _ => PasswordStrength::VeryStrong,
+    };
+    let hint = est
+        .feedback()
+        .and_then(|f| {
+            // Prefer a warning (specific failure mode) over the more
+            // generic suggestions when both are present.
+            if let Some(w) = f.warning() {
+                Some(w.to_string())
+            } else {
+                f.suggestions().first().map(|s| s.to_string())
+            }
+        });
+    (strength, hint)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn z(s: &str) -> Zeroizing<String> {
+        Zeroizing::new(s.to_string())
+    }
+
+    #[test]
+    fn empty_password_is_very_weak() {
+        let (s, _) = score(&z(""), &[]);
+        assert_eq!(s, PasswordStrength::VeryWeak);
+    }
+
+    #[test]
+    fn common_password_is_weak_or_worse() {
+        let (s, _) = score(&z("password"), &[]);
+        assert!(s <= PasswordStrength::Weak, "got {:?}", s);
+    }
+
+    #[test]
+    fn strong_random_passphrase_is_fair_or_better() {
+        // Four uncommon words — the canonical "correct horse battery
+        // staple" test. Should clear the Fair floor.
+        let (s, _) = score(&z("correct horse battery staple"), &[]);
+        assert!(s >= PasswordStrength::Fair, "got {:?}", s);
+    }
+
+    #[test]
+    fn user_inputs_penalise_reused_values() {
+        // Reusing the cube name as the password should be penalised.
+        let (s1, _) = score(&z("MyCube!"), &[]);
+        let (s2, _) = score(&z("MyCube!"), &["MyCube"]);
+        assert!(
+            s2 <= s1,
+            "user_inputs hint should not increase score (s1={:?}, s2={:?})",
+            s1,
+            s2
+        );
+    }
+
+    #[test]
+    fn is_acceptable_gates_on_fair() {
+        assert!(!PasswordStrength::VeryWeak.is_acceptable());
+        assert!(!PasswordStrength::Weak.is_acceptable());
+        assert!(PasswordStrength::Fair.is_acceptable());
+        assert!(PasswordStrength::Strong.is_acceptable());
+        assert!(PasswordStrength::VeryStrong.is_acceptable());
+    }
+}

--- a/coincube-gui/src/services/recovery/password.rs
+++ b/coincube-gui/src/services/recovery/password.rs
@@ -74,7 +74,10 @@ impl PasswordStrength {
 /// knows (the user's email, the cube name). Callers should include
 /// anything an attacker could trivially guess — that's exactly what
 /// zxcvbn is designed to down-weight.
-pub fn score(password: &Zeroizing<String>, user_inputs: &[&str]) -> (PasswordStrength, Option<String>) {
+pub fn score(
+    password: &Zeroizing<String>,
+    user_inputs: &[&str],
+) -> (PasswordStrength, Option<String>) {
     if password.is_empty() {
         return (PasswordStrength::VeryWeak, None);
     }
@@ -90,17 +93,15 @@ pub fn score(password: &Zeroizing<String>, user_inputs: &[&str]) -> (PasswordStr
         // downgrading to VeryWeak on an upgrade.
         _ => PasswordStrength::VeryStrong,
     };
-    let hint = est
-        .feedback()
-        .and_then(|f| {
-            // Prefer a warning (specific failure mode) over the more
-            // generic suggestions when both are present.
-            if let Some(w) = f.warning() {
-                Some(w.to_string())
-            } else {
-                f.suggestions().first().map(|s| s.to_string())
-            }
-        });
+    let hint = est.feedback().and_then(|f| {
+        // Prefer a warning (specific failure mode) over the more
+        // generic suggestions when both are present.
+        if let Some(w) = f.warning() {
+            Some(w.to_string())
+        } else {
+            f.suggestions().first().map(|s| s.to_string())
+        }
+    });
     (strength, hint)
 }
 

--- a/coincube-gui/src/services/recovery/plaintext.rs
+++ b/coincube-gui/src/services/recovery/plaintext.rs
@@ -21,14 +21,37 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 /// is safe.
 pub const BLOB_VERSION: u8 = 1;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+/// `Debug` is implemented manually — the derived version would
+/// recursively print `cube` and `mnemonic`, exposing PII (cube
+/// name, UUID, Lightning address) and the mnemonic phrase through
+/// any `{:?}` site. Keep the manual impl in sync with the struct
+/// fields.
+#[derive(Serialize, Deserialize, Clone)]
 pub struct SeedBlob {
     pub version: u8,
     pub cube: SeedBlobCube,
     pub mnemonic: SeedBlobMnemonic,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+impl std::fmt::Debug for SeedBlob {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Preserve `version` — it's non-sensitive and useful when
+        // diagnosing a version-mismatch rejection. Delegate the
+        // other two fields to their own redacting Debug impls.
+        f.debug_struct("SeedBlob")
+            .field("version", &self.version)
+            .field("cube", &self.cube)
+            .field("mnemonic", &self.mnemonic)
+            .finish()
+    }
+}
+
+/// Cube-scoped metadata on `SeedBlob`. `Debug` is manual to avoid
+/// leaking the UUID (cube identifier), user-chosen `name`, and
+/// `lightning_address` (directly identifying) via any `{:?}` site.
+/// Non-sensitive fields (`network`, `created_at`) stay visible
+/// because they're useful diagnostic context.
+#[derive(Serialize, Deserialize, Clone)]
 pub struct SeedBlobCube {
     pub uuid: String,
     pub name: String,
@@ -38,6 +61,21 @@ pub struct SeedBlobCube {
     pub created_at: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lightning_address: Option<String>,
+}
+
+impl std::fmt::Debug for SeedBlobCube {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SeedBlobCube")
+            .field("uuid", &"<redacted>")
+            .field("name", &"<redacted>")
+            .field("network", &self.network)
+            .field("created_at", &self.created_at)
+            .field(
+                "lightning_address",
+                &self.lightning_address.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
 }
 
 /// Wraps the mnemonic phrase in its own struct with `ZeroizeOnDrop` so
@@ -67,20 +105,49 @@ impl std::fmt::Debug for SeedBlobMnemonic {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+/// Top-level descriptor blob. Manual `Debug` so the recursive
+/// formatters never print the raw descriptor string or xpubs. The
+/// `version` field is preserved — useful for diagnosing a
+/// version-mismatch rejection.
+#[derive(Serialize, Deserialize, Clone)]
 pub struct DescriptorBlob {
     pub version: u8,
     pub cube: DescriptorBlobCube,
     pub vault: DescriptorBlobVault,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+impl std::fmt::Debug for DescriptorBlob {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DescriptorBlob")
+            .field("version", &self.version)
+            .field("cube", &self.cube)
+            .field("vault", &self.vault)
+            .finish()
+    }
+}
+
+/// Cube-scoped metadata on `DescriptorBlob`. Manual `Debug` redacts
+/// the UUID; `network` stays visible (non-sensitive).
+#[derive(Serialize, Deserialize, Clone)]
 pub struct DescriptorBlobCube {
     pub uuid: String,
     pub network: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+impl std::fmt::Debug for DescriptorBlobCube {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DescriptorBlobCube")
+            .field("uuid", &"<redacted>")
+            .field("network", &self.network)
+            .finish()
+    }
+}
+
+/// Wallet contents. Manual `Debug` redacts the descriptor (which
+/// contains xpubs inline), the change descriptor, and the vault
+/// `name`. Exposes the signer count so a `{:?}` dump still conveys
+/// "this is a 2-of-3 with two signers" at a glance for diagnostics.
+#[derive(Serialize, Deserialize, Clone)]
 pub struct DescriptorBlobVault {
     pub name: String,
     pub descriptor: String,
@@ -89,12 +156,42 @@ pub struct DescriptorBlobVault {
     pub signers: Vec<DescriptorBlobSigner>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+impl std::fmt::Debug for DescriptorBlobVault {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DescriptorBlobVault")
+            .field("name", &"<redacted>")
+            .field("descriptor", &"<redacted>")
+            .field(
+                "change_descriptor",
+                &self.change_descriptor.as_ref().map(|_| "<redacted>"),
+            )
+            .field("signers", &self.signers) // delegates to redacting impl
+            .finish()
+    }
+}
+
+/// Per-signer metadata. Manual `Debug` redacts the user-chosen `name`
+/// and the `xpub` (extended public key — watch-only spend access to
+/// every historical and future address). The `fingerprint` stays
+/// visible: it's a 4-byte hash of the xpub, commonly shown in UIs
+/// (hardware wallet displays, descriptor listings) and useful for
+/// identifying which signer a log line refers to.
+#[derive(Serialize, Deserialize, Clone)]
 pub struct DescriptorBlobSigner {
     pub name: String,
     /// Lowercase hex, no `0x` prefix, 8 chars — master key fingerprint.
     pub fingerprint: String,
     pub xpub: String,
+}
+
+impl std::fmt::Debug for DescriptorBlobSigner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DescriptorBlobSigner")
+            .field("name", &"<redacted>")
+            .field("fingerprint", &self.fingerprint)
+            .field("xpub", &"<redacted>")
+            .finish()
+    }
 }
 
 #[cfg(test)]
@@ -153,6 +250,150 @@ mod tests {
             "SeedBlob Debug leaked the phrase: {}",
             rendered,
         );
+    }
+
+    // Regression tests for the PII / wallet-privacy redaction in
+    // `SeedBlobCube` / `DescriptorBlob*`. Each uses a canary value
+    // that shouldn't appear in Debug output; the redacting impls
+    // preserve non-sensitive metadata (network, version, signer
+    // fingerprint) for diagnostic value.
+
+    #[test]
+    fn seed_blob_cube_debug_redacts_uuid_name_lightning() {
+        let cube = SeedBlobCube {
+            uuid: "uuid-canary-XYZZY".into(),
+            name: "name-canary-XYZZY".into(),
+            network: "mainnet".into(),
+            created_at: "2026-04-23T00:00:00Z".into(),
+            lightning_address: Some("lightning-canary-XYZZY@example".into()),
+        };
+        let r = format!("{:?}", cube);
+        assert!(!r.contains("uuid-canary-XYZZY"), "uuid leaked: {}", r);
+        assert!(!r.contains("name-canary-XYZZY"), "name leaked: {}", r);
+        assert!(
+            !r.contains("lightning-canary-XYZZY"),
+            "lightning address leaked: {}",
+            r
+        );
+        // Non-sensitive fields are preserved for diagnostics.
+        assert!(
+            r.contains("\"mainnet\""),
+            "network should be visible: {}",
+            r
+        );
+        assert!(
+            r.contains("2026-04-23T00:00:00Z"),
+            "created_at should be visible: {}",
+            r
+        );
+    }
+
+    #[test]
+    fn seed_blob_cube_debug_none_lightning_renders_as_none() {
+        let cube = SeedBlobCube {
+            uuid: "u".into(),
+            name: "n".into(),
+            network: "mainnet".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            lightning_address: None,
+        };
+        let r = format!("{:?}", cube);
+        // Absent address → `None`, not `Some(<redacted>)`.
+        assert!(r.contains("None"), "got: {}", r);
+    }
+
+    #[test]
+    fn descriptor_blob_cube_debug_redacts_uuid() {
+        let c = DescriptorBlobCube {
+            uuid: "uuid-canary-XYZZY".into(),
+            network: "mainnet".into(),
+        };
+        let r = format!("{:?}", c);
+        assert!(!r.contains("uuid-canary-XYZZY"), "uuid leaked: {}", r);
+        assert!(r.contains("\"mainnet\""));
+    }
+
+    #[test]
+    fn descriptor_blob_vault_debug_redacts_name_and_descriptors() {
+        let v = DescriptorBlobVault {
+            name: "vault-name-canary-XYZZY".into(),
+            descriptor: "wsh(descriptor-canary-XYZZY)".into(),
+            change_descriptor: Some("wsh(change-canary-XYZZY)".into()),
+            signers: vec![],
+        };
+        let r = format!("{:?}", v);
+        assert!(!r.contains("vault-name-canary-XYZZY"), "name leaked: {}", r);
+        assert!(
+            !r.contains("descriptor-canary-XYZZY"),
+            "descriptor leaked: {}",
+            r
+        );
+        assert!(
+            !r.contains("change-canary-XYZZY"),
+            "change_descriptor leaked: {}",
+            r
+        );
+    }
+
+    #[test]
+    fn descriptor_blob_signer_debug_redacts_name_and_xpub_but_keeps_fingerprint() {
+        let s = DescriptorBlobSigner {
+            name: "signer-name-canary-XYZZY".into(),
+            fingerprint: "deadbeef".into(),
+            xpub: "xpub-canary-XYZZY".into(),
+        };
+        let r = format!("{:?}", s);
+        assert!(
+            !r.contains("signer-name-canary-XYZZY"),
+            "name leaked: {}",
+            r
+        );
+        assert!(!r.contains("xpub-canary-XYZZY"), "xpub leaked: {}", r);
+        // Fingerprint is the low-entropy 4-byte identifier; exposing
+        // it aligns with hardware-wallet UI conventions and gives
+        // `{:?}` dumps enough context to distinguish signers.
+        assert!(
+            r.contains("deadbeef"),
+            "fingerprint should be visible: {}",
+            r
+        );
+    }
+
+    #[test]
+    fn descriptor_blob_debug_propagates_redaction_through_children() {
+        // Composite Debug on the top-level blob must delegate to
+        // the redacting child impls, not leak through a derived
+        // impl that went stale.
+        let blob = DescriptorBlob {
+            version: BLOB_VERSION,
+            cube: DescriptorBlobCube {
+                uuid: "uuid-canary-XYZZY".into(),
+                network: "mainnet".into(),
+            },
+            vault: DescriptorBlobVault {
+                name: "vault-canary-XYZZY".into(),
+                descriptor: "descriptor-canary-XYZZY".into(),
+                change_descriptor: None,
+                signers: vec![DescriptorBlobSigner {
+                    name: "signer-canary-XYZZY".into(),
+                    fingerprint: "deadbeef".into(),
+                    xpub: "xpub-canary-XYZZY".into(),
+                }],
+            },
+        };
+        let r = format!("{:?}", blob);
+        for canary in [
+            "uuid-canary-XYZZY",
+            "vault-canary-XYZZY",
+            "descriptor-canary-XYZZY",
+            "signer-canary-XYZZY",
+            "xpub-canary-XYZZY",
+        ] {
+            assert!(!r.contains(canary), "{} leaked: {}", canary, r);
+        }
+        // Version and fingerprint are preserved diagnostics.
+        assert!(r.contains("version: 1"), "version missing: {}", r);
+        assert!(r.contains("deadbeef"), "fingerprint missing: {}", r);
     }
 
     #[test]

--- a/coincube-gui/src/services/recovery/plaintext.rs
+++ b/coincube-gui/src/services/recovery/plaintext.rs
@@ -43,12 +43,28 @@ pub struct SeedBlobCube {
 /// Wraps the mnemonic phrase in its own struct with `ZeroizeOnDrop` so
 /// that even if `SeedBlob` leaks through state cloning (e.g. Iced message
 /// snapshots), the phrase material is wiped when the clone drops.
-#[derive(Serialize, Deserialize, Debug, Clone, Zeroize, ZeroizeOnDrop)]
+///
+/// `Debug` is implemented manually below with the `phrase` field
+/// redacted. **Do not `#[derive(Debug)]`** — the derived impl would
+/// print the mnemonic in plaintext to any `{:?}` format, tracing
+/// subscriber, or debugger watch-window, defeating the whole point of
+/// the zeroize wrapping. The manual impl below is the only `Debug`
+/// for this type; keep it that way.
+#[derive(Serialize, Deserialize, Clone, Zeroize, ZeroizeOnDrop)]
 pub struct SeedBlobMnemonic {
     pub phrase: String,
     /// BIP39 wordlist language, e.g. "en". Persisted so restore doesn't
     /// have to guess.
     pub language: String,
+}
+
+impl std::fmt::Debug for SeedBlobMnemonic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SeedBlobMnemonic")
+            .field("phrase", &"<redacted>")
+            .field("language", &self.language)
+            .finish()
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -84,6 +100,60 @@ pub struct DescriptorBlobSigner {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Canary string unlikely to appear anywhere else in the
+    /// `Debug` output (field names, "<redacted>" marker, etc.).
+    /// If this ever surfaces in a `{:?}` dump, the redacting
+    /// `Debug` impl has regressed.
+    const CANARY_PHRASE: &str = "sentinel-mnemonic-canary-word-sequence-XYZZY";
+
+    #[test]
+    fn seed_blob_mnemonic_debug_redacts_phrase() {
+        let m = SeedBlobMnemonic {
+            phrase: CANARY_PHRASE.to_string(),
+            language: "en".to_string(),
+        };
+        let rendered = format!("{:?}", m);
+        assert!(
+            !rendered.contains(CANARY_PHRASE),
+            "mnemonic phrase must not appear in Debug output, got: {}",
+            rendered,
+        );
+        assert!(
+            rendered.contains("<redacted>"),
+            "expected '<redacted>' marker in Debug output, got: {}",
+            rendered,
+        );
+        // Language is fine to leak — it's "en", not secret.
+        assert!(rendered.contains("\"en\""));
+    }
+
+    #[test]
+    fn seed_blob_debug_does_not_leak_mnemonic_through_parent() {
+        // The `SeedBlob` parent still derives `Debug`; verify the
+        // redacting impl on the child propagates cleanly so printing
+        // the whole blob doesn't accidentally re-expose the phrase.
+        let blob = SeedBlob {
+            version: BLOB_VERSION,
+            cube: SeedBlobCube {
+                uuid: "u".into(),
+                name: "n".into(),
+                network: "bitcoin".into(),
+                created_at: "2026-04-23T00:00:00Z".into(),
+                lightning_address: None,
+            },
+            mnemonic: SeedBlobMnemonic {
+                phrase: CANARY_PHRASE.to_string(),
+                language: "en".to_string(),
+            },
+        };
+        let rendered = format!("{:?}", blob);
+        assert!(
+            !rendered.contains(CANARY_PHRASE),
+            "SeedBlob Debug leaked the phrase: {}",
+            rendered,
+        );
+    }
 
     #[test]
     fn seed_blob_roundtrip_json() {

--- a/coincube-gui/src/services/recovery/plaintext.rs
+++ b/coincube-gui/src/services/recovery/plaintext.rs
@@ -1,0 +1,160 @@
+//! Plaintext blob types for the Cube Recovery Kit.
+//!
+//! Two blobs are carried independently inside the envelope:
+//!   * `SeedBlob`  — encryption of the master mnemonic + minimal cube
+//!     metadata needed to restore the cube shell.
+//!   * `DescriptorBlob` — encryption of the wallet descriptor and its
+//!     signer xpubs (no private keys).
+//!
+//! Both are serde-JSON before encryption and back to serde-JSON after
+//! decryption; the envelope carries the ciphertext bytes as opaque
+//! payload.
+//!
+//! Aligned with `PLAN-cube-recovery-kit-desktop.md` §2.1.
+
+use serde::{Deserialize, Serialize};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// Latest schema version this client writes for `SeedBlob` / `DescriptorBlob`.
+/// Bump on any breaking shape change; the reader should refuse unknown
+/// versions. Carried inside each blob so mixing kits across client versions
+/// is safe.
+pub const BLOB_VERSION: u8 = 1;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SeedBlob {
+    pub version: u8,
+    pub cube: SeedBlobCube,
+    pub mnemonic: SeedBlobMnemonic,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SeedBlobCube {
+    pub uuid: String,
+    pub name: String,
+    /// One of "bitcoin" | "testnet" | "signet" | "regtest". String rather
+    /// than an enum so a future network addition doesn't break older kits.
+    pub network: String,
+    pub created_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lightning_address: Option<String>,
+}
+
+/// Wraps the mnemonic phrase in its own struct with `ZeroizeOnDrop` so
+/// that even if `SeedBlob` leaks through state cloning (e.g. Iced message
+/// snapshots), the phrase material is wiped when the clone drops.
+#[derive(Serialize, Deserialize, Debug, Clone, Zeroize, ZeroizeOnDrop)]
+pub struct SeedBlobMnemonic {
+    pub phrase: String,
+    /// BIP39 wordlist language, e.g. "en". Persisted so restore doesn't
+    /// have to guess.
+    pub language: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DescriptorBlob {
+    pub version: u8,
+    pub cube: DescriptorBlobCube,
+    pub vault: DescriptorBlobVault,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DescriptorBlobCube {
+    pub uuid: String,
+    pub network: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DescriptorBlobVault {
+    pub name: String,
+    pub descriptor: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub change_descriptor: Option<String>,
+    pub signers: Vec<DescriptorBlobSigner>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DescriptorBlobSigner {
+    pub name: String,
+    /// Lowercase hex, no `0x` prefix, 8 chars — master key fingerprint.
+    pub fingerprint: String,
+    pub xpub: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_blob_roundtrip_json() {
+        let blob = SeedBlob {
+            version: BLOB_VERSION,
+            cube: SeedBlobCube {
+                uuid: "cube-uuid".into(),
+                name: "My Cube".into(),
+                network: "bitcoin".into(),
+                created_at: "2026-04-22T00:00:00Z".into(),
+                lightning_address: Some("alice@coincube.io".into()),
+            },
+            mnemonic: SeedBlobMnemonic {
+                phrase: "abandon abandon abandon abandon abandon abandon abandon abandon \
+                         abandon abandon abandon about"
+                    .into(),
+                language: "en".into(),
+            },
+        };
+        let json = serde_json::to_string(&blob).unwrap();
+        let back: SeedBlob = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.version, BLOB_VERSION);
+        assert_eq!(back.cube.uuid, "cube-uuid");
+        assert_eq!(back.mnemonic.language, "en");
+        assert_eq!(
+            back.cube.lightning_address.as_deref(),
+            Some("alice@coincube.io")
+        );
+    }
+
+    #[test]
+    fn descriptor_blob_roundtrip_json() {
+        let blob = DescriptorBlob {
+            version: BLOB_VERSION,
+            cube: DescriptorBlobCube {
+                uuid: "cube-uuid".into(),
+                network: "bitcoin".into(),
+            },
+            vault: DescriptorBlobVault {
+                name: "Vault A".into(),
+                descriptor: "wsh(...)".into(),
+                change_descriptor: Some("wsh(...change)".into()),
+                signers: vec![DescriptorBlobSigner {
+                    name: "Device 1".into(),
+                    fingerprint: "deadbeef".into(),
+                    xpub: "xpub...".into(),
+                }],
+            },
+        };
+        let json = serde_json::to_string(&blob).unwrap();
+        let back: DescriptorBlob = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.vault.name, "Vault A");
+        assert_eq!(back.vault.signers.len(), 1);
+        assert_eq!(back.vault.signers[0].fingerprint, "deadbeef");
+    }
+
+    #[test]
+    fn optional_lightning_address_missing_deserialises() {
+        // A kit written before we added the field (or by a client that
+        // didn't have one) must still load.
+        let json = r#"{
+            "version": 1,
+            "cube": {
+                "uuid": "x",
+                "name": "n",
+                "network": "bitcoin",
+                "created_at": "2026-01-01T00:00:00Z"
+            },
+            "mnemonic": { "phrase": "p", "language": "en" }
+        }"#;
+        let blob: SeedBlob = serde_json::from_str(json).unwrap();
+        assert!(blob.cube.lightning_address.is_none());
+    }
+}

--- a/coincube-gui/src/services/recovery/restore.rs
+++ b/coincube-gui/src/services/recovery/restore.rs
@@ -16,7 +16,7 @@
 
 use zeroize::Zeroizing;
 
-use super::{decrypt, DescriptorBlob, RecoveryError, SeedBlob};
+use super::{decrypt, DescriptorBlob, RecoveryError, SeedBlob, BLOB_VERSION};
 use crate::services::coincube::{CoincubeClient, CoincubeError};
 
 /// Errors produced by the restore helpers. Collapses coincube-client,
@@ -113,6 +113,7 @@ pub fn decrypt_seed_blob(
     let bytes = decrypt(ciphertext_b64, password)?;
     let blob: SeedBlob = serde_json::from_slice(&bytes)
         .map_err(|e| RestoreError::BlobParse(format!("seed blob: {}", e)))?;
+    check_blob_version("seed blob", blob.version)?;
     Ok(blob)
 }
 
@@ -126,7 +127,25 @@ pub fn decrypt_descriptor_blob(
     let bytes = decrypt(ciphertext_b64, password)?;
     let blob: DescriptorBlob = serde_json::from_slice(&bytes)
         .map_err(|e| RestoreError::BlobParse(format!("descriptor blob: {}", e)))?;
+    check_blob_version("descriptor blob", blob.version)?;
     Ok(blob)
+}
+
+/// Rejects blobs whose `version` field doesn't match the constant
+/// this client is built against. Keeps the plaintext module's
+/// promise ("the reader should refuse unknown versions") honest —
+/// a newer-schema blob can silently deserialise into the v1 shape
+/// if it kept the old fields, hiding the mismatch until it produces
+/// wrong on-chain behaviour at restore. Fail loud and early instead.
+fn check_blob_version(kind: &'static str, seen: u8) -> Result<(), RestoreError> {
+    if seen == BLOB_VERSION {
+        return Ok(());
+    }
+    Err(RestoreError::BlobParse(format!(
+        "{} version {} not supported by this client (expected {}). \
+         Update your Cube app to the latest version.",
+        kind, seen, BLOB_VERSION,
+    )))
 }
 
 /// Fetches the kit from Connect and decrypts whichever halves it
@@ -252,6 +271,66 @@ mod tests {
         let got = decrypt_seed_blob(&envelope, &password).unwrap();
         assert_eq!(got.cube.uuid, blob.cube.uuid);
         assert_eq!(got.mnemonic.phrase, blob.mnemonic.phrase);
+    }
+
+    // Regression tests for the blob-version gate. The plaintext
+    // module promises "the reader should refuse unknown versions";
+    // before this gate, a future-schema blob that still carried the
+    // v1 fields would silently deserialise and could produce wrong
+    // on-chain behaviour at restore.
+
+    #[test]
+    fn decrypt_seed_blob_rejects_unknown_version() {
+        let password = pw("pw");
+        let mut blob = sample_seed_blob();
+        blob.version = BLOB_VERSION + 1;
+        let bytes = serde_json::to_vec(&blob).unwrap();
+        let envelope = encrypt(&bytes, &password, TEST_PARAMS).unwrap();
+
+        let err = decrypt_seed_blob(&envelope, &password).expect_err("expected version rejection");
+        match err {
+            RestoreError::BlobParse(msg) => {
+                assert!(msg.contains("not supported"), "got: {}", msg);
+                assert!(msg.contains("seed blob"), "got: {}", msg);
+            }
+            other => panic!("expected BlobParse, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn decrypt_descriptor_blob_rejects_unknown_version() {
+        let password = pw("pw");
+        let mut blob = sample_descriptor_blob();
+        blob.version = BLOB_VERSION + 1;
+        let bytes = serde_json::to_vec(&blob).unwrap();
+        let envelope = encrypt(&bytes, &password, TEST_PARAMS).unwrap();
+
+        let err =
+            decrypt_descriptor_blob(&envelope, &password).expect_err("expected version rejection");
+        match err {
+            RestoreError::BlobParse(msg) => {
+                assert!(msg.contains("not supported"), "got: {}", msg);
+                assert!(msg.contains("descriptor blob"), "got: {}", msg);
+            }
+            other => panic!("expected BlobParse, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn decrypt_seed_blob_rejects_version_zero() {
+        // A v0 blob is just as unsupported as a future version.
+        // Covers the "older than us" branch (not reachable today,
+        // since we're already at v1, but the gate enforces it).
+        let password = pw("pw");
+        let mut blob = sample_seed_blob();
+        blob.version = 0;
+        let bytes = serde_json::to_vec(&blob).unwrap();
+        let envelope = encrypt(&bytes, &password, TEST_PARAMS).unwrap();
+
+        assert!(matches!(
+            decrypt_seed_blob(&envelope, &password),
+            Err(RestoreError::BlobParse(_))
+        ));
     }
 
     #[test]

--- a/coincube-gui/src/services/recovery/restore.rs
+++ b/coincube-gui/src/services/recovery/restore.rs
@@ -1,0 +1,615 @@
+//! Reusable service helpers for the restore half of Cube Recovery Kit.
+//!
+//! All three restore entry points (W13 installer restore, W14 post-
+//! mnemonic descriptor fetch, W15 vault-wizard restore) share the
+//! same crypto + API sequence:
+//!
+//!   1. Fetch the kit from Connect (`GET /recovery-kit`).
+//!   2. Decrypt the ciphertext envelope(s) with the user's recovery
+//!      password.
+//!   3. Parse JSON into `SeedBlob` / `DescriptorBlob`.
+//!
+//! Keeping the sequence here means the three UI integrations each
+//! become a thin shell around `fetch_and_decrypt_kit` — no duplicated
+//! crypto, no duplicated error mapping, and (importantly) one place
+//! to audit for zeroization correctness.
+
+use zeroize::Zeroizing;
+
+use super::{decrypt, DescriptorBlob, RecoveryError, SeedBlob};
+use crate::services::coincube::{CoincubeClient, CoincubeError};
+
+/// Errors produced by the restore helpers. Collapses coincube-client,
+/// envelope-decrypt, and JSON parse errors into a single enum so UI
+/// code can pattern-match without touching three sub-types.
+#[derive(Debug)]
+pub enum RestoreError {
+    /// The Cube has no kit on Connect (backend 404). UI should
+    /// surface as "No backup found for this Cube".
+    NotFound,
+    /// Connect returned 429 — the caller should back off. `retry_after`
+    /// is the parsed `Retry-After` duration.
+    RateLimited { retry_after: std::time::Duration },
+    /// Generic Connect error — auth, network, server 5xx.
+    Api(String),
+    /// The envelope failed to decrypt: wrong password, tampered
+    /// ciphertext, or unsupported wire version. Collapsed to a
+    /// single variant for the UI (see envelope codec notes) so an
+    /// offline bruteforcer can't distinguish the cases.
+    BadPasswordOrCorrupt,
+    /// Envelope decrypted cleanly but the plaintext JSON failed to
+    /// deserialize into the expected blob type. Indicates a client
+    /// writing a shape this client doesn't understand (e.g. a newer
+    /// blob version we should refuse rather than mis-parse).
+    BlobParse(String),
+    /// The kit exists on Connect but doesn't contain the half this
+    /// caller needs (e.g. W14 wants a descriptor; the server-side
+    /// kit is seed-only).
+    HalfMissing,
+}
+
+impl std::fmt::Display for RestoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "No Recovery Kit found on Connect for this Cube."),
+            Self::RateLimited { retry_after } => write!(
+                f,
+                "Rate limited — try again in {}s.",
+                retry_after.as_secs()
+            ),
+            Self::Api(msg) => write!(f, "Connect error: {}", msg),
+            Self::BadPasswordOrCorrupt => write!(
+                f,
+                "Recovery password is incorrect or the backup is corrupted."
+            ),
+            Self::BlobParse(msg) => write!(f, "Recovery Kit shape not recognised: {}", msg),
+            Self::HalfMissing => write!(
+                f,
+                "This Recovery Kit doesn't include the part you're trying to restore."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RestoreError {}
+
+impl From<CoincubeError> for RestoreError {
+    fn from(e: CoincubeError) -> Self {
+        match e {
+            CoincubeError::NotFound => Self::NotFound,
+            CoincubeError::RateLimited { retry_after } => Self::RateLimited { retry_after },
+            other => Self::Api(other.to_string()),
+        }
+    }
+}
+
+impl From<RecoveryError> for RestoreError {
+    fn from(e: RecoveryError) -> Self {
+        match e {
+            RecoveryError::BadPasswordOrCorrupt => Self::BadPasswordOrCorrupt,
+            other => Self::Api(other.to_string()),
+        }
+    }
+}
+
+/// Outcome of a successful fetch+decrypt. Either half may be absent
+/// depending on what's on the server. Passkey cubes never carry a
+/// seed half; mnemonic cubes without a Vault never carry a descriptor.
+///
+/// `SeedBlob` isn't wrapped in `Zeroizing` because the type doesn't
+/// impl `Zeroize` at the struct level — the sensitive mnemonic field
+/// inside it derives `ZeroizeOnDrop`, so the phrase material is wiped
+/// automatically when the blob drops regardless of how callers hold
+/// it. Don't clone `SeedBlob` unnecessarily in UI code.
+#[derive(Debug)]
+pub struct DecryptedKit {
+    pub seed: Option<SeedBlob>,
+    pub descriptor: Option<DescriptorBlob>,
+}
+
+/// Decrypts a single ciphertext envelope into `SeedBlob`.
+pub fn decrypt_seed_blob(
+    ciphertext_b64: &str,
+    password: &Zeroizing<String>,
+) -> Result<SeedBlob, RestoreError> {
+    let bytes = decrypt(ciphertext_b64, password)?;
+    let blob: SeedBlob = serde_json::from_slice(&bytes)
+        .map_err(|e| RestoreError::BlobParse(format!("seed blob: {}", e)))?;
+    Ok(blob)
+}
+
+/// Decrypts a single ciphertext envelope into `DescriptorBlob`.
+/// No `Zeroizing` wrap — the descriptor isn't secret; it's the
+/// public-facing half of the kit.
+pub fn decrypt_descriptor_blob(
+    ciphertext_b64: &str,
+    password: &Zeroizing<String>,
+) -> Result<DescriptorBlob, RestoreError> {
+    let bytes = decrypt(ciphertext_b64, password)?;
+    let blob: DescriptorBlob = serde_json::from_slice(&bytes)
+        .map_err(|e| RestoreError::BlobParse(format!("descriptor blob: {}", e)))?;
+    Ok(blob)
+}
+
+/// Fetches the kit from Connect and decrypts whichever halves it
+/// carries using the supplied password. Either half may come back
+/// as `None` when the server-side kit is partial (see plan §5 on
+/// partial-field kits).
+pub async fn fetch_and_decrypt_kit(
+    client: &CoincubeClient,
+    cube_id: u64,
+    password: &Zeroizing<String>,
+) -> Result<DecryptedKit, RestoreError> {
+    let kit = client.get_recovery_kit(cube_id).await?;
+
+    // Empty strings on the wire mean "this half wasn't uploaded."
+    // Treat them the same as `None` here so the caller can pattern-
+    // match cleanly.
+    let seed = if kit.encrypted_cube_seed.is_empty() {
+        None
+    } else {
+        Some(decrypt_seed_blob(&kit.encrypted_cube_seed, password)?)
+    };
+    let descriptor = if kit.encrypted_wallet_descriptor.is_empty() {
+        None
+    } else {
+        Some(decrypt_descriptor_blob(
+            &kit.encrypted_wallet_descriptor,
+            password,
+        )?)
+    };
+
+    Ok(DecryptedKit { seed, descriptor })
+}
+
+/// Specialisation for W14 and W15 — the restore-descriptor-only
+/// flows. Converts "kit exists but has no descriptor half" into a
+/// typed `HalfMissing` so the UI copy can be precise.
+pub async fn fetch_and_decrypt_descriptor(
+    client: &CoincubeClient,
+    cube_id: u64,
+    password: &Zeroizing<String>,
+) -> Result<DescriptorBlob, RestoreError> {
+    let DecryptedKit { descriptor, .. } = fetch_and_decrypt_kit(client, cube_id, password).await?;
+    descriptor.ok_or(RestoreError::HalfMissing)
+}
+
+/// Specialisation for W13 — the full-install restore flow. Returns
+/// the seed half paired with optional descriptor; missing seed is
+/// `HalfMissing` because a fresh install can't meaningfully proceed
+/// without one. The installer flow can still apply the descriptor
+/// after the seed is set up.
+pub async fn fetch_and_decrypt_for_install(
+    client: &CoincubeClient,
+    cube_id: u64,
+    password: &Zeroizing<String>,
+) -> Result<(SeedBlob, Option<DescriptorBlob>), RestoreError> {
+    let DecryptedKit { seed, descriptor } =
+        fetch_and_decrypt_kit(client, cube_id, password).await?;
+    let seed = seed.ok_or(RestoreError::HalfMissing)?;
+    Ok((seed, descriptor))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::recovery::{
+        encrypt, DescriptorBlobCube, DescriptorBlobVault, KdfParams, SeedBlobCube,
+        SeedBlobMnemonic, BLOB_VERSION,
+    };
+
+    // Minimum-cost params — keeps tests fast.
+    const TEST_PARAMS: KdfParams = KdfParams {
+        memory_kib: 512,
+        t_cost: 1,
+        p_cost: 1,
+    };
+
+    fn pw(s: &str) -> Zeroizing<String> {
+        Zeroizing::new(s.to_string())
+    }
+
+    fn sample_seed_blob() -> SeedBlob {
+        SeedBlob {
+            version: BLOB_VERSION,
+            cube: SeedBlobCube {
+                uuid: "cube-uuid".into(),
+                name: "My Cube".into(),
+                network: "bitcoin".into(),
+                created_at: "2026-04-22T00:00:00Z".into(),
+                lightning_address: None,
+            },
+            mnemonic: SeedBlobMnemonic {
+                phrase: "abandon abandon abandon abandon abandon abandon abandon abandon \
+                         abandon abandon abandon about"
+                    .into(),
+                language: "en".into(),
+            },
+        }
+    }
+
+    fn sample_descriptor_blob() -> DescriptorBlob {
+        DescriptorBlob {
+            version: BLOB_VERSION,
+            cube: DescriptorBlobCube {
+                uuid: "cube-uuid".into(),
+                network: "bitcoin".into(),
+            },
+            vault: DescriptorBlobVault {
+                name: "My Vault".into(),
+                descriptor: "wsh(...)".into(),
+                change_descriptor: None,
+                signers: vec![],
+            },
+        }
+    }
+
+    #[test]
+    fn decrypt_seed_blob_roundtrips() {
+        let password = pw("correct horse battery staple");
+        let blob = sample_seed_blob();
+        let bytes = serde_json::to_vec(&blob).unwrap();
+        let envelope = encrypt(&bytes, &password, TEST_PARAMS).unwrap();
+
+        let got = decrypt_seed_blob(&envelope, &password).unwrap();
+        assert_eq!(got.cube.uuid, blob.cube.uuid);
+        assert_eq!(got.mnemonic.phrase, blob.mnemonic.phrase);
+    }
+
+    #[test]
+    fn decrypt_descriptor_blob_roundtrips() {
+        let password = pw("correct horse battery staple");
+        let blob = sample_descriptor_blob();
+        let bytes = serde_json::to_vec(&blob).unwrap();
+        let envelope = encrypt(&bytes, &password, TEST_PARAMS).unwrap();
+
+        let got = decrypt_descriptor_blob(&envelope, &password).unwrap();
+        assert_eq!(got.vault.name, blob.vault.name);
+        assert_eq!(got.vault.descriptor, blob.vault.descriptor);
+    }
+
+    #[test]
+    fn wrong_password_maps_to_bad_or_corrupt() {
+        let bytes = serde_json::to_vec(&sample_seed_blob()).unwrap();
+        let envelope = encrypt(&bytes, &pw("right"), TEST_PARAMS).unwrap();
+        let err = decrypt_seed_blob(&envelope, &pw("wrong")).unwrap_err();
+        assert!(matches!(err, RestoreError::BadPasswordOrCorrupt));
+    }
+
+    #[test]
+    fn corrupt_plaintext_maps_to_blob_parse() {
+        // Encrypt garbage (valid envelope, invalid JSON payload). The
+        // decrypt step succeeds but JSON parsing fails — this is a
+        // separate error case from a wrong password / tampered tag.
+        let password = pw("pw");
+        let envelope = encrypt(b"not-json", &password, TEST_PARAMS).unwrap();
+        let err = decrypt_seed_blob(&envelope, &password).unwrap_err();
+        assert!(
+            matches!(err, RestoreError::BlobParse(_)),
+            "expected BlobParse, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn coincube_not_found_maps_to_restore_not_found() {
+        let err: RestoreError = CoincubeError::NotFound.into();
+        assert!(matches!(err, RestoreError::NotFound));
+    }
+
+    #[test]
+    fn coincube_rate_limited_preserves_retry_after() {
+        let err: RestoreError = CoincubeError::RateLimited {
+            retry_after: std::time::Duration::from_secs(42),
+        }
+        .into();
+        match err {
+            RestoreError::RateLimited { retry_after } => {
+                assert_eq!(retry_after, std::time::Duration::from_secs(42));
+            }
+            other => panic!("expected RateLimited, got {:?}", other),
+        }
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    //! Integration tests against a mocked Connect API. Exercises the
+    //! full fetch→decrypt path including the typed error mapping
+    //! from the client layer.
+    use super::*;
+    use crate::services::recovery::{encrypt, KdfParams, BLOB_VERSION};
+    use crate::services::recovery::{
+        DescriptorBlobCube, DescriptorBlobVault, SeedBlobCube, SeedBlobMnemonic,
+    };
+    use httpmock::{Method as MockMethod, MockServer};
+    use serde_json::json;
+
+    const TEST_PARAMS: KdfParams = KdfParams {
+        memory_kib: 512,
+        t_cost: 1,
+        p_cost: 1,
+    };
+
+    fn pw(s: &str) -> Zeroizing<String> {
+        Zeroizing::new(s.to_string())
+    }
+
+    fn sample_seed_blob() -> SeedBlob {
+        SeedBlob {
+            version: BLOB_VERSION,
+            cube: SeedBlobCube {
+                uuid: "cube-uuid".into(),
+                name: "My Cube".into(),
+                network: "bitcoin".into(),
+                created_at: "2026-04-22T00:00:00Z".into(),
+                lightning_address: None,
+            },
+            mnemonic: SeedBlobMnemonic {
+                phrase: "a".repeat(50),
+                language: "en".into(),
+            },
+        }
+    }
+
+    fn sample_descriptor_blob() -> DescriptorBlob {
+        DescriptorBlob {
+            version: BLOB_VERSION,
+            cube: DescriptorBlobCube {
+                uuid: "cube-uuid".into(),
+                network: "bitcoin".into(),
+            },
+            vault: DescriptorBlobVault {
+                name: "My Vault".into(),
+                descriptor: "wsh(multi(2,xpub1,xpub2))".into(),
+                change_descriptor: None,
+                signers: vec![],
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_and_decrypt_kit_returns_both_halves() {
+        let password = pw("correct horse battery staple");
+        let seed_ct = encrypt(
+            &serde_json::to_vec(&sample_seed_blob()).unwrap(),
+            &password,
+            TEST_PARAMS,
+        )
+        .unwrap();
+        let desc_ct = encrypt(
+            &serde_json::to_vec(&sample_descriptor_blob()).unwrap(),
+            &password,
+            TEST_PARAMS,
+        )
+        .unwrap();
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 1,
+                        "cubeId": 42,
+                        "encryptedCubeSeed": seed_ct,
+                        "encryptedWalletDescriptor": desc_ct,
+                        "encryptionScheme": "aes-256-gcm",
+                        "createdAt": "2026-04-22T00:00:00Z",
+                        "updatedAt": "2026-04-22T00:00:00Z"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let kit = fetch_and_decrypt_kit(&client, 42, &password)
+            .await
+            .expect("fetch+decrypt should succeed");
+        mock.assert();
+        assert!(kit.seed.is_some());
+        assert!(kit.descriptor.is_some());
+        assert_eq!(kit.seed.unwrap().cube.uuid, "cube-uuid");
+        assert_eq!(kit.descriptor.unwrap().vault.name, "My Vault");
+    }
+
+    #[tokio::test]
+    async fn fetch_and_decrypt_kit_handles_seed_only() {
+        let password = pw("pw");
+        let seed_ct = encrypt(
+            &serde_json::to_vec(&sample_seed_blob()).unwrap(),
+            &password,
+            TEST_PARAMS,
+        )
+        .unwrap();
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 1,
+                        "cubeId": 42,
+                        "encryptedCubeSeed": seed_ct,
+                        "encryptedWalletDescriptor": "",
+                        "encryptionScheme": "aes-256-gcm",
+                        "createdAt": "2026-04-22T00:00:00Z",
+                        "updatedAt": "2026-04-22T00:00:00Z"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let kit = fetch_and_decrypt_kit(&client, 42, &password)
+            .await
+            .expect("fetch+decrypt should succeed");
+        mock.assert();
+        assert!(kit.seed.is_some());
+        assert!(kit.descriptor.is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_descriptor_on_seed_only_kit_reports_half_missing() {
+        // W14/W15 case: the user has a seed-only kit and clicks
+        // "Restore descriptor from Connect" — we expect the typed
+        // HalfMissing error, not a generic parse failure.
+        let password = pw("pw");
+        let seed_ct = encrypt(
+            &serde_json::to_vec(&sample_seed_blob()).unwrap(),
+            &password,
+            TEST_PARAMS,
+        )
+        .unwrap();
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 1,
+                        "cubeId": 42,
+                        "encryptedCubeSeed": seed_ct,
+                        "encryptedWalletDescriptor": "",
+                        "encryptionScheme": "aes-256-gcm",
+                        "createdAt": "2026-04-22T00:00:00Z",
+                        "updatedAt": "2026-04-22T00:00:00Z"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = fetch_and_decrypt_descriptor(&client, 42, &password)
+            .await
+            .expect_err("expected HalfMissing");
+        mock.assert();
+        assert!(matches!(err, RestoreError::HalfMissing));
+    }
+
+    #[tokio::test]
+    async fn fetch_for_install_on_descriptor_only_kit_reports_half_missing() {
+        // W13 case: passkey cube's descriptor-only kit; full install
+        // restore needs the seed.
+        let password = pw("pw");
+        let desc_ct = encrypt(
+            &serde_json::to_vec(&sample_descriptor_blob()).unwrap(),
+            &password,
+            TEST_PARAMS,
+        )
+        .unwrap();
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 1,
+                        "cubeId": 42,
+                        "encryptedCubeSeed": "",
+                        "encryptedWalletDescriptor": desc_ct,
+                        "encryptionScheme": "aes-256-gcm",
+                        "createdAt": "2026-04-22T00:00:00Z",
+                        "updatedAt": "2026-04-22T00:00:00Z"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = fetch_and_decrypt_for_install(&client, 42, &password)
+            .await
+            .expect_err("expected HalfMissing");
+        mock.assert();
+        assert!(matches!(err, RestoreError::HalfMissing));
+    }
+
+    #[tokio::test]
+    async fn fetch_and_decrypt_kit_404_maps_to_not_found() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(404);
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = fetch_and_decrypt_kit(&client, 42, &pw("pw"))
+            .await
+            .expect_err("expected NotFound");
+        mock.assert();
+        assert!(matches!(err, RestoreError::NotFound));
+    }
+
+    #[tokio::test]
+    async fn fetch_and_decrypt_kit_429_preserves_retry_after() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(429).header("Retry-After", "17");
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = fetch_and_decrypt_kit(&client, 42, &pw("pw"))
+            .await
+            .expect_err("expected RateLimited");
+        mock.assert();
+        match err {
+            RestoreError::RateLimited { retry_after } => {
+                assert_eq!(retry_after, std::time::Duration::from_secs(17));
+            }
+            other => panic!("expected RateLimited, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_and_decrypt_kit_wrong_password_maps_to_bad_or_corrupt() {
+        let right_pw = pw("right password");
+        let wrong_pw = pw("wrong password");
+        let seed_ct = encrypt(
+            &serde_json::to_vec(&sample_seed_blob()).unwrap(),
+            &right_pw,
+            TEST_PARAMS,
+        )
+        .unwrap();
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 1,
+                        "cubeId": 42,
+                        "encryptedCubeSeed": seed_ct,
+                        "encryptedWalletDescriptor": "",
+                        "encryptionScheme": "aes-256-gcm",
+                        "createdAt": "2026-04-22T00:00:00Z",
+                        "updatedAt": "2026-04-22T00:00:00Z"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = fetch_and_decrypt_kit(&client, 42, &wrong_pw)
+            .await
+            .expect_err("expected BadPasswordOrCorrupt");
+        mock.assert();
+        assert!(matches!(err, RestoreError::BadPasswordOrCorrupt));
+    }
+}

--- a/coincube-gui/src/services/recovery/restore.rs
+++ b/coincube-gui/src/services/recovery/restore.rs
@@ -22,7 +22,11 @@ use crate::services::coincube::{CoincubeClient, CoincubeError};
 /// Errors produced by the restore helpers. Collapses coincube-client,
 /// envelope-decrypt, and JSON parse errors into a single enum so UI
 /// code can pattern-match without touching three sub-types.
-#[derive(Debug)]
+// `Clone` is required for Iced messages (the runtime clones between
+// update, task, and view); every variant is trivially clonable. `Debug`
+// is the stdlib derive — the variants don't carry secrets, only
+// metadata (Duration, error strings from the API).
+#[derive(Debug, Clone)]
 pub enum RestoreError {
     /// The Cube has no kit on Connect (backend 404). UI should
     /// surface as "No backup found for this Cube".

--- a/coincube-gui/src/services/recovery/restore.rs
+++ b/coincube-gui/src/services/recovery/restore.rs
@@ -52,11 +52,9 @@ impl std::fmt::Display for RestoreError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::NotFound => write!(f, "No Recovery Kit found on Connect for this Cube."),
-            Self::RateLimited { retry_after } => write!(
-                f,
-                "Rate limited — try again in {}s.",
-                retry_after.as_secs()
-            ),
+            Self::RateLimited { retry_after } => {
+                write!(f, "Rate limited — try again in {}s.", retry_after.as_secs())
+            }
             Self::Api(msg) => write!(f, "Connect error: {}", msg),
             Self::BadPasswordOrCorrupt => write!(
                 f,

--- a/coincube-gui/src/signer.rs
+++ b/coincube-gui/src/signer.rs
@@ -83,6 +83,35 @@ impl Signer {
             Some((checksum.to_string(), timestamp)),
         )
     }
+
+    /// AES-encrypted variant of [`Signer::store`] — writes the
+    /// mnemonic file protected by `password` (Argon2id-derived key).
+    ///
+    /// Used by the Recovery Kit restore flow so the stored mnemonic
+    /// matches the layout a fresh-install Cube produces: the Liquid /
+    /// Spark BreezClient decrypts via the Cube's PIN on every open.
+    /// Without encryption, `MasterSigner::from_datadir_by_fingerprint`
+    /// still succeeds (it handles both shapes) but `load_breez_client`
+    /// refuses to decrypt an unencrypted blob with a password and the
+    /// app hangs on "Starting daemon…". Keeping the PIN-encrypted
+    /// layout uniform across fresh-install and restored Cubes avoids
+    /// that branch.
+    pub fn store_encrypted(
+        &self,
+        datadir_root: &CoincubeDirectory,
+        network: Network,
+        checksum: &str,
+        timestamp: i64,
+        password: &str,
+    ) -> Result<(), SignerError> {
+        self.key.store_encrypted(
+            datadir_root.path(),
+            network,
+            &self.curve,
+            Some((checksum.to_string(), timestamp)),
+            Some(password),
+        )
+    }
 }
 
 pub fn delete_wallet_mnemonics(

--- a/docs/AVATAR-PROMPT-GUIDE.md
+++ b/docs/AVATAR-PROMPT-GUIDE.md
@@ -1,0 +1,260 @@
+# Avatar Prompt Guide — Kage Sumi-e Style
+
+Server-side reference for assembling the image-generation prompt from
+`AvatarUserTraits` + `AvatarDerivedTraits`.
+
+Every generated avatar must look like it was painted by the same artist
+as the Kage artwork in `design/artwork/sumi-e/kage/`. If placed next to
+`kage-bust.png`, the two should be indistinguishable in medium.
+
+---
+
+## 1. Base Style Block
+
+Prepend this to every assembled prompt, before any trait language.
+
+```
+Sumi-e ink wash painting of a samurai warrior in bust/portrait framing.
+Match the exact art style of the attached Kage reference images.
+
+INK TECHNIQUE — the most critical directives:
+- Painted with real sumi ink on paper. Wet, saturated black ink with
+  hard brush edges where the brush loads heavy, and dry streaked marks
+  (kasure) where the brush runs low.
+- HIGH CONTRAST: deep pure blacks against clean white/transparent space.
+  No muddy mid-tones. The darks must be rich and saturated, not gray
+  or chalky. The lights must be clean, not hazy.
+- Gray washes are TRANSLUCENT and LAYERED — like diluted ink on wet
+  paper, not opaque paint. You should sense the paper beneath the wash.
+- Ink drips bleed downward from the figure. Splatters are BLACK INK,
+  not white or chalk-colored.
+- The figure dissolves into ink drips at the bottom edge of the frame.
+
+COLOR — three tones only, no exceptions:
+- Pure black sumi ink
+- Translucent gray ink washes
+- Bitcoin orange #F7931A (ensō, eyes, and one small accent only)
+- Nothing else. No brown, no blue, no white paint, no skin tones,
+  no metallic sheen, no chalk textures.
+
+SIGNATURE ELEMENTS:
+- Large BOLD orange ensō behind the head — thick brushstroke, slightly
+  imperfect, with visible brush start/end points. The ensō must be
+  PROMINENT and HEAVY, not thin or recessed.
+- Glowing orange eyes — the ONLY visible facial feature
+- Red hanko seal stamp, bottom-right corner
+- Bust composition: head, shoulders, upper chest, centered
+
+BACKGROUND:
+- Fully transparent PNG (no solid background)
+- No paper texture, no scenery
+
+THIS IS NOT:
+- Not 3D, not CGI, not photorealistic, not a texture map
+- Not anime, not manga, not cartoon
+- Not soft, not blended, not airbrushed — the brush edges must be SHARP
+- Not chalky, not dusty, not matte clay — the ink must look WET
+- Not low contrast — if the darks and lights don't punch, it is wrong
+```
+
+### Why specific phrases matter
+
+| Problem in current avatars | Cause | Fix phrase |
+|---------------------------|-------|------------|
+| Muddy, low-contrast look | Model treats ink like a 3D texture | "HIGH CONTRAST: deep pure blacks against clean white space" |
+| Clay/plaster surface feel | Model renders ink as a material on a surface | "Painted with real sumi ink on paper — wet, saturated, hard brush edges" |
+| White/chalk splatters | Model adds highlight splatters | "Splatters are BLACK INK, not white or chalk-colored" |
+| Thin, recessed ensō | Ensō treated as background element | "The ensō must be PROMINENT and HEAVY, not thin or recessed" |
+| Gray muddy washes | Opaque gray paint instead of diluted ink | "Gray washes are TRANSLUCENT and LAYERED — like diluted ink on wet paper" |
+| Soft blended edges | Airbrush/diffusion artifact | "Brush edges must be SHARP — not soft, not blended, not airbrushed" |
+
+---
+
+## 2. Trait → Prompt Mapping
+
+### User Traits
+
+#### `archetype`
+
+| Value | Prompt |
+|-------|--------|
+| Ronin | "A wandering ronin — masterless, lean, travel-worn. Simple robes. Loose ink, more dry brush." |
+| Samurai | "A disciplined samurai — upright, squared shoulders, clean armor. Controlled, deliberate strokes." |
+| Shogun | "A commanding shogun — broad-shouldered, ornate headgear, heaviest armor. Dense, massive ink." |
+
+#### `gender`
+
+| Value | Prompt |
+|-------|--------|
+| Man | "Male figure. Broader shoulders, angular jaw shadow." |
+| Woman | "Female onna-bugeisha warrior. Femininity from silhouette (narrower taper, elegant collar, kanzashi pins) — NOT from softened brushwork. Identical ink weight and intensity as male figures." |
+
+#### `age_feel`
+
+| Value | Prompt |
+|-------|--------|
+| Young | "Youthful — sharper angles, thinner build, more splash energy." |
+| Mature | "Seasoned — balanced, steady, confident unhurried strokes." |
+| Elder | "Weathered veteran — heavier ink pooling, more dry brush texture, trailing elements." |
+
+#### `demeanor`
+
+| Value | Prompt |
+|-------|--------|
+| Calm | "Composed and still. Restrained splatters, slow vertical drips." |
+| Fierce | "Aggressive. Slashed brushstrokes, more splatter, ensō painted in one bold arc. Eyes burn brighter." |
+| Mysterious | "Enigmatic. More shadow than form, heavy gray washes dissolving edges. Face deeper in shadow." |
+
+#### `armor_style`
+
+| Value | Prompt |
+|-------|--------|
+| Light | "Minimal armor — travel robe, light haori. Fluid ink washes for fabric folds." |
+| Standard | "Traditional layered samurai armor — sode, chest plate. Heavy black ink, suggest plates without over-detailing." |
+| Heavy | "Full heavy armor — massive pauldrons, thick chest plate. Densest ink in the image." |
+
+#### `accent_motif`
+
+| Value | Prompt |
+|-------|--------|
+| OrangeSun | "Bold full ensō as radiant sun disc — slightly larger, with dry brush rays at the edges." |
+| Splatter | "Orange ink splatters scattered around shoulders and ensō — flicked from an orange brush." |
+| Seal | "Prominent orange hanko seal stamp on the chest plate — larger than the corner seal." |
+| Calligraphy | "Single bold orange calligraphic stroke across chest or shoulder." |
+
+#### `laser_eyes`
+
+| Value | Prompt |
+|-------|--------|
+| true | "Eyes emit visible orange light beams — twin horizontal rays cutting through shadow. Painterly glow, not digital lens flare." |
+| false | (standard glowing eyes) |
+
+### Derived Traits
+
+#### `hat_style` (silhouette — most important differentiator)
+
+| Value | Prompt |
+|-------|--------|
+| kabuto_horned | "Low wide kabuto with two short curved oni horns at the temples." |
+| kabuto_crescent | "Tall narrow kabuto with a vertical crescent moon crest." |
+| jingasa | "Wide-brimmed jingasa — broad flat disc extending past the shoulders." |
+| eboshi | "Tall cylindrical eboshi court cap — stovepipe shape." |
+| sugegasa | "Pointed sugegasa conical straw hat with weave texture." |
+| hood_peaked | "Deep peaked fabric hood casting face in shadow. No metal." |
+| cowl_rounded | "Heavy rounded sōhei monk's cowl, draped close to skull." |
+| tengai_basket | "Full tengai basket covering entire head. Eyes glow faintly through weave." |
+| crown | "Ornate pointed crown in dark ink with orange gemstone accents." |
+| headwrap | "Tenugui headwrap in Edo craftsman style, flat-topped, trailing tails." |
+| kanzashi_veil | "Kanzashi hairpins fanning upward from topknot with trailing white silk veil." |
+
+#### `pose`
+
+| Value | Prompt |
+|-------|--------|
+| frontal | "Facing forward, symmetrical." |
+| three_quarter | "Three-quarter turn, one shoulder closer." |
+| profile | "Near-profile, face turned ~70° to one side." |
+
+#### `enso_style`
+
+| Value | Prompt |
+|-------|--------|
+| full | "Complete ensō — bold, imperfect, visible brush lift point." |
+| broken | "Broken ensō — deliberate gap in the circle." |
+| double | "Double ensō — inner bright orange, outer faded gray." |
+| splashed | "Splashed ensō — a burst of orange suggesting the circle's energy." |
+
+#### `ink_density`
+
+| Value | Prompt |
+|-------|--------|
+| light | "Light ink — more dry brush and white space. Figure is suggested, not fully rendered." |
+| medium | "Balanced — confident black masses, gray washes, breathing room." |
+| heavy | "Heavy ink — dense saturated black, minimal white space. Orange burns through dark mass." |
+
+#### `brush_texture`
+
+| Value | Prompt |
+|-------|--------|
+| smooth | "Long flowing strokes, minimal bristle marks." |
+| dry | "Dominant dry brush — streaked, scratchy, paper showing through." |
+| wet | "Wet saturated ink — bleeds and feathers at edges, pools where brush paused." |
+
+#### `weapon_mode`
+
+| Value | Prompt |
+|-------|--------|
+| katana | "Katana hilt rising behind one shoulder, handle wrapped in orange cord." |
+| wakizashi | "Two short wakizashi crossed behind shoulders." |
+| naginata | "Naginata polearm haft rising behind one shoulder." |
+| none | "No visible weapons." |
+| flute | "Shakuhachi bamboo flute held across chest." |
+
+#### Other derived traits
+
+Map `face_visibility`, `eye_visibility`, `shoulder_profile`, `cloak_presence`,
+`armor_wear`, `splash_intensity`, `orange_placement`, and `ornament_level`
+to short descriptive phrases. Keep each to one sentence. Less is more —
+the base style block does the heavy lifting.
+
+---
+
+## 3. Prompt Assembly Order
+
+```
+1. Base Style Block (Section 1)
+2. Archetype
+3. Gender
+4. Age feel
+5. Demeanor
+6. Hat / silhouette
+7. Pose
+8. Face and eye treatment
+9. Armor
+10. Weapon
+11. Ensō style
+12. Ink density + brush texture
+13. Accent motif
+14. Laser eyes (if on)
+15. Negative prompt
+```
+
+### Negative prompt (always append)
+
+```
+3D render, CGI, photorealistic, anime, manga, cartoon, neon, colorful,
+gradient, watermark, text overlay, metallic sheen, lens flare, glossy,
+smooth digital shading, vector art, clean lines, airbrushed, soft focus,
+chalk texture, clay texture, matte surface, low contrast, muddy tones,
+white splatters, skin tones, any color besides black/gray/orange
+```
+
+---
+
+## 4. Style Drift Recovery
+
+| Problem | Inject this |
+|---------|-------------|
+| Too 3D / textured | "This is flat ink on paper, not a 3D texture map. The surface is PAPER, not clay or stone." |
+| Low contrast / muddy | "Increase contrast. Pure saturated blacks against clean white space. No muddy mid-tones." |
+| Soft / blended edges | "Sharpen all brush edges. Sumi-e brushstrokes have HARD edges where ink meets paper. No airbrushing." |
+| Ensō too thin | "The ensō must be painted with a THICK, fully loaded brush. Bold and heavy, not delicate." |
+| White splatters | "All splatters must be BLACK INK. Remove any white, chalk, or plaster-colored marks." |
+| Looks like a painting OF a statue | "This is a painting, not a painting of a 3D object. No sculptural lighting, no surface texture." |
+| Orange bleeding everywhere | "Orange appears ONLY in the ensō, eyes, and one accent. Everything else is black ink and gray wash." |
+| Too anime | "Traditional sumi-e, not anime. Think Sesshū Tōyō, not Masashi Kishimoto." |
+| Female figure softened | "Identical brushwork weight and splatter intensity as male figures. Silhouette alone indicates gender." |
+
+---
+
+## 5. Reference Image Anchoring
+
+If the image generation API supports style/reference images, upload 2–3
+of these alongside every prompt:
+
+- `kage-bust.png` — the gold standard for bust framing and ink technique
+- `kage-front.png` — standing pose, full armor detail
+- `kage-lightning-send.png` — dynamic pose with ensō
+
+This is the single highest-leverage improvement. Without reference images,
+models drift toward generic digital samurai art within 1–2 generations.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it introduces new encryption/secret-handling flows and modifies installer/launch paths that affect wallet restore and client initialization. Bugs here could cause failed restores, incorrect drift prompts, or accidental leakage of sensitive material if redaction/zeroization regresses.
> 
> **Overview**
> Implements a **Connect-hosted Cube Recovery Kit**: a new Settings card + wizard to **PIN-unlock (mnemonic cubes), choose a recovery password (strength-checked), encrypt locally, upload/update, and remove** the seed and/or wallet descriptor to Connect, with extensive **redaction/`Zeroizing`** safeguards and tests.
> 
> Adds **descriptor drift detection** by hashing a canonical descriptor blob and persisting the last-upload fingerprint in `CubeSettings`, while `App` mirrors panel-derived fields into `Cache` so the General Settings view can warn when the live descriptor differs from the last backup.
> 
> Extends onboarding/installer flows to **restore from Recovery Kit** (full restore and descriptor-only), including a new restore PIN setup to re-encrypt restored mnemonic on disk, forwarding authenticated clients where possible, and adding entry points like **“Restore from Connect”** in the UI and vault import/export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34d67bd926f2f5a600e98a85219ad34a8512f292. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery Kit: secure encrypted backup/restore for seed and descriptor via Connect, with upload/remove, descriptor-drift detection, and password-strength guidance
  * Settings/UI: Recovery Kit management card and guided wizard (PIN → password flows), “Restore from Connect” actions in onboarding, launcher, and vault
  * Installer: dedicated restore flows (full and descriptor-only) and PIN setup for restores

* **Services**
  * New recovery encryption/restore utilities and improved server-error handling

* **Security**
  * Better secret scrubbing for PINs/tokens and safer token handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->