### PR TITLE
Fixes for Vault receive unconfirmed TX UI

### DIFF
--- a/coincube-gui/src/app/message.rs
+++ b/coincube-gui/src/app/message.rs
@@ -76,6 +76,19 @@ pub enum Message {
         u64,
         Result<(Vec<HistoryTransaction>, Vec<HistoryTransaction>), Error>,
     ),
+    /// Vault transactions background-refresh result dispatched from
+    /// `Message::Tick`. Carries the same payload as `HistoryTransactions`,
+    /// but the handler does NOT clear the currently displayed rows on
+    /// dispatch and only overwrites `page_cache` when the user is still
+    /// on page 0 with no NextPage fetch in flight, so a concurrent
+    /// pagination action can't be stomped by a stale background reply.
+    /// Errors are logged and swallowed — a silent retry on the next Tick
+    /// is preferable to flashing an error banner over an otherwise-usable
+    /// view.
+    BackgroundHistoryTransactions(
+        u64,
+        Result<(Vec<HistoryTransaction>, Vec<HistoryTransaction>), Error>,
+    ),
     Payments(Result<Vec<Payment>, Error>),
     /// Extension of payments for pagination.
     /// Tuple contains (Vec<Payment>, u64) where the u64 is the actual page limit used

--- a/coincube-gui/src/app/state/vault/transactions.rs
+++ b/coincube-gui/src/app/state/vault/transactions.rs
@@ -302,16 +302,78 @@ impl State for VaultTransactionsPanel {
             Message::Tick => {
                 // Background refresh so a new mempool deposit shows up without
                 // the user navigating away and back. Gated to avoid disturbing
-                // an active drill-down: only reload when sitting on page 0, no
+                // an active drill-down: only fire when sitting on page 0, no
                 // tx selected, no fetch in flight, and the previous reload was
                 // long enough ago to be worth re-asking the daemon.
+                //
+                // Critically, this path does NOT clear `page_cache`,
+                // `pending_txs`, `displayed_txs`, or set `processing = true` —
+                // the existing rows stay rendered until the response replaces
+                // them atomically via `BackgroundHistoryTransactions`. That
+                // avoids the periodic "list disappears, loading flashes"
+                // glitch that would happen if we routed Tick through the
+                // user-initiated `reload()` every 10 s.
                 if self.current_page == 0
                     && self.selected_tx.is_none()
                     && self.pending_page.is_none()
                     && !self.processing
                     && Instant::now() > self.last_reload + TRANSACTIONS_RELOAD_MAX_TTL
                 {
-                    return self.reload(Some(daemon), Some(self.wallet.clone()));
+                    self.reload_token = self.reload_token.wrapping_add(1);
+                    let token = self.reload_token;
+                    self.last_reload = Instant::now();
+                    let daemon = daemon.clone();
+                    let now: u32 = now().as_secs().try_into().unwrap();
+                    return Task::perform(
+                        async move {
+                            let mut txs = daemon
+                                .list_history_txs(0, now, HISTORY_EVENT_PAGE_SIZE)
+                                .await?;
+                            txs.sort_by(|a, b| a.compare(b));
+                            let pending_txs = daemon.list_pending_txs().await?;
+                            Ok((pending_txs, txs))
+                        },
+                        move |result| Message::BackgroundHistoryTransactions(token, result),
+                    );
+                }
+            }
+            Message::BackgroundHistoryTransactions(token, res) => {
+                // Drop responses superseded by a newer reload (user-driven or
+                // background) — same staleness guard as `HistoryTransactions`.
+                if token != self.reload_token {
+                    return Task::none();
+                }
+                match res {
+                    Err(e) => {
+                        // Silently log: a periodic background refresh that
+                        // fails shouldn't pop an error modal over a working
+                        // view. The next Tick will retry.
+                        tracing::warn!(
+                            target: "coincube_gui::vault::transactions",
+                            "background tx refresh failed: {}",
+                            e
+                        );
+                    }
+                    Ok((pending_txs, page_txs)) => {
+                        self.warning = None;
+                        self.pending_txs = pending_txs;
+                        // Only replace the page-0 cache when the user is
+                        // actually still viewing page 0 and isn't mid-NextPage.
+                        // If they've paginated forward (current_page > 0) or a
+                        // NextPage fetch is in flight (`pending_page.is_some()`),
+                        // overwriting page_cache or last_page_index here would
+                        // yank them back to page 0 or contradict the NextPage
+                        // response that's about to arrive.
+                        if self.current_page == 0 && self.pending_page.is_none() {
+                            if (page_txs.len() as u64) < HISTORY_EVENT_PAGE_SIZE {
+                                self.last_page_index = Some(0);
+                            } else {
+                                self.last_page_index = None;
+                            }
+                            self.page_cache = vec![page_txs];
+                        }
+                        self.refresh_displayed();
+                    }
                 }
             }
             Message::View(view::Message::Reload) | Message::View(view::Message::Close) => {

--- a/coincube-gui/src/app/state/vault/transactions.rs
+++ b/coincube-gui/src/app/state/vault/transactions.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{HashMap, HashSet},
     convert::TryInto,
     sync::Arc,
+    time::{Duration, Instant},
 };
 
 use coincube_core::{
@@ -20,6 +21,11 @@ use iced::Task;
 /// pagination without needing 50+ transactions in a single wallet. Matches
 /// the PAGE_SIZE used by the Spark and Liquid Transactions panels.
 pub const HISTORY_EVENT_PAGE_SIZE: u64 = 10;
+
+/// Minimum gap between background `Message::Tick` reloads. Matches
+/// `HOME_RELOAD_MAX_TTL` on the Vault overview so the two panels surface
+/// new mempool/incoming activity on the same cadence.
+const TRANSACTIONS_RELOAD_MAX_TTL: Duration = Duration::from_secs(10);
 
 use crate::{
     app::{
@@ -89,6 +95,11 @@ pub struct VaultTransactionsPanel {
     /// overwrite fresher state. (Pagination fetches are guarded separately
     /// by `pending_page`.)
     reload_token: u64,
+    /// Timestamp of the last `reload` dispatch — used by the `Message::Tick`
+    /// handler to refresh `pending_txs` on a `TRANSACTIONS_RELOAD_MAX_TTL`
+    /// cadence so incoming mempool deposits surface without the user
+    /// manually leaving and re-entering the panel.
+    last_reload: Instant,
 }
 
 impl VaultTransactionsPanel {
@@ -110,6 +121,7 @@ impl VaultTransactionsPanel {
             current_page: 0,
             pending_page: None,
             reload_token: 0,
+            last_reload: Instant::now(),
         }
     }
 
@@ -287,6 +299,21 @@ impl State for VaultTransactionsPanel {
                     return Task::done(Message::View(view::Message::ShowError(err_msg)));
                 }
             },
+            Message::Tick => {
+                // Background refresh so a new mempool deposit shows up without
+                // the user navigating away and back. Gated to avoid disturbing
+                // an active drill-down: only reload when sitting on page 0, no
+                // tx selected, no fetch in flight, and the previous reload was
+                // long enough ago to be worth re-asking the daemon.
+                if self.current_page == 0
+                    && self.selected_tx.is_none()
+                    && self.pending_page.is_none()
+                    && !self.processing
+                    && Instant::now() > self.last_reload + TRANSACTIONS_RELOAD_MAX_TTL
+                {
+                    return self.reload(Some(daemon), Some(self.wallet.clone()));
+                }
+            }
             Message::View(view::Message::Reload) | Message::View(view::Message::Close) => {
                 return self.reload(Some(daemon), Some(self.wallet.clone()));
             }
@@ -512,6 +539,7 @@ impl State for VaultTransactionsPanel {
         self.page_cache.clear();
         self.pending_txs.clear();
         self.displayed_txs.clear();
+        self.last_reload = Instant::now();
         let now: u32 = now().as_secs().try_into().unwrap();
         Task::batch(vec![Task::perform(
             async move {

--- a/coincube-gui/src/installer/context.rs
+++ b/coincube-gui/src/installer/context.rs
@@ -168,7 +168,7 @@ impl Context {
             descriptor_template: DescriptorTemplate::default(),
             bitcoin_config: BitcoinConfig {
                 network,
-                poll_interval_secs: Duration::from_secs(30),
+                poll_interval_secs: Duration::from_secs(10),
             },
             hws: Vec::new(),
             keys: HashMap::new(),

--- a/coincubed/src/config.rs
+++ b/coincubed/src/config.rs
@@ -78,7 +78,7 @@ fn default_loglevel() -> log::LevelFilter {
 }
 
 fn default_poll_interval() -> Duration {
-    Duration::from_secs(30)
+    Duration::from_secs(10)
 }
 
 /// Bitcoin backend config.

--- a/contrib/coincubed_config_example.toml
+++ b/contrib/coincubed_config_example.toml
@@ -24,7 +24,7 @@ main_descriptor = "wsh(or_d(pk([0dd8c6f0/48'/1'/0'/2']tpubDFMbZ7U5k5hEfsttnZTKMm
 # How often should it poll the Bitcoin backend for updates?
 [bitcoin_config]
 network = "testnet"
-poll_interval_secs = 30
+poll_interval_secs = 10
 
 # This section depends on the Bitcoin backend being used.
 #


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches live transaction list state, pagination races, and global backend poll frequency; logic is guarded but increases RPC/load and must not corrupt paginated views.
> 
> **Overview**
> Improves how **unconfirmed / mempool Vault transactions** show up in the UI without forcing a full manual reload.
> 
> The Vault **Transactions** panel now runs a **10-second background refresh** on `Message::Tick` (aligned with the Vault overview’s `HOME_RELOAD_MAX_TTL`). It fetches pending txs and page-0 history via a new **`BackgroundHistoryTransactions`** message path that **keeps the list on screen** (no `processing` flash, no cache wipe). Updates apply only when the user is on **page 0**, has **no tx selected**, and **no pagination fetch** is in flight; stale responses are dropped via **`reload_token`**, and background errors are **logged only**.
> 
> **Bitcoin backend polling** defaults drop from **30s to 10s** in `coincubed` config, the installer `Context`, and the example TOML so daemon/GUI data refreshes faster.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56e61ec06484adf25a4bf76c35448c67c1a2efb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented intelligent throttling for background transaction refreshes to prevent unnecessary reloads while keeping transaction mempool activity current and visible.

* **Chores**
  * Reduced default Bitcoin polling interval from 30 to 10 seconds for faster backend communication and improved responsiveness throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coincubetech/coincube/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->