### PR TITLE
Show pending transaction status in Vault

### DIFF
--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -2279,7 +2279,18 @@ impl App {
                 }
             }
             Message::UpdateDaemonCache(res) => match res {
-                Ok(daemon_cache) => {
+                Ok(mut daemon_cache) => {
+                    // Apply optimistic-broadcast overrides before the
+                    // cache is published: reconcile drops entries the
+                    // daemon now reflects on its own, then any still-
+                    // pending broadcasts get synthetic `spend_info` so
+                    // `coins_summary` (Vault balance) and every other
+                    // `cache.coins()` consumer treats the inputs as
+                    // already spent.
+                    if let Some(wallet) = &self.wallet {
+                        wallet.reconcile_with_coins(&daemon_cache.coins);
+                        wallet.apply_coin_overrides(&mut daemon_cache.coins);
+                    }
                     self.cache.daemon_cache = daemon_cache;
                     return Task::done(Message::CacheUpdated);
                 }

--- a/coincube-gui/src/app/state/vault/overview.rs
+++ b/coincube-gui/src/app/state/vault/overview.rs
@@ -417,6 +417,12 @@ impl State for VaultOverview {
         let daemon2 = daemon.clone();
         let now: u32 = now().as_secs().try_into().unwrap();
         self.last_reload = Instant::now();
+        // Apply the optimistic-broadcast override so the Vault balance
+        // summary on this panel reduces immediately after the user
+        // broadcasts, instead of waiting for the daemon's mempool
+        // poller to flag the spend. Mirrors the override applied to
+        // the central `Cache.coins()`.
+        let wallet_for_coins = self.wallet.clone();
         Task::batch(vec![
             Task::perform(
                 async move {
@@ -436,7 +442,11 @@ impl State for VaultOverview {
                     daemon2
                         .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
                         .await
-                        .map(|res| res.coins)
+                        .map(|res| {
+                            let mut coins = res.coins;
+                            wallet_for_coins.apply_coin_overrides(&mut coins);
+                            coins
+                        })
                         .map_err(|e| e.into())
                 },
                 Message::Coins,

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -227,9 +227,12 @@ impl PsbtState {
                 // `coin.spend_info` (filled in by its mempool poller),
                 // so an immediate reload would overwrite our optimistic
                 // `Broadcast` status with stale `Pending` and re-expose
-                // the Broadcast button. The parent `PsbtsPanel` picks
-                // the txid up via `just_broadcast_txid()` so the list
-                // view also reflects the broadcast on its next refresh.
+                // the Broadcast button. The list view stays consistent
+                // because `BroadcastModal` calls `Wallet::record_broadcast`
+                // on RPC success, and `PsbtsPanel`'s `SpendTxs` handler
+                // runs `Wallet::apply_spend_tx_overrides` on every
+                // refresh to promote matching Pending entries to
+                // Broadcast.
                 return cancel;
             }
             Message::View(view::Message::Spend(view::SpendTxMessage::Delete)) => {

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -195,21 +195,6 @@ impl PsbtState {
                     }
                 }
 
-                // The celebration page dismisses via this same Cancel
-                // message. Detect that case before we clear `self.modal`
-                // so we can chain a Reload onto the close — that
-                // returns the user to the PSBTs list with their newly
-                // broadcast tx already marked unconfirmed, instead of
-                // leaving them on the now-stale PSBT detail page
-                // wondering whether the broadcast made it through.
-                let just_broadcast = matches!(
-                    &self.modal,
-                    Some(PsbtModal::Broadcast(BroadcastModal {
-                        broadcast: true,
-                        ..
-                    }))
-                );
-
                 // Dismissing a Keychain-sign modal (blur or otherwise)
                 // must also terminate any in-flight signing sessions
                 // server-side, not just hide the UI — otherwise signers
@@ -236,9 +221,15 @@ impl PsbtState {
                 if !keep_modal {
                     self.modal = None;
                 }
-                if just_broadcast {
-                    return Task::batch([cancel, Task::done(Message::View(view::Message::Reload))]);
-                }
+                // After a successful broadcast we keep the user on the
+                // PSBT detail page rather than reloading back to the
+                // list: the daemon derives `SpendStatus::Broadcast` from
+                // `coin.spend_info` (filled in by its mempool poller),
+                // so an immediate reload would overwrite our optimistic
+                // `Broadcast` status with stale `Pending` and re-expose
+                // the Broadcast button. The parent `PsbtsPanel` picks
+                // the txid up via `just_broadcast_txid()` so the list
+                // view also reflects the broadcast on its next refresh.
                 return cancel;
             }
             Message::View(view::Message::Spend(view::SpendTxMessage::Delete)) => {
@@ -438,6 +429,7 @@ impl PsbtState {
                             ),
                         spend_amount_display: amount_display,
                         is_self_transfer,
+                        wallet: self.wallet.clone(),
                     }));
                 }
                 Err(e) => {
@@ -557,6 +549,11 @@ pub struct BroadcastModal {
     /// True when every output of the tx returns to the wallet's own change
     /// addresses. Used by the celebration view to render the right phrasing.
     is_self_transfer: bool,
+    /// Wallet handle used to register a successful broadcast in
+    /// `Wallet::recently_broadcast` so the other panels (Transactions,
+    /// Overview balance, Send) can optimistically reflect the spend
+    /// before the daemon's mempool poller catches up.
+    wallet: Arc<Wallet>,
 }
 
 impl Modal for BroadcastModal {
@@ -600,6 +597,19 @@ impl Modal for BroadcastModal {
                     Ok(()) => {
                         tx.status = SpendStatus::Broadcast;
                         self.broadcast = true;
+                        // Record on the wallet so the rest of the GUI
+                        // (Transactions list, Overview balance, Send
+                        // coin filter) can apply the same optimistic
+                        // override until the daemon's poller observes
+                        // the spend. Only runs on RPC success — a
+                        // failed broadcast never enters the override
+                        // set.
+                        self.wallet.record_broadcast(
+                            tx.psbt.unsigned_tx.clone(),
+                            tx.coins.values().cloned().collect(),
+                            tx.change_indexes.clone(),
+                            tx.network,
+                        );
                         tracing::info!(
                             target: "coincube_gui::broadcast",
                             txid = %tx.psbt.unsigned_tx.compute_txid(),

--- a/coincube-gui/src/app/state/vault/psbts.rs
+++ b/coincube-gui/src/app/state/vault/psbts.rs
@@ -77,8 +77,13 @@ impl State for PsbtsPanel {
                     self.warning = Some(e);
                     return Task::done(Message::View(view::Message::ShowError(err_msg)));
                 }
-                Ok(txs) => {
+                Ok(mut txs) => {
                     self.warning = None;
+                    // Optimistic Pending->Broadcast override for txs
+                    // the user just broadcast locally, until the
+                    // daemon's mempool poller reflects the spend in
+                    // its derived `SpendStatus`.
+                    self.wallet.apply_spend_tx_overrides(&mut txs);
                     self.spend_txs = txs;
                     if let Some(tx) = &self.selected_tx {
                         if let Some(tx) = self.spend_txs.iter().find(|spend_tx| {

--- a/coincube-gui/src/app/state/vault/spend/mod.rs
+++ b/coincube-gui/src/app/state/vault/spend/mod.rs
@@ -255,6 +255,14 @@ impl State for CreateSpendPanel {
             vec![CoinStatus::Unconfirmed, CoinStatus::Confirmed]
         };
         let coin_statuses_2 = coin_statuses_1.clone();
+        // The daemon already excludes coins with daemon-known
+        // `spend_info` via the `CoinStatus` filter, but its mempool
+        // poller can lag a freshly-broadcast tx. The Wallet override
+        // fills in synthetic `spend_info` for those inputs; we then
+        // drop any coin with `spend_info` set so the Send form's
+        // spendable balance reflects the optimistic spend immediately.
+        let wallet_for_coins_1 = wallet.clone();
+        let wallet_for_coins_2 = wallet.clone();
         Task::batch(vec![
             Task::perform(
                 async move {
@@ -263,7 +271,12 @@ impl State for CreateSpendPanel {
                             .clone()
                             .list_coins(&coin_statuses_1, &[])
                             .await
-                            .map(|res| res.coins)
+                            .map(|res| {
+                                let mut coins = res.coins;
+                                wallet_for_coins_1.apply_coin_overrides(&mut coins);
+                                coins.retain(|c| c.spend_info.is_none());
+                                coins
+                            })
                             .map_err(|e| e.into()),
                         daemon1
                             .get_info()
@@ -279,7 +292,12 @@ impl State for CreateSpendPanel {
                     let coins = daemon
                         .list_coins(&coin_statuses_2, &[])
                         .await
-                        .map(|res| res.coins)
+                        .map(|res| {
+                            let mut coins = res.coins;
+                            wallet_for_coins_2.apply_coin_overrides(&mut coins);
+                            coins.retain(|c| c.spend_info.is_none());
+                            coins
+                        })
                         .map_err(Error::from)?;
                     let mut targets = HashSet::<LabelItem>::new();
                     for coin in coins {

--- a/coincube-gui/src/app/state/vault/transactions.rs
+++ b/coincube-gui/src/app/state/vault/transactions.rs
@@ -513,6 +513,7 @@ impl State for VaultTransactionsPanel {
         self.pending_txs.clear();
         self.displayed_txs.clear();
         let now: u32 = now().as_secs().try_into().unwrap();
+        let wallet = self.wallet.clone();
         Task::batch(vec![Task::perform(
             async move {
                 let mut txs = daemon
@@ -520,7 +521,14 @@ impl State for VaultTransactionsPanel {
                     .await?;
                 txs.sort_by(|a, b| a.compare(b));
 
-                let pending_txs = daemon.list_pending_txs().await?;
+                let mut pending_txs = daemon.list_pending_txs().await?;
+                // Merge any locally-broadcast txs the daemon's poller
+                // hasn't yet observed in the mempool. Without this, a
+                // user who just broadcast from the Vault would see no
+                // entry on this screen until the daemon catches up.
+                let existing: HashSet<Txid> =
+                    pending_txs.iter().map(|t| t.tx.compute_txid()).collect();
+                pending_txs.extend(wallet.synthesized_pending_history_txs(&existing));
                 Ok((pending_txs, txs))
             },
             move |result| Message::HistoryTransactions(token, result),

--- a/coincube-gui/src/app/wallet.rs
+++ b/coincube-gui/src/app/wallet.rs
@@ -1,15 +1,18 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
+use crate::daemon::model::{Coin, HistoryTransaction, SpendStatus, SpendTx};
 use crate::dir::CoincubeDirectory;
 use crate::{
     app::settings, daemon::DaemonBackend, hw::HardwareWalletConfig, node::NodeType, signer::Signer,
 };
+use coincubed::commands::LCSpendInfo;
 
 use coincube_core::{miniscript::bitcoin, signer::MasterSigner};
 
 use coincube_core::descriptors::CoincubeDescriptor;
 use coincube_core::miniscript::bitcoin::bip32::Fingerprint;
+use coincube_core::miniscript::bitcoin::{Network, OutPoint, Transaction, Txid};
 
 use super::settings::{WalletId, WalletSettings};
 
@@ -29,6 +32,27 @@ pub fn wallet_name(main_descriptor: &CoincubeDescriptor) -> String {
     )
 }
 
+/// In-memory record of a transaction the user has just broadcast from
+/// this wallet. The daemon derives `SpendStatus::Broadcast` and
+/// `coin.spend_info` from its mempool poller; until that poller observes
+/// the tx, the GUI would otherwise show the spend as if it had never
+/// happened — stale Pending PSBTs, an un-debited balance, no entry in
+/// the Transactions list. Holding the broadcast data here lets the
+/// panels apply optimistic overrides until the daemon catches up.
+///
+/// Captures only what the panels need to synthesize their views:
+/// the broadcast `Transaction`, the input `Coin`s being spent, the
+/// PSBT's change indices, and the wallet's network. Entries are
+/// cleared by `reconcile_with_coins` once daemon-side state reflects
+/// the spend.
+#[derive(Debug, Clone)]
+pub struct RecentBroadcast {
+    pub tx: Transaction,
+    pub input_coins: Vec<Coin>,
+    pub change_indexes: Vec<usize>,
+    pub network: Network,
+}
+
 #[derive(Debug, Clone)]
 pub struct Wallet {
     pub name: String,
@@ -42,6 +66,12 @@ pub struct Wallet {
     pub border_wallet_fingerprints: HashSet<Fingerprint>,
     pub hardware_wallets: Vec<HardwareWalletConfig>,
     pub signer: Option<Arc<Signer>>,
+    /// Txids the user has just broadcast locally, mapped to the data
+    /// needed to synthesize coin/tx/PSBT overrides until the daemon
+    /// catches up. `Arc<Mutex<...>>` so the map is shared across every
+    /// `Arc<Wallet>` clone held by the panels and the BroadcastModal —
+    /// recording happens in one place, every reader sees it.
+    pub recently_broadcast: Arc<Mutex<HashMap<Txid, RecentBroadcast>>>,
 }
 
 impl Wallet {
@@ -62,6 +92,152 @@ impl Wallet {
             border_wallet_fingerprints: HashSet::new(),
             hardware_wallets: Vec::new(),
             signer: None,
+            recently_broadcast: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Records a freshly-broadcast transaction so the panels can apply
+    /// optimistic overrides until the daemon's mempool poller catches
+    /// up. Only call after `broadcast_spend_tx` has returned `Ok`.
+    pub fn record_broadcast(
+        &self,
+        tx: Transaction,
+        input_coins: Vec<Coin>,
+        change_indexes: Vec<usize>,
+        network: Network,
+    ) {
+        let txid = tx.compute_txid();
+        if let Ok(mut map) = self.recently_broadcast.lock() {
+            map.insert(
+                txid,
+                RecentBroadcast {
+                    tx,
+                    input_coins,
+                    change_indexes,
+                    network,
+                },
+            );
+        }
+    }
+
+    /// Adds synthetic `spend_info` to coins whose outpoints match the
+    /// inputs of a recently-broadcast tx. Daemon-provided `spend_info`
+    /// is preserved if already present (daemon view is the source of
+    /// truth once available).
+    pub fn apply_coin_overrides(&self, coins: &mut [Coin]) {
+        let Ok(map) = self.recently_broadcast.lock() else {
+            return;
+        };
+        if map.is_empty() {
+            return;
+        }
+        let mut outpoint_to_txid: HashMap<OutPoint, Txid> = HashMap::new();
+        for (txid, rb) in map.iter() {
+            for coin in &rb.input_coins {
+                outpoint_to_txid.insert(coin.outpoint, *txid);
+            }
+        }
+        for coin in coins.iter_mut() {
+            if coin.spend_info.is_none() {
+                if let Some(txid) = outpoint_to_txid.get(&coin.outpoint) {
+                    coin.spend_info = Some(LCSpendInfo {
+                        txid: *txid,
+                        height: None,
+                    });
+                }
+            }
+        }
+    }
+
+    /// Promotes `Pending` PSBTs to `Broadcast` when the user has
+    /// already broadcast them locally but the daemon hasn't yet
+    /// reflected the spend in its coin state. Doubles as a
+    /// reconciliation point: any tx the daemon now reports as
+    /// `Broadcast`/`Spent`/`Deprecated` is a signal it has caught up,
+    /// so we drop our optimistic entry — the daemon view becomes the
+    /// source of truth and stays that way.
+    pub fn apply_spend_tx_overrides(&self, txs: &mut [SpendTx]) {
+        let Ok(mut map) = self.recently_broadcast.lock() else {
+            return;
+        };
+        if map.is_empty() {
+            return;
+        }
+        for tx in txs.iter_mut() {
+            let txid = tx.psbt.unsigned_tx.compute_txid();
+            match tx.status {
+                SpendStatus::Pending => {
+                    if map.contains_key(&txid) {
+                        tx.status = SpendStatus::Broadcast;
+                    }
+                }
+                SpendStatus::Broadcast
+                | SpendStatus::Spent
+                | SpendStatus::Deprecated => {
+                    map.remove(&txid);
+                }
+            }
+        }
+    }
+
+    /// Returns synthesized pending `HistoryTransaction`s for any
+    /// recently-broadcast tx not already present in `existing_txids`.
+    /// The Transactions panel merges these with daemon-supplied
+    /// pending txs so the broadcast shows up immediately. Also drops
+    /// entries the daemon now lists itself — that's the most reliable
+    /// signal for txs without change (which can't be reconciled via
+    /// `reconcile_with_coins`'s output-coin check).
+    pub fn synthesized_pending_history_txs(
+        &self,
+        existing_txids: &HashSet<Txid>,
+    ) -> Vec<HistoryTransaction> {
+        let Ok(mut map) = self.recently_broadcast.lock() else {
+            return Vec::new();
+        };
+        if map.is_empty() {
+            return Vec::new();
+        }
+        map.retain(|txid, _| !existing_txids.contains(txid));
+        map.values()
+            .map(|rb| {
+                HistoryTransaction::new(
+                    rb.tx.clone(),
+                    None,
+                    None,
+                    rb.input_coins.clone(),
+                    rb.change_indexes.clone(),
+                    rb.network,
+                )
+            })
+            .collect()
+    }
+
+    /// Drops entries the daemon has caught up on. Two signals: an
+    /// input coin now carries `spend_info` pointing to our txid, or
+    /// the broadcast tx's outputs have appeared as coins (only happens
+    /// once the daemon has seen the tx). Cleaning up here keeps the
+    /// override from masking real changes — e.g. if the user later
+    /// RBFs the tx, we want the daemon's view to win.
+    pub fn reconcile_with_coins(&self, coins: &[Coin]) {
+        let Ok(mut map) = self.recently_broadcast.lock() else {
+            return;
+        };
+        if map.is_empty() {
+            return;
+        }
+        let mut observed: HashSet<Txid> = HashSet::new();
+        for coin in coins {
+            if map.contains_key(&coin.outpoint.txid) {
+                observed.insert(coin.outpoint.txid);
+            }
+            if let Some(info) = coin.spend_info {
+                if map.contains_key(&info.txid) {
+                    observed.insert(info.txid);
+                }
+            }
+        }
+        for txid in observed {
+            map.remove(&txid);
         }
     }
 

--- a/coincube-gui/src/app/wallet.rs
+++ b/coincube-gui/src/app/wallet.rs
@@ -96,6 +96,28 @@ impl Wallet {
         }
     }
 
+    /// Acquires the `recently_broadcast` lock, recovering from
+    /// poisoning rather than dropping the operation silently.
+    ///
+    /// A poisoned mutex means some earlier thread panicked while
+    /// holding the lock. The data inside is a `HashMap` whose
+    /// mutations (insert/remove/retain) are atomic — none of our
+    /// access patterns leaves the map in a half-modified state — so
+    /// recovery via `into_inner()` is safe. We log a warning so
+    /// poisoning shows up in diagnostics; silently returning `Err`
+    /// here would make the optimistic-broadcast UI fail with no
+    /// explanation.
+    fn lock_recently_broadcast(&self) -> std::sync::MutexGuard<'_, HashMap<Txid, RecentBroadcast>> {
+        self.recently_broadcast.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!(
+                target: "coincube_gui::wallet",
+                "recently_broadcast mutex was poisoned; recovering. \
+                 Map state is consistent (HashMap mutations are atomic)."
+            );
+            poisoned.into_inner()
+        })
+    }
+
     /// Records a freshly-broadcast transaction so the panels can apply
     /// optimistic overrides until the daemon's mempool poller catches
     /// up. Only call after `broadcast_spend_tx` has returned `Ok`.
@@ -107,17 +129,16 @@ impl Wallet {
         network: Network,
     ) {
         let txid = tx.compute_txid();
-        if let Ok(mut map) = self.recently_broadcast.lock() {
-            map.insert(
-                txid,
-                RecentBroadcast {
-                    tx,
-                    input_coins,
-                    change_indexes,
-                    network,
-                },
-            );
-        }
+        let mut map = self.lock_recently_broadcast();
+        map.insert(
+            txid,
+            RecentBroadcast {
+                tx,
+                input_coins,
+                change_indexes,
+                network,
+            },
+        );
     }
 
     /// Adds synthetic `spend_info` to coins whose outpoints match the
@@ -125,9 +146,7 @@ impl Wallet {
     /// is preserved if already present (daemon view is the source of
     /// truth once available).
     pub fn apply_coin_overrides(&self, coins: &mut [Coin]) {
-        let Ok(map) = self.recently_broadcast.lock() else {
-            return;
-        };
+        let map = self.lock_recently_broadcast();
         if map.is_empty() {
             return;
         }
@@ -151,30 +170,25 @@ impl Wallet {
 
     /// Promotes `Pending` PSBTs to `Broadcast` when the user has
     /// already broadcast them locally but the daemon hasn't yet
-    /// reflected the spend in its coin state. Doubles as a
-    /// reconciliation point: any tx the daemon now reports as
-    /// `Broadcast`/`Spent`/`Deprecated` is a signal it has caught up,
-    /// so we drop our optimistic entry — the daemon view becomes the
-    /// source of truth and stays that way.
+    /// reflected the spend in its coin state.
+    ///
+    /// Pure: never mutates `recently_broadcast`. Entries are dropped
+    /// only by `reconcile_with_coins`, which runs on the cache update
+    /// path. Doing reconciliation here would race with an in-flight
+    /// cache update task — if this method ran first and removed an
+    /// entry, the cache update could then fetch stale (pre-catchup)
+    /// coins, find an empty map, and store coins without the synthetic
+    /// `spend_info` — yielding a temporarily-wrong balance.
     pub fn apply_spend_tx_overrides(&self, txs: &mut [SpendTx]) {
-        let Ok(mut map) = self.recently_broadcast.lock() else {
-            return;
-        };
+        let map = self.lock_recently_broadcast();
         if map.is_empty() {
             return;
         }
         for tx in txs.iter_mut() {
-            let txid = tx.psbt.unsigned_tx.compute_txid();
-            match tx.status {
-                SpendStatus::Pending => {
-                    if map.contains_key(&txid) {
-                        tx.status = SpendStatus::Broadcast;
-                    }
-                }
-                SpendStatus::Broadcast
-                | SpendStatus::Spent
-                | SpendStatus::Deprecated => {
-                    map.remove(&txid);
+            if matches!(tx.status, SpendStatus::Pending) {
+                let txid = tx.psbt.unsigned_tx.compute_txid();
+                if map.contains_key(&txid) {
+                    tx.status = SpendStatus::Broadcast;
                 }
             }
         }
@@ -183,23 +197,26 @@ impl Wallet {
     /// Returns synthesized pending `HistoryTransaction`s for any
     /// recently-broadcast tx not already present in `existing_txids`.
     /// The Transactions panel merges these with daemon-supplied
-    /// pending txs so the broadcast shows up immediately. Also drops
-    /// entries the daemon now lists itself — that's the most reliable
-    /// signal for txs without change (which can't be reconciled via
-    /// `reconcile_with_coins`'s output-coin check).
+    /// pending txs so the broadcast shows up immediately.
+    ///
+    /// Pure: never mutates `recently_broadcast` (see
+    /// `apply_spend_tx_overrides` for the race this avoids).
+    /// Read-time filtering against `existing_txids` is enough to
+    /// prevent a duplicate row once the daemon lists the tx itself —
+    /// the orphan entry stays in the map until `reconcile_with_coins`
+    /// observes a matching output coin, but that doesn't affect this
+    /// panel's display.
     pub fn synthesized_pending_history_txs(
         &self,
         existing_txids: &HashSet<Txid>,
     ) -> Vec<HistoryTransaction> {
-        let Ok(mut map) = self.recently_broadcast.lock() else {
-            return Vec::new();
-        };
+        let map = self.lock_recently_broadcast();
         if map.is_empty() {
             return Vec::new();
         }
-        map.retain(|txid, _| !existing_txids.contains(txid));
-        map.values()
-            .map(|rb| {
+        map.iter()
+            .filter(|(txid, _)| !existing_txids.contains(*txid))
+            .map(|(_, rb)| {
                 HistoryTransaction::new(
                     rb.tx.clone(),
                     None,
@@ -212,33 +229,43 @@ impl Wallet {
             .collect()
     }
 
-    /// Drops entries the daemon has caught up on. Two signals: an
-    /// input coin now carries `spend_info` pointing to our txid, or
-    /// the broadcast tx's outputs have appeared as coins (only happens
-    /// once the daemon has seen the tx). Cleaning up here keeps the
-    /// override from masking real changes — e.g. if the user later
-    /// RBFs the tx, we want the daemon's view to win.
+    /// Drops entries the daemon has caught up on. The cache path
+    /// calls this with the result of
+    /// `list_coins(&[Unconfirmed, Confirmed], &[])`, so `coins` never
+    /// contains spend_info-bearing coins — the daemon's filter
+    /// already excluded them. Two complementary signals catch the
+    /// catch-up:
+    ///
+    /// 1. **Any broadcast input is no longer in the returned coin
+    ///    set.** The inputs were Unconfirmed/Confirmed at
+    ///    `record_broadcast` time, so their absence means the daemon
+    ///    moved them to `Spending`/`Spent` — that catches our own
+    ///    broadcast, an RBF replacement, or a conflicting tx
+    ///    consuming the input. All three are reasons our optimistic
+    ///    override is no longer authoritative.
+    /// 2. **A wallet-tracked output of the broadcast tx has
+    ///    appeared.** Faster signal when the tx has change; the
+    ///    daemon may surface the new output coin before its poller
+    ///    finishes flagging the inputs.
+    ///
+    /// Guarded against an empty `coins` result — that's almost
+    /// always a transient (daemon restart, mid-rescan) rather than a
+    /// genuine wallet-wide spend, so we leave entries intact.
     pub fn reconcile_with_coins(&self, coins: &[Coin]) {
-        let Ok(mut map) = self.recently_broadcast.lock() else {
-            return;
-        };
-        if map.is_empty() {
+        let mut map = self.lock_recently_broadcast();
+        if map.is_empty() || coins.is_empty() {
             return;
         }
-        let mut observed: HashSet<Txid> = HashSet::new();
-        for coin in coins {
-            if map.contains_key(&coin.outpoint.txid) {
-                observed.insert(coin.outpoint.txid);
-            }
-            if let Some(info) = coin.spend_info {
-                if map.contains_key(&info.txid) {
-                    observed.insert(info.txid);
-                }
-            }
-        }
-        for txid in observed {
-            map.remove(&txid);
-        }
+        let present_outpoints: HashSet<OutPoint> = coins.iter().map(|c| c.outpoint).collect();
+        let output_txids: HashSet<Txid> = coins.iter().map(|c| c.outpoint.txid).collect();
+        map.retain(|txid, rb| {
+            let all_inputs_still_present = rb
+                .input_coins
+                .iter()
+                .all(|c| present_outpoints.contains(&c.outpoint));
+            let no_output_observed = !output_txids.contains(txid);
+            all_inputs_still_present && no_output_observed
+        });
     }
 
     pub fn with_name(mut self, name: String) -> Self {

--- a/coincube-gui/src/app/wallet.rs
+++ b/coincube-gui/src/app/wallet.rs
@@ -248,12 +248,19 @@ impl Wallet {
     ///    daemon may surface the new output coin before its poller
     ///    finishes flagging the inputs.
     ///
-    /// Guarded against an empty `coins` result — that's almost
-    /// always a transient (daemon restart, mid-rescan) rather than a
-    /// genuine wallet-wide spend, so we leave entries intact.
+    /// An empty `coins` result is treated as legitimate: it can
+    /// genuinely happen after the user spends every UTXO with no
+    /// change output, and skipping reconciliation in that case left a
+    /// stale entry that produced a duplicate pending row in the
+    /// Transactions panel once the tx confirmed. The input-
+    /// disappearance check already handles the empty case correctly
+    /// (all inputs absent ⇒ entry cleared). Mid-sync transients
+    /// briefly clearing entries is acceptable: they self-correct
+    /// once the daemon catches up, since by then the daemon shows
+    /// authoritative state on its own.
     pub fn reconcile_with_coins(&self, coins: &[Coin]) {
         let mut map = self.lock_recently_broadcast();
-        if map.is_empty() || coins.is_empty() {
+        if map.is_empty() {
             return;
         }
         let present_outpoints: HashSet<OutPoint> = coins.iter().map(|c| c.outpoint).collect();

--- a/coincube-ui/static/loading-quotes.json
+++ b/coincube-ui/static/loading-quotes.json
@@ -2,13 +2,11 @@
   "_meta": {
     "description": "Loading screen quotes for COINCUBE desktop and mobile apps. Displayed below Kage animations during loading, syncing, transaction, and other app states.",
     "usage": "Serve randomly within the matching context. Short quotes for brief states; medium quotes for longer screens. Every context has at least 3 quotes.",
-    "total": 76,
+    "total": 52,
     "categories": {
-      "booth": "Jeff Booth — Author of The Price of Tomorrow, Bitcoin advocate",
       "ammous": "Saifedean Ammous — Author of The Bitcoin Standard",
       "szabo": "Nick Szabo — Computer scientist, smart contracts pioneer",
       "finney": "Hal Finney — Cryptographer, first Bitcoin transaction recipient",
-      "back": "Adam Back — Inventor of Hashcash, Blockstream CEO",
       "satoshi": "Satoshi Nakamoto — Bitcoin whitepaper, forum posts, emails (2008–2010)",
       "hayek": "Friedrich A. Hayek — Nobel laureate, Austrian School economist",
       "mises": "Ludwig von Mises — Austrian School economist, monetary theorist",
@@ -32,43 +30,6 @@
   },
   "quotes": [
     {
-      "id": "booth-01",
-      "text": "Technology is deflationary, and deflation is abundance. Bitcoin is the first money that aligns with this truth.",
-      "author": "Jeff Booth",
-      "source": "The Price of Tomorrow, 2020",
-      "category": "booth",
-      "length": "short",
-      "contexts": ["loading", "syncing", "first-launch"]
-    },
-    {
-      "id": "booth-02",
-      "text": "In a world of infinite money printing, Bitcoin is the exit.",
-      "author": "Jeff Booth",
-      "source": "Interview, 2021",
-      "category": "booth",
-      "length": "short",
-      "contexts": ["first-launch", "idle"]
-    },
-    {
-      "id": "booth-03",
-      "text": "You don't change the existing system. You build a new one that makes the old one obsolete.",
-      "author": "Jeff Booth",
-      "source": "The Price of Tomorrow, 2020",
-      "category": "booth",
-      "length": "short",
-      "contexts": ["loading", "idle", "first-launch"]
-    },
-    {
-      "id": "booth-04",
-      "text": "Bitcoin fixes the money. Fixed money fixes the world.",
-      "author": "Jeff Booth",
-      "source": "Interview, 2022",
-      "category": "booth",
-      "length": "short",
-      "contexts": ["idle", "balance-update", "syncing"]
-    },
-
-    {
       "id": "ammous-01",
       "text": "Bitcoin is the hardest money ever invented: growth in its value cannot possibly increase its supply.",
       "author": "Saifedean Ammous",
@@ -79,24 +40,6 @@
     },
     {
       "id": "ammous-02",
-      "text": "Sound money is a prerequisite for individual freedom and honest commerce.",
-      "author": "Saifedean Ammous",
-      "source": "The Bitcoin Standard, 2018",
-      "category": "ammous",
-      "length": "short",
-      "contexts": ["first-launch", "idle"]
-    },
-    {
-      "id": "ammous-03",
-      "text": "The len­gth of time an asset has held value is the single most important indicator that it will continue to hold value.",
-      "author": "Saifedean Ammous",
-      "source": "The Bitcoin Standard, 2018",
-      "category": "ammous",
-      "length": "short",
-      "contexts": ["loading", "idle", "balance-update"]
-    },
-    {
-      "id": "ammous-04",
       "text": "Bitcoin can be best understood as distributed software that allows for transfer of value using a currency protected from unexpected inflation without relying on trusted third parties.",
       "author": "Saifedean Ammous",
       "source": "The Bitcoin Standard, 2018",
@@ -116,104 +59,40 @@
     },
     {
       "id": "szabo-02",
-      "text": "If clams can be money, furs can be money, gold can be money, and so on – if money is not just coins or notes issued by a government under legal tender laws, but rather can be a wide variety of objects – then just what is money anyway? ",
+      "text": "If clams can be money, furs can be money, gold can be money, and so on – if money is not just coins or notes issued by a government under legal tender laws, but rather can be a wide variety of objects – then just what is money anyway?",
       "author": "Nick Szabo",
       "source": "Shelling Out, 2002",
       "category": "szabo",
-      "length": "short",
-      "contexts": ["idle", "balance-update", "transaction-received"]
-    },
-    {
-      "id": "szabo-03",
-      "text": "A very unforgeable costly commodity provides money whose supply is unaffected by the lending cycle.",
-      "author": "Nick Szabo",
-      "source": "Bit Gold, 2005",
-      "category": "szabo",
-      "length": "short",
-      "contexts": ["loading", "syncing"]
-    },
-    {
-      "id": "szabo-04",
-      "text": "The problem is that our monetary system depends on trust — trust that a long and growing list of institutions won't abuse the power they wield.",
-      "author": "Nick Szabo",
-      "source": "Bit Gold, 2008",
-      "category": "szabo",
       "length": "medium",
-      "contexts": ["loading", "syncing", "first-launch"]
+      "contexts": ["idle", "balance-update", "transaction-received"]
     },
 
     {
       "id": "finney-01",
-      "text": "Running Bitcoin.",
+      "text": "Running bitcoin",
       "author": "Hal Finney",
-      "source": "First tweet about Bitcoin, 2009",
+      "source": "First tweet about Bitcoin, January 10, 2009",
       "category": "finney",
       "length": "short",
       "contexts": ["loading", "syncing", "first-launch"]
     },
     {
       "id": "finney-02",
-      "text": "I see Bitcoin as ultimately becoming a reserve currency for banks.",
+      "text": "I believe this will be the ultimate fate of Bitcoin, to be the 'high-powered money' that serves as a reserve currency for banks that issue their own digital cash.",
       "author": "Hal Finney",
       "source": "BitcoinTalk forum, 2010",
       "category": "finney",
-      "length": "short",
+      "length": "medium",
       "contexts": ["idle", "loading"]
     },
     {
       "id": "finney-03",
-      "text": "It seemed so obvious to me. Here we are, faced with the problems of loss of privacy, creeping computerization, massive databases. Crypto is the answer.",
+      "text": "It seemed so obvious to me: Here we are faced with the problems of loss of privacy, creeping computerization, massive databases, more centralization — and Chaum offers a completely different direction to go in, one which puts power into the hands of individuals rather than governments and corporations.",
       "author": "Hal Finney",
-      "source": "Cypherpunks mailing list, 1992",
+      "source": "Cypherpunks mailing list, November 1992",
       "category": "finney",
       "length": "medium",
       "contexts": ["first-launch", "backup-reminder"]
-    },
-    {
-      "id": "finney-04",
-      "text": "I'd like to die at peace, knowing that the technology I worked on will live on and continue to change the world.",
-      "author": "Hal Finney",
-      "source": "BitcoinTalk forum, 2013",
-      "category": "finney",
-      "length": "short",
-      "contexts": ["idle", "loading"]
-    },
-
-    {
-      "id": "back-01",
-      "text": "Bitcoin is the most important invention in the history of the world since the Internet.",
-      "author": "Adam Back",
-      "source": "Interview, 2015",
-      "category": "back",
-      "length": "short",
-      "contexts": ["first-launch", "idle", "loading"]
-    },
-    {
-      "id": "back-02",
-      "text": "I've been mass-producing hashcash tokens since 1997. But making it decentralized money — that's what Satoshi solved.",
-      "author": "Adam Back",
-      "source": "Interview, 2019",
-      "category": "back",
-      "length": "short",
-      "contexts": ["loading", "syncing"]
-    },
-    {
-      "id": "back-03",
-      "text": "Not your keys, not your coins.",
-      "author": "Adam Back",
-      "source": "Attributed",
-      "category": "back",
-      "length": "short",
-      "contexts": ["backup-reminder", "first-launch", "transaction-sent"]
-    },
-    {
-      "id": "back-04",
-      "text": "Bitcoin is a technological tour de force.",
-      "author": "Adam Back",
-      "source": "Interview, 2013",
-      "category": "back",
-      "length": "short",
-      "contexts": ["idle", "loading", "syncing", "transaction-received"]
     },
 
     {
@@ -301,7 +180,7 @@
       "id": "satoshi-10",
       "text": "I hope it's obvious it was only the centrally controlled nature of those systems that doomed them. I think this is the first time we're trying a decentralized, non-trust-based system.",
       "author": "Satoshi Nakamoto",
-      "source": "Cryptography mailing list, 2009",
+      "source": "P2P Foundation forum post, 2009",
       "category": "satoshi",
       "length": "medium",
       "contexts": ["loading", "first-launch"]
@@ -317,7 +196,7 @@
     },
     {
       "id": "satoshi-12",
-      "text": "With e-currency based on cryptographic proof, without the need to trust a third-party middleman, money can be secure and transactions effortless.",
+      "text": "With e-currency based on cryptographic proof, without the need to trust a third party middleman, money can be secure and transactions effortless.",
       "author": "Satoshi Nakamoto",
       "source": "P2P Foundation forum post, 2009",
       "category": "satoshi",
@@ -329,23 +208,23 @@
       "id": "hayek-01",
       "text": "I don't believe we shall ever have a good money again before we take the thing out of the hands of government.",
       "author": "Friedrich A. Hayek",
-      "source": "Interview, 1984",
+      "source": "Interview with James U. Blanchard III, 1984",
       "category": "hayek",
       "length": "short",
       "contexts": ["loading", "syncing", "first-launch"]
     },
     {
       "id": "hayek-02",
-      "text": "All we can do is by some sly roundabout way introduce something that they can't stop.",
+      "text": "All we can do is by some sly roundabout way introduce something they can't stop.",
       "author": "Friedrich A. Hayek",
-      "source": "Interview, 1984",
+      "source": "Interview with James U. Blanchard III, 1984",
       "category": "hayek",
       "length": "short",
       "contexts": ["loading", "idle", "first-launch"]
     },
     {
       "id": "hayek-03",
-      "text": "I do not think it is an exaggeration to say that history is largely a history of inflation, usually inflations engineered by governments for the gain of governments.",
+      "text": "I do not think it is an exaggeration to say that history is largely a history of inflation, and usually of inflations engineered for the gain of governments.",
       "author": "Friedrich A. Hayek",
       "source": "Choice in Currency, 1976",
       "category": "hayek",
@@ -353,17 +232,8 @@
       "contexts": ["loading", "syncing"]
     },
     {
-      "id": "hayek-04",
-      "text": "If we want free enterprise and a market economy to survive, we have no choice but to replace the governmental currency monopoly by free competition between private currencies.",
-      "author": "Friedrich A. Hayek",
-      "source": "Denationalisation of Money, 1976",
-      "category": "hayek",
-      "length": "medium",
-      "contexts": ["loading", "syncing"]
-    },
-    {
       "id": "hayek-05",
-      "text": "With the exception only of the period of the gold standard, practically all governments of history have used their exclusive power to issue money to defraud and plunder the people.",
+      "text": "With the exception only of the 200-year period of the gold standard, practically all governments of history have used their exclusive power to issue money in order to defraud and plunder the people.",
       "author": "Friedrich A. Hayek",
       "source": "Choice in Currency, 1976",
       "category": "hayek",
@@ -411,34 +281,16 @@
       "id": "mises-03",
       "text": "The first thing a genius needs is to breathe free air.",
       "author": "Ludwig von Mises",
-      "source": "Liberalism, 1927",
+      "source": "The Anti-Capitalistic Mentality, 1956",
       "category": "mises",
       "length": "short",
       "contexts": ["loading", "idle", "first-launch"]
     },
     {
-      "id": "mises-04",
-      "text": "All the enemies of the gold standard spurn it precisely because of its main virtue: its incompatibility with a policy of credit expansion.",
-      "author": "Ludwig von Mises",
-      "source": "Human Action, 1949",
-      "category": "mises",
-      "length": "short",
-      "contexts": ["loading", "syncing"]
-    },
-    {
-      "id": "mises-05",
-      "text": "Government is the only institution that can take a valuable commodity like paper, and make it worthless by applying ink.",
-      "author": "Ludwig von Mises",
-      "source": "Attributed",
-      "category": "mises",
-      "length": "short",
-      "contexts": ["loading", "idle"]
-    },
-    {
       "id": "mises-06",
       "text": "A prosperity created by an expansionist monetary and credit policy is illusory and must end in a slump, an economic crisis.",
       "author": "Ludwig von Mises",
-      "source": "Human Action, 1949",
+      "source": "Inflation Must End in a Slump, 1951",
       "category": "mises",
       "length": "short",
       "contexts": ["loading", "syncing"]
@@ -481,48 +333,12 @@
       "contexts": ["loading", "syncing"]
     },
     {
-      "id": "rothbard-03",
-      "text": "If government manages to establish paper tickets as money, then the government becomes free to create money costlessly and at will.",
-      "author": "Murray N. Rothbard",
-      "source": "What Has Government Done to Our Money?, 1963",
-      "category": "rothbard",
-      "length": "short",
-      "contexts": ["loading", "syncing"]
-    },
-    {
       "id": "rothbard-04",
       "text": "Monetary inflation not only raises prices and destroys the value of the currency unit; it also acts as a giant system of expropriation.",
       "author": "Murray N. Rothbard",
-      "source": "Man, Economy, and State, 1962",
+      "source": "The Mystery of Banking, 1983",
       "category": "rothbard",
       "length": "short",
-      "contexts": ["loading", "syncing"]
-    },
-    {
-      "id": "rothbard-05",
-      "text": "The Federal Reserve, instead of being reviled as a counterfeiter and destroyer, is hailed as the wise governor of our economy.",
-      "author": "Murray N. Rothbard",
-      "source": "The Case Against the Fed, 1994",
-      "category": "rothbard",
-      "length": "short",
-      "contexts": ["loading", "idle"]
-    },
-    {
-      "id": "rothbard-06",
-      "text": "The state has always had a love-hate relationship with counterfeiting: it loves its own, and hates the competition.",
-      "author": "Murray N. Rothbard",
-      "source": "What Has Government Done to Our Money?, 1963",
-      "category": "rothbard",
-      "length": "short",
-      "contexts": ["loading", "idle"]
-    },
-    {
-      "id": "rothbard-07",
-      "text": "Since the Federal Reserve has the unlimited power to print money, it can never go bankrupt. This is the ultimate source of the moral hazard in our banking system.",
-      "author": "Murray N. Rothbard",
-      "source": "The Case Against the Fed, 1994",
-      "category": "rothbard",
-      "length": "medium",
       "contexts": ["loading", "syncing"]
     },
 
@@ -536,48 +352,12 @@
       "contexts": ["loading", "syncing"]
     },
     {
-      "id": "hoppe-02",
-      "text": "As long as money is tied to a commodity like gold, the amount of money cannot be arbitrarily increased, because it is impossible to increase the physical amount of gold at will.",
-      "author": "Hans-Hermann Hoppe",
-      "source": "Democracy: The God That Failed, 2001",
-      "category": "hoppe",
-      "length": "medium",
-      "contexts": ["loading", "syncing"]
-    },
-    {
       "id": "hoppe-03",
       "text": "More money makes its monopolistic producer and its earliest recipients richer at the expense of making the money's late and latest receivers poorer.",
       "author": "Hans-Hermann Hoppe",
       "source": "Democracy: The God That Failed, 2001",
       "category": "hoppe",
       "length": "medium",
-      "contexts": ["loading", "syncing"]
-    },
-    {
-      "id": "hoppe-04",
-      "text": "No one would accept paper money if it were not stamped by the state as legal tender and backed by the state's coercive power.",
-      "author": "Hans-Hermann Hoppe",
-      "source": "A Theory of Socialism and Capitalism, 1989",
-      "category": "hoppe",
-      "length": "short",
-      "contexts": ["loading", "syncing"]
-    },
-    {
-      "id": "hoppe-05",
-      "text": "Every government tax and regulation and every governmental money manipulation is a violation of property rights.",
-      "author": "Hans-Hermann Hoppe",
-      "source": "The Economics and Ethics of Private Property, 1993",
-      "category": "hoppe",
-      "length": "short",
-      "contexts": ["loading", "idle"]
-    },
-    {
-      "id": "hoppe-06",
-      "text": "All government growth is financed by two means: taxation, and the monopolization and debasement of money.",
-      "author": "Hans-Hermann Hoppe",
-      "source": "Democracy: The God That Failed, 2001",
-      "category": "hoppe",
-      "length": "short",
       "contexts": ["loading", "syncing"]
     },
 
@@ -646,7 +426,7 @@
     },
     {
       "id": "scripture-08",
-      "text": "The getting of treasures by a lying tongue is a fleeting fantasy of those who seek death.",
+      "text": "Getting treasures by a lying tongue is the fleeting fantasy of those who seek death.",
       "author": "Proverbs 21:6",
       "source": "NKJV",
       "category": "scripture",

--- a/coincube-ui/static/loading-quotes.json
+++ b/coincube-ui/static/loading-quotes.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "description": "Loading screen quotes for COINCUBE desktop and mobile apps. Displayed below Kage animations during loading, syncing, transaction, and other app states.",
-    "usage": "Serve randomly within the matching context. Short quotes for brief states; medium quotes for longer screens. Every context has at least 3 quotes.",
+    "usage": "Serve randomly within the matching context. Short quotes for brief states; medium quotes for longer screens. Every context has at least 2 quotes.",
     "total": 52,
     "categories": {
       "ammous": "Saifedean Ammous — Author of The Bitcoin Standard",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches balance, spendable coins, PSBT status, and transaction list from shared in-memory state; reconciliation is designed to defer to daemon data but race/timing bugs could briefly show wrong balances or duplicate pending rows.
> 
> **Overview**
> Adds **optimistic Vault UI** after a successful broadcast: `Wallet` keeps a shared `recently_broadcast` map (`record_broadcast` on RPC success, `reconcile_with_coins` when daemon coin state catches up) and helpers to synthesize `spend_info`, promote PSBTs to **Broadcast**, and merge pending history rows.
> 
> **Wiring:** `UpdateDaemonCache` reconciles then applies coin overrides before publishing cache; Vault **Overview**, **Send**, **Transactions**, and **PSBTs** call the same overrides on their own fetches. **Broadcast** no longer reloads to the PSBT list (avoids stale **Pending** overwriting optimistic status); celebration modal records the broadcast via `wallet`.
> 
> Also trims and corrects **`loading-quotes.json`** (unrelated content change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be44002eee82b2980359dccef975ca17b38141d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimistic transaction broadcasting: balance updates and spend confirmations now display immediately after sending, without waiting for daemon confirmation.

* **Improvements**
  * Transaction history panels show locally broadcast transactions earlier, providing faster visibility.
  * All vault panels apply real-time overrides for more accurate balance and transaction status displays.
  * Improved wallet state reconciliation for consistent UI information across all panels.

* **Content Updates**
  * Refreshed loading screen quotes dataset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coincubetech/coincube/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->