### PR TITLE
fix(vault): associate new vaults with originating cube

### DIFF
--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -330,11 +330,18 @@ impl Tab {
                     let wallet_id = settings.wallet_id();
                     let wallet_alias = settings.alias.clone();
                     let network = i.network;
+                    let originating_cube_id = i.cube_settings.as_ref().map(|c| c.id.clone());
 
                     Task::perform(
                         async move {
-                            find_or_create_cube(&network_dir, &wallet_id, &wallet_alias, network)
-                                .await
+                            find_or_create_cube(
+                                &network_dir,
+                                &wallet_id,
+                                &wallet_alias,
+                                network,
+                                originating_cube_id,
+                            )
+                            .await
                         },
                         move |result| {
                             Message::Install(installer::Message::CubeSaved(
@@ -939,6 +946,7 @@ async fn find_or_create_cube(
     wallet_id: &WalletId,
     wallet_alias: &Option<String>,
     network: bitcoin::Network,
+    originating_cube_id: Option<String>,
 ) -> Result<app::settings::CubeSettings, String> {
     match app::settings::Settings::from_file(network_dir) {
         Ok(mut settings_data) => {
@@ -951,7 +959,39 @@ async fn find_or_create_cube(
                 return Ok(existing_cube.clone());
             }
 
-            // Second, find a cube without a vault and associate this wallet with it
+            // Second, if we have an originating cube ID, validate and use it
+            if let Some(target_cube_id) = originating_cube_id {
+                if let Some(target_cube) = settings_data
+                    .cubes
+                    .iter_mut()
+                    .find(|c| c.id == target_cube_id)
+                {
+                    if target_cube.vault_wallet_id.is_some() {
+                        return Err(format!(
+                            "Cube '{}' already has a vault. Remove the existing vault before creating a new one.",
+                            target_cube.name
+                        ));
+                    }
+                    target_cube.vault_wallet_id = Some(wallet_id.clone());
+                    let cube_clone = target_cube.clone();
+                    let cube_name = target_cube.name.clone();
+
+                    info!(
+                        "Associating wallet {} with originating cube '{}' on {} network",
+                        wallet_id, cube_name, network
+                    );
+
+                    return save_cube_settings(network_dir, cube_clone, network, settings_data)
+                        .await;
+                } else {
+                    return Err(format!(
+                        "Cannot find originating cube with ID '{}'. Please restart the app and try again.",
+                        target_cube_id
+                    ));
+                }
+            }
+
+            // Third, find a cube without a vault and associate this wallet with it
             if let Some(empty_cube) = settings_data
                 .cubes
                 .iter_mut()

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -1161,7 +1161,11 @@ async fn find_or_create_cube(
                         ));
                     }
                     target_cube.vault_wallet_id = Some(wallet_id.clone());
-                    let cube_clone = target_cube.clone();
+                    // Apply restore-flow credentials (PIN hash + fingerprint) if
+                    // restoring to this cube — same rationale as the empty-cube
+                    // fallback: the hash must match the newly-encrypted mnemonic.
+                    let cube_clone = decorate_new(target_cube.clone())?;
+                    *target_cube = cube_clone.clone();
                     let cube_name = target_cube.name.clone();
 
                     info!(


### PR DESCRIPTION
Previously, vault creation would cycle through empty cubes (cube3, cube4, etc.) instead of associating with the cube that initiated the setup. Now passes originating_cube_id through installer flow and prioritizes that cube, with error handling for missing/occupied cubes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Feature**
  * Installer can now attach a wallet to a specified existing cube during setup, preserving user intent.

* **Refactor**
  * Added validation to prevent linking a wallet to a cube that already has a vault; linkage is recorded and settings are saved immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->