### PR TITLE
Fix stable balance display issues for USDB

### DIFF
--- a/coincube-gui/src/app/breez_spark/assets.rs
+++ b/coincube-gui/src/app/breez_spark/assets.rs
@@ -41,3 +41,53 @@ impl SparkAsset {
 pub fn list_assets() -> Vec<SparkAsset> {
     vec![SparkAsset::Bitcoin, SparkAsset::Lightning]
 }
+
+/// Format a token base-unit amount with two decimal places of
+/// fractional precision. Mirrors [`crate::app::breez_liquid::assets::format_usdt_display`]
+/// but parameterized on the token's own decimals (USDB ships at 6,
+/// future tokens may differ). Half-up rounding with carry to keep the
+/// output stable when the fractional rounds up to ten.
+pub fn format_token_display(amount: u64, decimals: u32) -> String {
+    const DISPLAY_DECIMALS: u32 = 2;
+    if decimals == 0 {
+        return amount.to_string();
+    }
+    let divisor = 10_u64.pow(decimals);
+    let mut whole = amount / divisor;
+    let frac = amount % divisor;
+    if decimals <= DISPLAY_DECIMALS {
+        let scale = 10_u64.pow(DISPLAY_DECIMALS - decimals);
+        return format!(
+            "{}.{:0>width$}",
+            whole,
+            frac * scale,
+            width = DISPLAY_DECIMALS as usize
+        );
+    }
+    let scale = 10_u64.pow(decimals - DISPLAY_DECIMALS);
+    let mut frac_2dp = (frac + scale / 2) / scale;
+    let carry_threshold = 10_u64.pow(DISPLAY_DECIMALS);
+    if frac_2dp >= carry_threshold {
+        frac_2dp = 0;
+        whole += 1;
+    }
+    format!(
+        "{}.{:0>width$}",
+        whole,
+        frac_2dp,
+        width = DISPLAY_DECIMALS as usize
+    )
+}
+
+/// Convert a USDB-style stable token holding (a 1:1 USD peg) into its
+/// sat-equivalent at the supplied BTC/USD price. Used by the overview
+/// to fold Stable Balance into the unified portfolio total — same
+/// pattern as Liquid's `usdt_balance` → `usdt_as_sats` calculation.
+/// Returns `0` when there's no price reference yet.
+pub fn stable_token_as_sats(amount: u64, decimals: u32, btc_usd_price: Option<f64>) -> u64 {
+    let Some(price) = btc_usd_price.filter(|p| *p > 0.0) else {
+        return 0;
+    };
+    let usd_value = amount as f64 / 10_f64.powi(decimals as i32);
+    (usd_value / price * 100_000_000.0) as u64
+}

--- a/coincube-gui/src/app/breez_spark/assets.rs
+++ b/coincube-gui/src/app/breez_spark/assets.rs
@@ -42,6 +42,12 @@ pub fn list_assets() -> Vec<SparkAsset> {
     vec![SparkAsset::Bitcoin, SparkAsset::Lightning]
 }
 
+/// Largest base-10 exponent that fits in a `u64` (10^19 ≤ u64::MAX < 10^20).
+/// Real-world token metadata uses single-digit decimals; clamping rather
+/// than panicking shields the formatter from a malformed `decimals`
+/// coming back from the bridge.
+const MAX_TOKEN_DECIMALS_U64: u32 = 19;
+
 /// Format a token base-unit amount with two decimal places of
 /// fractional precision. Mirrors [`crate::app::breez_liquid::assets::format_usdt_display`]
 /// but parameterized on the token's own decimals (USDB ships at 6,
@@ -52,6 +58,10 @@ pub fn format_token_display(amount: u64, decimals: u32) -> String {
     if decimals == 0 {
         return amount.to_string();
     }
+    // Clamp once at the top so every subsequent `10_u64.pow(...)`
+    // stays within u64 range. 10^19 fits in u64; 10^20 would panic in
+    // debug and wrap in release.
+    let decimals = decimals.min(MAX_TOKEN_DECIMALS_U64);
     let divisor = 10_u64.pow(decimals);
     let mut whole = amount / divisor;
     let frac = amount % divisor;
@@ -88,6 +98,11 @@ pub fn stable_token_as_sats(amount: u64, decimals: u32, btc_usd_price: Option<f6
     let Some(price) = btc_usd_price.filter(|p| *p > 0.0) else {
         return 0;
     };
+    // Same clamp as `format_token_display`: keeps `decimals as i32`
+    // well-defined and `10_f64.powi(decimals)` far away from the f64
+    // ~10^308 ceiling. Anything past 19 is already implausible token
+    // metadata and would saturate the formatter anyway.
+    let decimals = decimals.min(MAX_TOKEN_DECIMALS_U64);
     let usd_value = amount as f64 / 10_f64.powi(decimals as i32);
     (usd_value / price * 100_000_000.0) as u64
 }

--- a/coincube-gui/src/app/breez_spark/assets.rs
+++ b/coincube-gui/src/app/breez_spark/assets.rs
@@ -46,7 +46,7 @@ pub fn list_assets() -> Vec<SparkAsset> {
 /// Real-world token metadata uses single-digit decimals; clamping rather
 /// than panicking shields the formatter from a malformed `decimals`
 /// coming back from the bridge.
-const MAX_TOKEN_DECIMALS_U64: u32 = 19;
+pub(crate) const MAX_TOKEN_DECIMALS_U64: u32 = 19;
 
 /// Format a token base-unit amount with two decimal places of
 /// fractional precision. Mirrors [`crate::app::breez_liquid::assets::format_usdt_display`]

--- a/coincube-gui/src/app/state/global_home.rs
+++ b/coincube-gui/src/app/state/global_home.rs
@@ -557,8 +557,28 @@ impl State for GlobalHome {
                         use crate::app::menu::SparkSubMenu;
                         crate::app::state::redirect(Menu::Spark(SparkSubMenu::Receive))
                     }
-                    HomeMessage::SparkBalanceUpdated(balance) => {
-                        self.spark_balance = balance;
+                    HomeMessage::SparkBalanceUpdated {
+                        btc,
+                        stable_balance,
+                    } => {
+                        // Fold any USDB holding into the displayed
+                        // Spark balance using the current BTC/USD
+                        // reference price. Stable Balance auto-sweeps
+                        // the BTC balance into USDB, so without this
+                        // the Home card would read 0 even though the
+                        // wallet has spendable value (the SDK
+                        // converts back to sats on send).
+                        let usdb_as_sats = stable_balance
+                            .map(|sb| {
+                                crate::app::breez_spark::assets::stable_token_as_sats(
+                                    sb.balance,
+                                    sb.decimals,
+                                    cache.btc_usd_price,
+                                )
+                            })
+                            .unwrap_or(0);
+                        self.spark_balance =
+                            Amount::from_sat(btc.to_sat().saturating_add(usdb_as_sats));
                         self.spark_balance_loaded = true;
                         Task::none()
                     }
@@ -2331,9 +2351,10 @@ impl GlobalHome {
         Some(Task::perform(
             async move { backend.get_info().await },
             |result| match result {
-                Ok(info) => Message::View(view::Message::Home(HomeMessage::SparkBalanceUpdated(
-                    Amount::from_sat(info.balance_sats),
-                ))),
+                Ok(info) => Message::View(view::Message::Home(HomeMessage::SparkBalanceUpdated {
+                    btc: Amount::from_sat(info.balance_sats),
+                    stable_balance: info.stable_balance,
+                })),
                 Err(e) => {
                     tracing::warn!("Home: spark get_info failed: {}", e);
                     // Soft-fail: leave the card showing whatever the

--- a/coincube-gui/src/app/state/global_home.rs
+++ b/coincube-gui/src/app/state/global_home.rs
@@ -568,12 +568,24 @@ impl State for GlobalHome {
                         // the Home card would read 0 even though the
                         // wallet has spendable value (the SDK
                         // converts back to sats on send).
+                        //
+                        // Fallback: `cache.btc_usd_price` is only set
+                        // when the user's fiat preference is USD. For
+                        // EUR/GBP/etc. fall back to the user-fiat
+                        // converter price so the holding still shows
+                        // up (with a small FX-spread approximation)
+                        // instead of collapsing to zero.
+                        let reference_price = cache.btc_usd_price.or_else(|| {
+                            let converter: Option<view::FiatAmountConverter> =
+                                cache.fiat_price.as_ref().and_then(|p| p.try_into().ok());
+                            converter.map(|c| c.price_per_btc())
+                        });
                         let usdb_as_sats = stable_balance
                             .map(|sb| {
                                 crate::app::breez_spark::assets::stable_token_as_sats(
                                     sb.balance,
                                     sb.decimals,
-                                    cache.btc_usd_price,
+                                    reference_price,
                                 )
                             })
                             .unwrap_or(0);

--- a/coincube-gui/src/app/state/spark/overview.rs
+++ b/coincube-gui/src/app/state/spark/overview.rs
@@ -33,6 +33,11 @@ use crate::utils::format_time_ago;
 #[derive(Debug, Clone)]
 pub struct SparkBalanceSnapshot {
     pub balance_sats: u64,
+    /// USDB amount in token base units, when Stable Balance is on
+    /// and the SDK reports a non-zero USDB holding. The view folds
+    /// this into the unified portfolio total at the current BTC
+    /// price, the same way Liquid folds USDt into L-BTC.
+    pub stable_balance: Option<coincube_spark_protocol::StableBalanceSnapshot>,
 }
 
 pub struct SparkOverview {
@@ -88,6 +93,7 @@ impl State for SparkOverview {
             bitcoin_unit: cache.bitcoin_unit,
             show_direction_badges: cache.show_direction_badges,
             stable_balance_active: self.stable_balance_active.unwrap_or(false),
+            btc_usd_price: cache.btc_usd_price,
             display_mode: cache.display_mode,
         }
         .render()
@@ -119,6 +125,7 @@ impl State for SparkOverview {
                 (Ok(info), Ok(list)) => Message::View(view::Message::SparkOverview(
                     view::SparkOverviewMessage::DataLoaded {
                         balance: Amount::from_sat(info.balance_sats),
+                        stable_balance: info.stable_balance,
                         recent_payments: list.payments,
                     },
                 )),
@@ -154,12 +161,14 @@ impl State for SparkOverview {
             match msg {
                 view::SparkOverviewMessage::DataLoaded {
                     balance,
+                    stable_balance,
                     recent_payments,
                 } => {
                     self.loading = false;
                     self.error = None;
                     self.snapshot = Some(SparkBalanceSnapshot {
                         balance_sats: balance.to_sat(),
+                        stable_balance,
                     });
 
                     let fiat_converter: Option<FiatAmountConverter> =
@@ -225,9 +234,14 @@ pub(crate) fn payment_summary_to_recent_tx(
 ) -> SparkRecentTransaction {
     let is_incoming = p.direction.eq_ignore_ascii_case("Receive");
     let status = parse_status(&p.status);
+
+    if let Some(token_amount) = p.token_amount {
+        return token_payment_to_recent_tx(p, token_amount, is_incoming, status);
+    }
+
     let method = parse_method(&p.method);
-    // PaymentSummary carries the signed sat amount; the view displays
-    // the absolute value and composes the direction separately.
+    // PaymentSummary carries the unsigned sat amount; the view displays
+    // it and composes the direction from the `direction` field.
     let amount = Amount::from_sat(p.amount_sat.unsigned_abs());
     let fees_sat = Amount::from_sat(p.fees_sat);
     let fiat_amount = fiat_converter.map(|c| c.convert(amount));
@@ -242,6 +256,7 @@ pub(crate) fn payment_summary_to_recent_tx(
             }
         }
         SparkPaymentMethod::Spark => "Spark transfer".to_string(),
+        SparkPaymentMethod::StableBalance => "Stable Balance".to_string(),
     });
 
     SparkRecentTransaction {
@@ -255,6 +270,61 @@ pub(crate) fn payment_summary_to_recent_tx(
         is_incoming,
         status,
         method,
+        token_display: None,
+    }
+}
+
+/// Build a recent-tx row for a `method=token` payment. The bridge
+/// strips the sat fields to zero in this case and ships the token
+/// amount + decimals + ticker; the view renders that as the headline
+/// figure ("1.58 USDB") instead of pretending it's sats. USDB pegs
+/// 1:1 to USD, so the secondary fiat line is the token amount itself,
+/// not a BTC-derived conversion.
+fn token_payment_to_recent_tx(
+    p: &PaymentSummary,
+    token_amount: u64,
+    is_incoming: bool,
+    status: DomainPaymentStatus,
+) -> SparkRecentTransaction {
+    use crate::app::breez_spark::assets::format_token_display;
+    use crate::app::view::vault::fiat::FiatAmount;
+    use crate::services::fiat::Currency;
+
+    let decimals = p.token_decimals.unwrap_or(0);
+    let ticker = p.token_ticker.clone().unwrap_or_else(|| "USDB".to_string());
+    let token_str = format_token_display(token_amount, decimals);
+    let token_display = format!("{} {}", token_str, ticker);
+
+    // USDB ≈ $1, so the dollar value is `amount / 10^decimals`. We
+    // surface that as the row's secondary text via `FiatAmount` so it
+    // matches the existing fiat label style.
+    let dollar_value = if decimals == 0 {
+        token_amount as f64
+    } else {
+        token_amount as f64 / 10_f64.powi(decimals as i32)
+    };
+    let fiat_amount = FiatAmount::new(dollar_value, Currency::USD).ok();
+
+    let description = p
+        .description
+        .clone()
+        .unwrap_or_else(|| "Stable Balance".to_string());
+
+    SparkRecentTransaction {
+        id: p.id.clone(),
+        description,
+        time_ago: format_time_ago(p.timestamp as i64),
+        timestamp: p.timestamp,
+        // Zero out the sat amount so the row's pending-sat sums and
+        // any callers that read `amount` for BTC totals don't pick up
+        // a token figure as if it were satoshis.
+        amount: Amount::ZERO,
+        fees_sat: Amount::ZERO,
+        fiat_amount,
+        is_incoming,
+        status,
+        method: SparkPaymentMethod::StableBalance,
+        token_display: Some(token_display),
     }
 }
 
@@ -276,6 +346,7 @@ fn parse_method(raw: &str) -> SparkPaymentMethod {
     match raw.to_lowercase().as_str() {
         "lightning" => SparkPaymentMethod::Lightning,
         "deposit" | "withdraw" => SparkPaymentMethod::OnChainBitcoin,
+        "token" => SparkPaymentMethod::StableBalance,
         _ => SparkPaymentMethod::Spark,
     }
 }

--- a/coincube-gui/src/app/state/spark/overview.rs
+++ b/coincube-gui/src/app/state/spark/overview.rs
@@ -286,11 +286,16 @@ fn token_payment_to_recent_tx(
     is_incoming: bool,
     status: DomainPaymentStatus,
 ) -> SparkRecentTransaction {
-    use crate::app::breez_spark::assets::format_token_display;
+    use crate::app::breez_spark::assets::{format_token_display, MAX_TOKEN_DECIMALS_U64};
     use crate::app::view::vault::fiat::FiatAmount;
     use crate::services::fiat::Currency;
 
-    let decimals = p.token_decimals.unwrap_or(0);
+    // Clamp once so the formatter and the fiat math see the same
+    // decimals value. `format_token_display` clamps internally, but
+    // the `10_f64.powi(decimals as i32)` below would wrap for
+    // pathological inputs (`decimals > i32::MAX` casts to negative,
+    // making `powi` near-zero and the dollar figure blow up).
+    let decimals = p.token_decimals.unwrap_or(0).min(MAX_TOKEN_DECIMALS_U64);
     let ticker = p.token_ticker.clone().unwrap_or_else(|| "USDB".to_string());
     let token_str = format_token_display(token_amount, decimals);
     let token_display = format!("{} {}", token_str, ticker);

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1165,8 +1165,16 @@ pub enum HomeMessage {
     /// Navigate to Spark Receive.
     ReceiveSparkBtc,
     /// Bridge returned a fresh Spark balance (used by the Home
-    /// page's periodic balance refresh).
-    SparkBalanceUpdated(Amount),
+    /// page's periodic balance refresh). Carries the raw
+    /// `balance_sats` and the optional Stable Balance USDB holding
+    /// so the handler can fold USDB into the headline at the
+    /// current BTC/USD price (same pattern as the Spark Overview
+    /// panel — when Stable Balance is on, raw `balance_sats` reads
+    /// 0 even though the wallet still has spendable value).
+    SparkBalanceUpdated {
+        btc: Amount,
+        stable_balance: Option<coincube_spark_protocol::StableBalanceSnapshot>,
+    },
     ToggleBalanceMask,
     /// Open the wallet-picker popup on the amount screen, editing the named side.
     OpenWalletPicker(PickerSide),

--- a/coincube-gui/src/app/view/spark/last_tx.rs
+++ b/coincube-gui/src/app/view/spark/last_tx.rs
@@ -53,6 +53,7 @@ pub fn last_transactions_section<'a, M: 'a + Clone + 'static>(
             SparkPaymentMethod::Lightning => asset_network_logo("btc", "lightning", 40.0),
             SparkPaymentMethod::OnChainBitcoin => asset_network_logo("btc", "bitcoin", 40.0),
             SparkPaymentMethod::Spark => asset_network_logo("btc", "spark", 40.0),
+            SparkPaymentMethod::StableBalance => asset_network_logo("btc", "spark", 40.0),
         };
 
         let display_amount = if tx.is_incoming {
@@ -67,6 +68,9 @@ pub fn last_transactions_section<'a, M: 'a + Clone + 'static>(
             .with_label(tx.description.clone())
             .with_time_ago(tx.time_ago.clone());
 
+        if let Some(token_str) = tx.token_display.as_ref() {
+            item = item.with_amount_override(token_str.clone());
+        }
         if let Some(fiat) = tx.fiat_amount.as_ref() {
             item =
                 item.with_fiat_amount(format!("{} {}", fiat.to_rounded_string(), fiat.currency()));

--- a/coincube-gui/src/app/view/spark/mod.rs
+++ b/coincube-gui/src/app/view/spark/mod.rs
@@ -26,6 +26,9 @@ pub enum SparkOverviewMessage {
     /// Bridge returned `get_info` + `list_payments` success.
     DataLoaded {
         balance: coincube_core::miniscript::bitcoin::Amount,
+        /// USDB holding from `get_info`, when present. Folded into
+        /// the unified portfolio total alongside the BTC balance.
+        stable_balance: Option<coincube_spark_protocol::StableBalanceSnapshot>,
         recent_payments: Vec<coincube_spark_protocol::PaymentSummary>,
     },
     /// Bridge returned an error response.

--- a/coincube-gui/src/app/view/spark/overview.rs
+++ b/coincube-gui/src/app/view/spark/overview.rs
@@ -168,8 +168,19 @@ fn connected_view<'a>(
     // Stable Balance feature promises the spendable balance stays
     // pegged to fiat; if we showed only `balance_sats` here, toggling
     // Stable Balance ON would look like the wallet was emptied.
+    //
+    // Fallback: `cache.btc_usd_price` is only populated when the
+    // user's fiat preference is USD. For users on EUR/GBP/etc. it
+    // stays `None`, which would collapse the headline to 0 — so we
+    // fall back to `fiat_converter.price_per_btc()` (user-fiat per
+    // BTC). That introduces a small FX-spread error since USDB is
+    // technically USD-denominated, not user-fiat-denominated, but
+    // the error is bounded and far better than the entire holding
+    // disappearing.
+    let reference_price =
+        btc_usd_price.or_else(|| fiat_converter.as_ref().map(|c| c.price_per_btc()));
     let usdb_as_sats = stable_balance
-        .map(|sb| stable_token_as_sats(sb.balance, sb.decimals, btc_usd_price))
+        .map(|sb| stable_token_as_sats(sb.balance, sb.decimals, reference_price))
         .unwrap_or(0);
     let total_balance = Amount::from_sat(balance_sats.saturating_add(usdb_as_sats));
     let total_fiat = fiat_converter.as_ref().map(|c| c.convert(total_balance));

--- a/coincube-gui/src/app/view/spark/overview.rs
+++ b/coincube-gui/src/app/view/spark/overview.rs
@@ -57,11 +57,19 @@ pub enum SparkPaymentMethod {
     Lightning,
     OnChainBitcoin,
     Spark,
+    /// Stable Balance conversion leg (BTC ↔ USDB). Surfaces in the
+    /// transaction list whenever the SDK records the receive side of
+    /// a conversion as a top-level `method=token` payment. Rendered
+    /// with the "Stable" branding rather than as a bitcoin transfer
+    /// — the amount is in token base units, not sats.
+    StableBalance,
 }
 
 /// Row data the overview renderer needs for each recent payment.
-/// Mirrors `view::liquid::RecentTransaction` but drops the USDt-only
-/// `usdt_display` field (Spark has no USDt support).
+/// Mirrors `view::liquid::RecentTransaction` plus a `token_display`
+/// override that the Stable Balance USDB rows use the same way Liquid
+/// uses `usdt_display` — when set, the row shows that string in place
+/// of the BTC amount and skips the BTC pending-sums.
 ///
 /// Carries the Spark payment `id` and raw `timestamp` so the detail
 /// view can render a full date and a copy-to-clipboard payment ID
@@ -78,6 +86,10 @@ pub struct SparkRecentTransaction {
     pub is_incoming: bool,
     pub status: DomainPaymentStatus,
     pub method: SparkPaymentMethod,
+    /// When set, render this string instead of the BTC `amount` (e.g.
+    /// "1.58 USDB"). Token-method payments populate this; bitcoin
+    /// rows leave it `None`.
+    pub token_display: Option<String>,
 }
 
 /// View wrapper for the Spark Overview panel.
@@ -91,6 +103,10 @@ pub struct SparkOverviewView<'a> {
     /// token. Rendered as a small "Stable" badge next to the balance
     /// header.
     pub stable_balance_active: bool,
+    /// Reference BTC/USD price used to fold USDB into the unified
+    /// portfolio total at the current rate. `None` skips the fold —
+    /// matches the Liquid panel's USDt behaviour.
+    pub btc_usd_price: Option<f64>,
     pub display_mode: DisplayMode,
 }
 
@@ -118,6 +134,8 @@ impl<'a> SparkOverviewView<'a> {
                 .into(),
             SparkStatus::Connected(snapshot) => connected_view(
                 snapshot.balance_sats,
+                snapshot.stable_balance.as_ref(),
+                self.btc_usd_price,
                 self.recent_transactions,
                 self.fiat_converter,
                 self.bitcoin_unit,
@@ -132,6 +150,8 @@ impl<'a> SparkOverviewView<'a> {
 #[allow(clippy::too_many_arguments)]
 fn connected_view<'a>(
     balance_sats: u64,
+    stable_balance: Option<&coincube_spark_protocol::StableBalanceSnapshot>,
+    btc_usd_price: Option<f64>,
     recent: &'a [SparkRecentTransaction],
     fiat_converter: Option<FiatAmountConverter>,
     bitcoin_unit: BitcoinDisplayUnit,
@@ -139,21 +159,41 @@ fn connected_view<'a>(
     stable_balance_active: bool,
     display_mode: DisplayMode,
 ) -> Element<'a, SparkOverviewMessage> {
+    use crate::app::breez_spark::assets::stable_token_as_sats;
+
     let mut content = Column::new().spacing(20);
 
-    let btc_balance = Amount::from_sat(balance_sats);
-    let btc_fiat = fiat_converter.as_ref().map(|c| c.convert(btc_balance));
+    // Fold USDB into the unified portfolio total at the current
+    // BTC/USD price — same pattern as Liquid's USDt fold. The
+    // Stable Balance feature promises the spendable balance stays
+    // pegged to fiat; if we showed only `balance_sats` here, toggling
+    // Stable Balance ON would look like the wallet was emptied.
+    let usdb_as_sats = stable_balance
+        .map(|sb| stable_token_as_sats(sb.balance, sb.decimals, btc_usd_price))
+        .unwrap_or(0);
+    let total_balance = Amount::from_sat(balance_sats.saturating_add(usdb_as_sats));
+    let total_fiat = fiat_converter.as_ref().map(|c| c.convert(total_balance));
 
     // Sum pending BTC (in/out) from the recent-transactions list for
-    // the small "pending" indicators underneath the total.
+    // the small "pending" indicators underneath the total. Skip
+    // token-display rows so a USDB conversion entry doesn't get
+    // counted as pending sats.
     let pending_outgoing_sats: u64 = recent
         .iter()
-        .filter(|t| !t.is_incoming && matches!(t.status, DomainPaymentStatus::Pending))
+        .filter(|t| {
+            !t.is_incoming
+                && t.token_display.is_none()
+                && matches!(t.status, DomainPaymentStatus::Pending)
+        })
         .map(|t| (t.amount + t.fees_sat).to_sat())
         .sum();
     let pending_incoming_sats: u64 = recent
         .iter()
-        .filter(|t| t.is_incoming && matches!(t.status, DomainPaymentStatus::Pending))
+        .filter(|t| {
+            t.is_incoming
+                && t.token_display.is_none()
+                && matches!(t.status, DomainPaymentStatus::Pending)
+        })
         .map(|t| t.amount.to_sat())
         .sum();
 
@@ -168,8 +208,8 @@ fn connected_view<'a>(
                 .push_maybe(stable_balance_active.then(stable_badge)),
         )
         .push(wallet_header::<SparkOverviewMessage>(WalletHeaderProps {
-            sats: btc_balance,
-            fiat: btc_fiat,
+            sats: total_balance,
+            fiat: total_fiat,
             balance_masked: false,
             bitcoin_unit,
             variant: HeaderVariant::Overview,
@@ -181,7 +221,16 @@ fn connected_view<'a>(
             on_swap: Some(SparkOverviewMessage::FlipDisplayMode),
         }));
 
-    let btc_fiat_str = btc_fiat
+    // Stable Balance auto-sweeps the BTC balance into USDB, so the
+    // raw `balance_sats` reads 0 even though the user can still send
+    // bitcoin normally — the SDK converts USDB back to sats as needed
+    // when sending. Surface the spendable total (= raw BTC + USDB
+    // folded at the current price) so the row matches the header and
+    // accurately represents what's spendable.
+    let btc_row_amount = total_balance;
+    let btc_row_fiat = total_fiat;
+
+    let btc_fiat_str = btc_row_fiat
         .as_ref()
         .map(|f| format!("{} {}", f.to_rounded_string(), f.currency()))
         .unwrap_or_default();
@@ -191,7 +240,7 @@ fn connected_view<'a>(
         .push(coincube_ui::image::asset_network_logo::<SparkOverviewMessage>("btc", "spark", 40.0))
         .push(text("BTC").size(P1_SIZE).bold().width(Length::Fixed(60.0)))
         .push(amount_with_size_and_unit(
-            &btc_balance,
+            &btc_row_amount,
             P1_SIZE,
             bitcoin_unit,
         ))
@@ -248,6 +297,9 @@ fn connected_view<'a>(
                 SparkPaymentMethod::Spark => {
                     coincube_ui::image::asset_network_logo("btc", "spark", 40.0)
                 }
+                SparkPaymentMethod::StableBalance => {
+                    coincube_ui::image::asset_network_logo("btc", "spark", 40.0)
+                }
             };
 
             let display_amount = if tx.is_incoming {
@@ -262,6 +314,12 @@ fn connected_view<'a>(
                 .with_label(tx.description.clone())
                 .with_time_ago(tx.time_ago.clone());
 
+            if let Some(token_str) = tx.token_display.as_ref() {
+                // Token rows: replace the BTC headline with the token
+                // string. The fiat label still rides along underneath
+                // because USDB is pegged to USD.
+                item = item.with_amount_override(token_str.clone());
+            }
             if let Some(fiat) = tx.fiat_amount.as_ref() {
                 item = item.with_fiat_amount(format!(
                     "{} {}",

--- a/coincube-gui/src/app/view/spark/transactions.rs
+++ b/coincube-gui/src/app/view/spark/transactions.rs
@@ -181,6 +181,7 @@ fn transaction_row<'a>(
         SparkPaymentMethod::Lightning => asset_network_logo("btc", "lightning", 40.0),
         SparkPaymentMethod::OnChainBitcoin => asset_network_logo("btc", "bitcoin", 40.0),
         SparkPaymentMethod::Spark => asset_network_logo("btc", "spark", 40.0),
+        SparkPaymentMethod::StableBalance => asset_network_logo("btc", "spark", 40.0),
     };
 
     // Outgoing amount includes fees so the headline figure matches what
@@ -197,10 +198,25 @@ fn transaction_row<'a>(
         .with_custom_icon(combo_icon)
         .with_show_direction_badge(show_direction_badges);
 
-    if let Some(fiat_amount) = fiat_converter.map(|converter| {
-        let fiat = converter.convert(display_amount);
-        format!("{} {}", fiat.to_rounded_string(), fiat.currency())
-    }) {
+    if let Some(token_str) = tx.token_display.as_ref() {
+        item = item.with_amount_override(token_str.clone());
+    }
+
+    // For token rows: the row's `tx.fiat_amount` is already the
+    // dollar value (USDB is pegged 1:1 to USD); for sat rows we
+    // derive fiat off the display_amount via the converter so it
+    // matches what the user sees in the headline figure.
+    let fiat_label = if tx.token_display.is_some() {
+        tx.fiat_amount
+            .as_ref()
+            .map(|f| format!("{} {}", f.to_rounded_string(), f.currency()))
+    } else {
+        fiat_converter.map(|converter| {
+            let fiat = converter.convert(display_amount);
+            format!("{} {}", fiat.to_rounded_string(), fiat.currency())
+        })
+    };
+    if let Some(fiat_amount) = fiat_label {
         item = item.with_fiat_amount(fiat_amount);
     }
 
@@ -235,17 +251,27 @@ pub fn transaction_detail_view<'a>(
     // matches the list-row total the user tapped. Fees are still listed
     // separately further down. Recompute the fiat off the same total
     // rather than reusing `tx.fiat_amount`, which is amount-only.
+    //
+    // Token rows (Stable Balance) zero out `tx.amount`/`tx.fees_sat`
+    // because the payment is denominated in token base units, not
+    // sats. For those we keep the precomputed `tx.fiat_amount` (the
+    // dollar value of the token leg) and skip the converter entirely.
     let total_amount = if is_incoming {
         tx.amount
     } else {
         tx.amount + tx.fees_sat
     };
-    let total_fiat = fiat_converter.as_ref().map(|c| c.convert(total_amount));
+    let total_fiat = if tx.token_display.is_some() {
+        tx.fiat_amount
+    } else {
+        fiat_converter.as_ref().map(|c| c.convert(total_amount))
+    };
 
     let method_icon = match tx.method {
         SparkPaymentMethod::Lightning => asset_network_logo::<Message>("btc", "lightning", 56.0),
         SparkPaymentMethod::OnChainBitcoin => asset_network_logo::<Message>("btc", "bitcoin", 56.0),
         SparkPaymentMethod::Spark => asset_network_logo::<Message>("btc", "spark", 56.0),
+        SparkPaymentMethod::StableBalance => asset_network_logo::<Message>("btc", "spark", 56.0),
     };
     let method_text = match tx.method {
         SparkPaymentMethod::Lightning => "Lightning payment",
@@ -257,6 +283,7 @@ pub fn transaction_detail_view<'a>(
             }
         }
         SparkPaymentMethod::Spark => "Spark transfer",
+        SparkPaymentMethod::StableBalance => "Stable Balance",
     };
     let status_text = match tx.status {
         DomainPaymentStatus::Complete => "Completed",
@@ -273,15 +300,23 @@ pub fn transaction_detail_view<'a>(
         .as_ref()
         .map(|f| format!("{} {}", f.to_rounded_string(), f.currency()));
 
-    let amount_row = Row::new()
-        .spacing(10)
-        .align_y(Alignment::Center)
-        .push(text(sign).size(H1_SIZE))
-        .push(amount_with_size_and_unit::<Message>(
-            &total_amount,
-            H1_SIZE,
-            bitcoin_unit,
-        ));
+    let amount_row = if let Some(token_str) = tx.token_display.as_ref() {
+        Row::new()
+            .spacing(10)
+            .align_y(Alignment::Center)
+            .push(text(sign).size(H1_SIZE))
+            .push(text(token_str.clone()).size(H1_SIZE))
+    } else {
+        Row::new()
+            .spacing(10)
+            .align_y(Alignment::Center)
+            .push(text(sign).size(H1_SIZE))
+            .push(amount_with_size_and_unit::<Message>(
+                &total_amount,
+                H1_SIZE,
+                bitcoin_unit,
+            ))
+    };
 
     let mut amount_block = Column::new().spacing(4).push(amount_row);
     if let Some(s) = fiat_str {

--- a/coincube-gui/src/export.rs
+++ b/coincube-gui/src/export.rs
@@ -678,14 +678,25 @@ pub async fn export_spark_payments(
         // `token_amount` at `token_decimals` precision; sats columns
         // are zero for those rows. Render the token figure with the
         // token's own decimals so the column is human-readable.
-        let (token_amount_str, token_ticker) =
-            match (payment.token_amount, payment.token_decimals) {
-                (Some(amount), Some(decimals)) => (
+        let (token_amount_str, token_ticker) = match (payment.token_amount, payment.token_decimals)
+        {
+            (Some(amount), Some(decimals)) => {
+                // The ticker comes from the token issuer's metadata
+                // (untrusted), so CSV-quote it the same way `description`
+                // is escaped above. The amount string is closed-form
+                // (digits + ".") so it doesn't need quoting.
+                let ticker = payment
+                    .token_ticker
+                    .as_deref()
+                    .map(|t| format!("\"{}\"", t.replace('"', "\"\"")))
+                    .unwrap_or_default();
+                (
                     crate::app::breez_spark::assets::format_token_display(amount, decimals),
-                    payment.token_ticker.clone().unwrap_or_default(),
-                ),
-                _ => (String::new(), String::new()),
-            };
+                    ticker,
+                )
+            }
+            _ => (String::new(), String::new()),
+        };
 
         let line = format!(
             "{},{},{},{},{},{},{},{},{}\n",

--- a/coincube-gui/src/export.rs
+++ b/coincube-gui/src/export.rs
@@ -633,7 +633,7 @@ pub async fn export_spark_payments(
 
     let mut file = open_file_write(&path).await?;
 
-    let header = "Date,PaymentType,Method,Description,Amount (sats),Fees (sats),Net (sats)\n";
+    let header = "Date,PaymentType,Method,Description,Amount (sats),Fees (sats),Net (sats),Token Amount,Token Ticker\n";
     file.write_all(header.as_bytes())?;
 
     let list = spark_backend
@@ -674,9 +674,30 @@ pub async fn export_spark_payments(
             amount_sats as i64
         };
 
+        // Token payments (Stable Balance) carry their value in
+        // `token_amount` at `token_decimals` precision; sats columns
+        // are zero for those rows. Render the token figure with the
+        // token's own decimals so the column is human-readable.
+        let (token_amount_str, token_ticker) =
+            match (payment.token_amount, payment.token_decimals) {
+                (Some(amount), Some(decimals)) => (
+                    crate::app::breez_spark::assets::format_token_display(amount, decimals),
+                    payment.token_ticker.clone().unwrap_or_default(),
+                ),
+                _ => (String::new(), String::new()),
+            };
+
         let line = format!(
-            "{},{},{},{},{},{},{}\n",
-            date_time, payment_type, method_label, description, amount_sats, fees_sats, net_sats
+            "{},{},{},{},{},{},{},{},{}\n",
+            date_time,
+            payment_type,
+            method_label,
+            description,
+            amount_sats,
+            fees_sats,
+            net_sats,
+            token_amount_str,
+            token_ticker
         );
         file.write_all(line.as_bytes())?;
     }

--- a/coincube-spark-bridge/src/sdk_adapter.rs
+++ b/coincube-spark-bridge/src/sdk_adapter.rs
@@ -19,7 +19,7 @@ use breez_sdk_spark::{
 /// the identifier is stable across deployments and leaking the
 /// knob to ops would just mean a way to silently misconfigure a
 /// production wallet.
-const USDB_MAINNET_TOKEN_IDENTIFIER: &str =
+pub const USDB_MAINNET_TOKEN_IDENTIFIER: &str =
     "btkn1xgrvjwey5ngcagvap2dzzvsy4uk8ua9x69k82dwvt5e7ef9drm9qztux87";
 
 /// Integrator-defined label used to reference the USDB token in

--- a/coincube-spark-bridge/src/server.rs
+++ b/coincube-spark-bridge/src/server.rs
@@ -34,7 +34,7 @@ use coincube_spark_protocol::{
     LightningAddressInfo as ProtocolLightningAddressInfo, ListPaymentsOk, ListUnclaimedDepositsOk,
     Method, OkPayload, ParseInputKind, ParseInputOk, PaymentSummary, PrepareSendOk,
     ReceivePaymentOk, RegisterLightningAddressOk, Request, Response, SendPaymentOk,
-    SetStableBalanceParams,
+    SetStableBalanceParams, StableBalanceSnapshot,
 };
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::{Mutex, RwLock};
@@ -377,13 +377,25 @@ async fn handle_get_info(
         })
         .await
     {
-        Ok(info) => Response::ok(
-            id,
-            OkPayload::GetInfo(GetInfoOk {
-                balance_sats: info.balance_sats,
-                identity_pubkey: info.identity_pubkey,
-            }),
-        ),
+        Ok(info) => {
+            let stable_balance = info
+                .token_balances
+                .get(crate::sdk_adapter::USDB_MAINNET_TOKEN_IDENTIFIER)
+                .filter(|tb| tb.balance > 0)
+                .map(|tb| StableBalanceSnapshot {
+                    balance: clamp_u128_to_u64(tb.balance),
+                    decimals: tb.token_metadata.decimals,
+                    ticker: tb.token_metadata.ticker.clone(),
+                });
+            Response::ok(
+                id,
+                OkPayload::GetInfo(GetInfoOk {
+                    balance_sats: info.balance_sats,
+                    identity_pubkey: info.identity_pubkey,
+                    stable_balance,
+                }),
+            )
+        }
         Err(e) => Response::err(id, ErrorKind::Sdk, format!("get_info failed: {e}")),
     }
 }
@@ -436,15 +448,56 @@ async fn handle_list_payments(
 /// direction so the protocol crate doesn't need to mirror Spark's enums
 /// yet — later phases can replace these with typed variants as the UI
 /// starts branching on them.
+///
+/// `Payment.amount` is overloaded in the SDK ("satoshis or token base
+/// units" depending on `method`). For `PaymentMethod::Token` payments
+/// the value is in token base units (e.g. microUSDB at 6 decimals),
+/// not sats — treating it as sats produces the wrong fiat figure and
+/// a wildly inflated headline number. Token payments populate the
+/// dedicated `token_*` fields and zero out the sat fields; the gui
+/// renders them with the token's own ticker / decimals.
 fn payment_to_summary(p: breez_sdk_spark::Payment) -> PaymentSummary {
     let description = match &p.details {
         Some(PaymentDetails::Lightning { description, .. }) => description.clone(),
         _ => None,
     };
+    let token_metadata = match &p.details {
+        Some(PaymentDetails::Token { metadata, .. }) => Some(metadata.clone()),
+        _ => None,
+    };
+    let is_token = matches!(p.method, breez_sdk_spark::PaymentMethod::Token);
+
+    let (amount_sat, fees_sat, token_amount, token_decimals, token_ticker) = if is_token {
+        let metadata = token_metadata;
+        (
+            0i64,
+            0u64,
+            Some(clamp_u128_to_u64(p.amount)),
+            metadata.as_ref().map(|m| m.decimals),
+            metadata.map(|m| m.ticker),
+        )
+    } else {
+        // Match the previous behavior: ship the magnitude as i64 and
+        // let the gui derive direction from the `direction` field.
+        // Consumers all call `unsigned_abs()` on this, so flipping the
+        // sign here would silently no-op for some and double-flip for
+        // others.
+        (
+            clamp_u128_to_u64(p.amount) as i64,
+            clamp_u128_to_u64(p.fees),
+            None,
+            None,
+            None,
+        )
+    };
+
     PaymentSummary {
         id: p.id,
-        amount_sat: clamp_u128_to_u64(p.amount) as i64,
-        fees_sat: clamp_u128_to_u64(p.fees),
+        amount_sat,
+        fees_sat,
+        token_amount,
+        token_decimals,
+        token_ticker,
         timestamp: p.timestamp,
         status: format!("{:?}", p.status),
         direction: format!("{:?}", p.payment_type),

--- a/coincube-spark-protocol/src/lib.rs
+++ b/coincube-spark-protocol/src/lib.rs
@@ -316,6 +316,28 @@ pub enum OkPayload {
 pub struct GetInfoOk {
     pub balance_sats: u64,
     pub identity_pubkey: String,
+    /// Stable Balance USDB holding when the SDK reports a non-zero
+    /// USDB token balance. `None` when the user has no USDB.
+    /// Carries enough metadata for the gui to render the holding
+    /// without hardcoding decimals or ticker.
+    #[serde(default)]
+    pub stable_balance: Option<StableBalanceSnapshot>,
+}
+
+/// Snapshot of the wallet's USDB (Stable Balance) holding. Mirrors the
+/// fields the gui needs to fold the holding into the unified portfolio
+/// total, the same way the Liquid panel folds USDt into the L-BTC
+/// total.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StableBalanceSnapshot {
+    /// USDB amount in token base units (`balance / 10^decimals` is
+    /// the dollar value).
+    pub balance: u64,
+    /// Token base-units precision (USDB ships at 6 decimals today).
+    pub decimals: u32,
+    /// Display ticker (e.g. "USDB"). Plumbing only — the gui still
+    /// renders the feature as "Stable Balance".
+    pub ticker: String,
 }
 
 /// Compact payment summary used by Phase 2. The full Spark `Payment` shape is
@@ -331,11 +353,29 @@ pub struct ListPaymentsOk {
 pub struct PaymentSummary {
     /// Payment id / tx id as reported by the Spark SDK.
     pub id: String,
-    /// Amount in satoshis (direction-signed).
+    /// Amount in satoshis (direction-signed). Zero for `method=token`
+    /// payments — the real amount is in `token_amount` because Spark's
+    /// `Payment.amount` is overloaded ("satoshis or token base units"
+    /// depending on method).
     pub amount_sat: i64,
-    /// Fees paid in satoshis (non-signed).
+    /// Fees paid in satoshis (non-signed). Zero for `method=token`
+    /// payments — token fees are tracked separately on the SDK side
+    /// and aren't surfaced here yet.
     #[serde(default)]
     pub fees_sat: u64,
+    /// Token amount in base units when `method=token`; `None` for
+    /// Bitcoin-side payments. Always positive — direction is in
+    /// [`PaymentSummary::direction`].
+    #[serde(default)]
+    pub token_amount: Option<u64>,
+    /// Decimals for [`PaymentSummary::token_amount`]. `None` for
+    /// non-token payments.
+    #[serde(default)]
+    pub token_decimals: Option<u32>,
+    /// Display ticker for [`PaymentSummary::token_amount`] (e.g.
+    /// "USDB"). `None` for non-token payments.
+    #[serde(default)]
+    pub token_ticker: Option<String>,
     /// Unix timestamp in seconds.
     pub timestamp: u64,
     pub status: String,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Spark bridge/protocol payloads and GUI balance/transaction rendering, so regressions could misstate balances or exports (especially around price conversion and token formatting). No authentication or key-management logic is changed.
> 
> **Overview**
> Fixes Spark *Stable Balance (USDB)* display by propagating a non-zero USDB holding from the bridge (`get_info`) through the protocol to the GUI, then folding that value into the Spark balance shown on **Home** and the **Spark Overview** using a BTC/USD reference price (with a fiat-converter fallback when USD pricing isn’t cached).
> 
> Adds token-aware handling for Spark `method=token` payments: the bridge now emits `token_amount`/`token_decimals`/`token_ticker` (and zeros sat fields), the GUI renders these rows with a `token_display` override (and excludes them from pending sat sums / BTC fiat conversion), and CSV export includes token amount/ticker columns. Also introduces shared token helpers (`format_token_display`, `stable_token_as_sats`) with decimal clamping and rounding safeguards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a054e927f601ed62932575184acd75ab8911195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Stable Balance (USDB) support: holdings are shown and folded into the unified wallet total using BTC/USD rates.
  * Token-based payments display as token rows with formatted token amounts, distinct labeling/icon, and correct fiat totals.
  * Transaction lists and details support token amount overrides and exclude token rows from BTC pending indicators.
  * CSV export includes Token Amount and Token Ticker columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->