### PR TITLE
Invite contacts

### DIFF
--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1158,15 +1158,12 @@ impl ConnectAccountPanel {
 
             ContactsMessage::ReceivedInviteAccepted(invite_id) => {
                 self.contacts_state.accepting_invite_ids.remove(&invite_id);
-                // Optimistically drop the row so the user gets instant
-                // feedback before the refetch lands. The
-                // `reload_contacts()` call below also resets
-                // `received_invites = None`, which will trigger the
-                // skeleton briefly — that's the same UX the existing
-                // Resend / Revoke flows have, so it's consistent.
-                if let Some(received) = self.contacts_state.received_invites.as_mut() {
-                    received.retain(|i| i.id != invite_id);
-                }
+                // Reload from the API. This resets `received_invites = None`
+                // and shows the skeleton briefly before the refetch lands —
+                // the same UX as the InviteCreated / Resend flows. (An
+                // optimistic `retain()` here would be a dead store: the view
+                // only renders after `update()` returns, by which point
+                // `reload_contacts()` has already cleared the list.)
                 return self.reload_contacts();
             }
 

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -9,8 +9,8 @@ use crate::{
     services::coincube::{
         BillingCycle, BillingHistoryEntry, ChargeStatus, CheckoutRequest, CheckoutResponse,
         CoincubeClient, ConnectPlan, Contact, ContactCube, ContactRole, CreateInviteRequest,
-        FeaturesResponse, Invite, LoginActivity, LoginResponse, OtpRequest, OtpVerifyRequest, User,
-        VerifiedDevice,
+        FeaturesResponse, Invite, LoginActivity, LoginResponse, OtpRequest, OtpVerifyRequest,
+        ReceivedInvite, User, VerifiedDevice,
     },
 };
 
@@ -72,6 +72,18 @@ pub struct ContactsState {
     pub step: ContactsStep,
     pub contacts: Option<Vec<Contact>>,
     pub invites: Option<Vec<Invite>>,
+    /// Pending invites addressed to the authenticated user (inbound).
+    /// `None` while the initial fetch is in flight; `Some(vec)` once
+    /// loaded (possibly empty). The backend filters server-side to
+    /// pending + non-expired
+    /// (`coincube-api/services/connect/invite/handlers/invite.go:374-429`),
+    /// so the view renders it as-is without a second filter pass.
+    pub received_invites: Option<Vec<ReceivedInvite>>,
+    /// Invite ids whose Accept request is currently in flight. Prevents
+    /// a double-tap from firing two `accept_invite_by_id` calls (the
+    /// second would race against the server-side row lock and surface
+    /// an opaque error); also drives the per-row "Accepting…" label.
+    pub accepting_invite_ids: std::collections::HashSet<u64>,
     pub invite_email: String,
     pub invite_role: ContactRole,
     pub invite_sending: bool,
@@ -147,6 +159,8 @@ impl ContactsState {
             step: ContactsStep::List,
             contacts: None,
             invites: None,
+            received_invites: None,
+            accepting_invite_ids: std::collections::HashSet::new(),
             invite_email: String::new(),
             invite_role: ContactRole::Keyholder,
             invite_sending: false,
@@ -364,6 +378,7 @@ impl ConnectAccountPanel {
         self.contacts_state.step = ContactsStep::List;
         self.contacts_state.contacts = None;
         self.contacts_state.invites = None;
+        self.contacts_state.received_invites = None;
         self.contacts_state.error = None;
         self.contacts_state.loading = true;
         load_contacts_data(&self.client, self.session_generation)
@@ -1077,8 +1092,13 @@ impl ConnectAccountPanel {
             ContactsMessage::ContactsLoaded(contacts, gen) => {
                 if gen == self.session_generation {
                     self.contacts_state.contacts = Some(contacts);
-                    // Clear loading only when both are done
-                    if self.contacts_state.invites.is_some() {
+                    // Clear loading only when all three sibling fetches
+                    // (contacts, sent invites, received invites) have
+                    // landed; otherwise the view flips from spinner to
+                    // empty-state before the late arrival paints.
+                    if self.contacts_state.invites.is_some()
+                        && self.contacts_state.received_invites.is_some()
+                    {
                         self.contacts_state.loading = false;
                     }
                 }
@@ -1087,10 +1107,72 @@ impl ConnectAccountPanel {
             ContactsMessage::InvitesLoaded(invites, gen) => {
                 if gen == self.session_generation {
                     self.contacts_state.invites = Some(invites);
-                    if self.contacts_state.contacts.is_some() {
+                    if self.contacts_state.contacts.is_some()
+                        && self.contacts_state.received_invites.is_some()
+                    {
                         self.contacts_state.loading = false;
                     }
                 }
+            }
+
+            ContactsMessage::ReceivedInvitesLoaded(received, gen) => {
+                if gen == self.session_generation {
+                    self.contacts_state.received_invites = Some(received);
+                    if self.contacts_state.contacts.is_some()
+                        && self.contacts_state.invites.is_some()
+                    {
+                        self.contacts_state.loading = false;
+                    }
+                }
+            }
+
+            ContactsMessage::AcceptReceivedInvite(invite_id) => {
+                // Guard against double-tap. The button is disabled
+                // while the id is in-flight, but the message can still
+                // arrive twice via keyboard activation; we drop the
+                // second silently.
+                if !self.contacts_state.accepting_invite_ids.insert(invite_id) {
+                    return iced::Task::none();
+                }
+                self.contacts_state.error = None;
+                let client = self.client.clone();
+                return iced::Task::perform(
+                    async move { client.accept_invite_by_id(invite_id).await },
+                    move |res| match res {
+                        Ok(()) => Message::View(view::Message::ConnectAccount(
+                            ConnectAccountMessage::Contacts(
+                                ContactsMessage::ReceivedInviteAccepted(invite_id),
+                            ),
+                        )),
+                        Err(e) => Message::View(view::Message::ConnectAccount(
+                            ConnectAccountMessage::Contacts(
+                                ContactsMessage::AcceptReceivedInviteFailed(
+                                    invite_id,
+                                    e.to_string(),
+                                ),
+                            ),
+                        )),
+                    },
+                );
+            }
+
+            ContactsMessage::ReceivedInviteAccepted(invite_id) => {
+                self.contacts_state.accepting_invite_ids.remove(&invite_id);
+                // Optimistically drop the row so the user gets instant
+                // feedback before the refetch lands. The
+                // `reload_contacts()` call below also resets
+                // `received_invites = None`, which will trigger the
+                // skeleton briefly — that's the same UX the existing
+                // Resend / Revoke flows have, so it's consistent.
+                if let Some(received) = self.contacts_state.received_invites.as_mut() {
+                    received.retain(|i| i.id != invite_id);
+                }
+                return self.reload_contacts();
+            }
+
+            ContactsMessage::AcceptReceivedInviteFailed(invite_id, msg) => {
+                self.contacts_state.accepting_invite_ids.remove(&invite_id);
+                self.contacts_state.error = Some(msg);
             }
 
             ContactsMessage::ShowInviteForm => {
@@ -1582,6 +1664,7 @@ impl Default for ConnectAccountPanel {
 pub fn load_contacts_data(client: &CoincubeClient, generation: u64) -> iced::Task<Message> {
     let c1 = client.clone();
     let c2 = client.clone();
+    let c3 = client.clone();
     iced::Task::batch([
         iced::Task::perform(
             async move { c1.get_contacts().await },
@@ -1602,6 +1685,19 @@ pub fn load_contacts_data(client: &CoincubeClient, generation: u64) -> iced::Tas
                 Ok(invites) => Message::View(view::Message::ConnectAccount(
                     ConnectAccountMessage::Contacts(ContactsMessage::InvitesLoaded(
                         invites, generation,
+                    )),
+                )),
+                Err(e) => Message::View(view::Message::ConnectAccount(
+                    ConnectAccountMessage::Contacts(ContactsMessage::Error(e.to_string())),
+                )),
+            },
+        ),
+        iced::Task::perform(
+            async move { c3.get_received_invites().await },
+            move |res| match res {
+                Ok(received) => Message::View(view::Message::ConnectAccount(
+                    ConnectAccountMessage::Contacts(ContactsMessage::ReceivedInvitesLoaded(
+                        received, generation,
                     )),
                 )),
                 Err(e) => Message::View(view::Message::ConnectAccount(

--- a/coincube-gui/src/app/view/connect/contacts.rs
+++ b/coincube-gui/src/app/view/connect/contacts.rs
@@ -12,7 +12,7 @@ use crate::{
         state::connect::{ConnectAccountPanel, ContactsStep},
         view::{ConnectAccountMessage, ContactsMessage},
     },
-    services::coincube::{ContactRole, Invite},
+    services::coincube::{ContactRole, Invite, ReceivedInvite},
 };
 
 use super::{card_style, format_date};
@@ -56,8 +56,15 @@ fn contacts_list_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAc
         .spacing(0)
         .width(Length::Fill);
 
-    // Loading state
-    if cs.loading && cs.contacts.is_none() && cs.invites.is_none() {
+    // Loading state — wait until all three sibling fetches (contacts,
+    // sent invites, received invites) are missing before showing the
+    // spinner. Once any one of them lands the spinner gives way to the
+    // section layout, which renders its own per-section loading state.
+    if cs.loading
+        && cs.contacts.is_none()
+        && cs.invites.is_none()
+        && cs.received_invites.is_none()
+    {
         col = col.push(
             text::p1_regular("Loading\u{2026}")
                 .color(color::GREY_3)
@@ -70,7 +77,10 @@ fn contacts_list_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAc
     // (errors during initial load are silently swallowed — the empty state is shown instead)
     if !cs.loading {
         if let Some(err) = cs.error.as_deref() {
-            if cs.contacts.is_some() || cs.invites.is_some() {
+            if cs.contacts.is_some()
+                || cs.invites.is_some()
+                || cs.received_invites.is_some()
+            {
                 col = col.push(
                     container(text::p2_regular(err).color(color::RED))
                         .padding(8)
@@ -79,6 +89,28 @@ fn contacts_list_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAc
                 col = col.push(iced::widget::Space::new().height(Length::Fixed(10.0)));
             }
         }
+    }
+
+    // Received invites section (invites addressed to this user).
+    // Rendered above "Pending Invites" so a freshly-arrived invite is
+    // the first thing the user sees on the Contacts surface. Backend
+    // pre-filters to pending + non-expired
+    // (`invite.go:374-429`), so no client-side filter pass.
+    let received: &[ReceivedInvite] = cs
+        .received_invites
+        .as_deref()
+        .unwrap_or_default();
+
+    if !received.is_empty() {
+        col = col.push(text::p1_bold("Received Invites").style(theme::text::primary));
+        col = col.push(iced::widget::Space::new().height(Length::Fixed(8.0)));
+
+        for invite in received {
+            let accepting = cs.accepting_invite_ids.contains(&invite.id);
+            col = col.push(received_invite_card(invite, accepting));
+            col = col.push(iced::widget::Space::new().height(Length::Fixed(8.0)));
+        }
+        col = col.push(iced::widget::Space::new().height(Length::Fixed(12.0)));
     }
 
     // Pending invites section
@@ -101,9 +133,12 @@ fn contacts_list_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAc
         col = col.push(iced::widget::Space::new().height(Length::Fixed(12.0)));
     }
 
-    // Contacts list
+    // Contacts list. Show the empty-state card only when all three
+    // sections (contacts, pending sent, received) are empty — a Free
+    // invitee with zero contacts but one received invite should see
+    // the invite, not "No contacts yet".
     let contacts = cs.contacts.as_deref().unwrap_or_default();
-    if contacts.is_empty() && pending.is_empty() {
+    if contacts.is_empty() && pending.is_empty() && received.is_empty() {
         // Empty state
         col = col.push(
             container(
@@ -224,6 +259,59 @@ fn invite_card<'a>(invite: &'a Invite) -> Element<'a, ConnectAccountMessage> {
             .push(info)
             .push(iced::widget::Space::new().width(Length::Fill))
             .push(actions)
+            .align_y(Alignment::Center)
+            .padding(12),
+    )
+    .style(card_style)
+    .width(Length::Fill)
+    .into()
+}
+
+/// Row for an invite addressed *to* the current user. Mirrors
+/// `invite_card` but flips inviter/invitee — shows the **sender's**
+/// email (`owner_email`), role, expiry, and a single primary Accept
+/// button. While the accept request is in flight the button reads
+/// "Accepting…" and is disabled (no `on_press`); the per-row state
+/// comes from `accepting_invite_ids` on `ContactsState`.
+fn received_invite_card<'a>(
+    invite: &'a ReceivedInvite,
+    accepting: bool,
+) -> Element<'a, ConnectAccountMessage> {
+    let role_label = invite.role.to_string();
+    let expiry_elem = expiry_element(&invite.expires_at);
+
+    let info = Column::new()
+        .push(text::p1_regular(invite.owner_email.as_str()).style(theme::text::primary))
+        .push(
+            Row::new()
+                .push(text::p2_regular(role_label).color(role_color(&invite.role)))
+                .push(iced::widget::Space::new().width(Length::Fixed(12.0)))
+                .push(expiry_elem)
+                .align_y(Alignment::Center),
+        )
+        .spacing(2);
+
+    let invite_id = invite.id;
+    let accept_button: Element<ConnectAccountMessage> = if accepting {
+        // Disabled "Accepting…" — `on_press_maybe(None)` keeps the
+        // primary styling while suppressing the click handler, so the
+        // button stays visually anchored in the row.
+        button::primary(None, "Accepting\u{2026}")
+            .on_press_maybe(None)
+            .into()
+    } else {
+        button::primary(None, "Accept")
+            .on_press(ConnectAccountMessage::Contacts(
+                ContactsMessage::AcceptReceivedInvite(invite_id),
+            ))
+            .into()
+    };
+
+    container(
+        Row::new()
+            .push(info)
+            .push(iced::widget::Space::new().width(Length::Fill))
+            .push(accept_button)
             .align_y(Alignment::Center)
             .padding(12),
     )

--- a/coincube-gui/src/app/view/connect/contacts.rs
+++ b/coincube-gui/src/app/view/connect/contacts.rs
@@ -60,10 +60,7 @@ fn contacts_list_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAc
     // sent invites, received invites) are missing before showing the
     // spinner. Once any one of them lands the spinner gives way to the
     // section layout, which renders its own per-section loading state.
-    if cs.loading
-        && cs.contacts.is_none()
-        && cs.invites.is_none()
-        && cs.received_invites.is_none()
+    if cs.loading && cs.contacts.is_none() && cs.invites.is_none() && cs.received_invites.is_none()
     {
         col = col.push(
             text::p1_regular("Loading\u{2026}")
@@ -77,10 +74,7 @@ fn contacts_list_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAc
     // (errors during initial load are silently swallowed — the empty state is shown instead)
     if !cs.loading {
         if let Some(err) = cs.error.as_deref() {
-            if cs.contacts.is_some()
-                || cs.invites.is_some()
-                || cs.received_invites.is_some()
-            {
+            if cs.contacts.is_some() || cs.invites.is_some() || cs.received_invites.is_some() {
                 col = col.push(
                     container(text::p2_regular(err).color(color::RED))
                         .padding(8)
@@ -96,10 +90,7 @@ fn contacts_list_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAc
     // the first thing the user sees on the Contacts surface. Backend
     // pre-filters to pending + non-expired
     // (`invite.go:374-429`), so no client-side filter pass.
-    let received: &[ReceivedInvite] = cs
-        .received_invites
-        .as_deref()
-        .unwrap_or_default();
+    let received: &[ReceivedInvite] = cs.received_invites.as_deref().unwrap_or_default();
 
     if !received.is_empty() {
         col = col.push(text::p1_bold("Received Invites").style(theme::text::primary));

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1009,6 +1009,21 @@ pub enum ContactsMessage {
     ContactsLoaded(Vec<crate::services::coincube::Contact>, u64),
     /// Invites list loaded.
     InvitesLoaded(Vec<crate::services::coincube::Invite>, u64),
+    /// Received-invites list loaded (invites addressed to the current
+    /// user). Carries `session_generation` for stale-response guarding,
+    /// matching the existing `ContactsLoaded` / `InvitesLoaded` pattern.
+    ReceivedInvitesLoaded(Vec<crate::services::coincube::ReceivedInvite>, u64),
+    /// User tapped Accept on a received-invite row.
+    AcceptReceivedInvite(u64),
+    /// Result of a successful accept. Carries the invite id so the row
+    /// can be removed optimistically before the contacts refetch lands.
+    ReceivedInviteAccepted(u64),
+    /// Accept request failed. Removes the id from the in-flight set so
+    /// the button re-enables, then surfaces the error via the contacts
+    /// `error` field. Plain `Error(String)` would also surface the
+    /// message but wouldn't know which invite to clear from the
+    /// in-flight set, leaving its Accept button stuck on "Accepting…".
+    AcceptReceivedInviteFailed(u64, String),
     /// Navigate to invite form.
     ShowInviteForm,
     /// Navigate back to list.

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -7,9 +7,9 @@ use super::{
     Invite, LightningAddress, LoginActivity, LoginResponse, OtpRequest, OtpVerifyRequest,
     PublicAvatarData, ReceivedInvite, RecoveryKit, RecoveryKitStatus, RefreshTokenRequest,
     RegenerationData, RegisterCubeRequest, ReserveLightningAddressRequest, SaveQuoteRequest,
-    SaveQuoteResponse,
-    StatsPeriod, TimeseriesResponse, TodayStats, UpdateCubeRequest, UpdateLightningAddressRequest,
-    UpsertRecoveryKitRequest, User, VaultMemberResponse, VerifiedDevice,
+    SaveQuoteResponse, StatsPeriod, TimeseriesResponse, TodayStats, UpdateCubeRequest,
+    UpdateLightningAddressRequest, UpsertRecoveryKitRequest, User, VaultMemberResponse,
+    VerifiedDevice,
 };
 use reqwest::{Client, Method};
 use serde::Deserialize;

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -5,8 +5,9 @@ use super::{
     ContactCube, Country, CreateConnectVaultRequest, CreateInviteRequest, CubeInviteOrAddResult,
     CubeKeyRaw, CubeLimitsResponse, CubeResponse, DownloadStats, FeaturesResponse, GetAvatarData,
     Invite, LightningAddress, LoginActivity, LoginResponse, OtpRequest, OtpVerifyRequest,
-    PublicAvatarData, RecoveryKit, RecoveryKitStatus, RefreshTokenRequest, RegenerationData,
-    RegisterCubeRequest, ReserveLightningAddressRequest, SaveQuoteRequest, SaveQuoteResponse,
+    PublicAvatarData, ReceivedInvite, RecoveryKit, RecoveryKitStatus, RefreshTokenRequest,
+    RegenerationData, RegisterCubeRequest, ReserveLightningAddressRequest, SaveQuoteRequest,
+    SaveQuoteResponse,
     StatsPeriod, TimeseriesResponse, TodayStats, UpdateCubeRequest, UpdateLightningAddressRequest,
     UpsertRecoveryKitRequest, User, VaultMemberResponse, VerifiedDevice,
 };
@@ -729,6 +730,42 @@ impl CoincubeClient {
     pub async fn revoke_invite(&self, invite_id: u64) -> Result<(), CoincubeError> {
         let url = format!(
             "{}/api/v1/connect/invites/{}/revoke",
+            self.base_url, invite_id
+        );
+        let res = self
+            .client
+            .post(&url)
+            .json(&serde_json::json!({}))
+            .send()
+            .await?;
+        res.check_success().await?;
+        Ok(())
+    }
+
+    /// GET /api/v1/connect/invites/received
+    ///
+    /// Returns the list of pending, non-expired invites addressed to
+    /// the authenticated user. The backend filters server-side
+    /// (see `services/connect/invite/handlers/invite.go:374-429`), so
+    /// callers should render the list as-is.
+    pub async fn get_received_invites(&self) -> Result<Vec<ReceivedInvite>, CoincubeError> {
+        let url = format!("{}/api/v1/connect/invites/received", self.base_url);
+        let res = self.client.get(&url).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<Vec<ReceivedInvite>> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// POST /api/v1/connect/invites/{id}/accept
+    ///
+    /// Accepts a received invite by its id. The handler returns
+    /// `{status, ownerEmail, role}` but we discard it — the caller
+    /// refetches the contacts + sent + received lists after a
+    /// successful accept, which is the single source of truth for the
+    /// new contact pairing and the dropped received-invite row.
+    pub async fn accept_invite_by_id(&self, invite_id: u64) -> Result<(), CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/invites/{}/accept",
             self.base_url, invite_id
         );
         let res = self

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -975,6 +975,23 @@ pub struct Invite {
     pub created_at: String,
 }
 
+/// A pending invite addressed to the authenticated user, returned by
+/// `GET /api/v1/connect/invites/received`. Distinct from [`Invite`] —
+/// `Invite` is outbound (sender's view) while `ReceivedInvite` is
+/// inbound (recipient's view). The backend filters this list to
+/// pending, non-expired invites only
+/// (`coincube-api/services/connect/invite/handlers/invite.go:374-429`),
+/// so the desktop renders it as-is without further filtering.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReceivedInvite {
+    pub id: u64,
+    pub owner_email: String,
+    pub role: ContactRole,
+    pub expires_at: String,
+    pub created_at: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateInviteRequest {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new Connect Contacts data flows and API calls to fetch and accept inbound invites, plus per-row in-flight tracking; main risk is UI/state inconsistencies or error handling regressions around the new async batch load and accept action.
> 
> **Overview**
> Adds support for **inbound (received) contact invites** in the Connect Contacts screen: the app now fetches received invites alongside contacts and sent invites, renders a new "Received Invites" section, and updates loading/empty-state logic to account for the third dataset.
> 
> Introduces an **Accept invite** flow for received invites, including new `CoincubeClient` endpoints (`GET /connect/invites/received`, `POST /connect/invites/{id}/accept`), new `ContactsMessage` variants, per-invite in-flight guarding to prevent double-accept, and a post-accept full contacts reload to refresh all lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66e2ff37183b34bed8859372ff37923ea782c977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->