### PR TITLE
Added ln address change function

### DIFF
--- a/coincube-gui/src/app/breez_spark/client.rs
+++ b/coincube-gui/src/app/breez_spark/client.rs
@@ -507,8 +507,8 @@ impl SparkClient {
     /// Spark leaf on the Breez-hosted LNURL server.
     ///
     /// Call after the API's reserve endpoint has returned 2xx — the
-    /// Go API commits the BIP353 TXT and persists the record in its
-    /// `confirm` step, but only if the SDK registration succeeds. On
+    /// Go API persists the record and the `confirm` step stamps it
+    /// permanent, but only after the SDK registration succeeds. On
     /// any failure here the caller must release the reservation via
     /// the API's DELETE endpoint.
     pub async fn register_lightning_address(

--- a/coincube-gui/src/app/state/connect/cube.rs
+++ b/coincube-gui/src/app/state/connect/cube.rs
@@ -90,6 +90,27 @@ pub enum ReconcileOutcome {
     NeedsReRegistration(String),
 }
 
+/// Terminal outcome of the username-change chain (PUT + SDK delete +
+/// SDK register). Carried in
+/// [`crate::app::view::ConnectCubeMessage::LightningAddressUpdated`].
+#[derive(Debug, Clone)]
+pub enum LightningAddressChangeOutcome {
+    /// Server committed and the SDK rebound to the new name.
+    Ok(LightningAddress),
+    /// Server rejected the request (409 conflict / 422 invalid /
+    /// 5xx). The cube's existing address is unchanged everywhere.
+    ServerError(String),
+    /// Server committed the rename but the SDK rebind failed
+    /// (delete or register errored). The DB-confirmed address is
+    /// the new one; the SDK is either still bound to the old name
+    /// (delete failed) or empty (register failed). The
+    /// re-registration prompt surfaces in either case.
+    SdkSyncFailed {
+        addr: LightningAddress,
+        message: String,
+    },
+}
+
 use super::{cube_members, AvatarFlowStep, ConnectCubeMembersState};
 
 /// Per-Cube Connect panel handling Lightning Address and Avatar.
@@ -115,6 +136,20 @@ pub struct ConnectCubePanel {
     pub ln_claim_error: Option<String>,
     pub ln_claiming: bool,
     pub ln_checking: bool,
+    /// True when the claimed-address card is rendered in its in-place
+    /// edit form. The unclaimed flow leaves this `false`.
+    pub ln_editing: bool,
+    /// `Some(new_username)` while the destructive-action confirmation
+    /// modal is showing for a proposed username change.
+    pub ln_change_confirm_pending: Option<String>,
+    /// True during the PUT + SDK delete + SDK register chain. Distinct
+    /// from `ln_claiming` so view code can spinner-gate the
+    /// edit form independently of the unclaimed-flow claim button.
+    pub ln_changing: bool,
+    /// True while a manual retry of the SDK rebind (delete + register
+    /// against the DB-confirmed username) is in flight, kicked off
+    /// from the re-registration prompt on the claimed-address card.
+    pub ln_reregistering: bool,
     ln_check_version: u32,
     ln_check_abort: Option<TaskHandle>,
     /// Spark subprocess client. Phase 4g routes the Lightning
@@ -166,6 +201,10 @@ impl ConnectCubePanel {
             ln_claim_error: None,
             ln_claiming: false,
             ln_checking: false,
+            ln_editing: false,
+            ln_change_confirm_pending: None,
+            ln_changing: false,
+            ln_reregistering: false,
             ln_check_version: 0,
             ln_check_abort: None,
             spark_client,
@@ -230,6 +269,10 @@ impl ConnectCubePanel {
         self.ln_claim_error = None;
         self.ln_claiming = false;
         self.ln_checking = false;
+        self.ln_editing = false;
+        self.ln_change_confirm_pending = None;
+        self.ln_changing = false;
+        self.ln_reregistering = false;
         self.ln_check_version += 1;
         if let Some(handle) = self.ln_check_abort.take() {
             handle.abort();
@@ -605,6 +648,274 @@ impl ConnectCubePanel {
                 self.ln_username_available = None;
                 self.ln_username_error = None;
                 self.ln_reconcile_needs_reregister = None;
+            }
+
+            ConnectCubeMessage::BeginEditLightningAddress => {
+                if self.ln_changing {
+                    return iced::Task::none();
+                }
+                self.ln_editing = true;
+                self.ln_username_input.clear();
+                self.ln_username_available = None;
+                self.ln_username_error = None;
+                self.ln_claim_error = None;
+                self.ln_change_confirm_pending = None;
+            }
+
+            ConnectCubeMessage::CancelEditLightningAddress => {
+                if self.ln_changing {
+                    return iced::Task::none();
+                }
+                self.ln_editing = false;
+                self.ln_change_confirm_pending = None;
+                self.ln_username_input.clear();
+                self.ln_username_available = None;
+                self.ln_username_error = None;
+                self.ln_claim_error = None;
+                self.ln_check_version += 1;
+                if let Some(handle) = self.ln_check_abort.take() {
+                    handle.abort();
+                }
+                self.ln_checking = false;
+            }
+
+            ConnectCubeMessage::RequestChangeLightningAddress => {
+                if self.ln_changing {
+                    return iced::Task::none();
+                }
+                let proposed = self.ln_username_input.trim().to_string();
+                let valid_format = self.ln_username_error.is_none() && !proposed.is_empty();
+                let available = self.ln_username_available == Some(true);
+                let current_username = self
+                    .lightning_address
+                    .as_ref()
+                    .and_then(|la| la.lightning_address.as_deref())
+                    .and_then(|addr| addr.split('@').next())
+                    .map(|u| u.to_string());
+                let differs = current_username
+                    .as_deref()
+                    .map(|u| u != proposed)
+                    .unwrap_or(true);
+                if valid_format && available && differs {
+                    self.ln_change_confirm_pending = Some(proposed);
+                }
+            }
+
+            ConnectCubeMessage::DismissChangeConfirmation => {
+                self.ln_change_confirm_pending = None;
+            }
+
+            ConnectCubeMessage::ConfirmChangeLightningAddress => {
+                if self.ln_changing {
+                    return iced::Task::none();
+                }
+                let Some(new_username) = self.ln_change_confirm_pending.take() else {
+                    return iced::Task::none();
+                };
+                let Some(client) = self.client.clone() else {
+                    return iced::Task::none();
+                };
+                let Some(spark) = self.spark_client.clone() else {
+                    self.ln_claim_error =
+                        Some("Spark wallet is not available on this cube".to_string());
+                    return iced::Task::none();
+                };
+                let Some(cube_id) = self.api_cube_id() else {
+                    self.ln_claim_error = Some(
+                        self.registration_error
+                            .clone()
+                            .unwrap_or_else(|| "Cube registration pending".to_string()),
+                    );
+                    return iced::Task::none();
+                };
+                self.ln_changing = true;
+                self.ln_claim_error = None;
+                return iced::Task::perform(
+                    async move {
+                        // Step 1: server-side atomic username swap.
+                        // Only the DB row changes — no DNS work.
+                        let new_addr = match client
+                            .update_lightning_address(&cube_id, &new_username)
+                            .await
+                        {
+                            Ok(addr) => addr,
+                            Err(e) => {
+                                return LightningAddressChangeOutcome::ServerError(format!(
+                                    "{}",
+                                    e
+                                ));
+                            }
+                        };
+
+                        // Step 2: release the old SDK binding from
+                        // Breez. Required because the SDK's register
+                        // call doesn't replace an existing binding —
+                        // see the reconciler at
+                        // `reconcile_spark_lightning_address`.
+                        if let Err(e) = spark.delete_lightning_address().await {
+                            log::error!(
+                                "[CONNECT-CUBE] change: SDK delete failed after \
+                                 server commit (cube={}, new={}): {}",
+                                cube_id,
+                                new_username,
+                                e
+                            );
+                            return LightningAddressChangeOutcome::SdkSyncFailed {
+                                addr: new_addr,
+                                message: format!(
+                                    "Could not release the previous Lightning Address \
+                                     binding on this device: {}. Tap Retry to finish \
+                                     switching to {}.",
+                                    e, new_username
+                                ),
+                            };
+                        }
+
+                        // Step 3: bind the new username on the
+                        // Breez-hosted LNURL server.
+                        if let Err(e) = spark
+                            .register_lightning_address(new_username.clone(), None)
+                            .await
+                        {
+                            log::error!(
+                                "[CONNECT-CUBE] change: SDK register failed after \
+                                 server commit + SDK delete (cube={}, new={}): {}",
+                                cube_id,
+                                new_username,
+                                e
+                            );
+                            return LightningAddressChangeOutcome::SdkSyncFailed {
+                                addr: new_addr,
+                                message: format!(
+                                    "Could not register {} with the Lightning Address \
+                                     server: {}. Tap Retry to finish.",
+                                    new_username, e
+                                ),
+                            };
+                        }
+
+                        LightningAddressChangeOutcome::Ok(new_addr)
+                    },
+                    |outcome| {
+                        Message::View(view::Message::ConnectCube(
+                            ConnectCubeMessage::LightningAddressUpdated(outcome),
+                        ))
+                    },
+                );
+            }
+
+            ConnectCubeMessage::LightningAddressUpdated(outcome) => {
+                self.ln_changing = false;
+                match outcome {
+                    LightningAddressChangeOutcome::Ok(addr) => {
+                        self.lightning_address = Some(addr);
+                        self.ln_editing = false;
+                        self.ln_change_confirm_pending = None;
+                        self.ln_username_input.clear();
+                        self.ln_username_available = None;
+                        self.ln_username_error = None;
+                        self.ln_claim_error = None;
+                        self.ln_reconcile_needs_reregister = None;
+                    }
+                    LightningAddressChangeOutcome::ServerError(msg) => {
+                        // Stay in edit mode so the user can correct
+                        // and retry; the address itself is unchanged.
+                        self.ln_claim_error = Some(msg);
+                    }
+                    LightningAddressChangeOutcome::SdkSyncFailed { addr, message } => {
+                        // Server committed; mirror that locally and
+                        // surface the existing re-registration prompt
+                        // so the user can retry the SDK side.
+                        self.lightning_address = Some(addr);
+                        self.ln_editing = false;
+                        self.ln_change_confirm_pending = None;
+                        self.ln_username_input.clear();
+                        self.ln_username_available = None;
+                        self.ln_username_error = None;
+                        self.ln_claim_error = None;
+                        self.ln_reconcile_needs_reregister = Some(message);
+                    }
+                }
+            }
+
+            ConnectCubeMessage::RetryLightningAddressReregister => {
+                if self.ln_reregistering {
+                    return iced::Task::none();
+                }
+                let Some(spark) = self.spark_client.clone() else {
+                    return iced::Task::none();
+                };
+                let Some(db_addr) = self
+                    .lightning_address
+                    .as_ref()
+                    .and_then(|la| la.lightning_address.as_ref())
+                    .cloned()
+                else {
+                    return iced::Task::none();
+                };
+                let db_username = match db_addr.split('@').next() {
+                    Some(u) if !u.is_empty() => u.to_string(),
+                    _ => return iced::Task::none(),
+                };
+                self.ln_reregistering = true;
+                return iced::Task::perform(
+                    async move {
+                        // Idempotent: tolerates an already-empty SDK.
+                        // Ignore failure here — the register that
+                        // follows is the authoritative success
+                        // signal, and a Breez-side "already gone"
+                        // error shouldn't block recovery.
+                        if let Err(e) = spark.delete_lightning_address().await {
+                            log::warn!(
+                                "[CONNECT-CUBE] retry rebind: SDK delete \
+                                 returned {} (continuing to register)",
+                                e
+                            );
+                        }
+                        spark
+                            .register_lightning_address(db_username, None)
+                            .await
+                            .map_err(|e| e.to_string())
+                    },
+                    |res| {
+                        Message::View(view::Message::ConnectCube(
+                            ConnectCubeMessage::LightningAddressReregistered(res),
+                        ))
+                    },
+                );
+            }
+
+            ConnectCubeMessage::LightningAddressReregistered(result) => {
+                self.ln_reregistering = false;
+                match result {
+                    Ok(info) => {
+                        let db_addr = self
+                            .lightning_address
+                            .as_ref()
+                            .and_then(|la| la.lightning_address.as_deref());
+                        if db_addr == Some(info.lightning_address.as_str()) {
+                            self.ln_reconcile_needs_reregister = None;
+                            log::info!(
+                                "[CONNECT-CUBE] manual rebind succeeded: {}",
+                                info.lightning_address
+                            );
+                        } else {
+                            // Domain-drift guard, mirroring the
+                            // reconciler. Don't claim "rebound" when
+                            // the SDK's full address doesn't match
+                            // the DB record.
+                            self.ln_reconcile_needs_reregister = Some(format!(
+                                "Spark SDK registered '{}' but the confirmed \
+                                 reservation is '{}'",
+                                info.lightning_address,
+                                db_addr.unwrap_or("")
+                            ));
+                        }
+                    }
+                    Err(e) => {
+                        self.ln_reconcile_needs_reregister = Some(e);
+                    }
+                }
             }
 
             ConnectCubeMessage::SparkLightningAddressChanged(info) => {

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -1092,15 +1092,16 @@ fn lightning_address_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectC
         } else if state.ln_username_available == Some(true) {
             text::p2_regular("✓ Available").color(color::GREEN).into()
         } else if username.is_empty() {
-            text::p2_regular("Choose a new username").color(color::GREY_3).into()
+            text::p2_regular("Choose a new username")
+                .color(color::GREY_3)
+                .into()
         } else {
             text::p2_regular(" ").into()
         };
 
-        let cancel_btn = button::secondary(None, "Cancel")
-            .on_press_maybe((!state.ln_changing).then_some(
-                ConnectCubeMessage::CancelEditLightningAddress,
-            ));
+        let cancel_btn = button::secondary(None, "Cancel").on_press_maybe(
+            (!state.ln_changing).then_some(ConnectCubeMessage::CancelEditLightningAddress),
+        );
         let change_btn: Element<ConnectCubeMessage> = if state.ln_changing {
             iced::widget::button(
                 container(text::p1_regular("Changing…").color(color::GREY_3))
@@ -1122,9 +1123,7 @@ fn lightning_address_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectC
             Column::new()
                 .push(text::p1_bold("Your Lightning Address").style(theme::text::primary))
                 .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
-                .push(
-                    text::p2_regular(format!("Current: {}", address)).color(color::GREY_3),
-                )
+                .push(text::p2_regular(format!("Current: {}", address)).color(color::GREY_3))
                 .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
                 .push(
                     Row::new()
@@ -1135,8 +1134,9 @@ fn lightning_address_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectC
                                         .then_some(ConnectCubeMessage::LnUsernameChanged),
                                 )
                                 .on_submit_maybe(
-                                    can_change
-                                        .then_some(ConnectCubeMessage::RequestChangeLightningAddress),
+                                    can_change.then_some(
+                                        ConnectCubeMessage::RequestChangeLightningAddress,
+                                    ),
                                 )
                                 .size(16)
                                 .padding(15),
@@ -1233,10 +1233,12 @@ fn lightning_address_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectC
                         .push(iced::widget::Space::new().height(Length::Fixed(4.0)))
                         .push(text::p2_regular(err).color(color::GREY_3))
                         .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
-                        .push(button::secondary(None, retry_label).on_press_maybe(
-                            (!state.ln_reregistering)
-                                .then_some(ConnectCubeMessage::RetryLightningAddressReregister),
-                        ))
+                        .push(
+                            button::secondary(None, retry_label)
+                                .on_press_maybe((!state.ln_reregistering).then_some(
+                                    ConnectCubeMessage::RetryLightningAddressReregister,
+                                )),
+                        )
                 }))
                 .padding(20)
                 .spacing(2),
@@ -1378,9 +1380,7 @@ fn lightning_address_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectC
                     current_addr
                 )))
                 .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
-                .push(
-                    text::p1_bold(format!("New address: {}", new_addr)).color(color::ORANGE),
-                )
+                .push(text::p1_bold(format!("New address: {}", new_addr)).color(color::ORANGE))
                 .push(iced::widget::Space::new().height(Length::Fixed(20.0)))
                 .push(
                     Row::new()

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 
 /// Domain suffix displayed in the Lightning Address claim form.
-/// Must match the backend's `lightningAddressDomain` / `bip353Domain`.
+/// Must match the backend's `lightningAddressDomain`.
 const LN_ADDRESS_DOMAIN: &str = "@coincube.io";
 
 use crate::app::view::Message as ViewMessage;
@@ -1053,22 +1053,133 @@ fn security_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccount
 }
 
 fn lightning_address_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectCubeMessage> {
-    let has_address = state
+    let current_address = state
         .lightning_address
         .as_ref()
-        .and_then(|la| la.lightning_address.as_deref())
-        .is_some();
+        .and_then(|la| la.lightning_address.clone())
+        .map(|mut a| {
+            if !a.contains('@') {
+                a.push_str(LN_ADDRESS_DOMAIN);
+            }
+            a
+        });
+    let has_address = current_address.is_some();
+    let current_username = current_address
+        .as_deref()
+        .and_then(|a| a.split('@').next())
+        .map(|u| u.to_string());
 
-    let card_content: Element<ConnectCubeMessage> = if has_address {
+    let card_content: Element<ConnectCubeMessage> = if has_address && state.ln_editing {
+        // Edit mode: in-place rename form on the claimed-address card.
+        let address = current_address.clone().unwrap_or_default();
+        let username = &state.ln_username_input;
+        let format_ok = state.ln_username_error.is_none() && !username.is_empty();
+        let available = state.ln_username_available == Some(true);
+        let differs = current_username
+            .as_deref()
+            .map(|u| u != username.as_str())
+            .unwrap_or(true);
+        let can_change = format_ok && available && differs && !state.ln_changing;
+
+        let status: Element<ConnectCubeMessage> = if state.ln_checking {
+            text::p2_regular("Checking…").color(color::GREY_3).into()
+        } else if let Some(err) = &state.ln_username_error {
+            text::p2_regular(err.as_str()).color(color::RED).into()
+        } else if !differs && !username.is_empty() {
+            text::p2_regular("This is your current username")
+                .color(color::GREY_3)
+                .into()
+        } else if state.ln_username_available == Some(true) {
+            text::p2_regular("✓ Available").color(color::GREEN).into()
+        } else if username.is_empty() {
+            text::p2_regular("Choose a new username").color(color::GREY_3).into()
+        } else {
+            text::p2_regular(" ").into()
+        };
+
+        let cancel_btn = button::secondary(None, "Cancel")
+            .on_press_maybe((!state.ln_changing).then_some(
+                ConnectCubeMessage::CancelEditLightningAddress,
+            ));
+        let change_btn: Element<ConnectCubeMessage> = if state.ln_changing {
+            iced::widget::button(
+                container(text::p1_regular("Changing…").color(color::GREY_3))
+                    .center_x(Length::Fixed(140.0))
+                    .center_y(Length::Fill),
+            )
+            .height(Length::Fixed(44.0))
+            .style(theme::button::primary)
+            .into()
+        } else {
+            button::primary(None, "Change")
+                .on_press_maybe(
+                    can_change.then_some(ConnectCubeMessage::RequestChangeLightningAddress),
+                )
+                .into()
+        };
+
+        container(
+            Column::new()
+                .push(text::p1_bold("Your Lightning Address").style(theme::text::primary))
+                .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+                .push(
+                    text::p2_regular(format!("Current: {}", address)).color(color::GREY_3),
+                )
+                .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
+                .push(
+                    Row::new()
+                        .push(
+                            TextInput::new("new username", username)
+                                .on_input_maybe(
+                                    (!state.ln_changing)
+                                        .then_some(ConnectCubeMessage::LnUsernameChanged),
+                                )
+                                .on_submit_maybe(
+                                    can_change
+                                        .then_some(ConnectCubeMessage::RequestChangeLightningAddress),
+                                )
+                                .size(16)
+                                .padding(15),
+                        )
+                        .push(
+                            container(text::p1_regular(LN_ADDRESS_DOMAIN).color(color::GREY_3))
+                                .padding(15)
+                                .center_y(Length::Fixed(50.0)),
+                        )
+                        .align_y(Alignment::Center),
+                )
+                .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+                .push(status)
+                .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
+                .push(
+                    Row::new()
+                        .push(cancel_btn)
+                        .push(iced::widget::Space::new().width(Length::Fill))
+                        .push(change_btn)
+                        .align_y(Alignment::Center),
+                )
+                .push_maybe(state.ln_claim_error.as_deref().map(|err| {
+                    Column::new()
+                        .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+                        .push(text::p2_regular(err).color(color::RED))
+                }))
+                .padding(20)
+                .spacing(2),
+        )
+        .style(|t| container::Style {
+            background: Some(iced::Background::Color(t.colors.cards.simple.background)),
+            border: iced::Border {
+                color: color::ORANGE,
+                width: 0.5,
+                radius: 16.0.into(),
+            },
+            ..Default::default()
+        })
+        .width(Length::Fill)
+        .into()
+    } else if has_address {
         // Display the claimed address
-        let mut address = state
-            .lightning_address
-            .as_ref()
-            .and_then(|la| la.lightning_address.clone())
-            .unwrap_or_default();
-        if !address.contains('@') {
-            address.push_str(LN_ADDRESS_DOMAIN);
-        }
+        let address = current_address.clone().unwrap_or_default();
 
         container(
             Column::new()
@@ -1082,6 +1193,11 @@ fn lightning_address_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectC
                             .push(
                                 button::secondary(Some(clipboard_icon()), "Copy")
                                     .on_press(ConnectCubeMessage::CopyToClipboard(address)),
+                            )
+                            .push(iced::widget::Space::new().width(Length::Fixed(8.0)))
+                            .push(
+                                button::secondary(None, "Change")
+                                    .on_press(ConnectCubeMessage::BeginEditLightningAddress),
                             )
                             .align_y(Alignment::Center),
                     )
@@ -1098,9 +1214,16 @@ fn lightning_address_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectC
                 )
                 .push_maybe(state.ln_reconcile_needs_reregister.as_deref().map(|err| {
                     // API↔SDK divergence — the DB confirms the
-                    // address but the Spark SDK couldn't bind it on
-                    // this device. Surface to the user so they
-                    // know manual action may be needed.
+                    // address but the Spark SDK isn't bound to it on
+                    // this device. The retry button fires
+                    // `RetryLightningAddressReregister`, which does
+                    // an idempotent SDK delete followed by a fresh
+                    // register against the DB-confirmed username.
+                    let retry_label = if state.ln_reregistering {
+                        "Retrying…"
+                    } else {
+                        "Retry"
+                    };
                     Column::new()
                         .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
                         .push(
@@ -1109,6 +1232,11 @@ fn lightning_address_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectC
                         )
                         .push(iced::widget::Space::new().height(Length::Fixed(4.0)))
                         .push(text::p2_regular(err).color(color::GREY_3))
+                        .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+                        .push(button::secondary(None, retry_label).on_press_maybe(
+                            (!state.ln_reregistering)
+                                .then_some(ConnectCubeMessage::RetryLightningAddressReregister),
+                        ))
                 }))
                 .padding(20)
                 .spacing(2),
@@ -1220,13 +1348,65 @@ fn lightning_address_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectC
         .into()
     };
 
-    Column::new()
+    let body: Element<ConnectCubeMessage> = Column::new()
         .push(text::h4_bold("Lightning Address").style(theme::text::primary))
         .push(iced::widget::Space::new().height(Length::Fixed(15.0)))
         .push(card_content)
         .spacing(0)
         .width(Length::Fill)
-        .into()
+        .into();
+
+    if let Some(proposed) = state.ln_change_confirm_pending.clone() {
+        let current_addr = current_address.clone().unwrap_or_default();
+        let new_addr = format!("{}{}", proposed, LN_ADDRESS_DOMAIN);
+        let confirm_card = container(
+            Column::new()
+                .push(text::h4_bold("Change your Lightning Address?").color(color::ORANGE))
+                .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
+                .push(text::p1_regular(format!(
+                    "Your current address {} will stop working immediately.",
+                    current_addr
+                )))
+                .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+                .push(text::p1_regular(
+                    "Anyone using the old address won't be able to send you bitcoin.",
+                ))
+                .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+                .push(text::p1_regular(format!(
+                    "You can claim a different name later, but {} may be taken \
+                     by someone else once you release it.",
+                    current_addr
+                )))
+                .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
+                .push(
+                    text::p1_bold(format!("New address: {}", new_addr)).color(color::ORANGE),
+                )
+                .push(iced::widget::Space::new().height(Length::Fixed(20.0)))
+                .push(
+                    Row::new()
+                        .push(
+                            button::secondary(None, "Cancel")
+                                .on_press(ConnectCubeMessage::DismissChangeConfirmation),
+                        )
+                        .push(iced::widget::Space::new().width(Length::Fill))
+                        .push(
+                            button::primary(None, "Yes, change it")
+                                .on_press(ConnectCubeMessage::ConfirmChangeLightningAddress),
+                        )
+                        .align_y(Alignment::Center),
+                )
+                .padding(24)
+                .spacing(0),
+        )
+        .style(card_style)
+        .width(Length::Fixed(560.0));
+
+        coincube_ui::widget::modal::Modal::new(body, confirm_card)
+            .on_blur(Some(ConnectCubeMessage::DismissChangeConfirmation))
+            .into()
+    } else {
+        body
+    }
 }
 
 fn duress_ux<'a>() -> Element<'a, ConnectAccountMessage> {

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1039,6 +1039,33 @@ pub enum ConnectCubeMessage {
     ClaimLightningAddress,
     LightningAddressClaimed(crate::services::coincube::LightningAddress),
     LightningAddressLoaded(Option<crate::services::coincube::LightningAddress>),
+    /// Flip the claimed-address card into the in-place edit form.
+    BeginEditLightningAddress,
+    /// Drop edit mode, clear the input, abort any pending availability check.
+    CancelEditLightningAddress,
+    /// User clicked "Change" on the edit form — open the destructive
+    /// confirmation modal with the proposed new username.
+    RequestChangeLightningAddress,
+    /// User backed out of the confirmation modal.
+    DismissChangeConfirmation,
+    /// User confirmed the swap — fires the PUT + SDK delete+register chain.
+    ConfirmChangeLightningAddress,
+    /// Terminal result of the change chain. The outcome variants
+    /// distinguish server-side rejection (address unchanged) from
+    /// server-committed-but-SDK-out-of-sync (the new address is
+    /// confirmed in the API and the existing re-registration prompt
+    /// is surfaced for the user to retry the SDK side).
+    LightningAddressUpdated(crate::app::state::connect::cube::LightningAddressChangeOutcome),
+    /// Terminal result of the manual SDK rebind retry kicked off by
+    /// `RetryLightningAddressReregister`. `Ok` clears the
+    /// re-registration prompt; `Err` keeps it surfaced with an
+    /// updated message.
+    LightningAddressReregistered(Result<coincube_spark_protocol::LightningAddressInfo, String>),
+    /// Manual retry of the SDK side of a Lightning Address rebind
+    /// when reconcile flagged `ln_reconcile_needs_reregister`. Performs
+    /// SDK delete (idempotent) then register against the DB-confirmed
+    /// username.
+    RetryLightningAddressReregister,
     /// Phase 4g: the Spark SDK forwarded a `LightningAddressChanged`
     /// event — either a register/unregister on this device, or a
     /// cross-device sync replay via realtime-sync. `None` with a

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -7,8 +7,8 @@ use super::{
     Invite, LightningAddress, LoginActivity, LoginResponse, OtpRequest, OtpVerifyRequest,
     PublicAvatarData, RecoveryKit, RecoveryKitStatus, RefreshTokenRequest, RegenerationData,
     RegisterCubeRequest, ReserveLightningAddressRequest, SaveQuoteRequest, SaveQuoteResponse,
-    StatsPeriod, TimeseriesResponse, TodayStats, UpdateCubeRequest, UpsertRecoveryKitRequest, User,
-    VaultMemberResponse, VerifiedDevice,
+    StatsPeriod, TimeseriesResponse, TodayStats, UpdateCubeRequest, UpdateLightningAddressRequest,
+    UpsertRecoveryKitRequest, User, VaultMemberResponse, VerifiedDevice,
 };
 use reqwest::{Client, Method};
 use serde::Deserialize;
@@ -434,10 +434,10 @@ impl CoincubeClient {
     }
 
     /// Phase 4g step 1: reserve `username` against the cube. The API
-    /// persists the pending record but does NOT publish the BIP353
-    /// TXT yet — that lands in the [`Self::confirm_lightning_address`]
-    /// step after the Spark SDK has registered the username with the
-    /// Breez-hosted LNURL server.
+    /// persists the pending record. The follow-up
+    /// [`Self::confirm_lightning_address`] step stamps the record
+    /// confirmed once the Spark SDK has registered the username with
+    /// the Breez-hosted LNURL server.
     pub async fn reserve_lightning_address(
         &self,
         cube_id: &str,
@@ -460,7 +460,7 @@ impl CoincubeClient {
     /// Spark SDK has successfully registered the username with the
     /// Breez-hosted LNURL server. Body is empty — the API stamps
     /// `lightning_address_confirmed_at = now()` on the existing
-    /// reservation, turning it permanent. No DNS work happens.
+    /// reservation, turning it permanent.
     pub async fn confirm_lightning_address(
         &self,
         cube_id: &str,
@@ -486,6 +486,31 @@ impl CoincubeClient {
         let res = self.client.delete(&url).send().await?;
         let _ = res.check_success().await?;
         Ok(())
+    }
+
+    /// Atomic server-side rename. The cube must already have a
+    /// confirmed Lightning Address — the API updates only the
+    /// `lightning_address` column and leaves
+    /// `lightning_address_confirmed_at` set. The Spark/Breez SDK
+    /// binding still has to be updated separately on this device
+    /// (delete-then-register) since it's not reachable from the
+    /// server.
+    pub async fn update_lightning_address(
+        &self,
+        cube_id: &str,
+        username: &str,
+    ) -> Result<LightningAddress, CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/lightning-address",
+            self.base_url, cube_id
+        );
+        let req = UpdateLightningAddressRequest {
+            username: username.to_string(),
+        };
+        let res = self.client.put(&url).json(&req).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<LightningAddress> = res.json().await?;
+        Ok(resp.data)
     }
 }
 

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -654,6 +654,15 @@ pub struct ReserveLightningAddressRequest {
     pub username: String,
 }
 
+/// Body for `PUT /api/v1/connect/cubes/{id}/lightning-address`.
+/// Atomic server-side username swap on a cube that already has a
+/// confirmed Lightning Address.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateLightningAddressRequest {
+    pub username: String,
+}
+
 pub fn get_countries() -> &'static [Country] {
     static COUNTRIES_JSON: &str = include_str!("../countries.json");
     static COUNTRIES: std::sync::OnceLock<Vec<Country>> = std::sync::OnceLock::new();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new destructive rename flow that updates server state and rebinds the Breez/Spark SDK, so partial failures can leave API and SDK temporarily out of sync until the user retries.
> 
> **Overview**
> Adds an in-place **Lightning Address rename** flow in Connect: users can switch their claimed username via an edit mode with a destructive confirmation modal.
> 
> Implements a new `PUT /connect/cubes/{id}/lightning-address` client call and a state-machine chain that performs **server rename → Spark SDK delete → Spark SDK register**, with explicit outcomes for server rejection vs server-committed-but-SDK-sync-failed.
> 
> Extends the claimed-address UI to show a **Retry** action when API↔SDK divergence is detected, performing an idempotent SDK delete+register to rebind to the DB-confirmed address.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcad89b84de17ad62c57db22318e41e4dac58b60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-place editing for Lightning Address usernames with confirmation dialog
  * Enhanced error recovery with retry functionality for address synchronization failures

* **Improvements**
  * Improved Lightning Address state management and validation feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->