### PR TITLE
Cleanup sats/BTC wording for receive

### DIFF
--- a/coincube-gui/src/app/state/liquid/receive.rs
+++ b/coincube-gui/src/app/state/liquid/receive.rs
@@ -1,6 +1,16 @@
 use std::convert::TryInto;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+/// Minimum gap between `Message::Tick` background refreshes of the
+/// Receive panel's "Last transactions" list. The SDK fires events
+/// (`PaymentSucceeded`, `PaymentWaitingConfirmation`, `Synced`) that
+/// already drive a `RefreshRequested` via `active_liquid_refresh`, so
+/// this Tick is a backstop for the case where the Breez Liquid SDK
+/// lags behind the chain (or an event is missed) and a freshly-
+/// observed incoming tx would otherwise sit invisible until the user
+/// navigates away and back.
+const LIQUID_RECEIVE_RELOAD_MAX_TTL: Duration = Duration::from_secs(10);
 
 use coincube_core::miniscript::bitcoin::{Amount, Denomination};
 use coincube_ui::component::form;
@@ -77,6 +87,10 @@ pub struct LiquidReceive {
     received_celebration_context: String,
     received_quote: coincube_ui::component::quote_display::Quote,
     received_image_handle: iced::widget::image::Handle,
+    /// Last time `load_recent_transactions` was issued — gates the
+    /// `Message::Tick` background refresh below
+    /// `LIQUID_RECEIVE_RELOAD_MAX_TTL`.
+    last_reload: Instant,
 }
 
 impl LiquidReceive {
@@ -137,6 +151,7 @@ impl LiquidReceive {
             received_image_handle: coincube_ui::component::quote_display::image_handle_for_context(
                 "liquid-receive",
             ),
+            last_reload: Instant::now(),
         }
     }
 
@@ -274,6 +289,35 @@ impl State for LiquidReceive {
         // When SideShift flow is active, ignore other messages
         if self.sideshift_flow.is_some() {
             return Task::none();
+        }
+
+        // Background refresh of the "Last transactions" list when the
+        // user is idle on the Receive panel. The SDK event path
+        // (`active_liquid_refresh` → `RefreshRequested`) is the primary
+        // refresh — this Tick covers the case where the Breez Liquid
+        // SDK lags behind the chain or never fires an event for a
+        // freshly-observed incoming tx, so a 1-confirmation deposit
+        // would otherwise sit invisible until the user navigates away
+        // and back.
+        //
+        // Calls `load_recent_transactions` (not the heavy `reload`) so
+        // the receive address / picker / sideshift flow state is
+        // preserved. The DataLoaded handler replaces `recent_payments`
+        // atomically, so the visible list doesn't flash.
+        //
+        // Gated to only fire when no picker / QR modal / sync is in
+        // progress, and only after `LIQUID_RECEIVE_RELOAD_MAX_TTL` has
+        // elapsed since the last reload — the TTL doubles as a
+        // debounce against SDK event bursts.
+        if matches!(message, Message::Tick)
+            && !self.receive_picker_open
+            && !self.sender_picker_open
+            && !self.show_qr_modal
+            && !self.loading
+            && Instant::now() > self.last_reload + LIQUID_RECEIVE_RELOAD_MAX_TTL
+        {
+            self.last_reload = Instant::now();
+            return self.load_recent_transactions();
         }
 
         if let Message::View(view::Message::LiquidReceive(msg)) = message {
@@ -737,6 +781,7 @@ impl State for LiquidReceive {
                     return redirect(Menu::Liquid(LiquidSubMenu::Transactions(None)));
                 }
                 LiquidReceiveMessage::RefreshRequested => {
+                    self.last_reload = Instant::now();
                     return self.load_recent_transactions();
                 }
             }
@@ -752,6 +797,7 @@ impl State for LiquidReceive {
         self.sideshift_flow = None;
         self.receive_picker_open = false;
         self.sender_picker_open = false;
+        self.last_reload = Instant::now();
         // Trigger an SDK sync in the background so on-chain state is fresh.
         // When the sync completes the SDK fires SdkEvent::Synced automatically.
         let breez = self.breez_client.clone();

--- a/coincube-gui/src/app/state/liquid/receive.rs
+++ b/coincube-gui/src/app/state/liquid/receive.rs
@@ -91,6 +91,14 @@ pub struct LiquidReceive {
     /// `Message::Tick` background refresh below
     /// `LIQUID_RECEIVE_RELOAD_MAX_TTL`.
     last_reload: Instant,
+    /// In-flight guard for `load_recent_transactions`. `self.loading`
+    /// can't fill this role because it's owned by the address /
+    /// invoice generation flows; recent-transactions refreshes need a
+    /// separate flag so two of them can't overlap and deliver
+    /// out-of-order `DataLoaded` updates (a slow earlier fetch
+    /// stomping a newer one's result). Set before each fetch issues,
+    /// cleared by both the `DataLoaded` and `Error` handlers.
+    reloading_transactions: bool,
 }
 
 impl LiquidReceive {
@@ -152,6 +160,7 @@ impl LiquidReceive {
                 "liquid-receive",
             ),
             last_reload: Instant::now(),
+            reloading_transactions: false,
         }
     }
 
@@ -314,6 +323,7 @@ impl State for LiquidReceive {
             && !self.sender_picker_open
             && !self.show_qr_modal
             && !self.loading
+            && !self.reloading_transactions
             && Instant::now() > self.last_reload + LIQUID_RECEIVE_RELOAD_MAX_TTL
         {
             self.last_reload = Instant::now();
@@ -527,6 +537,14 @@ impl State for LiquidReceive {
                 }
 
                 LiquidReceiveMessage::Error(err) => {
+                    // Clear the recent-transactions guard regardless of
+                    // whether this error came from `load_recent_transactions`
+                    // or from an invoice/address generation path —
+                    // clearing a guard that was never set is a no-op,
+                    // and the alternative (only clearing on fetch-
+                    // sourced errors) would require a separate Error
+                    // variant or message tagging.
+                    self.reloading_transactions = false;
                     self.error = Some(err.to_string());
                     return Task::perform(
                         async {
@@ -651,6 +669,7 @@ impl State for LiquidReceive {
                     usdt_balance,
                     recent_payment,
                 } => {
+                    self.reloading_transactions = false;
                     self.btc_balance = btc_balance;
                     self.usdt_balance = usdt_balance;
 
@@ -1030,7 +1049,13 @@ impl LiquidReceive {
         Amount::from_str_in(&self.amount_input.value, denomination).ok()
     }
 
-    fn load_recent_transactions(&self) -> Task<Message> {
+    fn load_recent_transactions(&mut self) -> Task<Message> {
+        // Marking the in-flight guard here (rather than at each call
+        // site) means every entrypoint — `Message::Tick`,
+        // `RefreshRequested`, `SetReceiveAsset`, `reload` — picks it
+        // up automatically. Cleared by the `DataLoaded` / `Error`
+        // handlers which are the only completion paths for this fetch.
+        self.reloading_transactions = true;
         let breez_client = self.breez_client.clone();
         Task::perform(
             async move {

--- a/coincube-gui/src/app/view/global_home.rs
+++ b/coincube-gui/src/app/view/global_home.rs
@@ -635,16 +635,18 @@ fn enter_amount_card<'a>(
                             Container::new(
                                 text(match (effective_min, effective_max) {
                                     (Some(min), Some(max)) => format!(
-                                        "Enter an amount between {} and {}",
+                                        "Enter an amount between {} and {} {}",
                                         Amount::from_sat(min)
                                             .to_formatted_string_with_unit(bitcoin_unit),
                                         Amount::from_sat(max)
                                             .to_formatted_string_with_unit(bitcoin_unit),
+                                        bitcoin_unit,
                                     ),
                                     (Some(min), None) => format!(
-                                        "Minimum transfer: {}",
+                                        "Minimum transfer: {} {}",
                                         Amount::from_sat(min)
                                             .to_formatted_string_with_unit(bitcoin_unit),
+                                        bitcoin_unit,
                                     ),
                                     _ => "Loading limits…".to_string(),
                                 })

--- a/coincube-gui/src/app/view/liquid/receive.rs
+++ b/coincube-gui/src/app/view/liquid/receive.rs
@@ -679,9 +679,10 @@ fn input_fields<'a>(
         let max_btc = Amount::from_sat(max_sat);
         hints = hints.push(
             text(format!(
-                "Enter an amount between {} and {}",
+                "Enter an amount between {} and {} {}",
                 min_btc.to_formatted_string_with_unit(bitcoin_unit),
                 max_btc.to_formatted_string_with_unit(bitcoin_unit),
+                bitcoin_unit,
             ))
             .size(12)
             .style(theme::text::secondary),

--- a/coincube-gui/src/app/view/liquid/send.rs
+++ b/coincube-gui/src/app/view/liquid/send.rs
@@ -1031,9 +1031,10 @@ pub fn amount_input_model<'a>(config: AmountInputConfig<'a>) -> Element<'a, Liqu
                         let max_btc = Amount::from_sat(max_sat);
                         amount_input_section = amount_input_section.push(
                             text(format!(
-                                "Enter an amount between {} and {}",
+                                "Enter an amount between {} and {} {}",
                                 min_btc.to_formatted_string_with_unit(config.bitcoin_unit),
                                 max_btc.to_formatted_string_with_unit(config.bitcoin_unit),
+                                config.bitcoin_unit,
                             ))
                             .size(12),
                         );
@@ -1043,9 +1044,10 @@ pub fn amount_input_model<'a>(config: AmountInputConfig<'a>) -> Element<'a, Liqu
                     let max_btc = Amount::from_sat(max_sat);
                     amount_input_section = amount_input_section.push(
                         text(format!(
-                            "Enter an amount between {} and {}",
+                            "Enter an amount between {} and {} {}",
                             min_btc.to_formatted_string_with_unit(config.bitcoin_unit),
                             max_btc.to_formatted_string_with_unit(config.bitcoin_unit),
+                            config.bitcoin_unit,
                         ))
                         .size(12),
                     );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI polling and hint text only; no auth or payment logic changes beyond safer, debounced recent-payment refresh on the receive screen.
> 
> **Overview**
> **Liquid Receive** now **polls “Last transactions” on idle `Message::Tick`** (at most every **10s**), calling **`load_recent_transactions`** instead of a full **`reload`** so address/QR state stays intact. Refreshes are **skipped** while pickers, QR modal, invoice **`loading`**, or an in-flight fetch run; **`reloading_transactions`** plus **`last_reload`** avoid overlapping/stale **`DataLoaded`** results. **`RefreshRequested`** and **`reload`** also reset the debounce clock.
> 
> **Copy:** min/max amount hints on **global home transfer**, **Liquid receive** (Lightning), and **Liquid send** now append the active **`bitcoin_unit`** (e.g. sats/BTC) after the formatted bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab056a64a38620ece6ce02580226fa4d404b92bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized automatic reload behavior for "Last transactions" panel on Liquid receive

* **Style**
  * Updated amount input hints to explicitly display selected bitcoin unit alongside transfer limits

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coincubetech/coincube/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->