### PR TITLE
Spark address and vault celebration clear

### DIFF
--- a/coincube-gui/src/app/breez_spark/client.rs
+++ b/coincube-gui/src/app/breez_spark/client.rs
@@ -386,6 +386,19 @@ impl SparkClient {
         }
     }
 
+    /// Generate a static, reusable Spark address for native
+    /// Spark-to-Spark transfers. No amount/invoice — the address is
+    /// identity-bound and token-agnostic, with zero receive fee.
+    pub async fn receive_spark(&self) -> Result<ReceivePaymentOk, SparkClientError> {
+        match self.request(Method::ReceiveSpark).await? {
+            OkPayload::ReceivePayment(resp) => Ok(resp),
+            other => Err(SparkClientError::Protocol(format!(
+                "receive_spark returned unexpected payload: {:?}",
+                other
+            ))),
+        }
+    }
+
     /// Phase 4f: list on-chain deposits the SDK has noticed but not
     /// yet claimed into the Spark wallet. Drives the "Pending
     /// deposits" card in the Receive panel.

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -2408,6 +2408,29 @@ impl App {
             }
             Message::View(view::Message::DismissReceivedCelebration) => {
                 self.show_received_celebration = false;
+                // Panels that render their own celebration overlay
+                // (e.g. the Vault overview) keep a separate
+                // `show_received_celebration` flag and reuse this same
+                // global dismiss message. Clearing only the app-level
+                // flag here would leave the panel stuck on the
+                // celebration screen, so forward the dismiss to the
+                // active panel as well — mirrors the generic
+                // message-forwarding catch-all below.
+                if let (Some(daemon), Some(panel)) =
+                    (self.daemon.clone(), self.panels.current_mut())
+                {
+                    return panel.update(
+                        Some(daemon),
+                        &self.cache,
+                        Message::View(view::Message::DismissReceivedCelebration),
+                    );
+                } else if let Some(panel) = self.panels.current_mut() {
+                    return panel.update(
+                        None,
+                        &self.cache,
+                        Message::View(view::Message::DismissReceivedCelebration),
+                    );
+                }
             }
             Message::View(view::Message::DismissBackupWarning) => {
                 self.cache.backup_warning_dismissed = true;

--- a/coincube-gui/src/app/state/spark/receive.rs
+++ b/coincube-gui/src/app/state/spark/receive.rs
@@ -41,6 +41,7 @@ use crate::app::wallets::SparkBackend;
 pub enum SparkReceiveMethod {
     Bolt11,
     OnchainBitcoin,
+    Spark,
 }
 
 impl SparkReceiveMethod {
@@ -48,6 +49,7 @@ impl SparkReceiveMethod {
         match self {
             Self::Bolt11 => "Lightning (BOLT11)",
             Self::OnchainBitcoin => "On-chain Bitcoin",
+            Self::Spark => "Spark",
         }
     }
 }
@@ -271,6 +273,17 @@ impl State for SparkReceive {
                     }
                     SparkReceiveMethod::OnchainBitcoin => Task::perform(
                         async move { backend.receive_onchain(None).await },
+                        |result| match result {
+                            Ok(ok) => Message::View(crate::app::view::Message::SparkReceive(
+                                SparkReceiveMessage::GenerateSucceeded(ok),
+                            )),
+                            Err(e) => Message::View(crate::app::view::Message::SparkReceive(
+                                SparkReceiveMessage::GenerateFailed(e.to_string()),
+                            )),
+                        },
+                    ),
+                    SparkReceiveMethod::Spark => Task::perform(
+                        async move { backend.receive_spark().await },
                         |result| match result {
                             Ok(ok) => Message::View(crate::app::view::Message::SparkReceive(
                                 SparkReceiveMessage::GenerateSucceeded(ok),

--- a/coincube-gui/src/app/state/spark/receive.rs
+++ b/coincube-gui/src/app/state/spark/receive.rs
@@ -282,17 +282,18 @@ impl State for SparkReceive {
                             )),
                         },
                     ),
-                    SparkReceiveMethod::Spark => Task::perform(
-                        async move { backend.receive_spark().await },
-                        |result| match result {
-                            Ok(ok) => Message::View(crate::app::view::Message::SparkReceive(
-                                SparkReceiveMessage::GenerateSucceeded(ok),
-                            )),
-                            Err(e) => Message::View(crate::app::view::Message::SparkReceive(
-                                SparkReceiveMessage::GenerateFailed(e.to_string()),
-                            )),
-                        },
-                    ),
+                    SparkReceiveMethod::Spark => {
+                        Task::perform(async move { backend.receive_spark().await }, |result| {
+                            match result {
+                                Ok(ok) => Message::View(crate::app::view::Message::SparkReceive(
+                                    SparkReceiveMessage::GenerateSucceeded(ok),
+                                )),
+                                Err(e) => Message::View(crate::app::view::Message::SparkReceive(
+                                    SparkReceiveMessage::GenerateFailed(e.to_string()),
+                                )),
+                            }
+                        })
+                    }
                 }
             }
             SparkReceiveMessage::GenerateSucceeded(ok) => {

--- a/coincube-gui/src/app/state/spark/send.rs
+++ b/coincube-gui/src/app/state/spark/send.rs
@@ -361,7 +361,11 @@ async fn resolve_and_prepare(
                 .await
                 .map_err(|e| format!("prepare_lnurl_pay failed: {e}"))
         }
-        ParseInputKind::Bolt11Invoice | ParseInputKind::BitcoinAddress | ParseInputKind::Other => {
+        ParseInputKind::Bolt11Invoice
+        | ParseInputKind::BitcoinAddress
+        | ParseInputKind::SparkAddress
+        | ParseInputKind::SparkInvoice
+        | ParseInputKind::Other => {
             backend
                 .prepare_send(input, amount_sat)
                 .await

--- a/coincube-gui/src/app/state/spark/send.rs
+++ b/coincube-gui/src/app/state/spark/send.rs
@@ -365,12 +365,10 @@ async fn resolve_and_prepare(
         | ParseInputKind::BitcoinAddress
         | ParseInputKind::SparkAddress
         | ParseInputKind::SparkInvoice
-        | ParseInputKind::Other => {
-            backend
-                .prepare_send(input, amount_sat)
-                .await
-                .map_err(|e| format!("prepare_send failed: {e}"))
-        }
+        | ParseInputKind::Other => backend
+            .prepare_send(input, amount_sat)
+            .await
+            .map_err(|e| format!("prepare_send failed: {e}")),
     }
 }
 

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -195,6 +195,21 @@ impl PsbtState {
                     }
                 }
 
+                // The celebration page dismisses via this same Cancel
+                // message. Detect that case before we clear `self.modal`
+                // so we can chain a Reload onto the close — that
+                // returns the user to the PSBTs list with their newly
+                // broadcast tx already marked unconfirmed, instead of
+                // leaving them on the now-stale PSBT detail page
+                // wondering whether the broadcast made it through.
+                let just_broadcast = matches!(
+                    &self.modal,
+                    Some(PsbtModal::Broadcast(BroadcastModal {
+                        broadcast: true,
+                        ..
+                    }))
+                );
+
                 // Dismissing a Keychain-sign modal (blur or otherwise)
                 // must also terminate any in-flight signing sessions
                 // server-side, not just hide the UI — otherwise signers
@@ -220,6 +235,9 @@ impl PsbtState {
                     };
                 if !keep_modal {
                     self.modal = None;
+                }
+                if just_broadcast {
+                    return Task::batch([cancel, Task::done(Message::View(view::Message::Reload))]);
                 }
                 return cancel;
             }
@@ -373,6 +391,7 @@ impl PsbtState {
                     self.modal = Some(PsbtModal::Broadcast(BroadcastModal {
                         conflicting_txids,
                         broadcast: false,
+                        broadcasting: false,
                         error: None,
                         sent_quote: coincube_ui::component::quote_display::random_quote(
                             "bitcoin-send",
@@ -482,7 +501,14 @@ impl Modal for SaveModal {
 }
 
 pub struct BroadcastModal {
+    /// Set once `broadcast_spend_tx` has returned successfully —
+    /// drives the celebration screen.
     broadcast: bool,
+    /// True while the daemon's `broadcast_spend_tx` RPC is in flight.
+    /// Used to give the user clear "Broadcasting…" feedback and to
+    /// suppress accidental duplicate clicks / blur-cancel during the
+    /// window between pressing Broadcast and the daemon's reply.
+    broadcasting: bool,
     error: Option<Error>,
     /// IDs of any directly conflicting transactions.
     conflicting_txids: HashSet<Txid>,
@@ -502,6 +528,16 @@ impl Modal for BroadcastModal {
     ) -> Task<Message> {
         match message {
             Message::View(view::Message::Spend(view::SpendTxMessage::Confirm)) => {
+                // Ignore re-clicks while a broadcast is already in
+                // flight or has succeeded — without this guard, the
+                // "Broadcast" button could fire `broadcast_spend_tx`
+                // twice on rapid double-taps, and the second call
+                // would error out with "unknown spend" after the first
+                // one drained the PSBT from the daemon's DB.
+                if self.broadcasting || self.broadcast {
+                    return Task::none();
+                }
+                self.broadcasting = true;
                 let daemon = daemon.clone();
                 let psbt = tx.psbt.clone();
                 self.error = None;
@@ -515,33 +551,49 @@ impl Modal for BroadcastModal {
                     Message::Updated,
                 );
             }
-            Message::Updated(res) => match res {
-                Ok(()) => {
-                    tx.status = SpendStatus::Broadcast;
-                    self.broadcast = true;
+            Message::Updated(res) => {
+                // Either outcome ends the in-flight state.
+                self.broadcasting = false;
+                match res {
+                    Ok(()) => {
+                        tx.status = SpendStatus::Broadcast;
+                        self.broadcast = true;
+                    }
+                    Err(e) => {
+                        let err_msg = e.to_string();
+                        self.error = Some(e);
+                        return Task::done(Message::View(view::Message::ShowError(err_msg)));
+                    }
                 }
-                Err(e) => {
-                    let err_msg = e.to_string();
-                    self.error = Some(e);
-                    return Task::done(Message::View(view::Message::ShowError(err_msg)));
-                }
-            },
+            }
             _ => {}
         }
         Task::none()
     }
     fn view<'a>(&'a self, content: Element<'a, view::Message>) -> Element<'a, view::Message> {
+        // While the broadcast RPC is in flight, suppress blur-to-cancel.
+        // An accidental tap outside the modal at that moment would
+        // dismiss the user's only visual confirmation that something
+        // is happening and look like an aborted broadcast — even
+        // though the daemon call itself is unaffected by closing the
+        // modal.
+        let on_blur = if self.broadcasting {
+            None
+        } else {
+            Some(view::Message::Spend(view::SpendTxMessage::Cancel))
+        };
         modal::Modal::new(
             content,
             view::vault::psbt::broadcast_action(
                 &self.conflicting_txids,
                 self.broadcast,
+                self.broadcasting,
                 &self.spend_amount_display,
                 &self.sent_quote,
                 &self.sent_image_handle,
             ),
         )
-        .on_blur(Some(view::Message::Spend(view::SpendTxMessage::Cancel)))
+        .on_blur(on_blur)
         .into()
     }
 }

--- a/coincube-gui/src/app/view/spark/receive.rs
+++ b/coincube-gui/src/app/view/spark/receive.rs
@@ -90,6 +90,11 @@ impl<'a> SparkReceiveView<'a> {
                         "On-chain Bitcoin",
                         self.method == SparkReceiveMethod::OnchainBitcoin,
                         SparkReceiveMethod::OnchainBitcoin,
+                    ))
+                    .push(method_chip(
+                        "Spark",
+                        self.method == SparkReceiveMethod::Spark,
+                        SparkReceiveMethod::Spark,
                     )),
             ),
         )
@@ -129,7 +134,7 @@ impl<'a> SparkReceiveView<'a> {
             .padding(16)
             .style(theme::card::simple);
             content = content.push(form_card);
-        } else {
+        } else if self.method == SparkReceiveMethod::OnchainBitcoin {
             // On-chain: nothing to configure in Phase 4c. Explain the
             // deposit model so the user knows what to expect.
             let info_card = Container::new(
@@ -144,6 +149,25 @@ impl<'a> SparkReceiveView<'a> {
                          process in a future phase; today the user may need \
                          to restart the cube to surface the claim). Phase \
                          4d wires the explicit claim lifecycle into the UI.",
+                    )),
+            )
+            .padding(16)
+            .style(theme::card::simple);
+            content = content.push(info_card);
+        } else {
+            // Spark: static, reusable, identity-bound address. No
+            // amount/invoice form — mirrors the on-chain UX.
+            let info_card = Container::new(
+                Column::new()
+                    .spacing(8)
+                    .push(h4_bold("Spark address"))
+                    .push(p2_regular(
+                        "This is a static, reusable Spark address bound to \
+                         this wallet's identity. Share it freely — anyone on \
+                         Spark can pay it directly. Spark-to-Spark transfers \
+                         settle instantly with a lower fee than Lightning or \
+                         on-chain, and the address is token-agnostic (it can \
+                         receive bitcoin or any Spark token).",
                     )),
             )
             .padding(16)

--- a/coincube-gui/src/app/view/spark/send.rs
+++ b/coincube-gui/src/app/view/spark/send.rs
@@ -13,7 +13,7 @@ use coincube_ui::{
         text::{h4_bold, p1_regular, p2_regular},
     },
     theme,
-    widget::{Column, Container, Element, Row},
+    widget::{Column, ColumnExt, Container, Element, Row},
 };
 use iced::{
     widget::{text_input, Space},
@@ -65,7 +65,7 @@ impl<'a> SparkSendView<'a> {
 
         // ── Input card ────────────────────────────────────────────────
         let destination = text_input(
-            "BOLT11 invoice, Lightning address, BIP21 URI, or Bitcoin address",
+            "Spark address/invoice, BOLT11 invoice, Lightning address, BIP21 URI, or Bitcoin address",
             self.destination_input,
         )
         .on_input(|v| {
@@ -151,6 +151,11 @@ fn phase_body<'a>(phase: &SparkSendPhase) -> Element<'a, Message> {
                     "Total",
                     format!("{} sats", ok.amount_sat.saturating_add(ok.fee_sat)),
                 ))
+                .push_maybe(ok.method.starts_with("Spark").then(|| {
+                    p2_regular(
+                        "Spark transfer — instant, lower fee than Lightning or on-chain.",
+                    )
+                }))
                 .push(Space::new().height(Length::Fixed(8.0)))
                 .push(
                     Row::new()

--- a/coincube-gui/src/app/view/spark/send.rs
+++ b/coincube-gui/src/app/view/spark/send.rs
@@ -152,9 +152,7 @@ fn phase_body<'a>(phase: &SparkSendPhase) -> Element<'a, Message> {
                     format!("{} sats", ok.amount_sat.saturating_add(ok.fee_sat)),
                 ))
                 .push_maybe(ok.method.starts_with("Spark").then(|| {
-                    p2_regular(
-                        "Spark transfer — instant, lower fee than Lightning or on-chain.",
-                    )
+                    p2_regular("Spark transfer — instant, lower fee than Lightning or on-chain.")
                 }))
                 .push(Space::new().height(Length::Fixed(8.0)))
                 .push(

--- a/coincube-gui/src/app/view/vault/psbt.rs
+++ b/coincube-gui/src/app/view/vault/psbt.rs
@@ -164,9 +164,15 @@ pub fn save_action<'a>(saved: bool) -> Element<'a, Message> {
 ///
 /// `conflicting_txids` contains the IDs of any directly conflicting transactions
 /// of the transaction to be broadcast.
+///
+/// `broadcasting` is `true` while the daemon's `broadcast_spend_tx` RPC is in
+/// flight — between the user pressing "Broadcast" and the daemon's reply.
+/// In that window the button swaps to a disabled "Broadcasting…" label so the
+/// user can see their click registered and isn't tempted to click again.
 pub fn broadcast_action<'a>(
     conflicting_txids: &HashSet<Txid>,
     saved: bool,
+    broadcasting: bool,
     spend_amount_display: &'a str,
     sent_quote: &'a coincube_ui::component::quote_display::Quote,
     sent_image_handle: &'a iced::widget::image::Handle,
@@ -237,12 +243,19 @@ pub fn broadcast_action<'a>(
                         ),
                     )
                 })
-                .push(
-                    Row::new().push(Column::new().width(Length::Fill)).push(
+                .push(Row::new().push(Column::new().width(Length::Fill)).push(
+                    // Disabled "Broadcasting…" state mirrors the
+                    // "Processing…" pattern used by the PSBT
+                    // update form below — leaving `on_press`
+                    // unset is this codebase's idiom for a
+                    // visually-disabled button.
+                    if broadcasting {
+                        button::primary(None, "Broadcasting…")
+                    } else {
                         button::primary(None, "Broadcast")
-                            .on_press(Message::Spend(SpendTxMessage::Confirm)),
-                    ),
-                ),
+                            .on_press(Message::Spend(SpendTxMessage::Confirm))
+                    },
+                )),
         )
         .width(Length::Fixed(if conflicting_txids.is_empty() {
             400.0

--- a/coincube-gui/src/app/wallets/spark.rs
+++ b/coincube-gui/src/app/wallets/spark.rs
@@ -114,6 +114,12 @@ impl SparkBackend {
         self.client.receive_onchain(new_address).await
     }
 
+    /// Generate a static, reusable Spark address (native
+    /// Spark-to-Spark receive). No amount/invoice; zero receive fee.
+    pub async fn receive_spark(&self) -> Result<ReceivePaymentOk, SparkClientError> {
+        self.client.receive_spark().await
+    }
+
     /// Phase 4f: list pending on-chain deposits.
     pub async fn list_unclaimed_deposits(
         &self,

--- a/coincube-spark-bridge/src/server.rs
+++ b/coincube-spark-bridge/src/server.rs
@@ -211,6 +211,7 @@ async fn handle_request(request: Request, state: Arc<ServerState>) -> Response {
         Method::SendPayment(params) => handle_send_payment(id, params, state).await,
         Method::ReceiveBolt11(params) => handle_receive_bolt11(id, params, state).await,
         Method::ReceiveOnchain(params) => handle_receive_onchain(id, params, state).await,
+        Method::ReceiveSpark => handle_receive_spark(id, state).await,
         Method::ListUnclaimedDeposits => handle_list_unclaimed_deposits(id, state).await,
         Method::ClaimDeposit(params) => handle_claim_deposit(id, params, state).await,
         Method::GetUserSettings => handle_get_user_settings(id, state).await,
@@ -768,6 +769,34 @@ async fn handle_receive_onchain(
     }
 }
 
+async fn handle_receive_spark(id: u64, state: Arc<ServerState>) -> Response {
+    let sdk = match state.sdk.read().await.clone() {
+        Some(s) => s,
+        None => {
+            return Response::err(
+                id,
+                ErrorKind::NotConnected,
+                "init must succeed before receive_spark",
+            );
+        }
+    };
+
+    let request = ReceivePaymentRequest {
+        payment_method: ReceivePaymentMethod::SparkAddress,
+    };
+
+    match sdk.sdk.receive_payment(request).await {
+        Ok(resp) => Response::ok(
+            id,
+            OkPayload::ReceivePayment(ReceivePaymentOk {
+                payment_request: resp.payment_request,
+                fee_sat: clamp_u128_to_u64(resp.fee),
+            }),
+        ),
+        Err(e) => Response::err(id, ErrorKind::Sdk, format!("receive_spark failed: {e}")),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Phase 4e: LNURL-pay support
 // ---------------------------------------------------------------------------
@@ -849,11 +878,34 @@ fn input_type_to_ok(input: InputType) -> ParseInputOk {
             lnurl_comment_allowed: addr.pay_request.comment_allowed,
             lnurl_address: Some(addr.address),
         },
+        InputType::SparkAddress(_details) => ParseInputOk {
+            // Static, identity-bound Spark address — no amount.
+            kind: ParseInputKind::SparkAddress,
+            amount_sat: None,
+            lnurl_min_sendable_sat: None,
+            lnurl_max_sendable_sat: None,
+            lnurl_comment_allowed: 0,
+            lnurl_address: None,
+        },
+        InputType::SparkInvoice(details) => ParseInputOk {
+            kind: ParseInputKind::SparkInvoice,
+            // `amount` is sats only for Bitcoin invoices; for token
+            // invoices it's token base units, which the sats-typed
+            // field can't represent — surface None in that case.
+            amount_sat: if details.token_identifier.is_none() {
+                details.amount.map(clamp_u128_to_u64)
+            } else {
+                None
+            },
+            lnurl_min_sendable_sat: None,
+            lnurl_max_sendable_sat: None,
+            lnurl_comment_allowed: 0,
+            lnurl_address: None,
+        },
         // Everything else — BOLT12 invoices/offers, LNURL-auth,
-        // LNURL-withdraw, silent payment, Spark-native types, bare
-        // URLs — falls through to `Other`. The gui shows a "not
-        // supported yet" error; future phases can break each one out
-        // as demand appears.
+        // LNURL-withdraw, silent payment, bare URLs — falls through
+        // to `Other`. The gui shows a "not supported yet" error;
+        // future phases can break each one out as demand appears.
         _ => ParseInputOk {
             kind: ParseInputKind::Other,
             amount_sat: None,

--- a/coincube-spark-protocol/src/lib.rs
+++ b/coincube-spark-protocol/src/lib.rs
@@ -94,6 +94,14 @@ pub enum Method {
     /// the gui watches for incoming deposits via
     /// [`Event::DepositsChanged`] and lets the user claim mature ones.
     ReceiveOnchain(ReceiveOnchainParams),
+    /// Generate a static, reusable Spark address for native
+    /// Spark-to-Spark transfers. Unlike Lightning/on-chain receive
+    /// there is no amount or invoice — the address is identity-bound
+    /// and token-agnostic. Maps to the SDK's
+    /// `ReceivePaymentMethod::SparkAddress` (no params, fee 0). The
+    /// reused [`OkPayload::ReceivePayment`] carries the address as
+    /// `payment_request`.
+    ReceiveSpark,
     /// Phase 4f: enumerate on-chain deposits the SDK has noticed but
     /// not yet claimed. Returns a [`Vec<DepositInfo>`] the gui renders
     /// as a "pending deposits" card in the Receive panel.
@@ -417,11 +425,18 @@ pub enum ParseInputKind {
     /// A Lightning address in the form `user@domain`. Resolves to an
     /// LNURL-pay flow internally. Use [`Method::PrepareLnurlPay`].
     LightningAddress,
+    /// A static Spark address (identity-bound, reusable). Native
+    /// Spark-to-Spark transfer. Use [`Method::PrepareSend`] — the
+    /// SDK auto-detects and routes it as a Spark send.
+    SparkAddress,
+    /// A Spark invoice (single-use, may carry an amount / token /
+    /// expiry). Native Spark-to-Spark transfer. Use
+    /// [`Method::PrepareSend`].
+    SparkInvoice,
     /// Anything else the SDK could parse (BOLT12, Bolt12 offer,
-    /// silent payment, Spark-native types, etc.). Phase 4e falls
-    /// through to [`Method::PrepareSend`] which handles the ones the
-    /// SDK supports; the gui shows a "not supported" error for the
-    /// rest.
+    /// silent payment, etc.). Phase 4e falls through to
+    /// [`Method::PrepareSend`] which handles the ones the SDK
+    /// supports; the gui shows a "not supported" error for the rest.
     Other,
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new Spark receive RPC/method and expands send parsing to support Spark addresses/invoices, touching payment-related flows across protocol, bridge, and GUI. Also adjusts modal/overlay lifecycle around PSBT broadcast and celebration dismissal, which could affect UX state transitions if regressions occur.
> 
> **Overview**
> **Spark receive/send now supports native Spark addresses.** This introduces a new `ReceiveSpark` protocol/bridge RPC and GUI plumbing (`SparkClient`/`SparkBackend`, receive state + view) to generate a static, reusable Spark address as an additional receive method.
> 
> **Spark send parsing is expanded** so `parse_input` results for `SparkAddress` and `SparkInvoice` route through the existing `prepare_send` path, and the send UI copy/preview adds Spark-specific hints.
> 
> **Vault PSBT broadcast UX/state is tightened** by adding an explicit in-flight `broadcasting` state (disables blur-cancel and duplicate clicks, shows “Broadcasting…”), and by reloading after dismissing the broadcast celebration so the PSBT list reflects the newly broadcast transaction. **Celebration dismissal is also forwarded to the active panel** to prevent panel-level overlays from getting stuck.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43336636d22b8f5b88c48e1d81986af3321c4b52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Added Spark address receiving: generate a reusable address for Spark-to-Spark transfers
* Added support for sending to Spark addresses and Spark invoices
* Spark is now available as a distinct receive method option

**Bug Fixes**
* Fixed celebration overlay remaining visible after dismissal

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coincubetech/coincube/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->