### PR TITLE
cleanup

### DIFF
--- a/coincube-gui/src/app/menu.rs
+++ b/coincube-gui/src/app/menu.rs
@@ -49,7 +49,6 @@ pub enum ConnectSubMenu {
     Security,
     Duress,
     Contacts,
-    Invites,
     /// Cube-scoped members + pending-invites management. Feature-flagged by
     /// `feature_flags::CUBE_MEMBERS_UI_ENABLED`; sidebar entry is hidden
     /// otherwise.

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1385,13 +1385,10 @@ impl ConnectAccountPanel {
 
             ContactsMessage::InviteResent(_invite_id) => {
                 log::info!("[CONTACTS] Invite resent successfully");
-            ContactsMessage::InviteResent(_invite_id) => {
-                log::info!("[CONTACTS] Invite resent successfully");
                 self.contacts_state.error = None;
                 return iced::Task::done(Message::View(view::Message::ShowSuccess(
                     "Invite resent".to_string(),
                 )));
-            }
             }
 
             ContactsMessage::RevokeInvite(invite_id) => {

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1385,9 +1385,13 @@ impl ConnectAccountPanel {
 
             ContactsMessage::InviteResent(_invite_id) => {
                 log::info!("[CONTACTS] Invite resent successfully");
+            ContactsMessage::InviteResent(_invite_id) => {
+                log::info!("[CONTACTS] Invite resent successfully");
+                self.contacts_state.error = None;
                 return iced::Task::done(Message::View(view::Message::ShowSuccess(
                     "Invite resent".to_string(),
                 )));
+            }
             }
 
             ContactsMessage::RevokeInvite(invite_id) => {

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1385,6 +1385,9 @@ impl ConnectAccountPanel {
 
             ContactsMessage::InviteResent(_invite_id) => {
                 log::info!("[CONTACTS] Invite resent successfully");
+                return iced::Task::done(Message::View(view::Message::ShowSuccess(
+                    "Invite resent".to_string(),
+                )));
             }
 
             ContactsMessage::RevokeInvite(invite_id) => {

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -78,7 +78,6 @@ pub fn connect_panel<'a>(state: &'a ConnectPanel) -> Element<'a, ViewMessage> {
             ConnectSubMenu::Contacts => {
                 contacts::contacts_ux(acct).map(ViewMessage::ConnectAccount)
             }
-            ConnectSubMenu::Invites => invites_ux(acct).map(ViewMessage::ConnectAccount),
             ConnectSubMenu::CubeMembers => {
                 cube_members::cube_members_ux(cube).map(ViewMessage::ConnectCube)
             }
@@ -1945,53 +1944,4 @@ fn avatar_settings_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectCub
     .style(card_style)
     .width(Length::Fill)
     .into()
-}
-
-fn invites_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMessage> {
-    let is_legacy = state
-        .plan
-        .as_ref()
-        .map(|p| *p.tier() == PlanTier::Legacy)
-        .unwrap_or(false);
-
-    let card_content: Element<ConnectAccountMessage> = if !is_legacy {
-        container(
-            Column::new()
-                .push(text::p1_bold("Legacy Plan Required").style(theme::text::primary))
-                .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
-                .push(
-                    text::p2_regular(
-                        "Invites are available on the Legacy plan. Upgrade to share \
-                         COINCUBE access with trusted contacts.",
-                    )
-                    .color(color::GREY_3),
-                )
-                .padding(16)
-                .spacing(2),
-        )
-        .style(card_style)
-        .width(Length::Fill)
-        .into()
-    } else {
-        container(
-            Column::new()
-                .push(
-                    text::p2_regular("Coming Soon — requires backend endpoint /connect/invites")
-                        .color(color::GREY_3),
-                )
-                .padding(16)
-                .spacing(2),
-        )
-        .style(card_style)
-        .width(Length::Fill)
-        .into()
-    };
-
-    Column::new()
-        .push(text::h4_bold("Invites").style(theme::text::primary))
-        .push(iced::widget::Space::new().height(Length::Fixed(15.0)))
-        .push(card_content)
-        .spacing(0)
-        .width(Length::Fill)
-        .into()
 }

--- a/coincube-gui/src/app/view/nav/connect.rs
+++ b/coincube-gui/src/app/view/nav/connect.rs
@@ -1,13 +1,14 @@
 use super::{NavContext, SubItem};
 use crate::app::menu::{ConnectSubMenu, Menu};
-use coincube_ui::icon::{coins_icon, home_icon, key_icon, lightning_icon, person_icon, plus_icon};
+use coincube_ui::icon::{coins_icon, home_icon, key_icon, lightning_icon, person_icon};
 
 /// Secondary-rail items for the Connect section.
 ///
 /// Unauthenticated users see only a "Sign In" button that routes to
 /// `Connect(Overview)` — the Connect panel renders the login form from
 /// there. Once signed in the rail populates with the full section
-/// (Lightning Address / Avatar / Contacts / Invites).
+/// (Lightning Address / Avatar / Contacts). Outbound + received invites
+/// live inside the Contacts tab, so there is no separate Invites entry.
 pub fn items(ctx: &NavContext) -> Vec<SubItem> {
     if !ctx.connect_authenticated {
         return vec![SubItem {
@@ -42,12 +43,6 @@ pub fn items(ctx: &NavContext) -> Vec<SubItem> {
             icon: person_icon,
             route: Menu::Connect(ConnectSubMenu::Contacts),
             matches: |m| matches!(m, Menu::Connect(ConnectSubMenu::Contacts)),
-        },
-        SubItem {
-            label: "Invites",
-            icon: plus_icon,
-            route: Menu::Connect(ConnectSubMenu::Invites),
-            matches: |m| matches!(m, Menu::Connect(ConnectSubMenu::Invites)),
         },
     ];
 

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -2094,7 +2094,6 @@ fn launcher_sidebar<'a>(launcher: &'a Launcher) -> Element<'a, Message> {
             // Duress is hidden until the backend endpoint (/connect/duress)
             // is implemented — keep the ConnectSubMenu::Duress variant and
             // duress_ux() so re-enabling is a one-line revert.
-            // Invites is per-Cube (key holders), not shown in launcher
         ];
         for (label, sub) in items {
             let is_active = matches!(

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -2329,4 +2329,117 @@ mod cube_member_tests {
         assert!(cube.members.is_empty());
         assert!(cube.pending_invites.is_empty());
     }
+
+    #[tokio::test]
+    async fn get_received_invites_parses_list() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/api/v1/connect/invites/received");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": [
+                        {
+                            "id": 42,
+                            "ownerEmail": "alice@example.com",
+                            "role": "keyholder",
+                            "expiresAt": "2026-05-25T12:00:00Z",
+                            "createdAt": "2026-05-18T12:00:00Z"
+                        }
+                    ]
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let received = client
+            .get_received_invites()
+            .await
+            .expect("get_received_invites should succeed");
+        mock.assert();
+
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].id, 42);
+        assert_eq!(received[0].owner_email, "alice@example.com");
+    }
+
+    #[tokio::test]
+    async fn get_received_invites_surfaces_unauthorized() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/api/v1/connect/invites/received");
+            then.status(401)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": false,
+                    "error": { "code": "unauthorized", "message": "missing token" }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .get_received_invites()
+            .await
+            .expect_err("401 should produce an error");
+        mock.assert();
+        assert!(err.is_auth_error(), "expected auth error; got {:?}", err);
+    }
+
+    #[tokio::test]
+    async fn accept_invite_by_id_returns_ok_on_success() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/invites/42/accept");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "status": "accepted",
+                        "ownerEmail": "alice@example.com",
+                        "role": "keyholder"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        client
+            .accept_invite_by_id(42)
+            .await
+            .expect("accept_invite_by_id should succeed");
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn accept_invite_by_id_surfaces_revoked_error() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/invites/42/accept");
+            then.status(400)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": false,
+                    "error": { "code": "invalid_request", "message": "Invite has been revoked" }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .accept_invite_by_id(42)
+            .await
+            .expect_err("400 should produce an error");
+        mock.assert();
+        assert!(
+            matches!(
+                &err,
+                CoincubeError::Unsuccessful(info) if info.status_code == 400
+            ),
+            "expected 400 Unsuccessful; got {:?}",
+            err
+        );
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: mostly removes unused UI routing for `Invites`, adds a small UX improvement (success toast), and introduces client-side tests around invite endpoints without changing core auth or wallet logic.
> 
> **Overview**
> **Removes the separate `Invites` Connect submenu** and its placeholder UI, updating navigation and routing so invite flows are accessed via `Contacts` instead.
> 
> **Improves invite resend UX** by clearing inline errors and showing a `ShowSuccess("Invite resent")` toast on successful resend.
> 
> **Adds client tests for invite endpoints** covering `GET /connect/invites/received` parsing/unauthorized handling and `POST /connect/invites/{id}/accept` success and revoked-error scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64ae6b0b33a46fd0e4d6d0b879e12a8e5b847cf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the separate Invites submenu from Connect; invites are now accessed via Contacts.

* **Tests**
  * Added end-to-end tests for invite-related API flows, covering received invites and accept/revoked scenarios.

* **Bug Fix / UX**
  * Resending an invite now shows a visible "Invite resent" success message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coincubetech/coincube/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->