### PR TITLE
Resend signup OTP for unverified users during login

### DIFF
--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -587,14 +587,19 @@ impl ConnectAccountPanel {
                             },
                         )),
                         Err(e) => {
-                            let msg = e.to_string();
-                            if msg.contains("Email not verified") {
+                            let is_unverified = matches!(
+                                &e,
+                                crate::services::coincube::CoincubeError::Unsuccessful(info)
+                                    if info.status_code == 401
+                                        && info.text.contains("Email not verified")
+                            );
+                            if is_unverified {
                                 Message::View(view::Message::ConnectAccount(
                                     ConnectAccountMessage::EmailNotVerified { email },
                                 ))
                             } else {
                                 Message::View(view::Message::ConnectAccount(
-                                    ConnectAccountMessage::Error(msg),
+                                    ConnectAccountMessage::Error(e.to_string()),
                                 ))
                             }
                         }
@@ -697,9 +702,7 @@ impl ConnectAccountPanel {
                 return iced::Task::perform(
                     async move {
                         if is_signup {
-                            client
-                                .signup_send_otp(OtpRequest { email: email_val })
-                                .await
+                            client.resend_signup_otp(&email_val).await
                         } else {
                             client.login_send_otp(OtpRequest { email: email_val }).await
                         }

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -572,23 +572,32 @@ impl ConnectAccountPanel {
                 let client = self.client.clone();
                 return iced::Task::perform(
                     async move {
-                        client
+                        let result = client
                             .login_send_otp(OtpRequest {
                                 email: email_val.clone(),
                             })
-                            .await
-                            .map(|()| email_val)
+                            .await;
+                        (email_val, result)
                     },
-                    |res| match res {
-                        Ok(email) => Message::View(view::Message::ConnectAccount(
+                    |(email, res)| match res {
+                        Ok(()) => Message::View(view::Message::ConnectAccount(
                             ConnectAccountMessage::OtpRequested {
                                 email,
                                 is_signup: false,
                             },
                         )),
-                        Err(e) => Message::View(view::Message::ConnectAccount(
-                            ConnectAccountMessage::Error(e.to_string()),
-                        )),
+                        Err(e) => {
+                            let msg = e.to_string();
+                            if msg.contains("Email not verified") {
+                                Message::View(view::Message::ConnectAccount(
+                                    ConnectAccountMessage::EmailNotVerified { email },
+                                ))
+                            } else {
+                                Message::View(view::Message::ConnectAccount(
+                                    ConnectAccountMessage::Error(msg),
+                                ))
+                            }
+                        }
                     },
                 );
             }
@@ -752,6 +761,28 @@ impl ConnectAccountPanel {
                     |res| match res {
                         Ok(login) => Message::View(view::Message::ConnectAccount(
                             ConnectAccountMessage::SetSession(login),
+                        )),
+                        Err(e) => Message::View(view::Message::ConnectAccount(
+                            ConnectAccountMessage::Error(e.to_string()),
+                        )),
+                    },
+                );
+            }
+
+            ConnectAccountMessage::EmailNotVerified { email } => {
+                self.step = ConnectFlowStep::OtpVerification {
+                    email: email.clone(),
+                    otp: String::new(),
+                    sending: true,
+                    is_signup: true,
+                    cooldown: 0,
+                };
+                let client = self.client.clone();
+                return iced::Task::perform(
+                    async move { client.resend_signup_otp(&email).await },
+                    |res| match res {
+                        Ok(()) => Message::View(view::Message::ConnectAccount(
+                            ConnectAccountMessage::OtpResent,
                         )),
                         Err(e) => Message::View(view::Message::ConnectAccount(
                             ConnectAccountMessage::Error(e.to_string()),

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1003,6 +1003,9 @@ pub enum ConnectAccountMessage {
     ResendOtp,
     OtpResent,
     VerifyOtp,
+    EmailNotVerified {
+        email: String,
+    },
     VerifiedDevicesLoaded(Vec<crate::services::coincube::VerifiedDevice>, u64),
     LoginActivityLoaded(Vec<crate::services::coincube::LoginActivity>, u64),
     CopyToClipboard(String),

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -231,6 +231,20 @@ impl CoincubeClient {
 
         Ok(response.json().await?)
     }
+
+    pub async fn resend_signup_otp(&self, email: &str) -> Result<(), CoincubeError> {
+        let body = serde_json::json!({
+            "email": email,
+            "otp_type": "signup_otp"
+        });
+        let response = {
+            let url = format!("{}{}", self.base_url, "/api/v1/auth/resend-otp");
+            self.client.post(&url).json(&body).send()
+        }
+        .await?;
+        response.check_success().await?;
+        Ok(())
+    }
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users with unverified emails are routed into a dedicated verification flow that immediately offers to resend a signup verification code.
  * Resend signup OTP action now triggers automatically for the verification flow and resets cooldown to allow immediate retry.

* **Bug Fixes**
  * Improved detection of "email not verified" responses and clearer guidance to complete verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coincubetech/coincube/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->