### PR TITLE
Cleanup Liquid wallet transactions, celebration screens and update qu…

### DIFF
--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -631,13 +631,20 @@ impl Panels {
                 crate::app::menu::LiquidSubMenu::Receive => Some(Message::View(
                     view::Message::LiquidReceive(view::LiquidReceiveMessage::RefreshRequested),
                 )),
-                // The Transactions panel handles `Reload` by re-running
-                // its SDK fetches (see `LiquidTransactions::update`).
-                // Without this arm, SDK events never reached the panel
-                // when the user was sitting on it, so a confirmed send
-                // wouldn't surface until they navigated away and back.
+                // Route to a dedicated `BackgroundRefresh` rather than
+                // the generic `Reload` — `Reload` would call the
+                // panel's `reload()` which clears `selected_payment`,
+                // `selected_refundable`, the refund modal and form
+                // state. SDK events fire frequently (Synced,
+                // PaymentSucceeded, etc.), so a Reload arm would kick
+                // the user out of any drill-down they're in.
+                // `BackgroundRefresh` is gated to only fire when the
+                // panel is idle and uses `fetch_page(0)` to replace
+                // payments atomically without disturbing state.
                 crate::app::menu::LiquidSubMenu::Transactions(_) => {
-                    Some(Message::View(view::Message::Reload))
+                    Some(Message::View(view::Message::LiquidTransactions(
+                        view::LiquidTransactionsMessage::BackgroundRefresh,
+                    )))
                 }
                 _ => None,
             },

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -631,6 +631,14 @@ impl Panels {
                 crate::app::menu::LiquidSubMenu::Receive => Some(Message::View(
                     view::Message::LiquidReceive(view::LiquidReceiveMessage::RefreshRequested),
                 )),
+                // The Transactions panel handles `Reload` by re-running
+                // its SDK fetches (see `LiquidTransactions::update`).
+                // Without this arm, SDK events never reached the panel
+                // when the user was sitting on it, so a confirmed send
+                // wouldn't surface until they navigated away and back.
+                crate::app::menu::LiquidSubMenu::Transactions(_) => {
+                    Some(Message::View(view::Message::Reload))
+                }
                 _ => None,
             },
             _ => None,

--- a/coincube-gui/src/app/state/liquid/transactions.rs
+++ b/coincube-gui/src/app/state/liquid/transactions.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use breez_sdk_liquid::model::RefundRequest;
 use coincube_core::miniscript::bitcoin::Amount;
@@ -44,6 +44,13 @@ const IN_FLIGHT_GRACE: std::time::Duration = std::time::Duration::from_secs(60);
 /// end-to-end on real wallets. Kept low during rollout so QA can exercise
 /// pagination without needing 50+ transactions per asset filter.
 pub const PAGE_SIZE: u32 = 10;
+
+/// Minimum gap between background `Message::Tick` refreshes. Mirrors the
+/// Vault Transactions cadence so the two panels surface fresh activity
+/// at the same rate. The primary refresh path is still the SDK event
+/// router (`active_liquid_refresh`); this Tick is a backstop in case an
+/// event ever fails to fire or arrives slowly.
+const LIQUID_TRANSACTIONS_RELOAD_MAX_TTL: Duration = Duration::from_secs(10);
 
 #[derive(Debug)]
 enum LiquidTransactionsModal {
@@ -95,6 +102,11 @@ pub struct LiquidTransactions {
     fetch_token: u64,
     is_last_page: bool,
     processing: bool,
+    /// Timestamp of the last reload — gates the `Message::Tick` background
+    /// refresh so we don't hammer the SDK on every tick. Bumped on full
+    /// `reload`, on SDK-event-driven `Reload`, and on each Tick-initiated
+    /// background fetch.
+    last_reload: Instant,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -133,6 +145,7 @@ impl LiquidTransactions {
             fetch_token: 0,
             is_last_page: false,
             processing: false,
+            last_reload: Instant::now(),
         }
     }
 
@@ -436,6 +449,40 @@ impl State for LiquidTransactions {
                 Task::none()
             }
             Message::View(view::Message::Reload) => self.reload(None, None),
+            Message::Tick => {
+                // Background refresh so a freshly-broadcast or freshly-
+                // confirmed Liquid tx surfaces without the user having
+                // to navigate away and back. The primary refresh path
+                // is still `active_liquid_refresh` (SDK events); this
+                // Tick is a defensive backstop for when events miss or
+                // arrive late.
+                //
+                // Gated to avoid disturbing an active drill-down:
+                // fires only on page 0, no selection, no modal open,
+                // no in-flight fetch, and only after
+                // `LIQUID_TRANSACTIONS_RELOAD_MAX_TTL` has elapsed
+                // since the last reload.
+                //
+                // Calls `fetch_page(0)` directly (not `reload`) so we
+                // don't clear `payments` or flip `loading` — the row
+                // list stays rendered until `PaymentsLoaded` replaces
+                // it atomically. Avoids the periodic "list disappears,
+                // loading flashes" glitch a Tick → reload loop would
+                // cause.
+                if self.current_page == 0
+                    && self.selected_payment.is_none()
+                    && self.selected_refundable.is_none()
+                    && matches!(self.modal, LiquidTransactionsModal::None)
+                    && !self.loading
+                    && !self.processing
+                    && self.pending_page.is_none()
+                    && Instant::now() > self.last_reload + LIQUID_TRANSACTIONS_RELOAD_MAX_TTL
+                {
+                    self.last_reload = Instant::now();
+                    return self.fetch_page(0);
+                }
+                Task::none()
+            }
             Message::View(view::Message::Close) => {
                 self.selected_payment = None;
                 self.selected_refundable = None;
@@ -813,6 +860,7 @@ impl State for LiquidTransactions {
         self.is_last_page = false;
         self.processing = false;
         self.payments.clear();
+        self.last_reload = Instant::now();
         let client2 = self.breez_client.clone();
 
         Task::batch(vec![

--- a/coincube-gui/src/app/state/liquid/transactions.rs
+++ b/coincube-gui/src/app/state/liquid/transactions.rs
@@ -449,26 +449,38 @@ impl State for LiquidTransactions {
                 Task::none()
             }
             Message::View(view::Message::Reload) => self.reload(None, None),
-            Message::Tick => {
+            Message::View(view::Message::LiquidTransactions(
+                view::LiquidTransactionsMessage::BackgroundRefresh,
+            ))
+            | Message::Tick => {
                 // Background refresh so a freshly-broadcast or freshly-
                 // confirmed Liquid tx surfaces without the user having
-                // to navigate away and back. The primary refresh path
-                // is still `active_liquid_refresh` (SDK events); this
-                // Tick is a defensive backstop for when events miss or
-                // arrive late.
+                // to navigate away and back. Two callers funnel through
+                // the same gated path:
+                //
+                // - `Message::Tick`: defensive backstop on a
+                //   `LIQUID_TRANSACTIONS_RELOAD_MAX_TTL` cadence, in
+                //   case an SDK event ever misses or arrives late
+                //   (also covers Liquid-only cubes where `on_tick`
+                //   normally skips when no Vault daemon is configured).
+                // - `BackgroundRefresh`: dispatched from
+                //   `active_liquid_refresh` when the SDK fires Synced,
+                //   PaymentSucceeded, etc.
                 //
                 // Gated to avoid disturbing an active drill-down:
                 // fires only on page 0, no selection, no modal open,
                 // no in-flight fetch, and only after
                 // `LIQUID_TRANSACTIONS_RELOAD_MAX_TTL` has elapsed
-                // since the last reload.
+                // since the last reload — the TTL doubles as a
+                // debounce when SDK events burst.
                 //
                 // Calls `fetch_page(0)` directly (not `reload`) so we
                 // don't clear `payments` or flip `loading` — the row
                 // list stays rendered until `PaymentsLoaded` replaces
                 // it atomically. Avoids the periodic "list disappears,
-                // loading flashes" glitch a Tick → reload loop would
-                // cause.
+                // loading flashes" glitch a reload-on-every-event
+                // approach would cause, and preserves any drill-down
+                // / refund modal state the user is currently in.
                 if self.current_page == 0
                     && self.selected_payment.is_none()
                     && self.selected_refundable.is_none()

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -144,6 +144,7 @@ pub enum Message {
     OpenUrl(String),
     Home(HomeMessage),
     LiquidOverview(LiquidOverviewMessage),
+    LiquidTransactions(LiquidTransactionsMessage),
     SparkOverview(crate::app::view::spark::SparkOverviewMessage),
     SparkTransactions(crate::app::view::spark::SparkTransactionsMessage),
     SparkSettings(crate::app::view::spark::SparkSettingsMessage),
@@ -504,6 +505,22 @@ pub enum SideshiftSendMessage {
     Reset,
     Error(String),
     Copy,
+}
+
+/// View-level messages for the Liquid Transactions panel. Currently
+/// only carries the SDK-event-driven background refresh signal; the
+/// rest of the panel's interactions still go through the generic
+/// `view::Message::{Reload, Close, Select, ...}` because most of the
+/// state changes were wired before this enum was introduced.
+#[derive(Debug, Clone)]
+pub enum LiquidTransactionsMessage {
+    /// Refresh payments in place without disturbing the user's current
+    /// view (selection, refund modal, pagination). The handler gates
+    /// the fetch to fire only when the panel is idle on page 0, and
+    /// uses `fetch_page(0)` directly rather than the heavy `reload()`
+    /// — so a freshly-confirmed Liquid tx surfaces from SDK events
+    /// without kicking the user out of any drill-down.
+    BackgroundRefresh,
 }
 
 #[derive(Debug, Clone)]

--- a/coincube-ui/src/component/mod.rs
+++ b/coincube-ui/src/component/mod.rs
@@ -80,6 +80,11 @@ pub fn received_celebration_page<'a, M: Clone + 'a>(
                 .width(Length::Fixed(150.0))
                 .on_press(on_dismiss),
         )
+        // Bottom breathing room below the Back button. Matches the
+        // 30px internal padding `sent_celebration_page` gets from its
+        // card wrapper — without it the button sits flush against the
+        // scrollable area's bottom edge.
+        .push(iced::widget::Space::new().height(Length::Fixed(30.0)))
         .into()
 }
 
@@ -130,10 +135,19 @@ pub fn sent_celebration_page<'a, M: Clone + 'a>(
     // but does not draw a surface behind its child, so without an opaque
     // wrapper the celebration text floats over the dimmed PSBT view. Wrap in
     // a card-styled Container so the celebration has a solid backing.
-    Container::new(inner)
+    let card = Container::new(inner)
         .padding(30)
         .max_width(640)
-        .style(theme::card::modal)
+        .style(theme::card::modal);
+
+    // The card itself caps at 640px; without an outer fill+center wrapper it
+    // would shrink to its content width and sit left-aligned inside the
+    // dashboard's content column (visible bug on Liquid Send / Spark Send /
+    // Vault PSBT full-page celebrations). The Modal widget centers its child
+    // on its own, so this extra wrapper is a no-op in the modal use case.
+    Container::new(card)
+        .width(Length::Fill)
+        .align_x(iced::alignment::Horizontal::Center)
         .into()
 }
 

--- a/coincube-ui/static/loading-quotes.json
+++ b/coincube-ui/static/loading-quotes.json
@@ -2,12 +2,16 @@
   "_meta": {
     "description": "Loading screen quotes for COINCUBE desktop and mobile apps. Displayed below Kage animations during loading, syncing, transaction, and other app states.",
     "usage": "Serve randomly within the matching context. Short quotes for brief states; medium quotes for longer screens. Every context has at least 2 quotes.",
-    "total": 52,
+    "total": 65,
     "categories": {
+      "booth": "Jeff Booth — Author of The Price of Tomorrow, Bitcoin advocate",
       "ammous": "Saifedean Ammous — Author of The Bitcoin Standard",
+      "svetski": "Aleks Svetski — Author of The Bushido of Bitcoin",
       "szabo": "Nick Szabo — Computer scientist, smart contracts pioneer",
       "finney": "Hal Finney — Cryptographer, first Bitcoin transaction recipient",
       "satoshi": "Satoshi Nakamoto — Bitcoin whitepaper, forum posts, emails (2008–2010)",
+      "sovereign": "James Dale Davidson & Lord William Rees-Mogg — The Sovereign Individual, 1997",
+      "fuller": "R. Buckminster Fuller — Inventor, futurist, systems thinker",
       "hayek": "Friedrich A. Hayek — Nobel laureate, Austrian School economist",
       "mises": "Ludwig von Mises — Austrian School economist, monetary theorist",
       "rothbard": "Murray N. Rothbard — Austrian School economist, libertarian theorist",
@@ -30,6 +34,43 @@
   },
   "quotes": [
     {
+      "id": "booth-01",
+      "text": "Exponentially advancing technological gains bring efficiency. That efficiency is deflationary.",
+      "author": "Jeff Booth",
+      "source": "The Greatest Game, The Bitcoin Times Ed. 3, 2020",
+      "category": "booth",
+      "length": "short",
+      "contexts": ["loading", "syncing", "first-launch", "idle"]
+    },
+    {
+      "id": "booth-02",
+      "text": "Inflation is a tax on those most unable to pay.",
+      "author": "Jeff Booth",
+      "source": "The Greatest Game, The Bitcoin Times Ed. 3, 2020",
+      "category": "booth",
+      "length": "short",
+      "contexts": ["loading", "balance-update", "transaction-sent", "idle"]
+    },
+    {
+      "id": "booth-03",
+      "text": "For the first time in history… the unique characteristics of Bitcoin give everyone a choice on how they play the game.",
+      "author": "Jeff Booth",
+      "source": "The Greatest Game, The Bitcoin Times Ed. 3, 2020",
+      "category": "booth",
+      "length": "medium",
+      "contexts": ["first-launch", "transaction-confirm", "transaction-sent"]
+    },
+    {
+      "id": "booth-04",
+      "text": "Learn about Bitcoin. Learn why its importance is so much greater than the wealth it might create for you and your family.",
+      "author": "Jeff Booth",
+      "source": "The Greatest Game, The Bitcoin Times Ed. 3, 2020",
+      "category": "booth",
+      "length": "medium",
+      "contexts": ["first-launch", "backup-reminder", "empty-wallet"]
+    },
+
+    {
       "id": "ammous-01",
       "text": "Bitcoin is the hardest money ever invented: growth in its value cannot possibly increase its supply.",
       "author": "Saifedean Ammous",
@@ -46,6 +87,43 @@
       "category": "ammous",
       "length": "medium",
       "contexts": ["loading", "syncing"]
+    },
+
+    {
+      "id": "svetski-01",
+      "text": "The Samurai believed in doing, not saying. Action and behavior demonstrated their faith, knowledge and values, more than words ever could.",
+      "author": "Aleks Svetski",
+      "source": "The Bushido of Bitcoin, 2024 (p. 56)",
+      "category": "svetski",
+      "length": "medium",
+      "contexts": ["backup-reminder", "transaction-confirm", "first-launch", "transaction-sent"]
+    },
+    {
+      "id": "svetski-02",
+      "text": "There is a biological and memetic recognition that a return to paternal leadership and traditional \"revolutionary\" stability are what's needed to correct our bent-out-of-shape society and inverted culture. For this, patriarchs of a new caliber must rise - mature and responsible men who both respect tradition and have the courage to venture forth and establish something new.",
+      "author": "Aleks Svetski",
+      "source": "The Bushido of Bitcoin, 2024 (p. 297)",
+      "category": "svetski",
+      "length": "medium",
+      "contexts": ["first-launch", "idle"]
+    },
+    {
+      "id": "svetski-03",
+      "text": "This period of human history will not only herald the largest wealth transfer in human history, but I'd go so far as to call it a speciation event.",
+      "author": "Aleks Svetski",
+      "source": "The Bushido of Bitcoin, 2024 (p. 465)",
+      "category": "svetski",
+      "length": "medium",
+      "contexts": ["first-launch", "idle", "balance-update"]
+    },
+    {
+      "id": "svetski-04",
+      "text": "Beauty and life always win in the end, and this is why I believe that we had to go through this. We are the marble, and we are sculpting something new.",
+      "author": "Aleks Svetski",
+      "source": "The Bushido of Bitcoin, 2024 (p. 466)",
+      "category": "svetski",
+      "length": "medium",
+      "contexts": ["first-launch", "idle", "error"]
     },
 
     {
@@ -202,6 +280,53 @@
       "category": "satoshi",
       "length": "medium",
       "contexts": ["transaction-confirm", "transaction-sent", "first-launch"]
+    },
+
+    {
+      "id": "sovereign-01",
+      "text": "Faster than all but a few now imagine, microprocessing will subvert and destroy the nationstate, creating new forms of social organization in the process.",
+      "author": "James Dale Davidson & Lord William Rees-Mogg",
+      "source": "The Sovereign Individual, 1997",
+      "category": "sovereign",
+      "length": "medium",
+      "contexts": ["loading", "first-launch", "syncing", "idle"]
+    },
+    {
+      "id": "sovereign-02",
+      "text": "In the new millennium, cybermoney controlled by private markets will supersede fiat money issued by governments. Only the poor will be victims of inflation.",
+      "author": "James Dale Davidson & Lord William Rees-Mogg",
+      "source": "The Sovereign Individual, 1997",
+      "category": "sovereign",
+      "length": "medium",
+      "contexts": ["loading", "balance-update", "idle", "transaction-sent"]
+    },
+    {
+      "id": "sovereign-03",
+      "text": "New technologies will allow the holders of wealth to bypass the national monopolies that have issued and regulated money in the modern period.",
+      "author": "James Dale Davidson & Lord William Rees-Mogg",
+      "source": "The Sovereign Individual, 1997",
+      "category": "sovereign",
+      "length": "medium",
+      "contexts": ["first-launch", "transaction-sent", "transaction-confirm", "backup-reminder"]
+    },
+    {
+      "id": "sovereign-04",
+      "text": "An entirely new realm of economic activity that is not hostage to physical violence will emerge in cyberspace.",
+      "author": "James Dale Davidson & Lord William Rees-Mogg",
+      "source": "The Sovereign Individual, 1997",
+      "category": "sovereign",
+      "length": "short",
+      "contexts": ["loading", "syncing", "first-launch", "idle"]
+    },
+
+    {
+      "id": "fuller-01",
+      "text": "You never change things by fighting the existing reality. To change something, build a new model that makes the existing model obsolete.",
+      "author": "R. Buckminster Fuller",
+      "source": "Widely attributed; cited by Jeff Booth in The Greatest Game, 2020",
+      "category": "fuller",
+      "length": "medium",
+      "contexts": ["loading", "first-launch", "idle", "empty-wallet"]
     },
 
     {


### PR DESCRIPTION
…otes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted UI/state gating for Liquid transactions refresh and presentation tweaks; no auth, payments signing, or persistence changes.
> 
> **Overview**
> **Liquid Transactions** no longer uses generic **`Reload`** when Breez events fire while that screen is open. SDK-driven updates now go through **`LiquidTransactionsMessage::BackgroundRefresh`**, which only runs when the list is idle (page 0, no selected payment/refundable, no modal) and at least **10s** since the last refresh. It calls **`fetch_page(0)`** instead of **`reload()`**, so the payment list stays visible and drill-down/refund UI is not cleared.
> 
> **Celebration / empty-state UI** in `coincube-ui`: extra bottom spacing on the simple celebration layout, and full-width centering for the modal celebration card so full-page send flows don’t sit left-aligned.
> 
> **Loading quotes** JSON grows with new authors/categories (Booth, Svetski, *The Sovereign Individual*, Fuller, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51977ac49d268c0b073e8953359375b79daafc15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Liquid Transactions panel reload requests while viewing transactions
  * Implemented rate-limiting for background refreshes to improve performance and reduce excessive data fetching

* **UI Improvements**
  * Enhanced celebration page layouts with improved spacing and better card styling for visual clarity

* **Content**
  * Expanded loading screen quotes collection with additional entries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coincubetech/coincube/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->