### PR TITLE
Use prev/next for transaction nav

### DIFF
--- a/coincube-gui/src/app/breez_liquid/client.rs
+++ b/coincube-gui/src/app/breez_liquid/client.rs
@@ -444,16 +444,26 @@ impl BreezClient {
     pub async fn list_payments(
         &self,
         limit: Option<u32>,
+        offset: Option<u32>,
+        asset_id: Option<String>,
     ) -> Result<Vec<breez::Payment>, BreezError> {
+        // `details = Liquid { asset_id }` is the SDK's only per-asset filter,
+        // and it restricts the result to Liquid-asset payments (i.e. Lightning
+        // and on-chain Bitcoin payments are excluded). The Transactions panel
+        // uses this for the L-BTC and USDt tabs; the "All" tab passes None.
+        let details = asset_id.map(|id| breez::ListPaymentDetails::Liquid {
+            asset_id: Some(id),
+            destination: None,
+        });
         self.get_sdk()?
             .list_payments(&breez::ListPaymentsRequest {
                 filters: None,
                 states: None,
                 from_timestamp: None,
                 to_timestamp: None,
-                offset: None,
+                offset,
                 limit,
-                details: None,
+                details,
                 sort_ascending: Some(false), // Most recent first
             })
             .await

--- a/coincube-gui/src/app/breez_spark/client.rs
+++ b/coincube-gui/src/app/breez_spark/client.rs
@@ -215,12 +215,10 @@ impl SparkClient {
     pub async fn list_payments(
         &self,
         limit: Option<u32>,
+        offset: Option<u32>,
     ) -> Result<ListPaymentsOk, SparkClientError> {
         match self
-            .request(Method::ListPayments(ListPaymentsParams {
-                limit,
-                offset: Some(0),
-            }))
+            .request(Method::ListPayments(ListPaymentsParams { limit, offset }))
             .await?
         {
             OkPayload::ListPayments(list) => Ok(list),

--- a/coincube-gui/src/app/message.rs
+++ b/coincube-gui/src/app/message.rs
@@ -68,9 +68,14 @@ pub enum Message {
     /// (i.e. end of history). It is measured on the raw response, before
     /// the inclusive-cursor overlap is deduplicated.
     HistoryTransactionsExtension(Result<(Vec<HistoryTransaction>, bool), Error>),
-    /// Initial Vault transactions page-0 fetch result.
-    /// Tuple: `(pending_txs, page_0_confirmed_txs)`.
-    HistoryTransactions(Result<(Vec<HistoryTransaction>, Vec<HistoryTransaction>), Error>),
+    /// Initial Vault transactions page-0 fetch result. The `u64` is the
+    /// reload-generation token: the panel discards any response whose
+    /// token isn't the latest, so a superseded reload can't overwrite
+    /// fresher state. The inner tuple is `(pending_txs, page_0_confirmed_txs)`.
+    HistoryTransactions(
+        u64,
+        Result<(Vec<HistoryTransaction>, Vec<HistoryTransaction>), Error>,
+    ),
     Payments(Result<Vec<Payment>, Error>),
     /// Extension of payments for pagination.
     /// Tuple contains (Vec<Payment>, u64) where the u64 is the actual page limit used
@@ -82,7 +87,14 @@ pub enum Message {
     BroadcastModal(Result<HashSet<Txid>, Error>),
     RbfModal(Box<HistoryTransaction>, bool, Result<HashSet<Txid>, Error>),
     Export(ImportExportMessage),
-    PaymentsLoaded(Result<Vec<crate::app::wallets::DomainPayment>, BreezError>),
+    /// Liquid transactions page fetch result. The `u64` is the
+    /// fetch-generation token: the panel discards any response whose token
+    /// is not the latest dispatched, so a stale pagination response can't
+    /// overwrite data fetched by a subsequent reload / filter change.
+    PaymentsLoaded(
+        u64,
+        Result<Vec<crate::app::wallets::DomainPayment>, BreezError>,
+    ),
     RefundablesLoaded(Result<Vec<crate::app::wallets::DomainRefundableSwap>, BreezError>),
     /// Result of a debounced background poll started by
     /// `App::refresh_refundables_task`. Distinct from `RefundablesLoaded`

--- a/coincube-gui/src/app/message.rs
+++ b/coincube-gui/src/app/message.rs
@@ -63,7 +63,9 @@ pub enum Message {
     StartRescan(Result<(), Error>),
     HardwareWallets(HardwareWalletMessage),
     HistoryTransactionsExtension(Result<Vec<HistoryTransaction>, Error>),
-    HistoryTransactions(Result<Vec<HistoryTransaction>, Error>),
+    /// Initial Vault transactions page-0 fetch result.
+    /// Tuple: `(pending_txs, page_0_confirmed_txs)`.
+    HistoryTransactions(Result<(Vec<HistoryTransaction>, Vec<HistoryTransaction>), Error>),
     Payments(Result<Vec<Payment>, Error>),
     /// Extension of payments for pagination.
     /// Tuple contains (Vec<Payment>, u64) where the u64 is the actual page limit used

--- a/coincube-gui/src/app/message.rs
+++ b/coincube-gui/src/app/message.rs
@@ -62,7 +62,12 @@ pub enum Message {
     Verified(Fingerprint, Result<(), Error>),
     StartRescan(Result<(), Error>),
     HardwareWallets(HardwareWalletMessage),
-    HistoryTransactionsExtension(Result<Vec<HistoryTransaction>, Error>),
+    /// Vault transactions next-page fetch result.
+    /// Tuple: `(page_txs, server_exhausted)` where `server_exhausted` is
+    /// `true` when the daemon returned fewer rows than the requested limit
+    /// (i.e. end of history). It is measured on the raw response, before
+    /// the inclusive-cursor overlap is deduplicated.
+    HistoryTransactionsExtension(Result<(Vec<HistoryTransaction>, bool), Error>),
     /// Initial Vault transactions page-0 fetch result.
     /// Tuple: `(pending_txs, page_0_confirmed_txs)`.
     HistoryTransactions(Result<(Vec<HistoryTransaction>, Vec<HistoryTransaction>), Error>),

--- a/coincube-gui/src/app/state/global_home.rs
+++ b/coincube-gui/src/app/state/global_home.rs
@@ -2413,7 +2413,7 @@ impl GlobalHome {
         let network = self.network;
         Task::perform(
             async move {
-                match breez_client.list_payments(Some(20)).await {
+                match breez_client.list_payments(Some(20), None, None).await {
                     Ok(payments) => {
                         let mut liquid_send_sats: u64 = 0;
                         let mut usdt_send_sats: u64 = 0;
@@ -2601,7 +2601,7 @@ impl GlobalHome {
                     .and_then(|cube| cube.pending_liquid_to_vault_transfer.clone())?;
 
                 let mut stage = TransferStage::Initiated;
-                let payments = breez_client.list_payments(None).await.ok();
+                let payments = breez_client.list_payments(None, None, None).await.ok();
 
                 if let Some(payment) = payments.and_then(|ps| {
                     ps.into_iter().find(|payment| {

--- a/coincube-gui/src/app/state/liquid/overview.rs
+++ b/coincube-gui/src/app/state/liquid/overview.rs
@@ -44,7 +44,7 @@ impl LiquidOverview {
         Task::perform(
             async move {
                 let info = breez_client.info().await;
-                let payments = breez_client.list_payments(Some(20)).await;
+                let payments = breez_client.list_payments(Some(20), None, None).await;
 
                 let balance = info
                     .as_ref()

--- a/coincube-gui/src/app/state/liquid/receive.rs
+++ b/coincube-gui/src/app/state/liquid/receive.rs
@@ -989,7 +989,7 @@ impl LiquidReceive {
         Task::perform(
             async move {
                 let info = breez_client.info().await;
-                let payments = breez_client.list_payments(Some(20)).await;
+                let payments = breez_client.list_payments(Some(20), None, None).await;
 
                 let btc_balance = info
                     .as_ref()

--- a/coincube-gui/src/app/state/liquid/send.rs
+++ b/coincube-gui/src/app/state/liquid/send.rs
@@ -303,7 +303,7 @@ impl LiquidSend {
         Task::perform(
             async move {
                 let info = breez_client.info().await;
-                let payments = breez_client.list_payments(Some(20)).await;
+                let payments = breez_client.list_payments(Some(20), None, None).await;
 
                 let balance = info
                     .as_ref()

--- a/coincube-gui/src/app/state/liquid/transactions.rs
+++ b/coincube-gui/src/app/state/liquid/transactions.rs
@@ -88,6 +88,11 @@ pub struct LiquidTransactions {
     /// `current_page` only on `PaymentsLoaded(Ok)`; dropped on error so a
     /// failed fetch doesn't desync the page counter from the shown data.
     pending_page: Option<u32>,
+    /// Monotonic fetch-generation counter. Every `fetch_page` (reload,
+    /// filter change, Prev/Next) bumps it and tags its result; the handler
+    /// discards any `PaymentsLoaded` whose token isn't the latest, so a
+    /// stale response can't clobber `payments` with wrong-page data.
+    fetch_token: u64,
     is_last_page: bool,
     processing: bool,
 }
@@ -125,6 +130,7 @@ impl LiquidTransactions {
             empty_state_image_handle,
             current_page: 0,
             pending_page: None,
+            fetch_token: 0,
             is_last_page: false,
             processing: false,
         }
@@ -149,17 +155,29 @@ impl LiquidTransactions {
     /// Fetch `page` (0-indexed). `current_page` is *not* moved here — it is
     /// only committed once `PaymentsLoaded(Ok)` lands, so a failed fetch
     /// leaves the panel showing the page it was already on.
-    fn fetch_page(&self, page: u32) -> Task<Message> {
+    ///
+    /// Bumps `fetch_token` and tags the result with it; the handler drops
+    /// any response that isn't the latest, so a stale page response can't
+    /// overwrite data from a newer reload / filter change.
+    ///
+    /// Requests `PAGE_SIZE + 1` rows: the extra row is a probe for whether
+    /// a further page exists. The handler trims it off before display and
+    /// sets `is_last_page` from whether it was returned — without it, a
+    /// total that is an exact multiple of `PAGE_SIZE` would leave Next
+    /// enabled onto an empty page.
+    fn fetch_page(&mut self, page: u32) -> Task<Message> {
+        self.fetch_token = self.fetch_token.wrapping_add(1);
+        let token = self.fetch_token;
         let client = self.breez_client.clone();
         let offset = page.saturating_mul(PAGE_SIZE);
         let asset_id = self.active_filter_asset_id();
         Task::perform(
             async move {
                 client
-                    .list_payments(Some(PAGE_SIZE), Some(offset), asset_id)
+                    .list_payments(Some(PAGE_SIZE + 1), Some(offset), asset_id)
                     .await
             },
-            Message::PaymentsLoaded,
+            move |result| Message::PaymentsLoaded(token, result),
         )
     }
 
@@ -346,7 +364,13 @@ impl State for LiquidTransactions {
         message: Message,
     ) -> Task<Message> {
         match message {
-            Message::PaymentsLoaded(Ok(payments)) => {
+            Message::PaymentsLoaded(token, Ok(mut payments)) => {
+                // Discard a stale response: a newer fetch (reload, filter
+                // change, or another Prev/Next) has since been dispatched, so
+                // applying this page would show wrong-page data.
+                if token != self.fetch_token {
+                    return Task::none();
+                }
                 self.loading = false;
                 self.processing = false;
                 // Commit the page navigation now that the fetch succeeded.
@@ -355,15 +379,25 @@ impl State for LiquidTransactions {
                 if let Some(page) = self.pending_page.take() {
                     self.current_page = page;
                 }
+                // `fetch_page` over-fetches one probe row: receiving more
+                // than `PAGE_SIZE` means a further page exists. Trim the
+                // probe row off before display.
+                self.is_last_page = (payments.len() as u32) <= PAGE_SIZE;
+                payments.truncate(PAGE_SIZE as usize);
                 // Server-side filtering (see `active_filter_asset_id`) means
                 // the payments arrived already restricted to the active tab;
                 // no further client-side asset filter is needed here.
-                self.is_last_page = (payments.len() as u32) < PAGE_SIZE;
                 self.payments = payments;
                 self.balance = self.calculate_balance();
                 Task::none()
             }
-            Message::PaymentsLoaded(Err(e)) => {
+            Message::PaymentsLoaded(token, Err(e)) => {
+                // Stale error from a superseded fetch — ignore it so it
+                // can't clear `pending_page` for the newer in-flight fetch
+                // or raise a spurious toast.
+                if token != self.fetch_token {
+                    return Task::none();
+                }
                 self.loading = false;
                 self.processing = false;
                 // Discard the in-flight navigation: `current_page` stays on

--- a/coincube-gui/src/app/state/liquid/transactions.rs
+++ b/coincube-gui/src/app/state/liquid/transactions.rs
@@ -10,7 +10,7 @@ use coincube_ui::component::quote_display::{self, Quote};
 use coincube_ui::widget::{Column, Element};
 use iced::{widget::image, Task};
 
-use crate::app::breez_liquid::assets::usdt_asset_id;
+use crate::app::breez_liquid::assets::{lbtc_asset_id, usdt_asset_id};
 use crate::app::view::FeeratePriority;
 use crate::app::wallets::{
     DomainPayment, DomainPaymentDetails, DomainPaymentDirection, DomainRefundableSwap,
@@ -39,6 +39,11 @@ pub struct InFlightRefund {
 /// `refund_onchain_tx` broadcast and the corresponding `RefundCompleted`
 /// message.
 const IN_FLIGHT_GRACE: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Bump to a larger value (e.g. 50) once Prev/Next pagination is verified
+/// end-to-end on real wallets. Kept low during rollout so QA can exercise
+/// pagination without needing 50+ transactions per asset filter.
+pub const PAGE_SIZE: u32 = 10;
 
 #[derive(Debug)]
 enum LiquidTransactionsModal {
@@ -77,6 +82,9 @@ pub struct LiquidTransactions {
     pending_vault_refund_id: Option<u64>,
     empty_state_quote: Quote,
     empty_state_image_handle: image::Handle,
+    current_page: u32,
+    is_last_page: bool,
+    processing: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -110,7 +118,40 @@ impl LiquidTransactions {
             pending_vault_refund_id: None,
             empty_state_quote,
             empty_state_image_handle,
+            current_page: 0,
+            is_last_page: false,
+            processing: false,
         }
+    }
+
+    /// Asset id to pass to the server-side filter for the active tab.
+    /// `All` returns `None` (server returns every payment type / asset).
+    /// `LbtcOnly` / `UsdtOnly` return the matching Liquid asset id, which
+    /// the SDK applies via `ListPaymentsRequest.details = Liquid { asset_id }`
+    /// — note that this narrows the result to Liquid-asset payments only, so
+    /// Lightning and on-chain Bitcoin payments no longer appear under the
+    /// L-BTC tab (they remain visible under "All").
+    fn active_filter_asset_id(&self) -> Option<String> {
+        let network = self.breez_client.network();
+        match self.asset_filter {
+            AssetFilter::All => None,
+            AssetFilter::LbtcOnly => lbtc_asset_id(network).map(|s| s.to_string()),
+            AssetFilter::UsdtOnly => usdt_asset_id(network).map(|s| s.to_string()),
+        }
+    }
+
+    fn fetch_page(&self) -> Task<Message> {
+        let client = self.breez_client.clone();
+        let offset = self.current_page.saturating_mul(PAGE_SIZE);
+        let asset_id = self.active_filter_asset_id();
+        Task::perform(
+            async move {
+                client
+                    .list_payments(Some(PAGE_SIZE), Some(offset), asset_id)
+                    .await
+            },
+            Message::PaymentsLoaded,
+        )
     }
 
     fn reconcile_in_flight(&mut self, mut refundables: Vec<DomainRefundableSwap>) {
@@ -254,6 +295,9 @@ impl State for LiquidTransactions {
                     cache.show_direction_badges,
                     &self.empty_state_quote,
                     &self.empty_state_image_handle,
+                    self.current_page,
+                    self.is_last_page,
+                    self.processing,
                 ),
             )
         };
@@ -295,23 +339,18 @@ impl State for LiquidTransactions {
         match message {
             Message::PaymentsLoaded(Ok(payments)) => {
                 self.loading = false;
-                let usdt_id = usdt_asset_id(self.breez_client.network()).unwrap_or("");
-                self.payments = match self.asset_filter {
-                    AssetFilter::UsdtOnly => payments
-                        .into_iter()
-                        .filter(|p| is_usdt_payment(&p.details, usdt_id))
-                        .collect(),
-                    AssetFilter::LbtcOnly => payments
-                        .into_iter()
-                        .filter(|p| !is_usdt_payment(&p.details, usdt_id))
-                        .collect(),
-                    AssetFilter::All => payments,
-                };
+                self.processing = false;
+                // Server-side filtering (see `active_filter_asset_id`) means
+                // the payments arrived already restricted to the active tab;
+                // no further client-side asset filter is needed here.
+                self.is_last_page = (payments.len() as u32) < PAGE_SIZE;
+                self.payments = payments;
                 self.balance = self.calculate_balance();
                 Task::none()
             }
             Message::PaymentsLoaded(Err(e)) => {
                 self.loading = false;
+                self.processing = false;
                 Task::done(Message::View(view::Message::ShowError(e.to_string())))
             }
             Message::RefundablesLoaded(Ok(refundables)) => {
@@ -365,8 +404,26 @@ impl State for LiquidTransactions {
             Message::View(view::Message::SetAssetFilter(filter)) => {
                 if self.asset_filter != filter {
                     self.asset_filter = filter;
-                    // Reload with the new filter
+                    // Reload with the new filter — also resets pagination
+                    // back to page 0 (see `reload`).
                     return self.reload(None, None);
+                }
+                Task::none()
+            }
+            Message::View(view::Message::LiquidPrevPage) => {
+                if self.current_page > 0 && !self.processing {
+                    self.current_page -= 1;
+                    self.is_last_page = false;
+                    self.processing = true;
+                    return self.fetch_page();
+                }
+                Task::none()
+            }
+            Message::View(view::Message::LiquidNextPage) => {
+                if !self.is_last_page && !self.processing {
+                    self.current_page += 1;
+                    self.processing = true;
+                    return self.fetch_page();
                 }
                 Task::none()
             }
@@ -698,14 +755,14 @@ impl State for LiquidTransactions {
         self.loading = true;
         self.selected_payment = None;
         self.selected_refundable = None;
-        let client = self.breez_client.clone();
+        self.current_page = 0;
+        self.is_last_page = false;
+        self.processing = false;
+        self.payments.clear();
         let client2 = self.breez_client.clone();
 
         Task::batch(vec![
-            Task::perform(
-                async move { client.list_payments(None).await },
-                Message::PaymentsLoaded,
-            ),
+            self.fetch_page(),
             Task::perform(
                 async move { client2.list_refundables().await },
                 Message::RefundablesLoaded,

--- a/coincube-gui/src/app/state/liquid/transactions.rs
+++ b/coincube-gui/src/app/state/liquid/transactions.rs
@@ -82,7 +82,12 @@ pub struct LiquidTransactions {
     pending_vault_refund_id: Option<u64>,
     empty_state_quote: Quote,
     empty_state_image_handle: image::Handle,
+    /// Page currently displayed (0-indexed).
     current_page: u32,
+    /// Target page of an in-flight Prev/Next fetch. Committed to
+    /// `current_page` only on `PaymentsLoaded(Ok)`; dropped on error so a
+    /// failed fetch doesn't desync the page counter from the shown data.
+    pending_page: Option<u32>,
     is_last_page: bool,
     processing: bool,
 }
@@ -119,6 +124,7 @@ impl LiquidTransactions {
             empty_state_quote,
             empty_state_image_handle,
             current_page: 0,
+            pending_page: None,
             is_last_page: false,
             processing: false,
         }
@@ -140,9 +146,12 @@ impl LiquidTransactions {
         }
     }
 
-    fn fetch_page(&self) -> Task<Message> {
+    /// Fetch `page` (0-indexed). `current_page` is *not* moved here — it is
+    /// only committed once `PaymentsLoaded(Ok)` lands, so a failed fetch
+    /// leaves the panel showing the page it was already on.
+    fn fetch_page(&self, page: u32) -> Task<Message> {
         let client = self.breez_client.clone();
-        let offset = self.current_page.saturating_mul(PAGE_SIZE);
+        let offset = page.saturating_mul(PAGE_SIZE);
         let asset_id = self.active_filter_asset_id();
         Task::perform(
             async move {
@@ -340,6 +349,12 @@ impl State for LiquidTransactions {
             Message::PaymentsLoaded(Ok(payments)) => {
                 self.loading = false;
                 self.processing = false;
+                // Commit the page navigation now that the fetch succeeded.
+                // `pending_page` is `None` for a reload/initial fetch, where
+                // `current_page` was already set to 0 by `reload`.
+                if let Some(page) = self.pending_page.take() {
+                    self.current_page = page;
+                }
                 // Server-side filtering (see `active_filter_asset_id`) means
                 // the payments arrived already restricted to the active tab;
                 // no further client-side asset filter is needed here.
@@ -351,6 +366,9 @@ impl State for LiquidTransactions {
             Message::PaymentsLoaded(Err(e)) => {
                 self.loading = false;
                 self.processing = false;
+                // Discard the in-flight navigation: `current_page` stays on
+                // the page whose data is still displayed.
+                self.pending_page = None;
                 Task::done(Message::View(view::Message::ShowError(e.to_string())))
             }
             Message::RefundablesLoaded(Ok(refundables)) => {
@@ -412,18 +430,19 @@ impl State for LiquidTransactions {
             }
             Message::View(view::Message::LiquidPrevPage) => {
                 if self.current_page > 0 && !self.processing {
-                    self.current_page -= 1;
-                    self.is_last_page = false;
+                    let target = self.current_page - 1;
+                    self.pending_page = Some(target);
                     self.processing = true;
-                    return self.fetch_page();
+                    return self.fetch_page(target);
                 }
                 Task::none()
             }
             Message::View(view::Message::LiquidNextPage) => {
                 if !self.is_last_page && !self.processing {
-                    self.current_page += 1;
+                    let target = self.current_page + 1;
+                    self.pending_page = Some(target);
                     self.processing = true;
-                    return self.fetch_page();
+                    return self.fetch_page(target);
                 }
                 Task::none()
             }
@@ -756,13 +775,14 @@ impl State for LiquidTransactions {
         self.selected_payment = None;
         self.selected_refundable = None;
         self.current_page = 0;
+        self.pending_page = None;
         self.is_last_page = false;
         self.processing = false;
         self.payments.clear();
         let client2 = self.breez_client.clone();
 
         Task::batch(vec![
-            self.fetch_page(),
+            self.fetch_page(0),
             Task::perform(
                 async move { client2.list_refundables().await },
                 Message::RefundablesLoaded,

--- a/coincube-gui/src/app/state/spark/mod.rs
+++ b/coincube-gui/src/app/state/spark/mod.rs
@@ -39,7 +39,7 @@ pub(crate) fn fetch_payments_task(
         return Task::none();
     };
     Task::perform(
-        async move { backend.list_payments(Some(20)).await },
+        async move { backend.list_payments(Some(20), None).await },
         move |result| match result {
             Ok(list) => on_loaded(list.payments),
             Err(e) => on_failed(e.to_string()),

--- a/coincube-gui/src/app/state/spark/overview.rs
+++ b/coincube-gui/src/app/state/spark/overview.rs
@@ -117,7 +117,7 @@ impl State for SparkOverview {
                 let backend = backend.clone();
                 async move {
                     let info = backend.get_info().await;
-                    let payments = backend.list_payments(Some(20)).await;
+                    let payments = backend.list_payments(Some(20), None).await;
                     (info, payments)
                 }
             },

--- a/coincube-gui/src/app/state/spark/transactions.rs
+++ b/coincube-gui/src/app/state/spark/transactions.rs
@@ -62,6 +62,11 @@ pub struct SparkTransactions {
     /// `current_page` only on `DataLoaded`; dropped on `Error` so a failed
     /// fetch doesn't desync the page counter from the shown data.
     pending_page: Option<u32>,
+    /// Monotonic fetch-generation counter. Every `fetch_page` (reload or
+    /// Prev/Next) bumps it and tags its result; the handler discards any
+    /// response whose token isn't the latest, so a stale response can't
+    /// clobber `payments` with wrong-page data.
+    fetch_token: u64,
     is_last_page: bool,
     processing: bool,
 }
@@ -82,6 +87,7 @@ impl SparkTransactions {
             empty_state_image_handle,
             current_page: 0,
             pending_page: None,
+            fetch_token: 0,
             is_last_page: false,
             processing: false,
         }
@@ -90,19 +96,35 @@ impl SparkTransactions {
     /// Fetch `page` (0-indexed). `current_page` is *not* moved here — it is
     /// only committed once `DataLoaded` lands, so a failed fetch leaves the
     /// panel showing the page it was already on.
-    fn fetch_page(&self, page: u32) -> Task<Message> {
+    ///
+    /// Bumps `fetch_token` and tags the result with it; the handler drops
+    /// any response that isn't the latest, so a stale page response can't
+    /// overwrite data from a newer reload.
+    ///
+    /// Requests `PAGE_SIZE + 1` rows: the extra row is a probe for whether
+    /// a further page exists. The handler trims it off before display and
+    /// sets `is_last_page` from whether it was returned — without it, a
+    /// total that is an exact multiple of `PAGE_SIZE` would leave Next
+    /// enabled onto an empty page.
+    fn fetch_page(&mut self, page: u32) -> Task<Message> {
         let Some(backend) = self.backend.clone() else {
             return Task::none();
         };
+        self.fetch_token = self.fetch_token.wrapping_add(1);
+        let token = self.fetch_token;
         let offset = page.saturating_mul(PAGE_SIZE);
         Task::perform(
-            async move { backend.list_payments(Some(PAGE_SIZE), Some(offset)).await },
-            |result| match result {
+            async move {
+                backend
+                    .list_payments(Some(PAGE_SIZE + 1), Some(offset))
+                    .await
+            },
+            move |result| match result {
                 Ok(list) => Message::View(crate::app::view::Message::SparkTransactions(
-                    crate::app::view::SparkTransactionsMessage::DataLoaded(list.payments),
+                    crate::app::view::SparkTransactionsMessage::DataLoaded(token, list.payments),
                 )),
                 Err(e) => Message::View(crate::app::view::Message::SparkTransactions(
-                    crate::app::view::SparkTransactionsMessage::Error(e.to_string()),
+                    crate::app::view::SparkTransactionsMessage::Error(token, e.to_string()),
                 )),
             },
         )
@@ -232,7 +254,13 @@ impl State for SparkTransactions {
     ) -> Task<Message> {
         match message {
             Message::View(view::Message::SparkTransactions(msg)) => match msg {
-                view::SparkTransactionsMessage::DataLoaded(payments) => {
+                view::SparkTransactionsMessage::DataLoaded(token, mut payments) => {
+                    // Discard a stale response: a newer fetch (reload or
+                    // another Prev/Next) has since been dispatched, so
+                    // applying this page would show wrong-page data.
+                    if token != self.fetch_token {
+                        return Task::none();
+                    }
                     self.loading = false;
                     self.processing = false;
                     // Commit the page navigation now that the fetch
@@ -241,12 +269,24 @@ impl State for SparkTransactions {
                     if let Some(page) = self.pending_page.take() {
                         self.current_page = page;
                     }
-                    self.is_last_page = (payments.len() as u32) < PAGE_SIZE;
+                    // `fetch_page` over-fetches one probe row: receiving more
+                    // than `PAGE_SIZE` means a further page exists. Trim the
+                    // probe row off before display. Because Next is only
+                    // offered when the probe row was returned, a committed
+                    // non-zero page always has at least one real row.
+                    self.is_last_page = (payments.len() as u32) <= PAGE_SIZE;
+                    payments.truncate(PAGE_SIZE as usize);
                     self.payments = payments;
                     self.error = None;
                     self.rebuild_rows(cache);
                 }
-                view::SparkTransactionsMessage::Error(err) => {
+                view::SparkTransactionsMessage::Error(token, err) => {
+                    // Stale error from a superseded fetch — ignore it so it
+                    // can't clear `pending_page` for the newer in-flight
+                    // fetch or surface a spurious error.
+                    if token != self.fetch_token {
+                        return Task::none();
+                    }
                     self.loading = false;
                     self.processing = false;
                     // Discard the in-flight navigation: `current_page` stays

--- a/coincube-gui/src/app/state/spark/transactions.rs
+++ b/coincube-gui/src/app/state/spark/transactions.rs
@@ -31,6 +31,11 @@ use crate::app::view::{self, FiatAmountConverter};
 use crate::app::wallets::SparkBackend;
 use crate::export::{ImportExportMessage, ImportExportState};
 
+/// Bump to a larger value (e.g. 50) once Prev/Next pagination is verified
+/// end-to-end on real wallets. Kept low during rollout so QA can exercise
+/// pagination without needing 50+ transactions in a single wallet.
+pub const PAGE_SIZE: u32 = 10;
+
 #[derive(Debug)]
 enum SparkTransactionsModal {
     None,
@@ -51,6 +56,9 @@ pub struct SparkTransactions {
     /// constructed so repeated reloads don't re-randomize the quote.
     empty_state_quote: Quote,
     empty_state_image_handle: image::Handle,
+    current_page: u32,
+    is_last_page: bool,
+    processing: bool,
 }
 
 impl SparkTransactions {
@@ -67,7 +75,28 @@ impl SparkTransactions {
             selected_payment: None,
             empty_state_quote,
             empty_state_image_handle,
+            current_page: 0,
+            is_last_page: false,
+            processing: false,
         }
+    }
+
+    fn fetch_page(&self) -> Task<Message> {
+        let Some(backend) = self.backend.clone() else {
+            return Task::none();
+        };
+        let offset = self.current_page.saturating_mul(PAGE_SIZE);
+        Task::perform(
+            async move { backend.list_payments(Some(PAGE_SIZE), Some(offset)).await },
+            |result| match result {
+                Ok(list) => Message::View(crate::app::view::Message::SparkTransactions(
+                    crate::app::view::SparkTransactionsMessage::DataLoaded(list.payments),
+                )),
+                Err(e) => Message::View(crate::app::view::Message::SparkTransactions(
+                    crate::app::view::SparkTransactionsMessage::Error(e.to_string()),
+                )),
+            },
+        )
     }
 
     fn rebuild_rows(&mut self, cache: &Cache) {
@@ -132,6 +161,9 @@ impl State for SparkTransactions {
                 show_direction_badges: cache.show_direction_badges,
                 empty_state_quote: &self.empty_state_quote,
                 empty_state_image_handle: &self.empty_state_image_handle,
+                current_page: self.current_page,
+                is_last_page: self.is_last_page,
+                processing: self.processing,
             }
             .render(),
         );
@@ -171,22 +203,15 @@ impl State for SparkTransactions {
         _daemon: Option<Arc<dyn crate::daemon::Daemon + Sync + Send>>,
         _wallet: Option<Arc<crate::app::wallet::Wallet>>,
     ) -> Task<Message> {
-        let Some(backend) = self.backend.clone() else {
+        if self.backend.is_none() {
             return Task::none();
-        };
+        }
         self.loading = true;
         self.error = None;
-        Task::perform(
-            async move { backend.list_payments(Some(100)).await },
-            |result| match result {
-                Ok(list) => Message::View(crate::app::view::Message::SparkTransactions(
-                    crate::app::view::SparkTransactionsMessage::DataLoaded(list.payments),
-                )),
-                Err(e) => Message::View(crate::app::view::Message::SparkTransactions(
-                    crate::app::view::SparkTransactionsMessage::Error(e.to_string()),
-                )),
-            },
-        )
+        self.current_page = 0;
+        self.is_last_page = false;
+        self.processing = false;
+        self.fetch_page()
     }
 
     fn update(
@@ -199,13 +224,31 @@ impl State for SparkTransactions {
             Message::View(view::Message::SparkTransactions(msg)) => match msg {
                 view::SparkTransactionsMessage::DataLoaded(payments) => {
                     self.loading = false;
+                    self.processing = false;
+                    self.is_last_page = (payments.len() as u32) < PAGE_SIZE;
                     self.payments = payments;
                     self.error = None;
                     self.rebuild_rows(cache);
                 }
                 view::SparkTransactionsMessage::Error(err) => {
                     self.loading = false;
+                    self.processing = false;
                     self.error = Some(err);
+                }
+                view::SparkTransactionsMessage::PrevPage => {
+                    if self.current_page > 0 && !self.processing {
+                        self.current_page -= 1;
+                        self.is_last_page = false;
+                        self.processing = true;
+                        return self.fetch_page();
+                    }
+                }
+                view::SparkTransactionsMessage::NextPage => {
+                    if !self.is_last_page && !self.processing {
+                        self.current_page += 1;
+                        self.processing = true;
+                        return self.fetch_page();
+                    }
                 }
                 view::SparkTransactionsMessage::Select(idx) => {
                     self.selected_payment = self.recent_transactions.get(idx).cloned();

--- a/coincube-gui/src/app/state/spark/transactions.rs
+++ b/coincube-gui/src/app/state/spark/transactions.rs
@@ -56,7 +56,12 @@ pub struct SparkTransactions {
     /// constructed so repeated reloads don't re-randomize the quote.
     empty_state_quote: Quote,
     empty_state_image_handle: image::Handle,
+    /// Page currently displayed (0-indexed).
     current_page: u32,
+    /// Target page of an in-flight Prev/Next fetch. Committed to
+    /// `current_page` only on `DataLoaded`; dropped on `Error` so a failed
+    /// fetch doesn't desync the page counter from the shown data.
+    pending_page: Option<u32>,
     is_last_page: bool,
     processing: bool,
 }
@@ -76,16 +81,20 @@ impl SparkTransactions {
             empty_state_quote,
             empty_state_image_handle,
             current_page: 0,
+            pending_page: None,
             is_last_page: false,
             processing: false,
         }
     }
 
-    fn fetch_page(&self) -> Task<Message> {
+    /// Fetch `page` (0-indexed). `current_page` is *not* moved here — it is
+    /// only committed once `DataLoaded` lands, so a failed fetch leaves the
+    /// panel showing the page it was already on.
+    fn fetch_page(&self, page: u32) -> Task<Message> {
         let Some(backend) = self.backend.clone() else {
             return Task::none();
         };
-        let offset = self.current_page.saturating_mul(PAGE_SIZE);
+        let offset = page.saturating_mul(PAGE_SIZE);
         Task::perform(
             async move { backend.list_payments(Some(PAGE_SIZE), Some(offset)).await },
             |result| match result {
@@ -209,9 +218,10 @@ impl State for SparkTransactions {
         self.loading = true;
         self.error = None;
         self.current_page = 0;
+        self.pending_page = None;
         self.is_last_page = false;
         self.processing = false;
-        self.fetch_page()
+        self.fetch_page(0)
     }
 
     fn update(
@@ -225,6 +235,12 @@ impl State for SparkTransactions {
                 view::SparkTransactionsMessage::DataLoaded(payments) => {
                     self.loading = false;
                     self.processing = false;
+                    // Commit the page navigation now that the fetch
+                    // succeeded. `pending_page` is `None` for a reload, where
+                    // `current_page` was already set to 0 by `reload`.
+                    if let Some(page) = self.pending_page.take() {
+                        self.current_page = page;
+                    }
                     self.is_last_page = (payments.len() as u32) < PAGE_SIZE;
                     self.payments = payments;
                     self.error = None;
@@ -233,21 +249,25 @@ impl State for SparkTransactions {
                 view::SparkTransactionsMessage::Error(err) => {
                     self.loading = false;
                     self.processing = false;
+                    // Discard the in-flight navigation: `current_page` stays
+                    // on the page whose data is still displayed.
+                    self.pending_page = None;
                     self.error = Some(err);
                 }
                 view::SparkTransactionsMessage::PrevPage => {
                     if self.current_page > 0 && !self.processing {
-                        self.current_page -= 1;
-                        self.is_last_page = false;
+                        let target = self.current_page - 1;
+                        self.pending_page = Some(target);
                         self.processing = true;
-                        return self.fetch_page();
+                        return self.fetch_page(target);
                     }
                 }
                 view::SparkTransactionsMessage::NextPage => {
                     if !self.is_last_page && !self.processing {
-                        self.current_page += 1;
+                        let target = self.current_page + 1;
+                        self.pending_page = Some(target);
                         self.processing = true;
-                        return self.fetch_page();
+                        return self.fetch_page(target);
                     }
                 }
                 view::SparkTransactionsMessage::Select(idx) => {

--- a/coincube-gui/src/app/state/vault/overview.rs
+++ b/coincube-gui/src/app/state/vault/overview.rs
@@ -132,6 +132,13 @@ impl State for VaultOverview {
                     &self.payments.list,
                     self.payments.is_last_page,
                     self.processing,
+                    // "Loading transactions" while the very first page fetch
+                    // is still in flight: no page loaded yet, nothing to
+                    // show, and no error reported. A background Tick reload
+                    // keeps `list` populated, so it won't flash to loading.
+                    self.payments.list.is_empty()
+                        && self.payments.loaded_page_count == 0
+                        && self.warning.is_none(),
                     &self.sync_status,
                     self.show_rescan_warning,
                     cache.bitcoin_unit,

--- a/coincube-gui/src/app/state/vault/transactions.rs
+++ b/coincube-gui/src/app/state/vault/transactions.rs
@@ -69,7 +69,13 @@ pub struct VaultTransactionsPanel {
     selected_tx: Option<HistoryTransaction>,
     warning: Option<Error>,
     modal: VaultTransactionsModal,
-    is_last_page: bool,
+    /// Index of the final page, once discovered. `None` means we don't yet
+    /// know where history ends. Stored as an index (rather than a per-page
+    /// bool derived from row count) because the daemon's blocktime cursor
+    /// is inclusive: a fetch can return a full page from the server yet,
+    /// after stripping the rows that overlap the previous page, leave a
+    /// short Vec — so row count is not a reliable end-of-history signal.
+    last_page_index: Option<u32>,
     processing: bool,
     current_page: u32,
 }
@@ -85,10 +91,19 @@ impl VaultTransactionsPanel {
             labels_edited: LabelsEdited::default(),
             warning: None,
             modal: VaultTransactionsModal::None,
-            is_last_page: false,
-            processing: false,
+            last_page_index: None,
+            // Starts true: the panel always fires a `reload` fetch the
+            // moment it's shown, so the first render should display the
+            // loading state rather than briefly flashing "No transactions".
+            processing: true,
             current_page: 0,
         }
+    }
+
+    /// True when the current page is the last page of history. Derived
+    /// from `last_page_index` rather than the displayed row count.
+    fn is_last_page(&self) -> bool {
+        self.last_page_index == Some(self.current_page)
     }
 
     /// Recompute `displayed_txs` from the current page + pending list.
@@ -136,7 +151,7 @@ impl State for VaultTransactionsPanel {
                 cache,
                 &self.displayed_txs,
                 self.current_page,
-                self.is_last_page,
+                self.is_last_page(),
                 self.processing,
             );
             match &self.modal {
@@ -166,7 +181,13 @@ impl State for VaultTransactionsPanel {
                 Ok((pending_txs, page_txs)) => {
                     self.warning = None;
                     self.pending_txs = pending_txs;
-                    self.is_last_page = (page_txs.len() as u64) < HISTORY_EVENT_PAGE_SIZE;
+                    // Page 0 is fetched with a flat limit and no dedup, so a
+                    // short response here genuinely means end-of-history.
+                    if (page_txs.len() as u64) < HISTORY_EVENT_PAGE_SIZE {
+                        self.last_page_index = Some(0);
+                    } else {
+                        self.last_page_index = None;
+                    }
                     self.page_cache = vec![page_txs];
                     self.current_page = 0;
                     self.processing = false;
@@ -180,24 +201,37 @@ impl State for VaultTransactionsPanel {
                     self.warning = Some(e);
                     return Task::done(Message::View(view::Message::ShowError(err_msg)));
                 }
-                Ok(mut txs) => {
+                Ok((mut txs, server_exhausted)) => {
                     self.processing = false;
                     self.warning = None;
                     // The cursor we used (last tx's blocktime) is inclusive,
                     // so the response can repeat txs that already appeared on
                     // the current page. Drop those by txid before storing the
-                    // next page, then advance.
+                    // next page. NOTE: `server_exhausted` is derived in the
+                    // fetch task from the *raw* response length vs. the
+                    // request limit — it must not be re-derived from the
+                    // post-dedup `txs.len()`, which can be short even when
+                    // more history exists.
                     if let Some(prev_page) = self.page_cache.get(self.current_page as usize) {
                         let prev_ids: std::collections::HashSet<_> =
                             prev_page.iter().map(|t| t.tx.compute_txid()).collect();
                         txs.retain(|t| !prev_ids.contains(&t.tx.compute_txid()));
                     }
-                    self.is_last_page = (txs.len() as u64) < HISTORY_EVENT_PAGE_SIZE;
-                    self.current_page += 1;
-                    if (self.current_page as usize) < self.page_cache.len() {
-                        self.page_cache[self.current_page as usize] = txs;
+                    if txs.is_empty() {
+                        // Every row overlapped the current page — there is
+                        // nothing new beyond it, so the current page is the
+                        // last. Don't advance onto an empty page.
+                        self.last_page_index = Some(self.current_page);
                     } else {
-                        self.page_cache.push(txs);
+                        self.current_page += 1;
+                        if server_exhausted {
+                            self.last_page_index = Some(self.current_page);
+                        }
+                        if (self.current_page as usize) < self.page_cache.len() {
+                            self.page_cache[self.current_page as usize] = txs;
+                        } else {
+                            self.page_cache.push(txs);
+                        }
                     }
                     self.refresh_displayed();
                 }
@@ -281,6 +315,12 @@ impl State for VaultTransactionsPanel {
                         ),
                 ) {
                     Ok(cmd) => {
+                        // `labels_edited.update` mutates labels in-place on
+                        // `pending_txs` / `page_cache`, but the view renders
+                        // the `displayed_txs` clone — rematerialise it so the
+                        // edited label is visible immediately rather than only
+                        // after a page change or reload.
+                        self.refresh_displayed();
                         return cmd;
                     }
                     Err(e) => {
@@ -293,12 +333,11 @@ impl State for VaultTransactionsPanel {
             Message::View(view::Message::VaultPrevPage) => {
                 if self.current_page > 0 && !self.processing {
                     self.current_page -= 1;
-                    self.is_last_page = false;
                     self.refresh_displayed();
                 }
             }
             Message::View(view::Message::VaultNextPage) => {
-                if self.is_last_page || self.processing {
+                if self.is_last_page() || self.processing {
                     return Task::none();
                 }
                 let next_page = (self.current_page as usize) + 1;
@@ -306,8 +345,6 @@ impl State for VaultTransactionsPanel {
                 // round-trip when the user pages back and forth.
                 if next_page < self.page_cache.len() {
                     self.current_page += 1;
-                    self.is_last_page =
-                        (self.page_cache[next_page].len() as u64) < HISTORY_EVENT_PAGE_SIZE;
                     self.refresh_displayed();
                     return Task::none();
                 }
@@ -344,7 +381,7 @@ impl State for VaultTransactionsPanel {
                         let blocktime = if let Some(tx) = txs.first() {
                             tx.time
                         } else {
-                            return Ok(txs);
+                            return Ok((txs, true));
                         };
 
                         // 2. Retrieve a larger batch of tx with the same cursor but
@@ -356,8 +393,13 @@ impl State for VaultTransactionsPanel {
                             limit += HISTORY_EVENT_PAGE_SIZE;
                             txs = daemon.list_history_txs(0, last_tx_date, limit).await?;
                         }
+                        // The server is exhausted when it returned fewer rows
+                        // than the (possibly bumped) limit we asked for. This
+                        // is measured on the raw response — the caller must
+                        // not re-derive it from the post-dedup length.
+                        let server_exhausted = (txs.len() as u64) < limit;
                         txs.sort_by(|a, b| a.compare(b));
-                        Ok(txs)
+                        Ok((txs, server_exhausted))
                     },
                     Message::HistoryTransactionsExtension,
                 );
@@ -408,7 +450,7 @@ impl State for VaultTransactionsPanel {
         };
         self.selected_tx = None;
         self.current_page = 0;
-        self.is_last_page = false;
+        self.last_page_index = None;
         self.processing = true;
         self.page_cache.clear();
         self.pending_txs.clear();

--- a/coincube-gui/src/app/state/vault/transactions.rs
+++ b/coincube-gui/src/app/state/vault/transactions.rs
@@ -83,6 +83,12 @@ pub struct VaultTransactionsPanel {
     /// handler ignores any response that arrives once this is `None`, so a
     /// reload mid-fetch can't let a stale page advance `current_page`.
     pending_page: Option<u32>,
+    /// Monotonic counter bumped on every `reload`. The fetch carries the
+    /// value at dispatch; the `HistoryTransactions` handler drops any
+    /// response whose token isn't the latest, so a superseded reload can't
+    /// overwrite fresher state. (Pagination fetches are guarded separately
+    /// by `pending_page`.)
+    reload_token: u64,
 }
 
 impl VaultTransactionsPanel {
@@ -103,6 +109,7 @@ impl VaultTransactionsPanel {
             processing: true,
             current_page: 0,
             pending_page: None,
+            reload_token: 0,
         }
     }
 
@@ -178,7 +185,13 @@ impl State for VaultTransactionsPanel {
             return Task::none();
         };
         match message {
-            Message::HistoryTransactions(res) => match res {
+            Message::HistoryTransactions(token, res) => match res {
+                // Stale-response guard: a `reload` fired after this fetch was
+                // dispatched bumps `reload_token`, so a late response from a
+                // superseded reload is dropped without touching any state
+                // (otherwise it could overwrite fresher page-0 data or flip
+                // `processing` while the newer reload is still loading).
+                _ if token != self.reload_token => return Task::none(),
                 Err(e) => {
                     // Must clear `processing` here: `reload` sets it true, so
                     // a failed initial fetch would otherwise leave the panel
@@ -390,12 +403,22 @@ impl State for VaultTransactionsPanel {
                 let Some(last_tx_date) = last.time else {
                     return Task::none();
                 };
+                // The cursor is inclusive of `last_tx_date`, so the fetch
+                // re-returns every current-page row sharing that blocktime
+                // and the handler dedups them out. Over-fetch by exactly
+                // that count so the post-dedup page is still a full
+                // HISTORY_EVENT_PAGE_SIZE rows — without it, every page
+                // after page 0 renders underfilled.
+                let overlap = current_page_txs
+                    .iter()
+                    .filter(|t| t.time == Some(last_tx_date))
+                    .count() as u64;
                 let daemon = daemon.clone();
                 self.pending_page = Some(self.current_page + 1);
                 self.processing = true;
                 return Task::perform(
                     async move {
-                        let mut limit = HISTORY_EVENT_PAGE_SIZE;
+                        let mut limit = HISTORY_EVENT_PAGE_SIZE + overlap;
                         let mut txs = daemon.list_history_txs(0_u32, last_tx_date, limit).await?;
 
                         // because gethistory cursor is inclusive and use blocktime
@@ -482,6 +505,10 @@ impl State for VaultTransactionsPanel {
         // Drop any in-flight NextPage fetch: its result must not advance
         // pages once this reload has reset pagination back to page 0.
         self.pending_page = None;
+        // Bump the reload token so a slower, superseded reload's response is
+        // dropped by the `HistoryTransactions` handler.
+        self.reload_token = self.reload_token.wrapping_add(1);
+        let token = self.reload_token;
         self.page_cache.clear();
         self.pending_txs.clear();
         self.displayed_txs.clear();
@@ -496,7 +523,7 @@ impl State for VaultTransactionsPanel {
                 let pending_txs = daemon.list_pending_txs().await?;
                 Ok((pending_txs, txs))
             },
-            Message::HistoryTransactions,
+            move |result| Message::HistoryTransactions(token, result),
         )])
     }
 

--- a/coincube-gui/src/app/state/vault/transactions.rs
+++ b/coincube-gui/src/app/state/vault/transactions.rs
@@ -15,7 +15,11 @@ use coincube_ui::{
 use coincubed::commands::CoinStatus;
 use iced::Task;
 
-pub const HISTORY_EVENT_PAGE_SIZE: u64 = 20;
+/// Bump to a larger value (e.g. 50) once Prev/Next pagination is verified
+/// end-to-end on real wallets. Kept low during rollout so QA can exercise
+/// pagination without needing 50+ transactions in a single wallet. Matches
+/// the PAGE_SIZE used by the Spark and Liquid Transactions panels.
+pub const HISTORY_EVENT_PAGE_SIZE: u64 = 10;
 
 use crate::{
     app::{
@@ -48,13 +52,26 @@ pub enum VaultTransactionsModal {
 
 pub struct VaultTransactionsPanel {
     wallet: Arc<Wallet>,
-    txs: Vec<HistoryTransaction>,
+    /// Cached pages keyed by page index. `page_cache[i]` holds the
+    /// transactions for page `i` (Prev navigation re-reads from cache so
+    /// there's no need to invert the daemon's blocktime cursor). Cleared
+    /// on `reload`.
+    page_cache: Vec<Vec<HistoryTransaction>>,
+    /// Pending (unconfirmed) txs from `list_pending_txs()`, fetched at
+    /// reload time and only shown on page 0.
+    pending_txs: Vec<HistoryTransaction>,
+    /// Materialised view of the current page (pending + cache[0] on page
+    /// 0, just cache[N] otherwise). Recomputed via `refresh_displayed`
+    /// whenever the displayed page or its underlying data changes, so the
+    /// view function can borrow it directly with `&self`'s lifetime.
+    displayed_txs: Vec<HistoryTransaction>,
     labels_edited: LabelsEdited,
     selected_tx: Option<HistoryTransaction>,
     warning: Option<Error>,
     modal: VaultTransactionsModal,
     is_last_page: bool,
     processing: bool,
+    current_page: u32,
 }
 
 impl VaultTransactionsPanel {
@@ -62,13 +79,34 @@ impl VaultTransactionsPanel {
         Self {
             wallet,
             selected_tx: None,
-            txs: Vec::new(),
+            page_cache: Vec::new(),
+            pending_txs: Vec::new(),
+            displayed_txs: Vec::new(),
             labels_edited: LabelsEdited::default(),
             warning: None,
             modal: VaultTransactionsModal::None,
             is_last_page: false,
             processing: false,
+            current_page: 0,
         }
+    }
+
+    /// Recompute `displayed_txs` from the current page + pending list.
+    /// Call after any change to `current_page`, `page_cache`, or
+    /// `pending_txs`.
+    fn refresh_displayed(&mut self) {
+        let page = self
+            .page_cache
+            .get(self.current_page as usize)
+            .cloned()
+            .unwrap_or_default();
+        self.displayed_txs = if self.current_page == 0 {
+            let mut combined = self.pending_txs.clone();
+            combined.extend(page);
+            combined
+        } else {
+            page
+        };
     }
 
     pub fn preselect(&mut self, tx: HistoryTransaction) {
@@ -96,7 +134,8 @@ impl State for VaultTransactionsPanel {
             let content = view::vault::transactions::transactions_view(
                 menu,
                 cache,
-                &self.txs,
+                &self.displayed_txs,
+                self.current_page,
                 self.is_last_page,
                 self.processing,
             );
@@ -124,10 +163,14 @@ impl State for VaultTransactionsPanel {
                     self.warning = Some(e);
                     return Task::done(Message::View(view::Message::ShowError(err_msg)));
                 }
-                Ok(txs) => {
+                Ok((pending_txs, page_txs)) => {
                     self.warning = None;
-                    self.txs = txs;
-                    self.is_last_page = (self.txs.len() as u64) < HISTORY_EVENT_PAGE_SIZE;
+                    self.pending_txs = pending_txs;
+                    self.is_last_page = (page_txs.len() as u64) < HISTORY_EVENT_PAGE_SIZE;
+                    self.page_cache = vec![page_txs];
+                    self.current_page = 0;
+                    self.processing = false;
+                    self.refresh_displayed();
                 }
             },
             Message::HistoryTransactionsExtension(res) => match res {
@@ -137,26 +180,26 @@ impl State for VaultTransactionsPanel {
                     self.warning = Some(e);
                     return Task::done(Message::View(view::Message::ShowError(err_msg)));
                 }
-                Ok(txs) => {
+                Ok(mut txs) => {
                     self.processing = false;
                     self.warning = None;
-                    self.is_last_page = (txs.len() as u64) < HISTORY_EVENT_PAGE_SIZE;
-                    if let Some(tx) = txs.first() {
-                        if let Some(position) = self.txs.iter().position(|tx2| tx2.txid == tx.txid)
-                        {
-                            let len = self.txs.len();
-                            for tx in txs {
-                                if !self.txs[position..len]
-                                    .iter()
-                                    .any(|tx2| tx2.txid == tx.txid)
-                                {
-                                    self.txs.push(tx);
-                                }
-                            }
-                        } else {
-                            self.txs.extend(txs);
-                        }
+                    // The cursor we used (last tx's blocktime) is inclusive,
+                    // so the response can repeat txs that already appeared on
+                    // the current page. Drop those by txid before storing the
+                    // next page, then advance.
+                    if let Some(prev_page) = self.page_cache.get(self.current_page as usize) {
+                        let prev_ids: std::collections::HashSet<_> =
+                            prev_page.iter().map(|t| t.tx.compute_txid()).collect();
+                        txs.retain(|t| !prev_ids.contains(&t.tx.compute_txid()));
                     }
+                    self.is_last_page = (txs.len() as u64) < HISTORY_EVENT_PAGE_SIZE;
+                    self.current_page += 1;
+                    if (self.current_page as usize) < self.page_cache.len() {
+                        self.page_cache[self.current_page as usize] = txs;
+                    } else {
+                        self.page_cache.push(txs);
+                    }
+                    self.refresh_displayed();
                 }
             },
             Message::RbfModal(tx, is_cancel, res) => match res {
@@ -175,7 +218,7 @@ impl State for VaultTransactionsPanel {
                 return self.reload(Some(daemon), Some(self.wallet.clone()));
             }
             Message::View(view::Message::Select(i)) => {
-                self.selected_tx = self.txs.get(i).cloned();
+                self.selected_tx = self.displayed_txs.get(i).cloned();
                 // Clear modal if it's for a different tx.
                 if let VaultTransactionsModal::CreateRbf(modal) = &self.modal {
                     if Some(modal.tx.tx.compute_txid())
@@ -227,8 +270,9 @@ impl State for VaultTransactionsPanel {
                 match self.labels_edited.update(
                     daemon,
                     message,
-                    self.txs
+                    self.pending_txs
                         .iter_mut()
+                        .chain(self.page_cache.iter_mut().flat_map(|p| p.iter_mut()))
                         .map(|tx| tx as &mut dyn LabelsLoader)
                         .chain(
                             self.selected_tx
@@ -246,45 +290,77 @@ impl State for VaultTransactionsPanel {
                     }
                 };
             }
-            Message::View(view::Message::Next) => {
-                if let Some(last) = self.txs.last() {
-                    let daemon = daemon.clone();
-                    let last_tx_date = last.time.unwrap();
-                    self.processing = true;
-                    return Task::perform(
-                        async move {
-                            let mut limit = HISTORY_EVENT_PAGE_SIZE;
-                            let mut txs =
-                                daemon.list_history_txs(0_u32, last_tx_date, limit).await?;
-
-                            // because gethistory cursor is inclusive and use blocktime
-                            // multiple txs can occur in the same block.
-                            // If there is more tx in the same block that the
-                            // HISTORY_EVENT_PAGE_SIZE they can not be retrieved by changing
-                            // the cursor value (blocktime) but by increasing the limit.
-                            //
-                            // 1. Check if the txs retrieved have all the same blocktime
-                            let blocktime = if let Some(tx) = txs.first() {
-                                tx.time
-                            } else {
-                                return Ok(txs);
-                            };
-
-                            // 2. Retrieve a larger batch of tx with the same cursor but
-                            //    a larger limit.
-                            while !txs.iter().any(|evt| evt.time != blocktime)
-                                && txs.len() as u64 == limit
-                            {
-                                // increments of the equivalent of one page more.
-                                limit += HISTORY_EVENT_PAGE_SIZE;
-                                txs = daemon.list_history_txs(0, last_tx_date, limit).await?;
-                            }
-                            txs.sort_by(|a, b| a.compare(b));
-                            Ok(txs)
-                        },
-                        Message::HistoryTransactionsExtension,
-                    );
+            Message::View(view::Message::VaultPrevPage) => {
+                if self.current_page > 0 && !self.processing {
+                    self.current_page -= 1;
+                    self.is_last_page = false;
+                    self.refresh_displayed();
                 }
+            }
+            Message::View(view::Message::VaultNextPage) => {
+                if self.is_last_page || self.processing {
+                    return Task::none();
+                }
+                let next_page = (self.current_page as usize) + 1;
+                // Already cached — jump straight there. Avoids a redundant
+                // round-trip when the user pages back and forth.
+                if next_page < self.page_cache.len() {
+                    self.current_page += 1;
+                    self.is_last_page =
+                        (self.page_cache[next_page].len() as u64) < HISTORY_EVENT_PAGE_SIZE;
+                    self.refresh_displayed();
+                    return Task::none();
+                }
+                // Need to fetch. Cursor is the blocktime of the last
+                // confirmed tx on the current page (mirrors the original
+                // "See more" forward-scan logic, including the
+                // duplicate-blocktime overflow handling — see comment in
+                // the async block).
+                let current_page_txs = self
+                    .page_cache
+                    .get(self.current_page as usize)
+                    .cloned()
+                    .unwrap_or_default();
+                let Some(last) = current_page_txs.last() else {
+                    return Task::none();
+                };
+                let Some(last_tx_date) = last.time else {
+                    return Task::none();
+                };
+                let daemon = daemon.clone();
+                self.processing = true;
+                return Task::perform(
+                    async move {
+                        let mut limit = HISTORY_EVENT_PAGE_SIZE;
+                        let mut txs = daemon.list_history_txs(0_u32, last_tx_date, limit).await?;
+
+                        // because gethistory cursor is inclusive and use blocktime
+                        // multiple txs can occur in the same block.
+                        // If there is more tx in the same block that the
+                        // HISTORY_EVENT_PAGE_SIZE they can not be retrieved by changing
+                        // the cursor value (blocktime) but by increasing the limit.
+                        //
+                        // 1. Check if the txs retrieved have all the same blocktime
+                        let blocktime = if let Some(tx) = txs.first() {
+                            tx.time
+                        } else {
+                            return Ok(txs);
+                        };
+
+                        // 2. Retrieve a larger batch of tx with the same cursor but
+                        //    a larger limit.
+                        while !txs.iter().any(|evt| evt.time != blocktime)
+                            && txs.len() as u64 == limit
+                        {
+                            // increments of the equivalent of one page more.
+                            limit += HISTORY_EVENT_PAGE_SIZE;
+                            txs = daemon.list_history_txs(0, last_tx_date, limit).await?;
+                        }
+                        txs.sort_by(|a, b| a.compare(b));
+                        Ok(txs)
+                    },
+                    Message::HistoryTransactionsExtension,
+                );
             }
             Message::View(view::Message::ImportExport(ImportExportMessage::Open)) => {
                 if let VaultTransactionsModal::None = &self.modal {
@@ -331,6 +407,12 @@ impl State for VaultTransactionsPanel {
             return Task::none();
         };
         self.selected_tx = None;
+        self.current_page = 0;
+        self.is_last_page = false;
+        self.processing = true;
+        self.page_cache.clear();
+        self.pending_txs.clear();
+        self.displayed_txs.clear();
         let now: u32 = now().as_secs().try_into().unwrap();
         Task::batch(vec![Task::perform(
             async move {
@@ -339,9 +421,8 @@ impl State for VaultTransactionsPanel {
                     .await?;
                 txs.sort_by(|a, b| a.compare(b));
 
-                let mut pending_txs = daemon.list_pending_txs().await?;
-                pending_txs.extend(txs);
-                Ok(pending_txs)
+                let pending_txs = daemon.list_pending_txs().await?;
+                Ok((pending_txs, txs))
             },
             Message::HistoryTransactions,
         )])

--- a/coincube-gui/src/app/state/vault/transactions.rs
+++ b/coincube-gui/src/app/state/vault/transactions.rs
@@ -78,6 +78,11 @@ pub struct VaultTransactionsPanel {
     last_page_index: Option<u32>,
     processing: bool,
     current_page: u32,
+    /// Target page of an in-flight `VaultNextPage` extension fetch. Set on
+    /// dispatch, cleared on the result *or* by `reload`. The extension
+    /// handler ignores any response that arrives once this is `None`, so a
+    /// reload mid-fetch can't let a stale page advance `current_page`.
+    pending_page: Option<u32>,
 }
 
 impl VaultTransactionsPanel {
@@ -97,6 +102,7 @@ impl VaultTransactionsPanel {
             // loading state rather than briefly flashing "No transactions".
             processing: true,
             current_page: 0,
+            pending_page: None,
         }
     }
 
@@ -174,6 +180,10 @@ impl State for VaultTransactionsPanel {
         match message {
             Message::HistoryTransactions(res) => match res {
                 Err(e) => {
+                    // Must clear `processing` here: `reload` sets it true, so
+                    // a failed initial fetch would otherwise leave the panel
+                    // stuck on the loading indicator with Prev/Next disabled.
+                    self.processing = false;
                     let err_msg = e.to_string();
                     self.warning = Some(e);
                     return Task::done(Message::View(view::Message::ShowError(err_msg)));
@@ -196,12 +206,28 @@ impl State for VaultTransactionsPanel {
             },
             Message::HistoryTransactionsExtension(res) => match res {
                 Err(e) => {
+                    // Stale-response guard (see the Ok arm): if `pending_page`
+                    // is already cleared a `reload` superseded this fetch —
+                    // discard the late error without touching `processing`,
+                    // which the reload's own fetch now owns.
+                    if self.pending_page.take().is_none() {
+                        return Task::none();
+                    }
                     self.processing = false;
                     let err_msg = e.to_string();
                     self.warning = Some(e);
                     return Task::done(Message::View(view::Message::ShowError(err_msg)));
                 }
                 Ok((mut txs, server_exhausted)) => {
+                    // Stale-response guard: this extension result is only
+                    // valid if `pending_page` still records the NextPage
+                    // fetch that produced it. A `reload` between dispatch and
+                    // arrival clears `pending_page`, so a late response is
+                    // discarded rather than advancing `current_page` and
+                    // injecting stale rows into `page_cache`.
+                    let Some(target) = self.pending_page.take() else {
+                        return Task::none();
+                    };
                     self.processing = false;
                     self.warning = None;
                     // The cursor we used (last tx's blocktime) is inclusive,
@@ -223,12 +249,12 @@ impl State for VaultTransactionsPanel {
                         // last. Don't advance onto an empty page.
                         self.last_page_index = Some(self.current_page);
                     } else {
-                        self.current_page += 1;
+                        self.current_page = target;
                         if server_exhausted {
                             self.last_page_index = Some(self.current_page);
                         }
-                        if (self.current_page as usize) < self.page_cache.len() {
-                            self.page_cache[self.current_page as usize] = txs;
+                        if (target as usize) < self.page_cache.len() {
+                            self.page_cache[target as usize] = txs;
                         } else {
                             self.page_cache.push(txs);
                         }
@@ -365,6 +391,7 @@ impl State for VaultTransactionsPanel {
                     return Task::none();
                 };
                 let daemon = daemon.clone();
+                self.pending_page = Some(self.current_page + 1);
                 self.processing = true;
                 return Task::perform(
                     async move {
@@ -452,6 +479,9 @@ impl State for VaultTransactionsPanel {
         self.current_page = 0;
         self.last_page_index = None;
         self.processing = true;
+        // Drop any in-flight NextPage fetch: its result must not advance
+        // pages once this reload has reset pagination back to page 0.
+        self.pending_page = None;
         self.page_cache.clear();
         self.pending_txs.clear();
         self.displayed_txs.clear();

--- a/coincube-gui/src/app/view/liquid/transactions.rs
+++ b/coincube-gui/src/app/view/liquid/transactions.rs
@@ -11,6 +11,7 @@ use coincube_ui::{
     component::{
         amount::DisplayAmount,
         button, card, form,
+        pagination::pagination_controls,
         quote_display::{self, Quote, QuoteDisplayProps},
         text::*,
         transaction::{TransactionDirection, TransactionListItem},
@@ -123,6 +124,9 @@ pub fn liquid_transactions_view<'a>(
     show_direction_badges: bool,
     empty_state_quote: &'a Quote,
     empty_state_image_handle: &'a image::Handle,
+    current_page: u32,
+    is_last_page: bool,
+    processing: bool,
 ) -> Element<'a, Message> {
     let mut content = Column::new().spacing(20).width(Length::Fill);
 
@@ -165,7 +169,10 @@ pub fn liquid_transactions_view<'a>(
         content = content.push(filter_row);
     }
 
-    if payments.is_empty() {
+    // On page 0 with no rows we render the empty state; on later pages an
+    // empty response just means we've paged past the end — keep the list
+    // shell and pagination controls visible so the user can Prev back.
+    if payments.is_empty() && current_page == 0 {
         // Empty state with Kage quote
         content = content.push(
             Column::new()
@@ -202,24 +209,32 @@ pub fn liquid_transactions_view<'a>(
                 ),
         );
     } else {
-        // Transaction list
-        content = content.push(
-            Column::new()
-                .spacing(10)
-                .push(payments.iter().enumerate().fold(
-                    Column::new().spacing(10),
-                    |col, (i, payment)| {
-                        col.push(transaction_row(
-                            i,
-                            payment,
-                            fiat_converter,
-                            bitcoin_unit,
-                            usdt_id,
-                            show_direction_badges,
-                        ))
-                    },
-                )),
-        );
+        // Transaction list — wrapped in a scrollable so a full page of rows
+        // stays bounded to the panel viewport instead of pushing the
+        // pagination controls (and the refundables card) off-screen.
+        let list =
+            payments
+                .iter()
+                .enumerate()
+                .fold(Column::new().spacing(10), |col, (i, payment)| {
+                    col.push(transaction_row(
+                        i,
+                        payment,
+                        fiat_converter,
+                        bitcoin_unit,
+                        usdt_id,
+                        show_direction_badges,
+                    ))
+                });
+        content = content.push(scrollable(list).height(Length::Fill));
+        content = content.push(pagination_controls(
+            Message::LiquidPrevPage,
+            Message::LiquidNextPage,
+            current_page > 0,
+            !is_last_page,
+            processing,
+            current_page,
+        ));
     }
 
     // Refundables are always BTC → L-BTC swap refunds, so they only belong

--- a/coincube-gui/src/app/view/liquid/transactions.rs
+++ b/coincube-gui/src/app/view/liquid/transactions.rs
@@ -209,9 +209,11 @@ pub fn liquid_transactions_view<'a>(
                 ),
         );
     } else {
-        // Transaction list — wrapped in a scrollable so a full page of rows
-        // stays bounded to the panel viewport instead of pushing the
-        // pagination controls (and the refundables card) off-screen.
+        // The dashboard already wraps the whole panel in a page-level
+        // scrollable, so the list is pushed directly — nesting another
+        // scrollable here would make its `Fill` height resolve against an
+        // unbounded parent and break layout. Pagination keeps each page
+        // bounded (PAGE_SIZE rows), so the page scroll is enough.
         let list =
             payments
                 .iter()
@@ -226,7 +228,7 @@ pub fn liquid_transactions_view<'a>(
                         show_direction_badges,
                     ))
                 });
-        content = content.push(scrollable(list).height(Length::Fill));
+        content = content.push(list);
         content = content.push(pagination_controls(
             Message::LiquidPrevPage,
             Message::LiquidNextPage,
@@ -264,6 +266,7 @@ pub fn liquid_transactions_view<'a>(
         );
     }
 
+    content = content.push(Space::new().height(Length::Fixed(30.0)));
     content.into()
 }
 

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -155,6 +155,14 @@ pub enum Message {
     LiquidSettings(LiquidSettingsMessage),
     PreselectPayment(DomainPayment),
     SetAssetFilter(crate::app::state::liquid::transactions::AssetFilter),
+    /// Liquid Transactions: navigate to previous page.
+    LiquidPrevPage,
+    /// Liquid Transactions: navigate to next page.
+    LiquidNextPage,
+    /// Vault Transactions: navigate to previous page.
+    VaultPrevPage,
+    /// Vault Transactions: navigate to next page.
+    VaultNextPage,
     ShowError(String),
     ShowSuccess(String),
     ShowToast(log::Level, String),

--- a/coincube-gui/src/app/view/mod.rs
+++ b/coincube-gui/src/app/view/mod.rs
@@ -271,6 +271,37 @@ pub fn placeholder<'a, T: Into<Element<'a, Message>>>(
         .into()
 }
 
+/// Loading-state card mirroring [`placeholder`]'s layout, but with the
+/// app's pulsing-dots `loading_indicator` (the same one shown while a Cube
+/// loads) below the title instead of a subtitle. Shown while an initial
+/// fetch is in flight so panels don't briefly flash an empty
+/// "No transactions" state before data arrives.
+pub fn loading_placeholder<'a, T: Into<Element<'a, Message>>>(
+    icon: T,
+    title: &'a str,
+) -> Element<'a, Message> {
+    let content = Column::new()
+        .push(icon)
+        .push(text(title).style(theme::text::secondary).bold())
+        .push(crate::loading::loading_indicator::<Message>(None))
+        .spacing(16)
+        .align_x(Alignment::Center);
+
+    Container::new(content)
+        .width(Length::Fill)
+        .padding(60)
+        .center_x(Length::Fill)
+        .style(|t| container::Style {
+            background: Some(iced::Background::Color(t.colors.cards.simple.background)),
+            border: iced::Border {
+                radius: 20.0.into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .into()
+}
+
 pub fn toast_overlay<'a, I: Iterator<Item = (usize, log::Level, &'a str)>>(
     iter: I,
     theme: &coincube_ui::theme::Theme,

--- a/coincube-gui/src/app/view/spark/mod.rs
+++ b/coincube-gui/src/app/view/spark/mod.rs
@@ -66,6 +66,10 @@ pub enum SparkTransactionsMessage {
     SendBtc,
     /// Empty-state navigation: "Receive sats" button.
     ReceiveBtc,
+    /// Go to the previous page in the paginated list.
+    PrevPage,
+    /// Go to the next page in the paginated list.
+    NextPage,
 }
 
 /// View-level messages for the Spark Settings panel.

--- a/coincube-gui/src/app/view/spark/mod.rs
+++ b/coincube-gui/src/app/view/spark/mod.rs
@@ -50,10 +50,14 @@ pub enum SparkOverviewMessage {
 /// View-level messages for the Spark Transactions panel.
 #[derive(Debug, Clone)]
 pub enum SparkTransactionsMessage {
-    /// Bridge returned `list_payments` success — carries the page.
-    DataLoaded(Vec<coincube_spark_protocol::PaymentSummary>),
-    /// Bridge returned an error response for `list_payments`.
-    Error(String),
+    /// Bridge returned `list_payments` success. The `u64` is the
+    /// fetch-generation token — the panel discards any response whose
+    /// token isn't the latest, so a stale pagination response can't
+    /// overwrite data from a newer reload.
+    DataLoaded(u64, Vec<coincube_spark_protocol::PaymentSummary>),
+    /// Bridge returned an error response for `list_payments`. The `u64`
+    /// is the fetch-generation token (see [`Self::DataLoaded`]).
+    Error(u64, String),
     /// User clicked a row. Opens the detail pane for the payment
     /// at that index in the current `recent_transactions` list.
     Select(usize),

--- a/coincube-gui/src/app/view/spark/transactions.rs
+++ b/coincube-gui/src/app/view/spark/transactions.rs
@@ -27,6 +27,7 @@ use coincube_ui::{
     component::{
         amount::{amount_with_size_and_unit, BitcoinDisplayUnit},
         button, card,
+        pagination::pagination_controls,
         quote_display::{self, Quote, QuoteDisplayProps},
         text::*,
         transaction::{TransactionDirection, TransactionListItem},
@@ -36,7 +37,10 @@ use coincube_ui::{
     theme,
     widget::*,
 };
-use iced::{widget::Space, Alignment, Length};
+use iced::{
+    widget::{scrollable, Space},
+    Alignment, Length,
+};
 
 use crate::app::menu::{Menu, SparkSubMenu};
 use crate::app::view::message::Message;
@@ -61,6 +65,9 @@ pub struct SparkTransactionsView<'a> {
     pub show_direction_badges: bool,
     pub empty_state_quote: &'a Quote,
     pub empty_state_image_handle: &'a image::Handle,
+    pub current_page: u32,
+    pub is_last_page: bool,
+    pub processing: bool,
 }
 
 impl<'a> SparkTransactionsView<'a> {
@@ -104,7 +111,10 @@ impl<'a> SparkTransactionsView<'a> {
             SparkTransactionsStatus::Loaded(_) => {}
         }
 
-        if self.recent_transactions.is_empty() {
+        // On page 0 with no rows we render the empty state; on later
+        // pages an empty response just means we've paged past the end, so
+        // keep the list shell + Prev control visible.
+        if self.recent_transactions.is_empty() && self.current_page == 0 {
             // Same empty-state layout as Liquid, minus the Liquid copy.
             content = content.push(
                 Column::new()
@@ -147,7 +157,7 @@ impl<'a> SparkTransactionsView<'a> {
             return content.into();
         }
 
-        content = content.push(self.recent_transactions.iter().enumerate().fold(
+        let list = self.recent_transactions.iter().enumerate().fold(
             Column::new().spacing(10),
             |col, (i, tx)| {
                 col.push(transaction_row(
@@ -158,6 +168,16 @@ impl<'a> SparkTransactionsView<'a> {
                     self.show_direction_badges,
                 ))
             },
+        );
+
+        content = content.push(scrollable(list).height(Length::Fill));
+        content = content.push(pagination_controls(
+            Message::SparkTransactions(crate::app::view::spark::SparkTransactionsMessage::PrevPage),
+            Message::SparkTransactions(crate::app::view::spark::SparkTransactionsMessage::NextPage),
+            self.current_page > 0,
+            !self.is_last_page,
+            self.processing,
+            self.current_page,
         ));
 
         content.into()

--- a/coincube-gui/src/app/view/spark/transactions.rs
+++ b/coincube-gui/src/app/view/spark/transactions.rs
@@ -37,10 +37,7 @@ use coincube_ui::{
     theme,
     widget::*,
 };
-use iced::{
-    widget::{scrollable, Space},
-    Alignment, Length,
-};
+use iced::{widget::Space, Alignment, Length};
 
 use crate::app::menu::{Menu, SparkSubMenu};
 use crate::app::view::message::Message;
@@ -170,7 +167,12 @@ impl<'a> SparkTransactionsView<'a> {
             },
         );
 
-        content = content.push(scrollable(list).height(Length::Fill));
+        // The dashboard already wraps the whole panel in a page-level
+        // scrollable, so the list is pushed directly — nesting another
+        // scrollable here would make its `Fill` height resolve against an
+        // unbounded parent and break layout. Pagination keeps each page
+        // bounded (PAGE_SIZE rows), so the page scroll is enough.
+        content = content.push(list);
         content = content.push(pagination_controls(
             Message::SparkTransactions(crate::app::view::spark::SparkTransactionsMessage::PrevPage),
             Message::SparkTransactions(crate::app::view::spark::SparkTransactionsMessage::NextPage),
@@ -179,6 +181,7 @@ impl<'a> SparkTransactionsView<'a> {
             self.processing,
             self.current_page,
         ));
+        content = content.push(Space::new().height(Length::Fixed(30.0)));
 
         content.into()
     }

--- a/coincube-gui/src/app/view/vault/overview.rs
+++ b/coincube-gui/src/app/view/vault/overview.rs
@@ -28,7 +28,7 @@ use crate::{
         menu::{self, Menu, VaultSubMenu},
         settings::display::DisplayMode,
         view::{
-            balance_header_card, dashboard,
+            balance_header_card, dashboard, loading_placeholder,
             message::Message,
             vault::coins,
             vault::label,
@@ -87,6 +87,7 @@ pub fn vault_overview_view<'a>(
     events: &'a [Payment],
     is_last_page: bool,
     processing: bool,
+    loading: bool,
     sync_status: &SyncStatus,
     show_rescan_warning: bool,
     bitcoin_unit: BitcoinDisplayUnit,
@@ -247,6 +248,9 @@ pub fn vault_overview_view<'a>(
             Column::new()
                 .spacing(10)
                 .push(h4_bold("Last transactions"))
+                .push_maybe(loading.then(|| {
+                    loading_placeholder(icon::receipt_icon().size(48), "Loading transactions")
+                }))
                 .push(events.iter().fold(Column::new().spacing(10), |col, event| {
                     if event.kind != PaymentKind::SendToSelf {
                         col.push(event_list_view(

--- a/coincube-gui/src/app/view/vault/transactions.rs
+++ b/coincube-gui/src/app/view/vault/transactions.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 
 use chrono::{DateTime, Local, Utc};
 use iced::{
-    widget::{scrollable, tooltip, Space},
+    widget::{tooltip, Space},
     Alignment, Length,
 };
 
@@ -26,6 +26,7 @@ use crate::{
         menu::{Menu, VaultSubMenu},
         view::{
             dashboard,
+            loading_placeholder,
             message::{CreateRbfMessage, Message},
             placeholder,
             vault::label,
@@ -47,7 +48,13 @@ pub fn transactions_view<'a>(
 ) -> Element<'a, Message> {
     let fiat_converter = cache.fiat_price.as_ref().and_then(|p| p.try_into().ok());
 
-    let show_empty_state = txs.is_empty() && current_page == 0;
+    // While the initial page-0 fetch is in flight, `txs` is empty but the
+    // wallet may well have history — show a loading state instead of the
+    // "No transactions" empty state, which would otherwise flash for a few
+    // seconds before the data lands.
+    let is_initial_empty = txs.is_empty() && current_page == 0;
+    let show_loading = is_initial_empty && processing;
+    let show_empty_state = is_initial_empty && !processing;
 
     let list = txs
         .iter()
@@ -62,17 +69,23 @@ pub fn transactions_view<'a>(
             ))
         });
 
-    let body: Element<'a, Message> = if show_empty_state {
+    let body: Element<'a, Message> = if show_loading {
+        loading_placeholder(receipt_icon().size(80), "Loading transactions")
+    } else if show_empty_state {
         placeholder(
             receipt_icon().size(80),
             "No transactions yet",
             "Your transaction history will appear here once you send or receive coins.",
         )
-        .into()
     } else {
+        // The dashboard already wraps the whole panel in a page-level
+        // scrollable, so the list is pushed directly — nesting another
+        // scrollable here would make its `Fill` height resolve against an
+        // unbounded parent and break layout. Pagination keeps each page
+        // bounded (PAGE_SIZE rows), so the page scroll is enough.
         Column::new()
             .spacing(10)
-            .push(scrollable(list).height(Length::Fill))
+            .push(list)
             .push(pagination_controls(
                 Message::VaultPrevPage,
                 Message::VaultNextPage,
@@ -81,6 +94,7 @@ pub fn transactions_view<'a>(
                 processing,
                 current_page,
             ))
+            .push(Space::new().height(Length::Fixed(30.0)))
             .into()
     };
 

--- a/coincube-gui/src/app/view/vault/transactions.rs
+++ b/coincube-gui/src/app/view/vault/transactions.rs
@@ -25,8 +25,7 @@ use crate::{
         cache::Cache,
         menu::{Menu, VaultSubMenu},
         view::{
-            dashboard,
-            loading_placeholder,
+            dashboard, loading_placeholder,
             message::{CreateRbfMessage, Message},
             placeholder,
             vault::label,

--- a/coincube-gui/src/app/view/vault/transactions.rs
+++ b/coincube-gui/src/app/view/vault/transactions.rs
@@ -3,8 +3,7 @@ use std::convert::TryInto;
 
 use chrono::{DateTime, Local, Utc};
 use iced::{
-    alignment,
-    widget::{tooltip, Space},
+    widget::{scrollable, tooltip, Space},
     Alignment, Length,
 };
 
@@ -12,6 +11,7 @@ use coincube_ui::{
     component::{
         amount::*,
         button, card, form,
+        pagination::pagination_controls,
         text::*,
         transaction::{TransactionBadge, TransactionDirection, TransactionListItem},
     },
@@ -41,10 +41,48 @@ pub fn transactions_view<'a>(
     menu: &'a Menu,
     cache: &'a Cache,
     txs: &'a [HistoryTransaction],
+    current_page: u32,
     is_last_page: bool,
     processing: bool,
 ) -> Element<'a, Message> {
     let fiat_converter = cache.fiat_price.as_ref().and_then(|p| p.try_into().ok());
+
+    let show_empty_state = txs.is_empty() && current_page == 0;
+
+    let list = txs
+        .iter()
+        .enumerate()
+        .fold(Column::new().spacing(10), |col, (i, tx)| {
+            col.push(tx_list_view(
+                i,
+                tx,
+                cache.bitcoin_unit,
+                fiat_converter,
+                cache.show_direction_badges,
+            ))
+        });
+
+    let body: Element<'a, Message> = if show_empty_state {
+        placeholder(
+            receipt_icon().size(80),
+            "No transactions yet",
+            "Your transaction history will appear here once you send or receive coins.",
+        )
+        .into()
+    } else {
+        Column::new()
+            .spacing(10)
+            .push(scrollable(list).height(Length::Fill))
+            .push(pagination_controls(
+                Message::VaultPrevPage,
+                Message::VaultNextPage,
+                current_page > 0,
+                !is_last_page,
+                processing,
+                current_page,
+            ))
+            .into()
+    };
 
     dashboard(
         menu,
@@ -59,57 +97,7 @@ pub fn transactions_view<'a>(
                             .on_press(ImportExportMessage::Open.into()),
                     ),
             )
-            .push(txs.is_empty().then(|| {
-                placeholder(
-                    receipt_icon().size(80),
-                    "No transactions yet",
-                    "Your transaction history will appear here once you send or receive coins.",
-                )
-            }))
-            .push(
-                Column::new()
-                    .spacing(10)
-                    .push(
-                        txs.iter()
-                            .enumerate()
-                            .fold(Column::new().spacing(10), |col, (i, tx)| {
-                                col.push(tx_list_view(
-                                    i,
-                                    tx,
-                                    cache.bitcoin_unit,
-                                    fiat_converter,
-                                    cache.show_direction_badges,
-                                ))
-                            }),
-                    )
-                    .push(if !is_last_page && !txs.is_empty() {
-                        Some(
-                            Container::new(
-                                Button::new(
-                                    text(if processing {
-                                        "Fetching ..."
-                                    } else {
-                                        "See more"
-                                    })
-                                    .width(Length::Fill)
-                                    .align_x(alignment::Horizontal::Center),
-                                )
-                                .width(Length::Fill)
-                                .padding(15)
-                                .style(theme::button::transparent_border)
-                                .on_press_maybe(if !processing {
-                                    Some(Message::Next)
-                                } else {
-                                    None
-                                }),
-                            )
-                            .width(Length::Fill)
-                            .style(theme::card::simple),
-                        )
-                    } else {
-                        None
-                    }),
-            )
+            .push(body)
             .align_x(Alignment::Center)
             .spacing(25),
     )

--- a/coincube-gui/src/app/wallets/liquid.rs
+++ b/coincube-gui/src/app/wallets/liquid.rs
@@ -47,12 +47,18 @@ impl LiquidBackend {
 
     /// Fetch the payment history and map each record into a [`DomainPayment`].
     ///
-    /// `limit` mirrors the underlying [`BreezClient::list_payments`] parameter.
+    /// `limit` / `offset` / `asset_id` mirror the underlying
+    /// [`BreezClient::list_payments`] parameters. `asset_id == None` returns
+    /// payments of every type and asset; passing an asset id restricts the
+    /// result to Liquid-asset payments matching that id (server-side, so
+    /// pagination stays accurate).
     pub async fn list_payments(
         &self,
         limit: Option<u32>,
+        offset: Option<u32>,
+        asset_id: Option<String>,
     ) -> Result<Vec<DomainPayment>, BreezError> {
-        let payments = self.client.list_payments(limit).await?;
+        let payments = self.client.list_payments(limit, offset, asset_id).await?;
         Ok(payments.into_iter().map(DomainPayment::from).collect())
     }
 

--- a/coincube-gui/src/app/wallets/spark.rs
+++ b/coincube-gui/src/app/wallets/spark.rs
@@ -52,8 +52,9 @@ impl SparkBackend {
     pub async fn list_payments(
         &self,
         limit: Option<u32>,
+        offset: Option<u32>,
     ) -> Result<ListPaymentsOk, SparkClientError> {
-        self.client.list_payments(limit).await
+        self.client.list_payments(limit, offset).await
     }
 
     /// Phase 4e: classify a destination string. The Send panel calls

--- a/coincube-gui/src/export.rs
+++ b/coincube-gui/src/export.rs
@@ -637,7 +637,7 @@ pub async fn export_spark_payments(
     file.write_all(header.as_bytes())?;
 
     let list = spark_backend
-        .list_payments(None)
+        .list_payments(None, None)
         .await
         .map_err(|e| Error::Daemon(e.to_string()))?;
 
@@ -741,7 +741,7 @@ pub async fn export_liquid_payments(
     // short-lived `LiquidBackend` just to get the domain read API.
     let backend = LiquidBackend::new(breez_client);
     let payments = backend
-        .list_payments(None)
+        .list_payments(None, None, None)
         .await
         .map_err(|e| Error::Daemon(e.to_string()))?;
 

--- a/coincube-ui/src/component/mod.rs
+++ b/coincube-ui/src/component/mod.rs
@@ -7,6 +7,7 @@ pub mod form;
 pub mod hw;
 pub mod modal;
 pub mod notification;
+pub mod pagination;
 pub mod quote_display;
 pub mod spinner;
 pub mod tabs;

--- a/coincube-ui/src/component/pagination.rs
+++ b/coincube-ui/src/component/pagination.rs
@@ -1,0 +1,72 @@
+//! Shared Prev / Next pagination control used by the Spark, Liquid, and
+//! Vault Transactions panels.
+//!
+//! Layout: `[< Prev]   Page N   [Next >]` centered inside a
+//! `theme::card::simple` container so it matches the panel cards above.
+//! Each side disables independently — Prev when on page 0, Next when the
+//! last response returned fewer rows than `PAGE_SIZE`. Both disable while
+//! a fetch is in flight so rapid double-clicks can't skip pages.
+
+use iced::{alignment, Length};
+
+use crate::{
+    theme,
+    widget::{Button, Container, Element, Row},
+};
+
+use super::text::{text, P1_SIZE};
+
+pub fn pagination_controls<'a, Message: Clone + 'a>(
+    on_prev: Message,
+    on_next: Message,
+    prev_enabled: bool,
+    next_enabled: bool,
+    processing: bool,
+    current_page: u32,
+) -> Element<'a, Message> {
+    let interactive = !processing;
+    let prev_button = Button::new(
+        text("< Prev")
+            .size(P1_SIZE)
+            .align_x(alignment::Horizontal::Center)
+            .width(Length::Fill),
+    )
+    .width(Length::Fixed(120.0))
+    .padding(12)
+    .style(theme::button::transparent_border)
+    .on_press_maybe((prev_enabled && interactive).then_some(on_prev));
+
+    let next_button = Button::new(
+        text("Next >")
+            .size(P1_SIZE)
+            .align_x(alignment::Horizontal::Center)
+            .width(Length::Fill),
+    )
+    .width(Length::Fixed(120.0))
+    .padding(12)
+    .style(theme::button::transparent_border)
+    .on_press_maybe((next_enabled && interactive).then_some(on_next));
+
+    let label = if processing {
+        "Loading…".to_string()
+    } else {
+        format!("Page {}", current_page.saturating_add(1))
+    };
+
+    let row = Row::new()
+        .align_y(iced::Alignment::Center)
+        .spacing(20)
+        .push(prev_button)
+        .push(
+            Container::new(text(label).size(P1_SIZE))
+                .center_x(Length::Fill)
+                .width(Length::Fill),
+        )
+        .push(next_button);
+
+    Container::new(row)
+        .width(Length::Fill)
+        .padding(8)
+        .style(theme::card::simple)
+        .into()
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches transaction pagination/reload logic across Liquid, Spark, and Vault panels; incorrect token handling could still lead to missing/duplicated rows or wrong-page UI state, but changes are UI/state-management only with no security impact.
> 
> **Overview**
> Improves transaction list pagination robustness across **Liquid**, **Spark**, and **Vault** by tagging async fetches with generation tokens and discarding stale results so older reloads/page requests can’t overwrite newer state.
> 
> Adjusts last-page detection by over-fetching `PAGE_SIZE + 1` items (Liquid/Spark) and trimming the probe row, and fixes Vault next-page underfill by increasing the requested limit to account for inclusive-cursor overlap within the last blocktime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fce9a6d7747e7d9a1e598f503d1a22942c39be4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prev/Next pagination controls for transaction/payment lists in Liquid, Spark, and Vault panels.
  * Added per-asset filtering for Liquid transaction lists.
* **Refactor**
  * Transactions and payments now load in pages with improved background-loading behavior to avoid showing empty-state before data arrives.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coincubetech/coincube/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->