### PR TITLE
Add Noop variant and stop_task support

### DIFF
--- a/coincube-gui/src/app/message.rs
+++ b/coincube-gui/src/app/message.rs
@@ -31,6 +31,7 @@ use crate::{
 
 #[derive(Debug)]
 pub enum Message {
+    Noop,
     Tick,
     UpdateDaemonCache(Result<DaemonCache, Error>),
     CacheUpdated,

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1603,6 +1603,32 @@ impl App {
         }
     }
 
+    pub fn stop_task(&mut self) -> Task<Message> {
+        info!("Close requested");
+        if !self.daemon_backend().is_embedded() {
+            return Task::none();
+        }
+
+        let daemon = self.daemon.clone();
+        let bitcoind = self.internal_bitcoind.take();
+
+        Task::perform(
+            async move {
+                if let Some(daemon) = daemon {
+                    if let Err(e) = daemon.stop().await {
+                        error!("{}", e);
+                    } else {
+                        info!("Internal daemon stopped");
+                    }
+                }
+                if let Some(bitcoind) = bitcoind {
+                    bitcoind.stop();
+                }
+            },
+            |_| Message::Noop,
+        )
+    }
+
     pub fn on_tick(&mut self) -> Task<Message> {
         // Skip tick processing if no vault is configured
         if self.daemon.is_none() {
@@ -1843,6 +1869,7 @@ impl App {
 
     fn update_dispatch(&mut self, message: Message) -> Task<Message> {
         match message {
+            Message::Noop => {}
             Message::View(view::Message::DismissToast(id)) => {
                 self.errors.retain(|(i, ..)| *i != id);
             }

--- a/coincube-gui/src/gui/mod.rs
+++ b/coincube-gui/src/gui/mod.rs
@@ -111,6 +111,16 @@ async fn ctrl_c() -> Result<(), ()> {
 }
 
 impl GUI {
+    fn active_pane(&self) -> Option<pane_grid::Pane> {
+        if let Some(pane) = self.focus {
+            if self.panes.get(pane).is_some() {
+                return Some(pane);
+            }
+        }
+
+        self.panes.iter().next().map(|(&id, _)| id)
+    }
+
     pub fn title(&self) -> String {
         match cfg!(debug_assertions) {
             true => format!("COINCUBE v{} (development)", env!("CARGO_PKG_VERSION")),
@@ -320,13 +330,17 @@ impl GUI {
                 Task::none()
             }
             Message::Pane(pane_id, pane::Message::View(pane::ViewMessage::CloseTab(i))) => {
+                let mut tasks = Vec::new();
+                let pane_active = self.active_pane() == Some(pane_id);
                 if let Some(pane) = self.panes.get_mut(pane_id) {
-                    let _ = pane
-                        .update(
+                    tasks.push(
+                        pane.update(
                             pane::Message::View(pane::ViewMessage::CloseTab(i)),
                             &self.config,
+                            pane_active,
                         )
-                        .map(move |msg| Message::Pane(pane_id, msg));
+                        .map(move |msg| Message::Pane(pane_id, msg)),
+                    );
                     if pane.tabs.is_empty() {
                         self.panes.close(pane_id);
                         if self.focus == Some(pane_id) {
@@ -335,9 +349,9 @@ impl GUI {
                     }
                 }
                 if !self.panes.iter().any(|(_, p)| !p.tabs.is_empty()) {
-                    return iced::window::latest().and_then(iced::window::close);
+                    tasks.push(iced::window::latest().and_then(iced::window::close));
                 }
-                Task::none()
+                Task::batch(tasks)
             }
             // In case of cube deletion, remove any tab where the cube/wallet is currently running.
             Message::Pane(p, pane::Message::Tab(t, tab::Message::Launch(msg))) => {
@@ -357,7 +371,9 @@ impl GUI {
                                 pane.tabs[i].state,
                                 tab::State::App(_) | tab::State::Loader(_)
                             ) {
-                                pane.close_tab(i);
+                                let pane_id = *id;
+                                let close_task = pane.close_tab(i);
+                                tasks.push(close_task.map(move |msg| Message::Pane(pane_id, msg)));
                             }
                         }
                         if pane.tabs.is_empty() {
@@ -382,11 +398,13 @@ impl GUI {
                     }
                 }
 
+                let pane_active = self.active_pane() == Some(p);
                 if let Some(pane) = self.panes.get_mut(p) {
                     tasks.push(
                         pane.update(
                             pane::Message::Tab(t, tab::Message::Launch(msg)),
                             &self.config,
+                            pane_active,
                         )
                         .map(move |msg| Message::Pane(p, msg)),
                     );
@@ -441,9 +459,10 @@ impl GUI {
                         }
                     }
                     _ => {
+                        let pane_active = self.active_pane() == Some(i);
                         if let Some(pane) = self.panes.get_mut(i) {
                             return pane
-                                .update(msg, &self.config)
+                                .update(msg, &self.config, pane_active)
                                 .map(move |msg| Message::Pane(i, msg));
                         }
                     }
@@ -590,11 +609,12 @@ impl GUI {
                         );
                     }
                 }
-                tasks.extend(
-                    self.panes
-                        .iter_mut()
-                        .map(|(&id, p)| p.on_tick().map(move |msg| Message::Pane(id, msg))),
-                );
+                let active_pane = self.active_pane();
+                tasks.extend(self.panes.iter_mut().map(|(&id, p)| {
+                    let pane_active = active_pane == Some(id);
+                    p.on_tick(pane_active)
+                        .map(move |msg| Message::Pane(id, msg))
+                }));
 
                 Task::batch(tasks)
             }
@@ -624,9 +644,11 @@ impl GUI {
                 _ => None,
             }),
         ];
+        let active_pane = self.active_pane();
         for (id, pane) in self.panes.iter() {
+            let pane_active = active_pane == Some(*id);
             vec.push(
-                pane.subscription()
+                pane.subscription(pane_active)
                     .with(*id)
                     .map(|(id, msg)| Message::Pane(id, msg)),
             );

--- a/coincube-gui/src/gui/mod.rs
+++ b/coincube-gui/src/gui/mod.rs
@@ -342,9 +342,9 @@ impl GUI {
                         .map(move |msg| Message::Pane(pane_id, msg)),
                     );
                     if pane.tabs.is_empty() {
-                        self.panes.close(pane_id);
+                        `self.panes.close(pane_id);
                         if self.focus == Some(pane_id) {
-                            self.focus = None;
+                            self.focus = self.panes.iter().next().map(|(&id, _)| id);
                         }
                     }
                 }
@@ -644,11 +644,9 @@ impl GUI {
                 _ => None,
             }),
         ];
-        let active_pane = self.active_pane();
         for (id, pane) in self.panes.iter() {
-            let pane_active = active_pane == Some(*id);
             vec.push(
-                pane.subscription(pane_active)
+                pane.subscription()
                     .with(*id)
                     .map(|(id, msg)| Message::Pane(id, msg)),
             );

--- a/coincube-gui/src/gui/mod.rs
+++ b/coincube-gui/src/gui/mod.rs
@@ -342,7 +342,7 @@ impl GUI {
                         .map(move |msg| Message::Pane(pane_id, msg)),
                     );
                     if pane.tabs.is_empty() {
-                        `self.panes.close(pane_id);
+                        self.panes.close(pane_id);
                         if self.focus == Some(pane_id) {
                             self.focus = self.panes.iter().next().map(|(&id, _)| id);
                         }

--- a/coincube-gui/src/gui/pane.rs
+++ b/coincube-gui/src/gui/pane.rs
@@ -74,10 +74,12 @@ impl Pane {
         task.map(move |msg| Message::Tab(id, msg))
     }
 
-    pub fn close_tab(&mut self, i: usize) {
+    pub fn close_tab(&mut self, i: usize) -> Task<Message> {
         if let Some(mut tab) = self.remove_tab(i) {
-            tab.stop();
+            let id = tab.id;
+            return tab.stop_task().map(move |msg| Message::Tab(id, msg));
         }
+        Task::none()
     }
 
     pub fn remove_tab(&mut self, i: usize) -> Option<tab::Tab> {
@@ -113,11 +115,30 @@ impl Pane {
         }
     }
 
-    pub fn on_tick(&mut self) -> Task<Message> {
-        Task::batch(self.tabs.iter_mut().map(|t| {
-            let id = t.id;
-            t.on_tick().map(move |msg| Message::Tab(id, msg))
+    pub fn on_tick(&mut self, pane_active: bool) -> Task<Message> {
+        let focused = self.focused_tab;
+        Task::batch(self.tabs.iter_mut().enumerate().filter_map(|(i, t)| {
+            if (pane_active && i == focused) || !matches!(t.state, tab::State::App(_)) {
+                let id = t.id;
+                Some(t.on_tick().map(move |msg| Message::Tab(id, msg)))
+            } else {
+                None
+            }
         }))
+    }
+
+    fn kick_focused_app(&mut self, pane_active: bool) -> Task<Message> {
+        if !pane_active {
+            return Task::none();
+        }
+
+        if let Some(t) = self.tabs.get_mut(self.focused_tab) {
+            if matches!(t.state, tab::State::App(_)) {
+                let id = t.id;
+                return t.on_tick().map(move |msg| Message::Tab(id, msg));
+            }
+        }
+        Task::none()
     }
 
     /// Helper to update a tab with an app message.
@@ -127,10 +148,14 @@ impl Pane {
         app_msg: impl Into<app::Message>,
         cfg: &Config,
     ) -> Task<Message> {
-        self.update(Message::Tab(tab_id, tab::Message::Run(app_msg.into())), cfg)
+        self.update(
+            Message::Tab(tab_id, tab::Message::Run(app_msg.into())),
+            cfg,
+            true,
+        )
     }
 
-    pub fn update(&mut self, message: Message, cfg: &Config) -> Task<Message> {
+    pub fn update(&mut self, message: Message, cfg: &Config, pane_active: bool) -> Task<Message> {
         match message {
             Message::Tab(id, msg) => {
                 return self
@@ -151,11 +176,17 @@ impl Pane {
             Message::View(ViewMessage::FocusTab(i)) => {
                 if i < self.tabs.len() {
                     self.focused_tab = i;
+                    return self.kick_focused_app(pane_active);
                 }
             }
             Message::View(ViewMessage::AddTab) => return self.add_tab(cfg),
             Message::View(ViewMessage::CloseTab(i)) => {
-                self.close_tab(i);
+                let focus_may_have_changed = i <= self.focused_tab;
+                let stop_task = self.close_tab(i);
+                if focus_may_have_changed {
+                    return Task::batch([stop_task, self.kick_focused_app(pane_active)]);
+                }
+                return stop_task;
             }
             // handle by the pane grid update.
             Message::View(ViewMessage::SplitTab(_)) => {}
@@ -166,11 +197,16 @@ impl Pane {
         Task::none()
     }
 
-    pub fn subscription(&self) -> Subscription<Message> {
+    pub fn subscription(&self, pane_active: bool) -> Subscription<Message> {
+        let focused = self.focused_tab;
         let subs: Vec<Subscription<Message>> = self
             .tabs
             .iter()
-            .map(|t| {
+            .enumerate()
+            .filter(|(i, t)| {
+                (pane_active && *i == focused) || !matches!(t.state, tab::State::App(_))
+            })
+            .map(|(_, t)| {
                 t.subscription()
                     .with(t.id)
                     .map(|(id, msg)| Message::Tab(id, msg))

--- a/coincube-gui/src/gui/pane.rs
+++ b/coincube-gui/src/gui/pane.rs
@@ -197,16 +197,11 @@ impl Pane {
         Task::none()
     }
 
-    pub fn subscription(&self, pane_active: bool) -> Subscription<Message> {
-        let focused = self.focused_tab;
+    pub fn subscription(&self) -> Subscription<Message> {
         let subs: Vec<Subscription<Message>> = self
             .tabs
             .iter()
-            .enumerate()
-            .filter(|(i, t)| {
-                (pane_active && *i == focused) || !matches!(t.state, tab::State::App(_))
-            })
-            .map(|(_, t)| {
+            .map(|t| {
                 t.subscription()
                     .with(t.id)
                     .map(|(id, msg)| Message::Tab(id, msg))

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -1131,6 +1131,17 @@ impl Tab {
             State::PinEntry(_) => {}
         }
     }
+
+    pub fn stop_task(&mut self) -> Task<Message> {
+        match &mut self.state {
+            State::Loader(s) => s.stop_task().map(Message::Load),
+            State::App(s) => s.stop_task().map(Message::Run),
+            _ => {
+                self.stop();
+                Task::none()
+            }
+        }
+    }
 }
 
 async fn save_cube_settings(

--- a/coincube-gui/src/loader.rs
+++ b/coincube-gui/src/loader.rs
@@ -420,6 +420,38 @@ impl Loader {
         }
     }
 
+    pub fn stop_task(&mut self) -> Task<Message> {
+        info!("Close requested");
+        let daemon = match &mut self.step {
+            Step::Syncing { daemon, .. } if daemon.backend().is_embedded() => Some(daemon.clone()),
+            _ => None,
+        };
+
+        let bitcoind = self.internal_bitcoind.take();
+
+        if daemon.is_none() && bitcoind.is_none() {
+            return Task::none();
+        }
+
+        Task::perform(
+            async move {
+                if let Some(daemon) = daemon {
+                    info!("Stopping internal daemon...");
+                    if let Err(e) = daemon.stop().await {
+                        warn!("Internal daemon failed to stop: {}", e);
+                    } else {
+                        info!("Internal daemon stopped");
+                    }
+                }
+
+                if let Some(bitcoind) = bitcoind {
+                    bitcoind.stop();
+                }
+            },
+            |_| Message::None,
+        )
+    }
+
     pub fn update(&mut self, message: Message) -> Task<Message> {
         match message {
             Message::View(ViewMessage::Retry) => {


### PR DESCRIPTION
- Introduce Noop to Message to signal no operation
- Implement stop_task on App, Loader, Pane, and Tab to gracefully stop embedded services
- Map stop completion to appropriate Message variants
- Thread pane_active through updates, on_tick and subscriptions so the active pane's app tab ticks while others still update
- Ignore Noop in update_dispatch and batch task handling for close/tab flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable, non-blocking shutdown of embedded services to avoid hangs during app close.

* **Improvements**
  * Batched task handling for tab/pane operations, improving responsiveness when closing tabs or windows.
  * Focus-aware ticking and lifecycle updates so the active pane/tab behaves more consistently.
  * Cleaner async task flow to reduce spurious UI updates during stop sequences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coincubetech/coincube/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->