### PR TITLE
Work on plan tiers

### DIFF
--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -772,8 +772,9 @@ pub mod global {
         Free,
         /// Pro Connect account — 4 Cubes per network (with Lightning address & avatar).
         Pro,
-        /// Legacy Connect account — 7 Cubes per network (with Lightning address & avatar).
-        Legacy,
+        /// Estate Connect account — 7 Cubes per network (with Lightning address & avatar).
+        #[serde(alias = "legacy")]
+        Estate,
     }
 
     impl AccountTier {
@@ -782,7 +783,7 @@ pub mod global {
             match self {
                 Self::Free => 2,
                 Self::Pro => 4,
-                Self::Legacy => 7,
+                Self::Estate => 7,
             }
         }
 
@@ -790,7 +791,7 @@ pub mod global {
             match self {
                 Self::Free => "Free",
                 Self::Pro => "Pro",
-                Self::Legacy => "Legacy",
+                Self::Estate => "Estate",
             }
         }
     }

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -18,6 +18,7 @@ use iced::{
 use crate::{
     app::{
         menu::ConnectSubMenu,
+        settings::global::AccountTier,
         state::connect::{
             AvatarFlowStep, CheckoutPhase, ConnectAccountPanel, ConnectCubePanel, ConnectFlowStep,
             ConnectPanel,
@@ -446,7 +447,15 @@ fn plan_tier_color(tier: &PlanTier) -> iced::Color {
     match tier {
         PlanTier::Free => color::GREY_3,
         PlanTier::Pro => color::ORANGE,
-        PlanTier::Legacy => color::LIGHT_BLUE,
+        PlanTier::Estate => color::LIGHT_BLUE,
+    }
+}
+
+fn cube_limit_for(tier: &PlanTier) -> usize {
+    match tier {
+        PlanTier::Free => AccountTier::Free.cube_limit(),
+        PlanTier::Pro => AccountTier::Pro.cube_limit(),
+        PlanTier::Estate => AccountTier::Estate.cube_limit(),
     }
 }
 
@@ -499,12 +508,12 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
         .push(annual_btn)
         .width(Length::Fill);
 
-    // Determine upgrade order: Free < Pro < Legacy
+    // Determine upgrade order: Free < Pro < Estate
     let tier_rank = |t: &PlanTier| -> u8 {
         match t {
             PlanTier::Free => 0,
             PlanTier::Pro => 1,
-            PlanTier::Legacy => 2,
+            PlanTier::Estate => 2,
         }
     };
 
@@ -524,7 +533,7 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
                 let tier = match info.name.as_str() {
                     "free" => PlanTier::Free,
                     "pro" => PlanTier::Pro,
-                    "legacy" => PlanTier::Legacy,
+                    "estate" | "legacy" => PlanTier::Estate,
                     _ => return None,
                 };
                 let price_label = match &info.price {
@@ -534,53 +543,32 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
                     },
                     None => "Free".to_string(),
                 };
+                let mut features =
+                    vec![format!("{} cubes per network", cube_limit_for(&tier))];
+                features.extend(info.features.iter().cloned());
                 Some(PlanCardData {
                     name: tier.to_string(),
                     tier,
-                    features: info.features.clone(),
+                    features,
                     price_label,
                 })
             })
             .collect()
     } else {
-        vec![
-            PlanCardData {
-                name: "Free".to_string(),
-                tier: PlanTier::Free,
-                features: vec![
-                    "Esplora access".into(),
-                    "Cube Recovery Wallet".into(),
-                    "1 signing key (no policies)".into(),
-                ],
-                price_label: "Free".to_string(),
-            },
-            PlanCardData {
-                name: "Pro".to_string(),
-                tier: PlanTier::Pro,
-                features: vec![
-                    "Signing policies".into(),
-                    "Unlimited self keys".into(),
-                    "Keychain backup/migration".into(),
-                ],
-                price_label: match cycle {
-                    BillingCycle::Monthly => "$12/mo".to_string(),
-                    BillingCycle::Annual => "$120/yr".to_string(),
-                },
-            },
-            PlanCardData {
-                name: "Legacy".to_string(),
-                tier: PlanTier::Legacy,
-                features: vec![
-                    "Invites".into(),
-                    "Linked keychains".into(),
-                    "Inheritance coordination".into(),
-                ],
-                price_label: match cycle {
-                    BillingCycle::Monthly => "$35/mo".to_string(),
-                    BillingCycle::Annual => "$350/yr".to_string(),
-                },
-            },
-        ]
+        return container(
+            Column::new()
+                .push(text::h4_bold("Plan & Billing").style(theme::text::primary))
+                .push(iced::widget::Space::new().height(Length::Fixed(20.0)))
+                .push(
+                    text::p1_regular(
+                        "Pricing temporarily unavailable.\n\
+                         Reconnect to the internet to view current plans and features.",
+                    )
+                    .color(color::GREY_3),
+                ),
+        )
+        .padding(16)
+        .into();
     };
 
     let mut col = Column::new()
@@ -637,7 +625,7 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
             } else if is_upgrade {
                 let label = match &card.tier {
                     PlanTier::Pro => "Upgrade to Pro",
-                    PlanTier::Legacy => "Upgrade to Legacy",
+                    PlanTier::Estate => "Upgrade to Estate",
                     _ => "Upgrade",
                 };
                 button::primary(None, label)

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -543,8 +543,7 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
                     },
                     None => "Free".to_string(),
                 };
-                let mut features =
-                    vec![format!("{} cubes per network", cube_limit_for(&tier))];
+                let mut features = vec![format!("{} cubes per network", cube_limit_for(&tier))];
                 features.extend(info.features.iter().cloned());
                 Some(PlanCardData {
                     name: tier.to_string(),

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -517,7 +517,6 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
         }
     };
 
-    // Build plan cards from features response, or static fallback
     struct PlanCardData {
         name: String,
         tier: PlanTier,
@@ -525,35 +524,41 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
         price_label: String,
     }
 
-    let cards: Vec<PlanCardData> = if let Some(ref features) = state.features {
-        features
-            .plans
-            .iter()
-            .filter_map(|info| {
-                let tier = match info.name.as_str() {
-                    "free" => PlanTier::Free,
-                    "pro" => PlanTier::Pro,
-                    "estate" | "legacy" => PlanTier::Estate,
-                    _ => return None,
-                };
-                let price_label = match &info.price {
-                    Some(p) => match cycle {
-                        BillingCycle::Monthly => format!("${}/mo", p.monthly),
-                        BillingCycle::Annual => format!("${}/yr", p.annual),
-                    },
-                    None => "Free".to_string(),
-                };
-                let mut features = vec![format!("{} cubes per network", cube_limit_for(&tier))];
-                features.extend(info.features.iter().cloned());
-                Some(PlanCardData {
-                    name: tier.to_string(),
-                    tier,
-                    features,
-                    price_label,
+    let cards: Vec<PlanCardData> = state
+        .features
+        .as_ref()
+        .map(|features| {
+            features
+                .plans
+                .iter()
+                .filter_map(|info| {
+                    let tier = match info.name.as_str() {
+                        "free" => PlanTier::Free,
+                        "pro" => PlanTier::Pro,
+                        "estate" | "legacy" => PlanTier::Estate,
+                        _ => return None,
+                    };
+                    let price_label = match &info.price {
+                        Some(p) => match cycle {
+                            BillingCycle::Monthly => format!("${}/mo", p.monthly),
+                            BillingCycle::Annual => format!("${}/yr", p.annual),
+                        },
+                        None => "Free".to_string(),
+                    };
+                    let mut features = vec![format!("{} cubes per network", cube_limit_for(&tier))];
+                    features.extend(info.features.iter().cloned());
+                    Some(PlanCardData {
+                        name: tier.to_string(),
+                        tier,
+                        features,
+                        price_label,
+                    })
                 })
-            })
-            .collect()
-    } else {
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if cards.is_empty() {
         return container(
             Column::new()
                 .push(text::h4_bold("Plan & Billing").style(theme::text::primary))
@@ -568,7 +573,7 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
         )
         .padding(16)
         .into();
-    };
+    }
 
     let mut col = Column::new()
         .push(text::h4_bold("Plan & Billing").style(theme::text::primary))

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1492,7 +1492,7 @@ impl Home {
                         .map_or(AccountTier::default(), |plan| match plan.tier() {
                             crate::services::coincube::PlanTier::Free => AccountTier::Free,
                             crate::services::coincube::PlanTier::Pro => AccountTier::Pro,
-                            crate::services::coincube::PlanTier::Legacy => AccountTier::Legacy,
+                            crate::services::coincube::PlanTier::Estate => AccountTier::Estate,
                         });
                 // When the plan tier changes (e.g. upgrade), invalidate the
                 // cached server limit so `cube_limit()` uses the new tier

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -257,7 +257,8 @@ pub struct Currency {
 pub enum PlanTier {
     Free,
     Pro,
-    Legacy,
+    #[serde(alias = "legacy")]
+    Estate,
 }
 
 impl std::fmt::Display for PlanTier {
@@ -265,7 +266,7 @@ impl std::fmt::Display for PlanTier {
         match self {
             PlanTier::Free => write!(f, "Free"),
             PlanTier::Pro => write!(f, "Pro"),
-            PlanTier::Legacy => write!(f, "Legacy"),
+            PlanTier::Estate => write!(f, "Estate"),
         }
     }
 }
@@ -281,12 +282,14 @@ pub enum PlanStatus {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PlanEntitlements {
-    pub free_signing_key_count: i32,
-    pub policy_editing: bool,
-    pub legacy_invites: bool,
-    pub linked_keychains: bool,
-    pub duress_remote_lock: bool,
-    pub business_orgs: bool,
+    pub personal_key_limit: u32,
+    pub cube_limit: u32,
+    pub recovery_kit_limit: u32,
+    /// `None` = unlimited regenerations; `Some(n)` = capped at n; `Some(0)` = disabled.
+    pub avatar_regeneration_limit: Option<u32>,
+    pub duress: bool,
+    pub attach_policies: bool,
+    pub collaborative_invitations: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Tier renaming and entitlement schema changes affect billing, cube limits, and persisted settings; serde aliases mitigate breakage, but any code still expecting old entitlement fields could fail at runtime until aligned with the API.
> 
> **Overview**
> Renames the top Connect tier from **Legacy** to **Estate** across settings, API types, home sync, and Plan & Billing UI, while keeping **`serde(alias = "legacy")`** so saved settings and API payloads still deserialize.
> 
> **Plan & Billing** now builds cards only from the remote features response: each card leads with **per-network cube limits** (via shared `AccountTier` limits), accepts plan names **`estate` or `legacy`**, and shows **“Pricing temporarily unavailable”** when that data is missing instead of hard-coded fallback plans. Upgrade copy and tier ordering use **Estate**.
> 
> **`PlanEntitlements`** is updated to match the backend’s new camelCase fields (limits, avatar regeneration, duress, policies, collaborative invitations) instead of the older boolean-heavy shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a75d5b18c227368ec54b34161751c5dabfd00337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Renamed "Legacy" account tier to "Estate" across the UI and plan text; existing saved settings remain supported.
  * Plan & Billing shows per-network cube limits on plan cards, uses Estate in upgrade flows and ordering, and updates plan coloring/labels.
  * Pricing UI now displays "Pricing temporarily unavailable" when remote data can't load instead of fallback plan cards.
  * Plan entitlement details moved to a quota-and-capabilities model (updated feature/limits shown on plans).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coincubetech/coincube/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->