### PR TITLE
Cleanup Lightning Address integration

### DIFF
--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -155,6 +155,59 @@ pub async fn mark_cube_synced(
     .await
 }
 
+/// Backfill helper for Cubes created before
+/// [`CubeSettings::master_signer_fingerprint`] was tracked: walks
+/// `<datadir>/<network>/mnemonics/` for master-seed files
+/// (`mnemonic-<fp>-master_<ts>-<ts>.txt`) and returns the
+/// fingerprint of the file whose timestamp is closest to
+/// `cube_created_at` and whose contents successfully decrypt with
+/// `pin`. Returns `None` when no master seed for this Cube lives
+/// on this device (e.g. Cube was created elsewhere and never
+/// restored here).
+///
+/// Caller is responsible for persisting the result via
+/// [`update_settings_file`] and updating their in-memory
+/// [`CubeSettings`] copy. Without persistence the next launch
+/// would re-run the same scan, so callers should always write
+/// the result back.
+pub fn derive_master_signer_fingerprint(
+    datadir_root: &std::path::Path,
+    network: Network,
+    pin: &str,
+    cube_created_at: i64,
+) -> Option<Fingerprint> {
+    use coincube_core::signer::{
+        MasterSigner, MnemonicFileName, MASTER_SEED_LABEL, MNEMONICS_FOLDER_NAME,
+    };
+    use std::str::FromStr;
+
+    let mnemonics_folder = datadir_root
+        .join(network.to_string())
+        .join(MNEMONICS_FOLDER_NAME);
+    let entries = std::fs::read_dir(&mnemonics_folder).ok()?;
+
+    // Sort by closeness to `cube_created_at` so the matching Cube's
+    // seed wins before we waste an Argon2 decrypt on another Cube's
+    // file (master-seed files share the network folder across all
+    // Cubes on this device).
+    let mut candidates: Vec<(Fingerprint, i64)> = entries
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let name = e.file_name().to_str()?.to_owned();
+            let parsed = MnemonicFileName::from_str(&name).ok()?;
+            let (checksum, ts) = parsed.descriptor_info?;
+            checksum
+                .starts_with(MASTER_SEED_LABEL)
+                .then_some((parsed.fingerprint, ts))
+        })
+        .collect();
+    candidates.sort_by_key(|(_, ts)| (ts - cube_created_at).abs());
+
+    candidates.into_iter().map(|(fp, _)| fp).find(|&fp| {
+        MasterSigner::from_datadir_by_fingerprint(datadir_root, network, fp, Some(pin)).is_ok()
+    })
+}
+
 /// Cubes represent user accounts that can contain multiple features (Vault, Liquid wallet, etc.)
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CubeSettings {

--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -159,11 +159,22 @@ pub async fn mark_cube_synced(
 /// [`CubeSettings::master_signer_fingerprint`] was tracked: walks
 /// `<datadir>/<network>/mnemonics/` for master-seed files
 /// (`mnemonic-<fp>-master_<ts>-<ts>.txt`) and returns the
-/// fingerprint of the file whose timestamp is closest to
-/// `cube_created_at` and whose contents successfully decrypt with
-/// `pin`. Returns `None` when no master seed for this Cube lives
-/// on this device (e.g. Cube was created elsewhere and never
-/// restored here).
+/// fingerprint of the file whose timestamp matches
+/// `cube_created_at` (within [`MASTER_SEED_CREATION_WINDOW_SECS`])
+/// and whose contents successfully decrypt with `pin`. Returns
+/// `None` when no master seed for this Cube lives on this device
+/// (e.g. Cube was created elsewhere and never restored here) or
+/// when no file falls inside the creation window.
+///
+/// PIN check alone is *not* sufficient evidence of ownership —
+/// two Cubes can share a PIN, and if this Cube's master file is
+/// missing/corrupted the PIN would still decrypt some *other*
+/// Cube's seed and we'd silently bind the wrong wallet. The
+/// timestamp-window guard is what makes the match safe: the file
+/// is written `Utc::now()` milliseconds before `CubeSettings.
+/// created_at` is stamped (see `launcher.rs`), so a tight window
+/// uniquely associates the file with this Cube. PIN decryption
+/// stays as a second layer.
 ///
 /// Caller is responsible for persisting the result via
 /// [`update_settings_file`] and updating their in-memory
@@ -181,26 +192,41 @@ pub fn derive_master_signer_fingerprint(
     };
     use std::str::FromStr;
 
+    /// Tolerance (seconds) between a master-seed file's timestamp
+    /// and the owning Cube's `created_at`. Two seconds covers the
+    /// Argon2 + AES-GCM encryption pause between the two
+    /// `Utc::now()` reads in the create-cube path; any wider and
+    /// we'd risk admitting a different Cube's file.
+    const MASTER_SEED_CREATION_WINDOW_SECS: i64 = 2;
+
     let mnemonics_folder = datadir_root
         .join(network.to_string())
         .join(MNEMONICS_FOLDER_NAME);
     let entries = std::fs::read_dir(&mnemonics_folder).ok()?;
 
-    // Sort by closeness to `cube_created_at` so the matching Cube's
-    // seed wins before we waste an Argon2 decrypt on another Cube's
-    // file (master-seed files share the network folder across all
-    // Cubes on this device).
     let mut candidates: Vec<(Fingerprint, i64)> = entries
         .filter_map(|e| e.ok())
         .filter_map(|e| {
             let name = e.file_name().to_str()?.to_owned();
             let parsed = MnemonicFileName::from_str(&name).ok()?;
             let (checksum, ts) = parsed.descriptor_info?;
-            checksum
-                .starts_with(MASTER_SEED_LABEL)
-                .then_some((parsed.fingerprint, ts))
+            if !checksum.starts_with(MASTER_SEED_LABEL) {
+                return None;
+            }
+            // Hard ownership filter: only consider files whose
+            // creation timestamp falls in the Cube's creation
+            // window. A PIN match alone is not enough — see fn
+            // doc above.
+            if (ts - cube_created_at).abs() > MASTER_SEED_CREATION_WINDOW_SECS {
+                return None;
+            }
+            Some((parsed.fingerprint, ts))
         })
         .collect();
+    // If two files happen to fall inside the window (extremely
+    // unlikely — would require two Cubes minted within 2s), prefer
+    // the closer one so the deterministic order matches user
+    // expectation.
     candidates.sort_by_key(|(_, ts)| (ts - cube_created_at).abs());
 
     candidates.into_iter().map(|(fp, _)| fp).find(|&fp| {

--- a/coincube-gui/src/app/state/connect/cube.rs
+++ b/coincube-gui/src/app/state/connect/cube.rs
@@ -93,7 +93,8 @@ pub enum ReconcileOutcome {
 use super::{cube_members, AvatarFlowStep, ConnectCubeMembersState};
 
 /// Per-Cube Connect panel handling Lightning Address and Avatar.
-/// These features are tied to the Cube's Breez wallet (BOLT12 offer).
+/// The Lightning Address claim flow is fulfilled by the Cube's
+/// Spark wallet via Breez-hosted LNURL.
 pub struct ConnectCubePanel {
     /// The Cube's client-side UUID (from CubeSettings.id)
     pub cube_uuid: String,
@@ -568,10 +569,10 @@ impl ConnectCubePanel {
 
                         // Step 3: commit. API stamps
                         // `lightning_address_confirmed_at` on the
-                        // existing reservation. Empty body — no
-                        // BOLT12 offer, no DNS work. On failure
-                        // roll back both the SDK registration and
-                        // the reservation.
+                        // existing reservation. Empty body — the
+                        // reserve step already carried all the data
+                        // the API needs. On failure roll back both
+                        // the SDK registration and the reservation.
                         match client.confirm_lightning_address(&cube_id).await {
                             Ok(ln_addr) => Ok(ln_addr),
                             Err(e) => {

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -1092,8 +1092,7 @@ fn lightning_address_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectC
                 .push(
                     text::p2_regular(
                         "Anyone can send you bitcoin using this address. \
-                         BOLT12 / BIP353 payments are received automatically and work if you are offline. \
-                         BOLT11 / LNURL payments require this app to be open and active.",
+                         This app must be open and active to receive payments.",
                     )
                     .color(color::GREY_3),
                 )

--- a/coincube-gui/src/app/view/settings/lightning.rs
+++ b/coincube-gui/src/app/view/settings/lightning.rs
@@ -7,8 +7,8 @@
 //! wallet's own Settings panel matches the mental model: Lightning
 //! routing is a cross-wallet concern, not a Spark-specific control.
 //!
-//! Additional Lightning-flavored preferences (BOLT12 toggles, LNURL
-//! pay defaults, etc.) can pile into this page as they land.
+//! Additional Lightning-flavored preferences (LNURL pay defaults,
+//! invoice expiry, etc.) can pile into this page as they land.
 
 use iced::widget::{Column, Row, Space};
 use iced::{Alignment, Length};

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -65,6 +65,10 @@ pub enum Message {
         network: bitcoin::Network,
         config: app::Config,
         breez_client: Result<Arc<app::breez_liquid::BreezClient>, app::breez_liquid::BreezError>,
+        /// Spark backend carried over from the Login state (loaded during
+        /// PIN entry alongside the Liquid client). `None` if the cube has
+        /// no Spark signer or the bridge failed to spawn.
+        spark_backend: Option<Arc<app::wallets::SparkBackend>>,
     },
     BreezClientLoadedAfterPin {
         breez_client: Result<Arc<app::breez_liquid::BreezClient>, app::breez_liquid::BreezError>,
@@ -314,6 +318,7 @@ impl Tab {
                             network: l.network,
                             config,
                             breez_client: Ok(breez),
+                            spark_backend: l.spark_backend.clone(),
                         });
                     }
 
@@ -333,6 +338,7 @@ impl Tab {
                              Liquid wallet is encrypted and cannot be loaded without PIN."
                                 .to_string(),
                         )),
+                        spark_backend: l.spark_backend.clone(),
                     })
                 }
                 _ => l.update(msg).map(Message::Login),
@@ -498,6 +504,7 @@ impl Tab {
                             // the restore path; fall back to whatever
                             // the installer was launched with.
                             restored_breez_client.or_else(|| i.breez_client.clone()),
+                            restored_spark_backend.or_else(|| i.spark_backend.clone()),
                         );
                         self.state = State::Login(login);
                         command.map(Message::Login)
@@ -799,6 +806,58 @@ impl Tab {
 
                             Task::perform(
                                 async move {
+                                    let mut cube = cube;
+                                    // Backfill `master_signer_fingerprint` for
+                                    // Cubes minted before the field existed —
+                                    // without it, the Liquid + Spark loaders
+                                    // below silently skip and the Connect
+                                    // Lightning Address claim flow / Spark
+                                    // panels stay disabled. Only the cube's
+                                    // own master seed will decrypt with this
+                                    // PIN, so a successful match is sound.
+                                    if cube.master_signer_fingerprint.is_none() {
+                                        if let Some(fp) =
+                                            app::settings::derive_master_signer_fingerprint(
+                                                datadir_clone.path(),
+                                                network_val,
+                                                &pin,
+                                                cube.created_at,
+                                            )
+                                        {
+                                            cube.master_signer_fingerprint = Some(fp);
+                                            let cube_id = cube.id.clone();
+                                            let network_dir =
+                                                datadir_clone.network_directory(network_val);
+                                            if let Err(e) = app::settings::update_settings_file(
+                                                &network_dir,
+                                                |mut s| {
+                                                    if let Some(c) =
+                                                        s.cubes.iter_mut().find(|c| c.id == cube_id)
+                                                    {
+                                                        c.master_signer_fingerprint = Some(fp);
+                                                    }
+                                                    Some(s)
+                                                },
+                                            )
+                                            .await
+                                            {
+                                                tracing::warn!(
+                                                    "Failed to persist backfilled \
+                                                     master_signer_fingerprint for cube {}: {}",
+                                                    cube.id,
+                                                    e
+                                                );
+                                            } else {
+                                                tracing::info!(
+                                                    "Backfilled master_signer_fingerprint {} \
+                                                     for legacy cube {}",
+                                                    fp,
+                                                    cube.id
+                                                );
+                                            }
+                                        }
+                                    }
+
                                     // Both Breez SDKs (Liquid + Spark) load
                                     // from the same master seed fingerprint.
                                     let breez_signer_fingerprint = cube.master_signer_fingerprint;
@@ -918,6 +977,7 @@ impl Tab {
                     network,
                     config,
                     breez_client,
+                    spark_backend,
                 },
             ) => {
                 // The Vault is independent of Liquid: any Breez load failure
@@ -943,6 +1003,7 @@ impl Tab {
                     network,
                     config,
                     breez,
+                    spark_backend,
                 ) {
                     Ok((app, command)) => {
                         self.state = State::App(app);
@@ -990,15 +1051,12 @@ impl Tab {
                 };
                 if let Some(wallet_settings) = wallet_settings {
                     if wallet_settings.remote_backend_auth.is_some() {
-                        // Remote-backend login path doesn't plumb Spark yet —
-                        // the remote backend uses `create_app_with_remote_backend`
-                        // which takes its own `None` for Spark. Wiring the
-                        // remote-backend Spark path is a follow-up.
                         let (login, command) = login::CoincubeLiteLogin::new(
                             datadir.clone(),
                             network,
                             wallet_settings.clone(),
                             Some(breez),
+                            spark_backend,
                         );
                         self.state = State::Login(login);
                         command.map(Message::Login)
@@ -1271,6 +1329,7 @@ pub fn create_app_with_remote_backend(
     network: bitcoin::Network,
     config: app::Config,
     breez_client: Arc<app::breez_liquid::BreezClient>,
+    spark_backend: Option<Arc<app::wallets::SparkBackend>>,
 ) -> Result<(app::App, iced::Task<app::Message>), String> {
     // If someone modified the wallet_alias on Liana-Connect,
     // then the new alias is imported and stored in the settings file.
@@ -1411,7 +1470,7 @@ pub fn create_app_with_remote_backend(
                 .expect("Datadir should be conform"),
         ),
         breez_client,
-        None, // Spark backend — Phase 4 wires the runtime spawn
+        spark_backend,
         config,
         Arc::new(remote_backend),
         coincube_dir,

--- a/coincube-gui/src/services/connect/login.rs
+++ b/coincube-gui/src/services/connect/login.rs
@@ -117,6 +117,12 @@ pub struct CoincubeLiteLogin {
     pub network: Network,
     pub settings: WalletSettings,
     pub breez_client: Option<std::sync::Arc<crate::app::breez_liquid::BreezClient>>,
+    /// Spark backend loaded alongside the Liquid client during PIN
+    /// entry / restore. `None` for cubes without a Spark signer or
+    /// when the bridge subprocess failed to spawn. Threaded through
+    /// to `create_app_with_remote_backend` so the Connect Lightning
+    /// Address claim flow has a SparkClient to talk to.
+    pub spark_backend: Option<std::sync::Arc<crate::app::wallets::SparkBackend>>,
 
     wallet_id: String,
     email: String,
@@ -147,6 +153,7 @@ impl CoincubeLiteLogin {
         network: Network,
         settings: WalletSettings,
         breez_client: Option<std::sync::Arc<crate::app::breez_liquid::BreezClient>>,
+        spark_backend: Option<std::sync::Arc<crate::app::wallets::SparkBackend>>,
     ) -> (Self, Task<Message>) {
         let auth = settings.remote_backend_auth.clone().unwrap();
         (
@@ -161,6 +168,7 @@ impl CoincubeLiteLogin {
                 auth_error: None,
                 processing: true,
                 breez_client,
+                spark_backend,
             },
             Task::perform(
                 async move {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches PIN-entry/login initialization and seed-fingerprint resolution logic; a bad match or persistence failure could disable Spark/Liquid features or associate the wrong signer, though the timestamp+PIN guards reduce the chance.
> 
> **Overview**
> Adds a legacy backfill path to recover missing `CubeSettings::master_signer_fingerprint` by scanning master-seed mnemonic files within a tight creation-time window and verifying decryption with the entered PIN, then persisting the recovered fingerprint to `settings.json`.
> 
> Threads an already-loaded `spark_backend` through the remote-backend login/app creation path so Connect’s Lightning Address claim/reconcile flows and Spark panels can run after PIN entry/restore.
> 
> Cleans up Lightning Address/Spark wording in Connect and Settings UI copy (removing BOLT12 references and simplifying payment-receipt guidance).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab4eea0bcd4f3d997908d1065ae45194773d2bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-recovery of master signer fingerprints for legacy Cube devices during PIN validation (backfills and persists fingerprint).
  * Spark wallet backend propagated into remote-backend login/app creation to enable Spark-backed operations.

* **Documentation**
  * Updated Lightning settings text to reflect Spark/Breez/LNURL changes.
  * Simplified Lightning Address claim card and explanatory comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->