### PR TITLE
cleanup local node controls

### DIFF
--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -682,6 +682,11 @@ pub struct App {
     /// Prevents duplicate concurrent SDK calls when several BreezEvents arrive
     /// in quick succession. Cleared in the `RefundablesLoaded` handler.
     refundables_fetch_in_flight: bool,
+    /// Set when the user clicked "Switch to COINCUBE | Connect" on Vault →
+    /// Settings → Node while not signed in to Connect. We routed them to the
+    /// Connect tab to sign in; on the next auth transition (false → true) we
+    /// jump back to Vault Settings → Node and re-fire the switch.
+    pending_switch_to_connect_after_login: bool,
 }
 
 /// Returns true when a `DaemonError` indicates the daemon process is no longer
@@ -829,6 +834,7 @@ impl App {
                 toasted_incoming_waiting_tx_ids: VecDeque::with_capacity(16),
                 last_refundables_fetch: None,
                 refundables_fetch_in_flight: false,
+                pending_switch_to_connect_after_login: false,
             },
             cmd,
         )
@@ -925,6 +931,7 @@ impl App {
                 toasted_incoming_waiting_tx_ids: VecDeque::with_capacity(16),
                 last_refundables_fetch: None,
                 refundables_fetch_in_flight: false,
+                pending_switch_to_connect_after_login: false,
             },
             cmd,
         )
@@ -1587,9 +1594,10 @@ impl App {
                         self.cache.node_bitcoind_ibd = Some(ibd);
                         // Only auto-switch when we have observed the node transition
                         // OUT of IBD (was_in_ibd=true → ibd=false).  This prevents
-                        // the immediately reversal that occurs when ConnectLoginVerified
-                        // saves an already-synced Bitcoind into pending_bitcoind: the
-                        // first poll would otherwise see ibd=false and switch back.
+                        // the immediate reversal that occurs when the
+                        // SwitchToConnect flow saves an already-synced Bitcoind
+                        // into pending_bitcoind: the first poll would otherwise
+                        // see ibd=false and switch back.
                         if !ibd && was_in_ibd {
                             let switch =
                                 self.daemon.as_ref().and_then(|d| d.config()).and_then(|c| {
@@ -1954,6 +1962,14 @@ impl App {
                 // orphan route like Marketplace(BuySell) with no vault).
                 // Otherwise rail clicks get silently dropped and the
                 // user is trapped on whichever screen is rendering.
+                if self.pending_switch_to_connect_after_login
+                    && !matches!(menu, menu::Menu::Connect(_))
+                {
+                    // User abandoned the auto-return trip by going somewhere
+                    // else; don't surprise them with a backend swap on a
+                    // future, unrelated Connect login.
+                    self.pending_switch_to_connect_after_login = false;
+                }
                 let close_task = self
                     .panels
                     .current_mut()
@@ -1993,6 +2009,26 @@ impl App {
                 } else if was_authenticated && !self.cache.connect_authenticated {
                     // Logout occurred - clear the avatar
                     self.cache.avatar_handle = None;
+                }
+                // Auto-return for the "Switch to Connect" flow. When the user
+                // clicked it without an active session, we routed them to the
+                // Connect tab and set this flag. Now that they've signed in,
+                // jump back to Vault → Settings → Node and re-fire the switch
+                // — which will fast-path through the new session's JWT.
+                if !was_authenticated
+                    && self.cache.connect_authenticated
+                    && self.pending_switch_to_connect_after_login
+                {
+                    self.pending_switch_to_connect_after_login = false;
+                    let nav = self.set_current_panel(menu::Menu::Vault(
+                        menu::VaultSubMenu::Settings(Some(menu::SettingsOption::Node)),
+                    ));
+                    let switch = Task::done(Message::View(view::Message::Settings(
+                        view::SettingsMessage::NodeSettings(
+                            view::NodeSettingsMessage::SwitchToConnect,
+                        ),
+                    )));
+                    return Task::batch([task, nav, switch]);
                 }
                 return task;
             }
@@ -2429,6 +2465,38 @@ impl App {
                     .panels
                     .global_settings
                     .update(self.daemon.clone(), &self.cache, msg);
+            }
+
+            // Vault → Settings → Node "Switch to COINCUBE | Connect". The
+            // canonical Connect session lives in `panels.connect.account`; we
+            // either reuse its JWT for an immediate switch, or send the user
+            // to the Connect tab to sign in and auto-return on success.
+            Message::View(view::Message::Settings(view::SettingsMessage::NodeSettings(
+                view::NodeSettingsMessage::SwitchToConnect,
+            ))) => {
+                let existing_jwt = self
+                    .panels
+                    .connect
+                    .account
+                    .authenticated_client()
+                    .and_then(|c| c.token().map(str::to_owned));
+                if let Some(jwt) = existing_jwt {
+                    let routed = Message::View(view::Message::Settings(
+                        view::SettingsMessage::NodeSettings(
+                            view::NodeSettingsMessage::SwitchToConnectFastPath(jwt),
+                        ),
+                    ));
+                    if let (Some(daemon), Some(panel)) =
+                        (self.daemon.clone(), self.panels.current_mut())
+                    {
+                        return panel.update(Some(daemon), &self.cache, routed);
+                    }
+                } else {
+                    self.pending_switch_to_connect_after_login = true;
+                    return self.set_current_panel(menu::Menu::Connect(
+                        menu::ConnectSubMenu::Overview,
+                    ));
+                }
             }
 
             // Cube Recovery Kit dispatch. Handled at App level because

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1766,9 +1766,24 @@ impl App {
                             .and_then(|c| {
                                 c.fallback_esplora.as_ref().map(|fb| {
                                     let mut new_cfg = c.clone();
+                                    // Demote the current Bitcoind to
+                                    // `pending_bitcoind` so the syncing card
+                                    // reappears and the user can retry once
+                                    // the node is healthy. Without this the
+                                    // fallback strands the user on Connect
+                                    // with an empty pending slot, which
+                                    // surfaces the "Set up local node" prompt
+                                    // and forces a full re-install.
+                                    let preserved_bitcoind = match &c.bitcoin_backend {
+                                        Some(coincubed::config::BitcoinBackend::Bitcoind(bc)) => {
+                                            Some(bc.clone())
+                                        }
+                                        _ => None,
+                                    };
                                     new_cfg.bitcoin_backend = Some(
                                         coincubed::config::BitcoinBackend::Esplora(fb.clone()),
                                     );
+                                    new_cfg.pending_bitcoind = preserved_bitcoind;
                                     new_cfg.fallback_esplora = None;
                                     new_cfg
                                 })
@@ -2483,7 +2498,9 @@ impl App {
                 if let Some(jwt) = existing_jwt {
                     let routed = Message::View(view::Message::Settings(
                         view::SettingsMessage::NodeSettings(
-                            view::NodeSettingsMessage::SwitchToConnectFastPath(jwt),
+                            view::NodeSettingsMessage::SwitchToConnectFastPath(
+                                view::ConnectJwt::new(jwt),
+                            ),
                         ),
                     ));
                     if let (Some(daemon), Some(panel)) =
@@ -2493,9 +2510,8 @@ impl App {
                     }
                 } else {
                     self.pending_switch_to_connect_after_login = true;
-                    return self.set_current_panel(menu::Menu::Connect(
-                        menu::ConnectSubMenu::Overview,
-                    ));
+                    return self
+                        .set_current_panel(menu::Menu::Connect(menu::ConnectSubMenu::Overview));
                 }
             }
 

--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -271,7 +271,7 @@ impl State for BitcoindSettingsState {
                         // Connect tab to sign in. We never land here directly.
                     }
                     NodeSettingsMessage::SwitchToConnectFastPath(jwt) => {
-                        return self.apply_connect_jwt(&daemon, cache, jwt);
+                        return self.apply_connect_jwt(&daemon, cache, jwt.into_string());
                     }
                     NodeSettingsMessage::SetupLocalNode => {
                         let default_addr = match cache.network {

--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -8,8 +8,6 @@ use chrono::{NaiveDate, Utc};
 use iced::{clipboard, Task};
 use tracing::info;
 
-use crate::services::coincube::{CoincubeClient, OtpRequest, OtpVerifyRequest};
-
 use coincube_core::miniscript::bitcoin::Network;
 use coincubed::config::{
     BitcoinBackend, BitcoinConfig, BitcoindConfig, BitcoindRpcAuth, Config, ElectrumConfig,
@@ -38,23 +36,6 @@ use crate::{
         NodeType,
     },
 };
-
-#[derive(Debug)]
-enum ConnectLoginState {
-    EnterEmail {
-        client: CoincubeClient,
-        email: String,
-        loading: bool,
-        error: Option<String>,
-    },
-    EnterOtp {
-        client: CoincubeClient,
-        email: String,
-        otp: String,
-        loading: bool,
-        error: Option<String>,
-    },
-}
 
 #[derive(Debug, PartialEq)]
 enum InternalSetupStage {
@@ -85,7 +66,6 @@ pub struct BitcoindSettingsState {
     config_updated: bool,
     full_config: Option<Config>,
     node_switch_processing: bool,
-    connect_login: Option<ConnectLoginState>,
     pending_node_setup: Option<PendingNodeSetup>,
     cancel_node_setup_in_flight: bool,
 
@@ -119,7 +99,6 @@ impl BitcoindSettingsState {
             config_updated: false,
             full_config: config.clone(),
             node_switch_processing: false,
-            connect_login: None,
             bitcoind_settings: bitcoind_config.map(|bitcoind_config| {
                 BitcoindSettings::new(
                     configured_node_type,
@@ -147,6 +126,43 @@ impl BitcoindSettingsState {
             cancel_node_setup_in_flight: false,
         }
     }
+
+    /// Build an `EsploraConfig` carrying `jwt` and dispatch a `LoadDaemonConfig`
+    /// task that flips the active backend to Connect. Shared by the post-OTP
+    /// path and the App-level fast path that reuses an existing Connect
+    /// session.
+    fn apply_connect_jwt(
+        &mut self,
+        daemon: &Arc<dyn Daemon + Sync + Send>,
+        cache: &Cache,
+        jwt: String,
+    ) -> Task<Message> {
+        let Some(cfg) = daemon.config() else {
+            return Task::none();
+        };
+        // Reconstruct URL from cache.network so a stale fallback_esplora.addr
+        // (e.g. written before Testnet4 was handled) is never used.
+        use coincubed::config::EsploraConfig;
+        let esplora_url = crate::installer::connect_url(cache.network);
+        info!(
+            "Switching to Connect: url={} token_len={}",
+            esplora_url,
+            jwt.len()
+        );
+        let esplora = EsploraConfig {
+            addr: esplora_url,
+            token: Some(jwt),
+        };
+        let mut new_cfg = cfg.clone();
+        if let Some(BitcoinBackend::Bitcoind(current)) = cfg.bitcoin_backend.clone() {
+            new_cfg.pending_bitcoind = Some(current);
+        }
+        new_cfg.bitcoin_backend = Some(BitcoinBackend::Esplora(esplora));
+        new_cfg.fallback_esplora = None;
+        self.node_switch_processing = true;
+        self.warning = None;
+        Task::done(Message::LoadDaemonConfig(Box::new(new_cfg)))
+    }
 }
 
 impl State for BitcoindSettingsState {
@@ -165,7 +181,6 @@ impl State for BitcoindSettingsState {
                 Ok(()) => {
                     self.config_updated = true;
                     self.node_switch_processing = false;
-                    self.connect_login = None;
                     self.pending_node_setup = None;
                     self.warning = None;
                     self.full_config = daemon.config().cloned();
@@ -197,7 +212,6 @@ impl State for BitcoindSettingsState {
                 Err(e) => {
                     self.config_updated = false;
                     self.node_switch_processing = false;
-                    self.connect_login = None;
                     self.pending_node_setup = None;
                     self.cancel_node_setup_in_flight = false;
                     let err_msg = e.to_string();
@@ -251,189 +265,14 @@ impl State for BitcoindSettingsState {
                 use view::NodeSettingsMessage;
                 match msg {
                     NodeSettingsMessage::SwitchToConnect => {
-                        // Gate the switch behind a fresh COINCUBE | Connect login
-                        // to obtain a valid JWT before starting the daemon.
-                        self.connect_login = Some(ConnectLoginState::EnterEmail {
-                            client: CoincubeClient::new(),
-                            email: String::new(),
-                            loading: false,
-                            error: None,
-                        });
+                        // The App-level dispatcher always rewrites this into
+                        // either `SwitchToConnectFastPath(jwt)` (if a Connect
+                        // session is already live) or a navigation to the
+                        // Connect tab to sign in. We never land here directly.
                     }
-                    NodeSettingsMessage::ConnectLoginCancel => {
-                        self.connect_login = None;
+                    NodeSettingsMessage::SwitchToConnectFastPath(jwt) => {
+                        return self.apply_connect_jwt(&daemon, cache, jwt);
                     }
-                    NodeSettingsMessage::ConnectLoginEmailChanged(email) => {
-                        if let Some(ConnectLoginState::EnterEmail {
-                            email: ref mut e, ..
-                        }) = self.connect_login
-                        {
-                            *e = email;
-                        }
-                    }
-                    NodeSettingsMessage::ConnectLoginRequestOtp => {
-                        if let Some(ConnectLoginState::EnterEmail {
-                            ref client,
-                            ref email,
-                            ref mut loading,
-                            ref mut error,
-                        }) = self.connect_login
-                        {
-                            if email.contains('@')
-                                && email.contains('.')
-                                && email.len() >= 6
-                                && !*loading
-                            {
-                                *loading = true;
-                                *error = None;
-                                let client = client.clone();
-                                let req = OtpRequest {
-                                    email: email.clone(),
-                                };
-                                return Task::perform(
-                                    async move {
-                                        client.login_send_otp(req).await.map_err(|e| e.to_string())
-                                    },
-                                    |res| {
-                                        Message::View(view::Message::Settings(
-                                            view::SettingsMessage::NodeSettings(
-                                                view::NodeSettingsMessage::ConnectLoginOtpRequested(
-                                                    res,
-                                                ),
-                                            ),
-                                        ))
-                                    },
-                                );
-                            }
-                        }
-                    }
-                    NodeSettingsMessage::ConnectLoginOtpRequested(res) => match res {
-                        Ok(()) => {
-                            let (client, email) = match self.connect_login.take() {
-                                Some(ConnectLoginState::EnterEmail { client, email, .. }) => {
-                                    (client, email)
-                                }
-                                other => {
-                                    self.connect_login = other;
-                                    return Task::none();
-                                }
-                            };
-                            self.connect_login = Some(ConnectLoginState::EnterOtp {
-                                client,
-                                email,
-                                otp: String::new(),
-                                loading: false,
-                                error: None,
-                            });
-                        }
-                        Err(e) => {
-                            if let Some(ConnectLoginState::EnterEmail {
-                                ref mut loading,
-                                ref mut error,
-                                ..
-                            }) = self.connect_login
-                            {
-                                *loading = false;
-                                *error = Some(e);
-                            }
-                        }
-                    },
-                    NodeSettingsMessage::ConnectLoginOtpChanged(otp) => {
-                        if let Some(ConnectLoginState::EnterOtp { otp: ref mut o, .. }) =
-                            self.connect_login
-                        {
-                            *o = otp;
-                        }
-                    }
-                    NodeSettingsMessage::ConnectLoginVerifyOtp => {
-                        if let Some(ConnectLoginState::EnterOtp {
-                            ref client,
-                            ref email,
-                            ref otp,
-                            ref mut loading,
-                            ref mut error,
-                        }) = self.connect_login
-                        {
-                            if otp.len() == 6 && !*loading {
-                                *loading = true;
-                                *error = None;
-                                let client = client.clone();
-                                let req = OtpVerifyRequest {
-                                    email: email.clone(),
-                                    otp: otp.clone(),
-                                };
-                                return Task::perform(
-                                    async move {
-                                        client
-                                            .login_verify_otp(req)
-                                            .await
-                                            .map(|resp| resp.token)
-                                            .map_err(|e| e.to_string())
-                                    },
-                                    |res| {
-                                        Message::View(view::Message::Settings(
-                                            view::SettingsMessage::NodeSettings(
-                                                view::NodeSettingsMessage::ConnectLoginVerified(
-                                                    res,
-                                                ),
-                                            ),
-                                        ))
-                                    },
-                                );
-                            }
-                        }
-                    }
-                    NodeSettingsMessage::ConnectLoginVerified(res) => match res {
-                        Ok(jwt) => {
-                            if matches!(
-                                self.connect_login,
-                                Some(ConnectLoginState::EnterOtp { .. })
-                            ) {
-                                self.connect_login = None;
-                                if let Some(cfg) = daemon.config() {
-                                    // Reconstruct URL from cache.network so a
-                                    // stale fallback_esplora.addr (e.g. written
-                                    // before Testnet4 was handled) is never used.
-                                    use coincubed::config::EsploraConfig;
-                                    let esplora_url = crate::installer::connect_url(cache.network);
-                                    info!(
-                                        "Switching to Connect: url={} token_len={}",
-                                        esplora_url,
-                                        jwt.len()
-                                    );
-                                    let esplora = EsploraConfig {
-                                        addr: esplora_url,
-                                        token: Some(jwt),
-                                    };
-                                    let mut new_cfg = cfg.clone();
-                                    if let Some(BitcoinBackend::Bitcoind(current)) =
-                                        cfg.bitcoin_backend.clone()
-                                    {
-                                        new_cfg.pending_bitcoind = Some(current);
-                                    }
-                                    new_cfg.bitcoin_backend =
-                                        Some(BitcoinBackend::Esplora(esplora));
-                                    new_cfg.fallback_esplora = None;
-                                    self.node_switch_processing = true;
-                                    self.warning = None;
-                                    return Task::done(Message::LoadDaemonConfig(Box::new(
-                                        new_cfg,
-                                    )));
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            if let Some(ConnectLoginState::EnterOtp {
-                                ref mut loading,
-                                ref mut error,
-                                ..
-                            }) = self.connect_login
-                            {
-                                *loading = false;
-                                *error = Some(e);
-                            }
-                        }
-                    },
                     NodeSettingsMessage::SetupLocalNode => {
                         let default_addr = match cache.network {
                             Network::Bitcoin => "127.0.0.1:8332",
@@ -770,38 +609,6 @@ impl State for BitcoindSettingsState {
                         );
                     }
                 }
-            } else if let Some(login) = &self.connect_login {
-                let (step, email, otp, loading, error) = match login {
-                    ConnectLoginState::EnterEmail {
-                        email,
-                        loading,
-                        error,
-                        ..
-                    } => (
-                        view::vault::settings::ConnectLoginViewStep::EnterEmail,
-                        email.as_str(),
-                        "",
-                        *loading,
-                        error.clone(),
-                    ),
-                    ConnectLoginState::EnterOtp {
-                        email,
-                        otp,
-                        loading,
-                        error,
-                        ..
-                    } => (
-                        view::vault::settings::ConnectLoginViewStep::EnterOtp,
-                        email.as_str(),
-                        otp.as_str(),
-                        *loading,
-                        error.clone(),
-                    ),
-                };
-                setting_panels.push(
-                    view::vault::settings::connect_login_panel(&step, email, otp, loading, error)
-                        .map(map_node_msg),
-                );
             } else {
                 let (
                     active_backend,
@@ -844,6 +651,7 @@ impl State for BitcoindSettingsState {
                         active_backend,
                         active_icon,
                         cache.node_bitcoind_sync_progress,
+                        cache.node_bitcoind_ibd,
                         cache.node_bitcoind_last_log.as_deref(),
                         can_switch_to_connect,
                         can_switch_to_bitcoind,

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -15,6 +15,37 @@ use crate::{
     },
 };
 use coincubed::config::BitcoindConfig;
+use zeroize::Zeroizing;
+
+/// Wrapper around a Connect bearer token that redacts its contents from
+/// `Debug` output and zeroes the heap allocation on drop.
+///
+/// Carried by [`NodeSettingsMessage::SwitchToConnectFastPath`] so the JWT
+/// does not leak through `{:?}` on a parent message — `NodeSettingsMessage`
+/// derives `Debug`, and tracing/panic dumps elsewhere format messages
+/// transitively. Mirrors the pattern used by `CoincubeClient` and
+/// `EsploraConfig` (services/coincube/client.rs, coincubed/src/config.rs).
+#[derive(Clone)]
+pub struct ConnectJwt(Zeroizing<String>);
+
+impl ConnectJwt {
+    pub fn new(token: String) -> Self {
+        Self(Zeroizing::new(token))
+    }
+
+    /// Consume the wrapper and yield the bearer token. The original
+    /// `Zeroizing<String>` is dropped here and its heap bytes are wiped;
+    /// the returned `String` is a fresh allocation owned by the caller.
+    pub fn into_string(self) -> String {
+        (*self.0).clone()
+    }
+}
+
+impl std::fmt::Debug for ConnectJwt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ConnectJwt(<redacted>)")
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum FeeratePriority {
@@ -287,8 +318,10 @@ pub enum NodeSettingsMessage {
     /// state.
     SwitchToConnect,
     /// Carries an existing Connect JWT directly to the per-panel state so the
-    /// switch can complete without the user signing in again.
-    SwitchToConnectFastPath(String),
+    /// switch can complete without the user signing in again. The JWT is
+    /// wrapped in [`ConnectJwt`] so `{:?}` on this message redacts the token
+    /// rather than printing it verbatim.
+    SwitchToConnectFastPath(ConnectJwt),
     SwitchToBitcoind,
     // "Set up local node while on Connect" sub-flow
     SetupLocalNode,

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -280,16 +280,16 @@ pub enum InstallStatsViewMessage {
 
 #[derive(Debug, Clone)]
 pub enum NodeSettingsMessage {
+    /// Trigger from the "Switch to COINCUBE | Connect" button. Always
+    /// rewritten by the App-level dispatcher into either
+    /// `SwitchToConnectFastPath(jwt)` (when a Connect session is live) or a
+    /// navigation to the Connect tab to sign in. Never reaches the per-panel
+    /// state.
     SwitchToConnect,
+    /// Carries an existing Connect JWT directly to the per-panel state so the
+    /// switch can complete without the user signing in again.
+    SwitchToConnectFastPath(String),
     SwitchToBitcoind,
-    // COINCUBE | Connect re-authentication sub-flow (gates the Switch to Connect action)
-    ConnectLoginEmailChanged(String),
-    ConnectLoginRequestOtp,
-    ConnectLoginOtpRequested(Result<(), String>),
-    ConnectLoginOtpChanged(String),
-    ConnectLoginVerifyOtp,
-    ConnectLoginVerified(Result<String, String>), // Ok(jwt_token)
-    ConnectLoginCancel,
     // "Set up local node while on Connect" sub-flow
     SetupLocalNode,
     SetupLocalNodeCancel,

--- a/coincube-gui/src/app/view/vault/settings/mod.rs
+++ b/coincube-gui/src/app/view/vault/settings/mod.rs
@@ -1263,13 +1263,22 @@ pub fn node_backend_status<'a>(
     );
 
     if let Some(progress) = pending_progress.filter(|_| still_syncing) {
-        let desc = if progress > 0.98 {
-            "Bitcoin Core is synchronising the blockchain. This may take a few minutes, depending on the last time it was done, your internet connection, and your computer performance."
+        let pace = if progress > 0.98 {
+            "This may take a few minutes, depending on the last time it was done, your internet connection, and your computer performance."
         } else if progress > 0.9 {
-            "Bitcoin Core is synchronising the blockchain. This will take a while, depending on the last time it was done, your internet connection, and your computer performance."
+            "This will take a while, depending on the last time it was done, your internet connection, and your computer performance."
         } else {
-            "Bitcoin Core is synchronising the blockchain. A full synchronisation typically takes a few days and is resource-intensive. Once the initial synchronisation is done, the next ones will be much faster."
+            "A full synchronisation typically takes a few days and is resource-intensive. Once the initial synchronisation is done, the next ones will be much faster."
         };
+        // Mirror the wording from `internal_node_setup_panel` so the user
+        // sees the same promise from both entry points: a freshly installed
+        // managed node, and a pending node we previously set aside when
+        // toggling to Connect.
+        let desc = format!(
+            "Bitcoin Core is running and syncing in the background. \
+             COINCUBE will automatically switch to this node once syncing is complete. {}",
+            pace,
+        );
 
         let mut sync_col = Column::new()
             .spacing(8)
@@ -1303,13 +1312,16 @@ pub fn node_backend_status<'a>(
             btn.on_press(NodeSettingsMessage::SwitchToConnect)
         });
     }
-    if can_switch_to_bitcoind {
-        let label = if pending_progress.is_some() && still_syncing {
-            "Switch to local node (still syncing)"
-        } else {
-            "Switch to local node"
-        };
-        let btn = button::secondary(None, label).padding([8, 15]);
+    // While the pending local node is still in IBD the auto-switch on the
+    // App side will flip the backend the moment it completes; surfacing a
+    // "Switch to local node" button here just produces a "still syncing"
+    // warning and adds no value. When IBD status is still unknown (the
+    // first sync probe hasn't returned yet) we keep the button visible —
+    // the defensive guard in `SwitchToBitcoind` will warn cleanly if the
+    // user clicks before the probe lands.
+    let show_switch_to_bitcoind_btn = can_switch_to_bitcoind && pending_ibd != Some(true);
+    if show_switch_to_bitcoind_btn {
+        let btn = button::secondary(None, "Switch to local node").padding([8, 15]);
         btn_row = btn_row.push(if processing {
             btn
         } else {
@@ -1324,7 +1336,7 @@ pub fn node_backend_status<'a>(
             btn.on_press(NodeSettingsMessage::SetupLocalNode)
         });
     }
-    if can_switch_to_connect || can_switch_to_bitcoind || can_setup_local_node {
+    if can_switch_to_connect || show_switch_to_bitcoind_btn || can_setup_local_node {
         col = col.push(btn_row);
     }
 

--- a/coincube-gui/src/app/view/vault/settings/mod.rs
+++ b/coincube-gui/src/app/view/vault/settings/mod.rs
@@ -1226,103 +1226,12 @@ fn expire_message_units(sequence: u32) -> Vec<String> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum ConnectLoginViewStep {
-    EnterEmail,
-    EnterOtp,
-}
-
-pub fn connect_login_panel<'a>(
-    step: &ConnectLoginViewStep,
-    email: &'a str,
-    otp: &'a str,
-    loading: bool,
-    error: Option<String>,
-) -> Element<'a, NodeSettingsMessage> {
-    let mut col = Column::new().spacing(15);
-
-    col = col.push(
-        Row::new()
-            .push(text("Sign in to COINCUBE | Connect").bold())
-            .push(Space::new().width(Length::Fill))
-            .push(
-                button::transparent(None, "Cancel")
-                    .on_press(NodeSettingsMessage::ConnectLoginCancel),
-            )
-            .align_y(Alignment::Center),
-    );
-
-    match step {
-        ConnectLoginViewStep::EnterEmail => {
-            let valid = email.contains('@') && email.contains('.') && email.len() >= 6;
-            let mut email_input = TextInput::new("your@email.com", email)
-                .on_input(NodeSettingsMessage::ConnectLoginEmailChanged)
-                .size(16)
-                .padding(12)
-                .width(Length::Fill);
-            if valid {
-                email_input = email_input.on_submit(NodeSettingsMessage::ConnectLoginRequestOtp);
-            }
-            col = col.push(
-                Column::new()
-                    .spacing(8)
-                    .push(caption("Email address"))
-                    .push(email_input),
-            );
-            let mut send_btn = button::primary(None, if loading { "Sending…" } else { "Send OTP" })
-                .padding([10, 20]);
-            if valid && !loading {
-                send_btn = send_btn.on_press(NodeSettingsMessage::ConnectLoginRequestOtp);
-            }
-            col = col.push(send_btn);
-        }
-        ConnectLoginViewStep::EnterOtp => {
-            col = col.push(
-                text(format!("A one-time code was sent to {}", email))
-                    .style(theme::text::secondary),
-            );
-            let mut otp_input = TextInput::new("6-digit code", otp)
-                .on_input(NodeSettingsMessage::ConnectLoginOtpChanged)
-                .size(16)
-                .padding(12)
-                .width(Length::Fill);
-            if otp.len() == 6 && !loading {
-                otp_input = otp_input.on_submit(NodeSettingsMessage::ConnectLoginVerifyOtp);
-            }
-            col = col.push(
-                Column::new()
-                    .spacing(8)
-                    .push(caption("One-time code"))
-                    .push(otp_input),
-            );
-            let mut verify_btn = button::primary(
-                None,
-                if loading {
-                    "Verifying…"
-                } else {
-                    "Verify & Switch"
-                },
-            )
-            .padding([10, 20]);
-            if otp.len() == 6 && !loading {
-                verify_btn = verify_btn.on_press(NodeSettingsMessage::ConnectLoginVerifyOtp);
-            }
-            col = col.push(verify_btn);
-        }
-    }
-
-    if let Some(e) = error {
-        col = col.push(text(e).style(theme::text::warning));
-    }
-
-    card::simple(Container::new(col).padding(15).width(Length::Fill)).into()
-}
-
 #[allow(clippy::too_many_arguments)]
 pub fn node_backend_status<'a>(
     active_backend: &'static str,
     active_icon: coincube_ui::widget::Text<'static>,
     pending_progress: Option<f64>,
+    pending_ibd: Option<bool>,
     pending_bitcoind_log: Option<&'a str>,
     can_switch_to_connect: bool,
     can_switch_to_bitcoind: bool,
@@ -1330,6 +1239,10 @@ pub fn node_backend_status<'a>(
     processing: bool,
     warning: Option<String>,
 ) -> Element<'a, NodeSettingsMessage> {
+    // Once the node reports it has left initial block download, treat it as
+    // ready even if `verificationprogress` still pins at 1.0 — otherwise the
+    // syncing copy/button label keep saying "syncing" at 100%.
+    let still_syncing = pending_ibd != Some(false);
     let mut col = Column::new().spacing(15);
 
     col = col.push(
@@ -1349,7 +1262,7 @@ pub fn node_backend_status<'a>(
         .width(Length::Fill),
     );
 
-    if let Some(progress) = pending_progress {
+    if let Some(progress) = pending_progress.filter(|_| still_syncing) {
         let desc = if progress > 0.98 {
             "Bitcoin Core is synchronising the blockchain. This may take a few minutes, depending on the last time it was done, your internet connection, and your computer performance."
         } else if progress > 0.9 {
@@ -1391,7 +1304,7 @@ pub fn node_backend_status<'a>(
         });
     }
     if can_switch_to_bitcoind {
-        let label = if pending_progress.is_some() {
+        let label = if pending_progress.is_some() && still_syncing {
             "Switch to local node (still syncing)"
         } else {
             "Switch to local node"

--- a/coincubed/src/bitcoin/electrum/mod.rs
+++ b/coincubed/src/bitcoin/electrum/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use bdk_electrum::bdk_chain::{
     bitcoin::{self, bip32::ChildNumber, BlockHash, OutPoint},
-    local_chain::LocalChain,
+    local_chain::{CannotConnectError, LocalChain},
     spk_client::{FullScanRequest, SyncRequest},
     ChainPosition,
 };
@@ -21,6 +21,10 @@ pub enum ElectrumError {
         BlockHash, /*server hash*/
         BlockHash, /*wallet hash*/
     ),
+    /// Electrum returned a chain update that doesn't connect to the wallet's
+    /// existing local_chain. The poller will retry, and `full_scan` has been
+    /// flipped on so the next iteration rebuilds from genesis.
+    CannotConnect(CannotConnectError),
 }
 
 impl std::fmt::Display for ElectrumError {
@@ -35,6 +39,12 @@ impl std::fmt::Display for ElectrumError {
                     expected, server, wallet,
                 )
             }
+            ElectrumError::CannotConnect(e) => write!(
+                f,
+                "Electrum chain update did not connect to the local chain: '{}'. \
+                 Falling back to a full scan.",
+                e
+            ),
         }
     }
 }
@@ -201,7 +211,16 @@ impl Electrum {
         if let Some(keychain_update) = keychain_update {
             self.bdk_wallet.apply_keychain_update(keychain_update);
         }
-        let changeset = self.bdk_wallet.apply_connected_chain_update(chain_update);
+        let changeset = match self.bdk_wallet.apply_connected_chain_update(chain_update) {
+            Ok(cs) => cs,
+            Err(e) => {
+                // Trigger a full scan on the next poll so the chain rebuilds
+                // from genesis and connects unconditionally. The poller
+                // already retries on `Err`.
+                self.full_scan = true;
+                return Err(ElectrumError::CannotConnect(e));
+            }
+        };
 
         let mut changes_iter = changeset.into_iter();
         let reorg_common_ancestor = if let Some((height, _)) = changes_iter.next() {

--- a/coincubed/src/bitcoin/electrum/wallet.rs
+++ b/coincubed/src/bitcoin/electrum/wallet.rs
@@ -7,7 +7,7 @@ use std::{
 use bdk_electrum::bdk_chain::{
     bitcoin::{self, bip32, BlockHash, OutPoint, ScriptBuf, TxOut},
     keychain::KeychainTxOutIndex,
-    local_chain::{ChangeSet as ChainChangeSet, CheckPoint, LocalChain},
+    local_chain::{CannotConnectError, ChangeSet as ChainChangeSet, CheckPoint, LocalChain},
     miniscript::{Descriptor, DescriptorPublicKey},
     tx_graph::{self, TxGraph},
     ChainOracle, ChainPosition, ConfirmationTimeHeightAnchor, IndexedTxGraph,
@@ -313,11 +313,18 @@ impl BdkWallet {
     }
 
     /// Apply an update to the local chain.
-    /// Panics if update does not connect to the local chain.
-    pub fn apply_connected_chain_update(&mut self, chain_update: CheckPoint) -> ChainChangeSet {
-        self.local_chain
-            .apply_update(chain_update)
-            .expect("update must connect to local chain")
+    ///
+    /// Returns `Err(CannotConnectError)` when the update cannot be spliced
+    /// onto the wallet's existing chain — typically right after switching
+    /// backends, when the new server's first sync update doesn't share a
+    /// checkpoint with the local chain that came from the old backend. The
+    /// caller's correct response is to trigger a full scan, which always
+    /// connects (worst case at genesis).
+    pub fn apply_connected_chain_update(
+        &mut self,
+        chain_update: CheckPoint,
+    ) -> Result<ChainChangeSet, CannotConnectError> {
+        self.local_chain.apply_update(chain_update)
     }
 
     /// Apply a graph update.

--- a/coincubed/src/bitcoin/esplora/mod.rs
+++ b/coincubed/src/bitcoin/esplora/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use bdk_electrum::bdk_chain::{
     bitcoin::{self, bip32::ChildNumber, BlockHash, OutPoint},
-    local_chain::LocalChain,
+    local_chain::{CannotConnectError, LocalChain},
     spk_client::{FullScanRequest, SyncRequest},
     ChainPosition,
 };
@@ -21,6 +21,10 @@ pub enum EsploraError {
         BlockHash, /*server hash*/
         BlockHash, /*wallet hash*/
     ),
+    /// Esplora returned a chain update that doesn't connect to the wallet's
+    /// existing local_chain. The poller will retry, and `full_scan` has been
+    /// flipped on so the next iteration rebuilds from genesis.
+    CannotConnect(CannotConnectError),
 }
 
 impl std::fmt::Display for EsploraError {
@@ -35,6 +39,12 @@ impl std::fmt::Display for EsploraError {
                     expected, server, wallet,
                 )
             }
+            EsploraError::CannotConnect(e) => write!(
+                f,
+                "Esplora chain update did not connect to the local chain: '{}'. \
+                 Falling back to a full scan.",
+                e
+            ),
         }
     }
 }
@@ -184,7 +194,16 @@ impl Esplora {
         if let Some(keychain_update) = keychain_update {
             self.bdk_wallet.apply_keychain_update(keychain_update);
         }
-        let changeset = self.bdk_wallet.apply_connected_chain_update(chain_update);
+        let changeset = match self.bdk_wallet.apply_connected_chain_update(chain_update) {
+            Ok(cs) => cs,
+            Err(e) => {
+                // Trigger a full scan on the next poll so the chain rebuilds
+                // from genesis and connects unconditionally. The poller
+                // already retries on `Err`.
+                self.full_scan = true;
+                return Err(EsploraError::CannotConnect(e));
+            }
+        };
 
         let mut changes_iter = changeset.into_iter();
         let reorg_common_ancestor = if let Some((height, _)) = changes_iter.next() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches node-backend switching logic and wallet sync error handling; misrouting or state bugs could leave users on the wrong backend or trigger extra rescans, but changes are localized and add guards.
> 
> **Overview**
> Streamlines the **"Switch to COINCUBE | Connect"** flow by reusing an existing Connect session JWT when available, otherwise routing the user to the Connect tab and auto-returning to Vault → Settings → Node after login to complete the switch.
> 
> Cleans up Vault node settings by removing the embedded OTP login UI, adding a redacted/zeroizing `ConnectJwt` message wrapper, and improving Bitcoind fallback behavior (preserve current Bitcoind as `pending_bitcoind`, clearer syncing UI using IBD state, and hide the manual switch button while IBD is true).
> 
> Hardens backend sync in `coincubed` by handling non-connecting chain updates for Electrum/Esplora as recoverable errors (`CannotConnect`), triggering a full rescan instead of panicking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a6b3e83fcdff89fcc5e7b49c6ed7921c5069981. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined authentication for switching to Connect backend
  * Automatic return to Vault settings after successful login

* **Refactor**
  * Enhanced node status display with block synchronization progress tracking
  * Improved safeguards against unintended backend changes during navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->