### PR TITLE
Use client esplora

### DIFF
--- a/coincube-gui/src/app/state/vault/receive.rs
+++ b/coincube-gui/src/app/state/vault/receive.rs
@@ -509,6 +509,19 @@ mod tests {
             Address::from_str("tb1qkldgvljmjpxrjq2ev5qxe8dvhn0dph9q85pwtfkjeanmwdue2akqj4twxj")
                 .unwrap()
                 .assume_checked();
+        // The mock daemon is a strict ordered queue (see
+        // `utils::mock::Daemon`). Each entry consumes the next
+        // outgoing RPC. The Receive panel's `reload` and
+        // `NextReceiveAddress` paths both fire a fire-and-forget
+        // `requestsync` after their primary RPC, so the queue has
+        // to interleave them in real call order:
+        //   1. listrevealedaddresses    (reload's primary)
+        //   2. requestsync              (reload's eager-sync kick)
+        //   3. getnewaddress            (NextReceiveAddress primary)
+        //   4. requestsync              (NextReceiveAddress kick)
+        // The daemon answers `requestsync` with the empty JSON
+        // object `{}`; the client deserialises into a discarded
+        // `serde_json::Value`.
         let daemon = Daemon::new(vec![
             (
                 Some(
@@ -520,11 +533,19 @@ mod tests {
                 })),
             ),
             (
+                Some(json!({"method": "requestsync", "params": Option::<Request>::None})),
+                Ok(json!({})),
+            ),
+            (
                 Some(json!({"method": "getnewaddress", "params": Option::<Request>::None})),
                 Ok(json!(GetAddressResult::new(
                     addr.clone(),
                     ChildNumber::from_normal_idx(0).unwrap()
                 ))),
+            ),
+            (
+                Some(json!({"method": "requestsync", "params": Option::<Request>::None})),
+                Ok(json!({})),
             ),
         ]);
         let wallet = Arc::new(Wallet::new(CoincubeDescriptor::from_str(DESC).unwrap()));

--- a/coincube-gui/src/app/state/vault/receive.rs
+++ b/coincube-gui/src/app/state/vault/receive.rs
@@ -221,11 +221,19 @@ impl State for VaultReceivePanel {
                 let daemon = daemon.clone();
                 Task::perform(
                     async move {
-                        daemon
+                        let res = daemon
                             .get_new_address()
                             .await
                             .map(|res| (res.address, res.derivation_index))
-                            .map_err(|e| e.into())
+                            .map_err(|e| e.into());
+                        // User just generated a fresh receive
+                        // address — they're staring at the QR
+                        // waiting for an incoming payment, so kick
+                        // the poller for a per-SPK rescan on the
+                        // next tick instead of waiting up to 10
+                        // min for the smart-poll cadence.
+                        let _ = daemon.request_sync().await;
+                        res
                     },
                     Message::ReceiveAddress,
                 )
@@ -332,10 +340,18 @@ impl State for VaultReceivePanel {
         *self = Self::new(data_dir, wallet);
         Task::perform(
             async move {
-                daemon
+                let res = daemon
                     .list_revealed_addresses(false, true, PREV_ADDRESSES_PAGE_SIZE, None)
                     .await
-                    .map_err(|e| e.into())
+                    .map_err(|e| e.into());
+                // The Receive panel just opened — user is here to
+                // either generate a new address or check on an
+                // existing one. Kick the poller for fresh mempool
+                // state so an incoming unconfirmed tx shows up
+                // promptly instead of waiting for the smart-poll
+                // safety-net rescan.
+                let _ = daemon.request_sync().await;
+                res
             },
             |res| Message::RevealedAddresses(res, None),
         )

--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -148,23 +148,38 @@ impl BitcoindSettingsState {
             return Task::done(Message::View(view::Message::ShowError(err_msg)));
         };
         // Reconstruct URLs from cache.network so a stale fallback_esplora.addr
-        // (e.g. written before Testnet4 was handled) is never used. Primary is
-        // public Esplora; Connect is the fallback so this user's wallet sync
-        // hits the per-IP rate limits on their own IP, not on coincube-api's.
+        // (e.g. written before Testnet4 was handled) is never used. Three-tier
+        // chain: mempool.space → blockstream.info (where available) → Connect
+        // (JWT). Two independent public providers in front means a 429 from
+        // one doesn't immediately push the user onto the metered Connect URL.
         use coincubed::config::EsploraConfig;
         let primary_url = crate::installer::public_esplora_url(cache.network);
+        let public_fallback = crate::installer::public_esplora_fallback_url(cache.network);
         let connect_url = crate::installer::connect_url(cache.network);
         info!(
-            "Switching to Connect: primary={} fallback={} token_len={}",
+            "Switching to Connect: primary={} public_fallback={:?} backstop={} token_len={}",
             primary_url,
+            public_fallback,
             connect_url,
             jwt.len()
         );
+        let (fallback_addr, fallback_token, secondary_fallback_addr, secondary_fallback_token) =
+            match public_fallback {
+                Some(public_fallback) => (
+                    Some(public_fallback),
+                    None,
+                    Some(connect_url),
+                    Some(jwt),
+                ),
+                None => (Some(connect_url), Some(jwt), None, None),
+            };
         let esplora = EsploraConfig {
             addr: primary_url,
             token: None,
-            fallback_addr: Some(connect_url),
-            fallback_token: Some(jwt),
+            fallback_addr,
+            fallback_token,
+            secondary_fallback_addr,
+            secondary_fallback_token,
         };
         let mut new_cfg = cfg.clone();
         if let Some(BitcoinBackend::Bitcoind(current)) = cfg.bitcoin_backend.clone() {

--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -147,18 +147,24 @@ impl BitcoindSettingsState {
             self.warning = Some(err);
             return Task::done(Message::View(view::Message::ShowError(err_msg)));
         };
-        // Reconstruct URL from cache.network so a stale fallback_esplora.addr
-        // (e.g. written before Testnet4 was handled) is never used.
+        // Reconstruct URLs from cache.network so a stale fallback_esplora.addr
+        // (e.g. written before Testnet4 was handled) is never used. Primary is
+        // public Esplora; Connect is the fallback so this user's wallet sync
+        // hits the per-IP rate limits on their own IP, not on coincube-api's.
         use coincubed::config::EsploraConfig;
-        let esplora_url = crate::installer::connect_url(cache.network);
+        let primary_url = crate::installer::public_esplora_url(cache.network);
+        let connect_url = crate::installer::connect_url(cache.network);
         info!(
-            "Switching to Connect: url={} token_len={}",
-            esplora_url,
+            "Switching to Connect: primary={} fallback={} token_len={}",
+            primary_url,
+            connect_url,
             jwt.len()
         );
         let esplora = EsploraConfig {
-            addr: esplora_url,
-            token: Some(jwt),
+            addr: primary_url,
+            token: None,
+            fallback_addr: Some(connect_url),
+            fallback_token: Some(jwt),
         };
         let mut new_cfg = cfg.clone();
         if let Some(BitcoinBackend::Bitcoind(current)) = cfg.bitcoin_backend.clone() {

--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -183,6 +183,13 @@ impl BitcoindSettingsState {
             new_cfg.pending_bitcoind = Some(current);
         }
         new_cfg.bitcoin_backend = Some(BitcoinBackend::Esplora(esplora));
+        // Bump the poll cadence to the Esplora-safe interval so
+        // we don't carry a snappy localhost cadence into a path
+        // that pays HTTP cost per poll and would burn through
+        // public-tier rate windows. See
+        // `coincubed::config::ESPLORA_POLL_INTERVAL_SECS`.
+        new_cfg.bitcoin_config.poll_interval_secs =
+            std::time::Duration::from_secs(coincubed::config::ESPLORA_POLL_INTERVAL_SECS);
         new_cfg.fallback_esplora = None;
         self.node_switch_processing = true;
         self.warning = None;
@@ -568,6 +575,16 @@ impl State for BitcoindSettingsState {
                                 new_cfg.bitcoin_backend = Some(BitcoinBackend::Bitcoind(pending));
                                 new_cfg.pending_bitcoind = None;
                                 new_cfg.fallback_esplora = old_esplora;
+                                // Drop the poll cadence back to the
+                                // snappy local-node interval. The
+                                // Esplora-safe 10-min value made
+                                // sense for HTTPS-per-poll against
+                                // a rate-limited public provider;
+                                // bitcoind is a free localhost RPC.
+                                new_cfg.bitcoin_config.poll_interval_secs =
+                                    std::time::Duration::from_secs(
+                                        coincubed::config::LOCAL_BACKEND_POLL_INTERVAL_SECS,
+                                    );
                                 self.node_switch_processing = true;
                                 self.warning = None;
                                 return Task::done(Message::LoadDaemonConfig(Box::new(new_cfg)));

--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -165,12 +165,9 @@ impl BitcoindSettingsState {
         );
         let (fallback_addr, fallback_token, secondary_fallback_addr, secondary_fallback_token) =
             match public_fallback {
-                Some(public_fallback) => (
-                    Some(public_fallback),
-                    None,
-                    Some(connect_url),
-                    Some(jwt),
-                ),
+                Some(public_fallback) => {
+                    (Some(public_fallback), None, Some(connect_url), Some(jwt))
+                }
                 None => (Some(connect_url), Some(jwt), None, None),
             };
         let esplora = EsploraConfig {

--- a/coincube-gui/src/daemon/client/mod.rs
+++ b/coincube-gui/src/daemon/client/mod.rs
@@ -89,6 +89,13 @@ impl<C: Client + Send + Sync + Debug> Daemon for Coincubed<C> {
         self.call("getinfo", Option::<Request>::None)
     }
 
+    async fn request_sync(&self) -> Result<(), DaemonError> {
+        // The daemon returns `{}`; we don't need the payload, so
+        // deserialise into a unit value and discard.
+        let _: serde_json::Value = self.call("requestsync", Option::<Request>::None)?;
+        Ok(())
+    }
+
     async fn get_new_address(&self) -> Result<GetAddressResult, DaemonError> {
         self.call("getnewaddress", Option::<Request>::None)
     }

--- a/coincube-gui/src/daemon/embedded.rs
+++ b/coincube-gui/src/daemon/embedded.rs
@@ -101,6 +101,14 @@ impl Daemon for EmbeddedDaemon {
         self.command(|daemon| Ok(daemon.get_info())).await
     }
 
+    async fn request_sync(&self) -> Result<(), DaemonError> {
+        self.command(|daemon| {
+            daemon.request_sync();
+            Ok(())
+        })
+        .await
+    }
+
     async fn get_new_address(&self) -> Result<GetAddressResult, DaemonError> {
         self.command(|daemon| Ok(daemon.get_new_address())).await
     }

--- a/coincube-gui/src/daemon/mod.rs
+++ b/coincube-gui/src/daemon/mod.rs
@@ -108,6 +108,14 @@ pub trait Daemon: Debug {
     ) -> Result<(), DaemonError>;
     async fn stop(&self) -> Result<(), DaemonError>;
     async fn get_info(&self) -> Result<model::GetInfoResult, DaemonError>;
+    /// Ask the daemon's poller to run a sync now, bypassing both
+    /// the remaining sleep on the poll-interval timer and the
+    /// Esplora backend's smart-poll tip-guard. Fire-and-forget —
+    /// the daemon kicks the poller and returns immediately; the
+    /// new state surfaces via the next `get_info`/state refresh.
+    /// Hooked into the GUI on app focus, Receive panel opens, and
+    /// new receive-address generation.
+    async fn request_sync(&self) -> Result<(), DaemonError>;
     async fn get_new_address(&self) -> Result<model::GetAddressResult, DaemonError>;
     async fn list_revealed_addresses(
         &self,

--- a/coincube-gui/src/installer/migration.rs
+++ b/coincube-gui/src/installer/migration.rs
@@ -1,0 +1,558 @@
+//! One-shot migration of an existing per-vault `daemon.toml` from the
+//! old Connect-only Esplora layout to the new public-primary +
+//! Connect-fallback layout.
+//!
+//! Before this round, [`super::connect_url`] was the daemon's only
+//! Esplora endpoint. New installs now use [`super::public_esplora_url`]
+//! as `addr` and the Connect URL as `fallback_addr`, so wallet sync
+//! traffic distributes across users' IPs instead of consolidating on
+//! coincube-api's IP. Existing vaults already on disk wouldn't pick
+//! that up without re-running the installer; this module rewrites
+//! their `daemon.toml` in place at GUI startup.
+//!
+//! Idempotent: a daemon.toml that already has `fallback_addr` set, or
+//! whose `addr` doesn't exactly match the Connect URL for its
+//! network, is left untouched. So users who chose a custom Esplora
+//! during install (or who already migrated) aren't disturbed.
+
+use std::path::Path;
+
+use coincube_core::miniscript::bitcoin::Network;
+
+/// Migrate the daemon config at `path`, if applicable. Returns
+/// `Ok(true)` when the file was rewritten, `Ok(false)` when no
+/// migration was needed (missing file, already migrated, custom
+/// Esplora, non-Esplora backend).
+///
+/// I/O failures while reading or writing surface as `Err`; a parse
+/// failure on the existing TOML is treated as "leave it alone" and
+/// returns `Ok(false)` after a warning log, because we'd rather skip
+/// migration than corrupt a user's config on a schema we don't
+/// understand.
+pub(crate) fn migrate_esplora_config(path: &Path) -> std::io::Result<bool> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e),
+    };
+
+    // toml 0.9 dropped `FromStr` for `Value`; top-level documents
+    // parse as `Table` now.
+    let mut value: toml::Table = match toml::from_str(&text) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                "esplora-config migration: skipping {} (parse failed: {})",
+                path.display(),
+                e,
+            );
+            return Ok(false);
+        }
+    };
+
+    // Identify the network from the bitcoin_config block — we need
+    // it to compute the expected Connect URL for the comparison
+    // below. Reading it from the same file (rather than asking the
+    // caller) keeps the migration self-contained and removes a way
+    // for caller/file disagreement to silently misclassify the addr.
+    let network = match value
+        .get("bitcoin_config")
+        .and_then(|v| v.get("network"))
+        .and_then(|v| v.as_str())
+        .and_then(parse_network)
+    {
+        Some(n) => n,
+        None => return Ok(false),
+    };
+
+    // `bitcoin_backend` on `coincubed::config::Config` is
+    // `#[serde(flatten)]`, so an `Esplora(EsploraConfig)` variant
+    // serialises with `[esplora_config]` at the document root rather
+    // than under a `[bitcoin_backend.esplora_config]` table. (This
+    // bit me on the first cut of this migration — it parsed but
+    // matched nothing in the wild because the path didn't exist.)
+    let Some(esplora) = value
+        .get_mut("esplora_config")
+        .and_then(|v| v.as_table_mut())
+    else {
+        // Not an Esplora backend (Bitcoind / Electrum / missing) —
+        // nothing to migrate.
+        return Ok(false);
+    };
+
+    let connect = super::connect_url(network);
+    let mempool = super::public_esplora_url(network);
+
+    // Three distinct cases we accept:
+    //   Case A — pre-fallback (addr=Connect, no fallback):
+    //     promote Connect to fallback, set mempool.space as primary,
+    //     and (where blockstream is available) insert it as
+    //     fallback so Connect ends up at secondary_fallback.
+    //   Case B — previously migrated two-tier (addr=mempool,
+    //     fallback=Connect, no secondary_fallback): insert
+    //     blockstream as fallback and shift Connect to
+    //     secondary_fallback. This is the path users on the
+    //     intermediate two-tier shape take when upgrading.
+    //   Anything else — user-customised addr, three-tier already in
+    //     place, non-Esplora backend — gets left alone.
+    let public_fallback = super::public_esplora_fallback_url(network);
+    let addr = esplora
+        .get("addr")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let has_fallback_addr = esplora.contains_key("fallback_addr");
+    let fallback_addr_str = esplora
+        .get("fallback_addr")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let has_secondary_fallback_addr = esplora.contains_key("secondary_fallback_addr");
+
+    if addr == connect && !has_fallback_addr {
+        // Case A.
+        let primary_token = esplora
+            .get("token")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        esplora.insert("addr".to_string(), toml::Value::String(mempool));
+        // mempool.space is anonymous — drop the inherited token from
+        // the primary slot; it re-appears below on whichever slot the
+        // Connect URL ends up in.
+        esplora.remove("token");
+        match public_fallback {
+            Some(blockstream) => {
+                esplora.insert(
+                    "fallback_addr".to_string(),
+                    toml::Value::String(blockstream),
+                );
+                esplora.insert(
+                    "secondary_fallback_addr".to_string(),
+                    toml::Value::String(connect),
+                );
+                if let Some(token) = primary_token {
+                    esplora.insert(
+                        "secondary_fallback_token".to_string(),
+                        toml::Value::String(token),
+                    );
+                }
+            }
+            None => {
+                esplora.insert("fallback_addr".to_string(), toml::Value::String(connect));
+                if let Some(token) = primary_token {
+                    esplora.insert(
+                        "fallback_token".to_string(),
+                        toml::Value::String(token),
+                    );
+                }
+            }
+        }
+    } else if addr == mempool
+        && fallback_addr_str.as_deref() == Some(connect.as_str())
+        && !has_secondary_fallback_addr
+    {
+        // Case B — needs `public_fallback` to actually be available;
+        // otherwise we'd shift Connect down to secondary_fallback
+        // and leave nothing in the middle slot, which is no better
+        // than what we started with.
+        let Some(blockstream) = public_fallback else {
+            return Ok(false);
+        };
+        let fallback_token = esplora
+            .get("fallback_token")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        esplora.insert(
+            "fallback_addr".to_string(),
+            toml::Value::String(blockstream),
+        );
+        // blockstream.info is anonymous — drop any inherited
+        // fallback_token; it re-appears under secondary_fallback_token
+        // below.
+        esplora.remove("fallback_token");
+        esplora.insert(
+            "secondary_fallback_addr".to_string(),
+            toml::Value::String(connect),
+        );
+        if let Some(token) = fallback_token {
+            esplora.insert(
+                "secondary_fallback_token".to_string(),
+                toml::Value::String(token),
+            );
+        }
+    } else {
+        // Customised, already three-tier, or some other shape — skip.
+        return Ok(false);
+    }
+
+    let serialized = toml::to_string_pretty(&value)
+        .map_err(|e| std::io::Error::other(format!("serialize daemon.toml: {}", e)))?;
+
+    // Atomic rewrite: write to a sibling tmp and rename. A
+    // crash mid-write would otherwise leave a half-written file
+    // that the daemon would refuse to start with.
+    let tmp = path.with_extension("toml.tmp");
+    std::fs::write(&tmp, serialized)?;
+    std::fs::rename(&tmp, path)?;
+
+    tracing::info!(
+        "esplora-config migration: rewrote provider chain in {}",
+        path.display(),
+    );
+    Ok(true)
+}
+
+/// Map the `network` field from the daemon TOML to a [`Network`].
+/// Mirrors the strings serde uses for `bitcoin::Network` so we don't
+/// have to thread a serde-typed Config through the migration.
+fn parse_network(s: &str) -> Option<Network> {
+    match s {
+        "bitcoin" => Some(Network::Bitcoin),
+        "testnet" => Some(Network::Testnet),
+        "testnet4" => Some(Network::Testnet4),
+        "signet" => Some(Network::Signet),
+        "regtest" => Some(Network::Regtest),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh_path() -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "coincube-migration-test-{}.toml",
+            uuid::Uuid::new_v4()
+        ));
+        p
+    }
+
+    /// Build a daemon.toml string that points `addr` at the Connect
+    /// URL for the given network, optionally with a JWT token. This
+    /// is the shape every existing pre-migration vault has on disk.
+    ///
+    /// Critically, `[esplora_config]` lives at the document root
+    /// (not under `[bitcoin_backend]`) because the `bitcoin_backend`
+    /// field on the real `Config` struct is `#[serde(flatten)]`.
+    fn legacy_connect_toml(network: Network, token: Option<&str>) -> String {
+        let network_str = match network {
+            Network::Bitcoin => "bitcoin",
+            Network::Testnet => "testnet",
+            Network::Testnet4 => "testnet4",
+            Network::Signet => "signet",
+            Network::Regtest => "regtest",
+        };
+        let token_line = match token {
+            Some(t) => format!("token = \"{}\"\n", t),
+            None => String::new(),
+        };
+        format!(
+            r#"
+data_directory = "/tmp/whatever"
+log_level = "debug"
+
+[bitcoin_config]
+network = "{network}"
+poll_interval_secs = 30
+
+[esplora_config]
+addr = "{addr}"
+{token_line}
+"#,
+            network = network_str,
+            addr = super::super::connect_url(network),
+            token_line = token_line,
+        )
+    }
+
+    #[test]
+    fn missing_file_is_a_noop() {
+        let p = fresh_path();
+        assert!(!p.exists());
+        let migrated = migrate_esplora_config(&p).expect("ok");
+        assert!(!migrated);
+        assert!(!p.exists(), "migration must not create the file");
+    }
+
+    #[test]
+    fn migrates_connect_addr_with_token_to_three_tier() {
+        let p = fresh_path();
+        std::fs::write(
+            &p,
+            legacy_connect_toml(Network::Bitcoin, Some("jwt-token-here")),
+        )
+        .expect("seed");
+
+        let migrated = migrate_esplora_config(&p).expect("ok");
+        assert!(migrated, "legacy-Connect addr must trigger migration");
+
+        let after = std::fs::read_to_string(&p).expect("read back");
+        let parsed: toml::Table = toml::from_str(&after).expect("re-parse");
+        let esplora = parsed
+            .get("esplora_config")
+            .and_then(|v| v.as_table())
+            .expect("esplora_config table present");
+
+        assert_eq!(
+            esplora.get("addr").and_then(|v| v.as_str()),
+            Some(super::super::public_esplora_url(Network::Bitcoin).as_str()),
+            "primary must now be mempool.space",
+        );
+        assert!(
+            !esplora.contains_key("token"),
+            "primary token must be cleared (mempool.space is anonymous)",
+        );
+        assert_eq!(
+            esplora.get("fallback_addr").and_then(|v| v.as_str()),
+            super::super::public_esplora_fallback_url(Network::Bitcoin).as_deref(),
+            "blockstream.info must be inserted as the middle fallback on mainnet",
+        );
+        assert!(
+            !esplora.contains_key("fallback_token"),
+            "blockstream.info is anonymous so no fallback_token should be written",
+        );
+        assert_eq!(
+            esplora.get("secondary_fallback_addr").and_then(|v| v.as_str()),
+            Some(super::super::connect_url(Network::Bitcoin).as_str()),
+            "Connect URL must move to secondary_fallback_addr",
+        );
+        assert_eq!(
+            esplora.get("secondary_fallback_token").and_then(|v| v.as_str()),
+            Some("jwt-token-here"),
+            "JWT must move to secondary_fallback_token",
+        );
+
+        std::fs::remove_file(&p).ok();
+    }
+
+    /// Case B — user is already on the intermediate two-tier shape
+    /// (`addr=mempool, fallback=Connect`). The migration must insert
+    /// blockstream.info as the new middle tier and shift Connect to
+    /// `secondary_fallback`, preserving its JWT.
+    #[test]
+    fn migrates_two_tier_to_three_tier_inserting_blockstream() {
+        let p = fresh_path();
+        let two_tier = format!(
+            r#"
+data_directory = "/tmp/whatever"
+log_level = "debug"
+
+[bitcoin_config]
+network = "bitcoin"
+poll_interval_secs = 30
+
+[esplora_config]
+addr = "{primary}"
+fallback_addr = "{connect}"
+fallback_token = "jwt-token-here"
+"#,
+            primary = super::super::public_esplora_url(Network::Bitcoin),
+            connect = super::super::connect_url(Network::Bitcoin),
+        );
+        std::fs::write(&p, two_tier).expect("seed");
+
+        let migrated = migrate_esplora_config(&p).expect("ok");
+        assert!(migrated, "two-tier shape must trigger insertion of blockstream");
+
+        let after = std::fs::read_to_string(&p).expect("read back");
+        let parsed: toml::Table = toml::from_str(&after).expect("re-parse");
+        let esplora = parsed
+            .get("esplora_config")
+            .and_then(|v| v.as_table())
+            .expect("esplora_config table present");
+
+        assert_eq!(
+            esplora.get("addr").and_then(|v| v.as_str()),
+            Some(super::super::public_esplora_url(Network::Bitcoin).as_str()),
+            "primary stays at mempool.space",
+        );
+        assert_eq!(
+            esplora.get("fallback_addr").and_then(|v| v.as_str()),
+            super::super::public_esplora_fallback_url(Network::Bitcoin).as_deref(),
+            "fallback must now be blockstream.info",
+        );
+        assert!(
+            !esplora.contains_key("fallback_token"),
+            "blockstream.info is anonymous — fallback_token must be cleared",
+        );
+        assert_eq!(
+            esplora.get("secondary_fallback_addr").and_then(|v| v.as_str()),
+            Some(super::super::connect_url(Network::Bitcoin).as_str()),
+            "Connect URL must shift down to secondary_fallback_addr",
+        );
+        assert_eq!(
+            esplora.get("secondary_fallback_token").and_then(|v| v.as_str()),
+            Some("jwt-token-here"),
+            "JWT must move from fallback_token to secondary_fallback_token",
+        );
+
+        std::fs::remove_file(&p).ok();
+    }
+
+    /// A second pass over an already-three-tier config must be a
+    /// byte-identical no-op. This catches a class of bugs where
+    /// the migration would re-apply Case B to its own output.
+    #[test]
+    fn three_tier_config_is_idempotent_noop() {
+        let p = fresh_path();
+        std::fs::write(
+            &p,
+            legacy_connect_toml(Network::Bitcoin, Some("jwt-token-here")),
+        )
+        .expect("seed");
+        // Case-A → three tier.
+        assert!(migrate_esplora_config(&p).expect("ok"));
+        let after_first = std::fs::read_to_string(&p).expect("read");
+
+        // Second pass must no-op.
+        assert!(!migrate_esplora_config(&p).expect("ok"));
+        let after_second = std::fs::read_to_string(&p).expect("read");
+        assert_eq!(after_first, after_second);
+
+        std::fs::remove_file(&p).ok();
+    }
+
+    /// On a network where blockstream has no public Esplora
+    /// (signet / testnet4 / regtest), Case A still applies but the
+    /// result is only two-tier (mempool → Connect), with nothing
+    /// in `secondary_fallback`. This matches the previous behaviour
+    /// exactly for those networks — we don't synthesise a middle
+    /// tier we don't actually have an endpoint for.
+    #[test]
+    fn case_a_falls_back_to_two_tier_when_blockstream_unavailable() {
+        let p = fresh_path();
+        std::fs::write(&p, legacy_connect_toml(Network::Signet, Some("sig-jwt"))).expect("seed");
+        let migrated = migrate_esplora_config(&p).expect("ok");
+        assert!(migrated);
+
+        let after = std::fs::read_to_string(&p).expect("read back");
+        let parsed: toml::Table = toml::from_str(&after).expect("re-parse");
+        let esplora = parsed
+            .get("esplora_config")
+            .and_then(|v| v.as_table())
+            .expect("esplora_config table");
+
+        assert_eq!(
+            esplora.get("addr").and_then(|v| v.as_str()),
+            Some(super::super::public_esplora_url(Network::Signet).as_str()),
+        );
+        assert_eq!(
+            esplora.get("fallback_addr").and_then(|v| v.as_str()),
+            Some(super::super::connect_url(Network::Signet).as_str()),
+        );
+        assert_eq!(
+            esplora.get("fallback_token").and_then(|v| v.as_str()),
+            Some("sig-jwt"),
+        );
+        assert!(!esplora.contains_key("secondary_fallback_addr"));
+        assert!(!esplora.contains_key("secondary_fallback_token"));
+
+        std::fs::remove_file(&p).ok();
+    }
+
+    /// An input config that had no primary `token` (which would be
+    /// unusual but is supported by the schema) must not synthesise
+    /// either a `fallback_token` or a `secondary_fallback_token` — we
+    /// only ever propagate tokens that actually existed.
+    #[test]
+    fn migration_without_token_leaves_token_slots_absent() {
+        let p = fresh_path();
+        std::fs::write(&p, legacy_connect_toml(Network::Bitcoin, None)).expect("seed");
+
+        let migrated = migrate_esplora_config(&p).expect("ok");
+        assert!(migrated);
+
+        let after = std::fs::read_to_string(&p).expect("read back");
+        let parsed: toml::Table = toml::from_str(&after).expect("re-parse");
+        let esplora = parsed
+            .get("esplora_config")
+            .and_then(|v| v.as_table())
+            .expect("esplora_config table");
+        assert!(!esplora.contains_key("fallback_token"));
+        assert!(!esplora.contains_key("secondary_fallback_token"));
+
+        std::fs::remove_file(&p).ok();
+    }
+
+    // The older `already_migrated_file_is_idempotent_noop` test was
+    // replaced by `three_tier_config_is_idempotent_noop` below — both
+    // exercise the same "second pass is a byte-identical no-op"
+    // property, but the new test runs against the current three-tier
+    // output, which is what we actually persist now.
+
+    #[test]
+    fn user_customized_addr_is_left_alone() {
+        // User chose mempool.space (or any non-Connect URL) during
+        // install. The migration must not touch their `addr`, even
+        // though `fallback_addr` is absent.
+        let p = fresh_path();
+        let custom = r#"
+data_directory = "/tmp/whatever"
+log_level = "debug"
+
+[bitcoin_config]
+network = "bitcoin"
+poll_interval_secs = 30
+
+[esplora_config]
+addr = "https://blockstream.info/api"
+"#;
+        std::fs::write(&p, custom).expect("seed");
+        let before = std::fs::read_to_string(&p).expect("read");
+
+        let migrated = migrate_esplora_config(&p).expect("ok");
+        assert!(!migrated, "custom addr must be left alone");
+
+        let after = std::fs::read_to_string(&p).expect("read");
+        assert_eq!(before, after, "file must be byte-identical");
+
+        std::fs::remove_file(&p).ok();
+    }
+
+    #[test]
+    fn non_esplora_backend_is_left_alone() {
+        // Bitcoind backend has no esplora_config table — must skip.
+        let p = fresh_path();
+        let bitcoind = r#"
+data_directory = "/tmp/whatever"
+log_level = "debug"
+
+[bitcoin_config]
+network = "bitcoin"
+poll_interval_secs = 30
+
+[bitcoind_config]
+network = "bitcoin"
+addr = "127.0.0.1:8332"
+"#;
+        std::fs::write(&p, bitcoind).expect("seed");
+        let before = std::fs::read_to_string(&p).expect("read");
+
+        let migrated = migrate_esplora_config(&p).expect("ok");
+        assert!(!migrated);
+
+        let after = std::fs::read_to_string(&p).expect("read");
+        assert_eq!(before, after);
+
+        std::fs::remove_file(&p).ok();
+    }
+
+    #[test]
+    fn parse_failure_is_a_noop_not_an_error() {
+        // A daemon.toml the migration can't parse (perhaps a future
+        // schema we don't recognise) must be left untouched, not
+        // raised as an error that blocks GUI startup.
+        let p = fresh_path();
+        std::fs::write(&p, "this is = not [valid TOML").expect("seed");
+        let before = std::fs::read_to_string(&p).expect("read");
+
+        let migrated = migrate_esplora_config(&p).expect("must not raise");
+        assert!(!migrated);
+
+        let after = std::fs::read_to_string(&p).expect("read");
+        assert_eq!(before, after);
+
+        std::fs::remove_file(&p).ok();
+    }
+}

--- a/coincube-gui/src/installer/migration.rs
+++ b/coincube-gui/src/installer/migration.rs
@@ -151,10 +151,7 @@ pub(crate) fn migrate_esplora_config(path: &Path) -> std::io::Result<bool> {
             None => {
                 esplora.insert("fallback_addr".to_string(), toml::Value::String(connect));
                 if let Some(token) = primary_token {
-                    esplora.insert(
-                        "fallback_token".to_string(),
-                        toml::Value::String(token),
-                    );
+                    esplora.insert("fallback_token".to_string(), toml::Value::String(token));
                 }
             }
         }
@@ -380,8 +377,7 @@ secondary_fallback_addr = "{connect}"
 secondary_fallback_token = "jwt-here"
 "#,
             primary = super::super::public_esplora_url(Network::Bitcoin),
-            blockstream =
-                super::super::public_esplora_fallback_url(Network::Bitcoin).unwrap(),
+            blockstream = super::super::public_esplora_fallback_url(Network::Bitcoin).unwrap(),
             connect = super::super::connect_url(Network::Bitcoin),
         );
         std::fs::write(&p, three_tier).expect("seed");
@@ -426,8 +422,7 @@ fallback_addr = "{blockstream}"
 secondary_fallback_addr = "{connect}"
 "#,
             primary = super::super::public_esplora_url(Network::Bitcoin),
-            blockstream =
-                super::super::public_esplora_fallback_url(Network::Bitcoin).unwrap(),
+            blockstream = super::super::public_esplora_fallback_url(Network::Bitcoin).unwrap(),
             connect = super::super::connect_url(Network::Bitcoin),
         );
         std::fs::write(&p, custom).expect("seed");
@@ -465,7 +460,10 @@ addr = "127.0.0.1:8332"
         assert!(!migrate_esplora_config(&p).expect("ok"));
 
         let after = std::fs::read_to_string(&p).expect("read");
-        assert_eq!(before, after, "bitcoind backend must not have its poll bumped");
+        assert_eq!(
+            before, after,
+            "bitcoind backend must not have its poll bumped"
+        );
 
         std::fs::remove_file(&p).ok();
     }
@@ -517,12 +515,16 @@ addr = "127.0.0.1:8332"
             "blockstream.info is anonymous so no fallback_token should be written",
         );
         assert_eq!(
-            esplora.get("secondary_fallback_addr").and_then(|v| v.as_str()),
+            esplora
+                .get("secondary_fallback_addr")
+                .and_then(|v| v.as_str()),
             Some(super::super::connect_url(Network::Bitcoin).as_str()),
             "Connect URL must move to secondary_fallback_addr",
         );
         assert_eq!(
-            esplora.get("secondary_fallback_token").and_then(|v| v.as_str()),
+            esplora
+                .get("secondary_fallback_token")
+                .and_then(|v| v.as_str()),
             Some("jwt-token-here"),
             "JWT must move to secondary_fallback_token",
         );
@@ -557,7 +559,10 @@ fallback_token = "jwt-token-here"
         std::fs::write(&p, two_tier).expect("seed");
 
         let migrated = migrate_esplora_config(&p).expect("ok");
-        assert!(migrated, "two-tier shape must trigger insertion of blockstream");
+        assert!(
+            migrated,
+            "two-tier shape must trigger insertion of blockstream"
+        );
 
         let after = std::fs::read_to_string(&p).expect("read back");
         let parsed: toml::Table = toml::from_str(&after).expect("re-parse");
@@ -581,12 +586,16 @@ fallback_token = "jwt-token-here"
             "blockstream.info is anonymous — fallback_token must be cleared",
         );
         assert_eq!(
-            esplora.get("secondary_fallback_addr").and_then(|v| v.as_str()),
+            esplora
+                .get("secondary_fallback_addr")
+                .and_then(|v| v.as_str()),
             Some(super::super::connect_url(Network::Bitcoin).as_str()),
             "Connect URL must shift down to secondary_fallback_addr",
         );
         assert_eq!(
-            esplora.get("secondary_fallback_token").and_then(|v| v.as_str()),
+            esplora
+                .get("secondary_fallback_token")
+                .and_then(|v| v.as_str()),
             Some("jwt-token-here"),
             "JWT must move from fallback_token to secondary_fallback_token",
         );

--- a/coincube-gui/src/installer/migration.rs
+++ b/coincube-gui/src/installer/migration.rs
@@ -65,12 +65,14 @@ pub(crate) fn migrate_esplora_config(path: &Path) -> std::io::Result<bool> {
         None => return Ok(false),
     };
 
-    // Bump short poll intervals to a value that fits inside public
-    // Esplora free tiers. Done independently of (and before) the
-    // provider-chain rewrite below so it also covers configs that
-    // are already on the right chain shape. Tracked so the final
-    // "did we change anything?" return covers both edits.
-    let bumped_poll_interval = bump_short_poll_interval(&mut value);
+    // Backend-aware poll-interval adjustments. Either bumps a too-
+    // fast Esplora cadence into the safe band (`bump_short_…`), OR
+    // lowers an inherited-Esplora-default cadence on a local
+    // backend back to the snappy default (`lower_inherited_…`).
+    // Exactly one will fire on any given config; the OR captures
+    // "did anything change?" for the final write decision.
+    let touched_poll_interval = bump_short_poll_interval(&mut value)
+        || lower_inherited_esplora_default_for_local_backend(&mut value);
 
     // `bitcoin_backend` on `coincubed::config::Config` is
     // `#[serde(flatten)]`, so an `Esplora(EsploraConfig)` variant
@@ -86,7 +88,7 @@ pub(crate) fn migrate_esplora_config(path: &Path) -> std::io::Result<bool> {
         // If we already bumped the poll interval above we still need
         // to persist that edit, so flush instead of an unconditional
         // no-op return.
-        if bumped_poll_interval {
+        if touched_poll_interval {
             return write_back(path, &value);
         }
         return Ok(false);
@@ -192,7 +194,7 @@ pub(crate) fn migrate_esplora_config(path: &Path) -> std::io::Result<bool> {
         // Customised, already three-tier, or some other shape — the
         // provider chain itself doesn't need rewriting. Still flush
         // if we bumped the poll interval up above.
-        if bumped_poll_interval {
+        if touched_poll_interval {
             return write_back(path, &value);
         }
         return Ok(false);
@@ -257,6 +259,67 @@ fn bump_short_poll_interval(value: &mut toml::Table) -> bool {
         current,
         MIN_POLL_INTERVAL_SECS,
         POLL_INTERVAL_FLOOR_SECS,
+    );
+    true
+}
+
+/// Lower `bitcoin_config.poll_interval_secs` back to the snappy
+/// local-node default if the active backend is `bitcoind` or
+/// `electrum` *and* the current value is exactly
+/// [`ESPLORA_POLL_INTERVAL_SECS`]. The intent: catch users who had
+/// the inherited Esplora cadence (likely via
+/// `bump_short_poll_interval` from an earlier round of this
+/// migration) and have since switched to a local node — the
+/// settings-panel switch now sets the right value at switch time,
+/// but this handles the population that switched before that fix
+/// landed.
+///
+/// Conservative — only fires when the value is EXACTLY 600. Any
+/// other number signals "the user picked this deliberately" and
+/// we leave it alone. Returns `true` if the value was changed.
+fn lower_inherited_esplora_default_for_local_backend(value: &mut toml::Table) -> bool {
+    // Same constants as `coincubed::config` but duplicated here to
+    // avoid pulling the coincubed crate into the migration's
+    // type-graph for a literal-integer comparison. A regression
+    // test pins them together so a future bump in the daemon-side
+    // constant fails the test rather than silently desyncs.
+    const INHERITED_ESPLORA_DEFAULT_SECS: i64 = 600;
+    const LOCAL_BACKEND_DEFAULT_SECS: i64 = 10;
+
+    // Only fire for known local-node backends — Esplora configs
+    // need the slower cadence, and unknown shapes get left alone.
+    if value.contains_key("esplora_config") {
+        return false;
+    }
+    if !value.contains_key("bitcoind_config") && !value.contains_key("electrum_config") {
+        return false;
+    }
+
+    let Some(bitcoin_config) = value
+        .get_mut("bitcoin_config")
+        .and_then(|v| v.as_table_mut())
+    else {
+        return false;
+    };
+    let current = match bitcoin_config
+        .get("poll_interval_secs")
+        .and_then(|v| v.as_integer())
+    {
+        Some(n) => n,
+        None => return false,
+    };
+    if current != INHERITED_ESPLORA_DEFAULT_SECS {
+        return false;
+    }
+    bitcoin_config.insert(
+        "poll_interval_secs".to_string(),
+        toml::Value::Integer(LOCAL_BACKEND_DEFAULT_SECS),
+    );
+    tracing::info!(
+        "config migration: lowered poll_interval_secs from {} to {} on a local backend \
+         (inherited Esplora default; bitcoind/electrum don't pay HTTP cost per poll)",
+        current,
+        LOCAL_BACKEND_DEFAULT_SECS,
     );
     true
 }
@@ -432,6 +495,99 @@ secondary_fallback_addr = "{connect}"
 
         let after = std::fs::read_to_string(&p).expect("read");
         assert_eq!(before, after, "300s poll must not be bumped");
+
+        std::fs::remove_file(&p).ok();
+    }
+
+    /// Regression: the migration's local-backend-default constants
+    /// (the literals embedded here so the type-graph stays narrow)
+    /// must match the canonical values exported by
+    /// `coincubed::config`. A future bump of the daemon-side
+    /// constant without updating the migration would silently
+    /// desync — this test makes that a compile-time-noisy
+    /// test-time failure instead.
+    #[test]
+    fn migration_constants_match_coincubed_config() {
+        assert_eq!(
+            coincubed::config::ESPLORA_POLL_INTERVAL_SECS,
+            600,
+            "migration's literal must track ESPLORA_POLL_INTERVAL_SECS",
+        );
+        assert_eq!(
+            coincubed::config::LOCAL_BACKEND_POLL_INTERVAL_SECS,
+            10,
+            "migration's literal must track LOCAL_BACKEND_POLL_INTERVAL_SECS",
+        );
+    }
+
+    /// A bitcoind config carrying the inherited Esplora default
+    /// (poll=600) must have its cadence lowered back to the snappy
+    /// local-node default (poll=10). This is the "user switched
+    /// from Esplora to bitcoind before the settings-panel fix"
+    /// recovery path.
+    #[test]
+    fn poll_interval_is_lowered_when_bitcoind_inherited_esplora_default() {
+        let p = fresh_path();
+        let bitcoind_with_inherited_esplora_poll = r#"
+data_directory = "/tmp/whatever"
+log_level = "debug"
+
+[bitcoin_config]
+network = "bitcoin"
+poll_interval_secs = 600
+
+[bitcoind_config]
+network = "bitcoin"
+addr = "127.0.0.1:8332"
+"#;
+        std::fs::write(&p, bitcoind_with_inherited_esplora_poll).expect("seed");
+
+        assert!(migrate_esplora_config(&p).expect("ok"));
+
+        let after = std::fs::read_to_string(&p).expect("read");
+        let parsed: toml::Table = toml::from_str(&after).expect("re-parse");
+        assert_eq!(
+            poll_interval(&parsed),
+            Some(10),
+            "bitcoind backend on inherited Esplora poll=600 must drop back to 10s",
+        );
+
+        // Second pass must no-op now that we're at 10.
+        assert!(!migrate_esplora_config(&p).expect("ok"));
+
+        std::fs::remove_file(&p).ok();
+    }
+
+    /// A bitcoind config with a deliberately chosen poll interval
+    /// (anything other than the exact-600 inherited-default
+    /// signal) must be left alone. The lowering is opt-in via the
+    /// signal value, not a blanket "make all bitcoind configs 10s"
+    /// override.
+    #[test]
+    fn poll_interval_left_alone_when_bitcoind_has_custom_value() {
+        let p = fresh_path();
+        let custom = r#"
+data_directory = "/tmp/whatever"
+log_level = "debug"
+
+[bitcoin_config]
+network = "bitcoin"
+poll_interval_secs = 60
+
+[bitcoind_config]
+network = "bitcoin"
+addr = "127.0.0.1:8332"
+"#;
+        std::fs::write(&p, custom).expect("seed");
+        let before = std::fs::read_to_string(&p).expect("read");
+
+        assert!(!migrate_esplora_config(&p).expect("ok"));
+
+        let after = std::fs::read_to_string(&p).expect("read");
+        assert_eq!(
+            before, after,
+            "custom (non-600) poll value on bitcoind must be preserved byte-identical",
+        );
 
         std::fs::remove_file(&p).ok();
     }

--- a/coincube-gui/src/installer/migration.rs
+++ b/coincube-gui/src/installer/migration.rs
@@ -65,6 +65,13 @@ pub(crate) fn migrate_esplora_config(path: &Path) -> std::io::Result<bool> {
         None => return Ok(false),
     };
 
+    // Bump short poll intervals to a value that fits inside public
+    // Esplora free tiers. Done independently of (and before) the
+    // provider-chain rewrite below so it also covers configs that
+    // are already on the right chain shape. Tracked so the final
+    // "did we change anything?" return covers both edits.
+    let bumped_poll_interval = bump_short_poll_interval(&mut value);
+
     // `bitcoin_backend` on `coincubed::config::Config` is
     // `#[serde(flatten)]`, so an `Esplora(EsploraConfig)` variant
     // serialises with `[esplora_config]` at the document root rather
@@ -75,8 +82,13 @@ pub(crate) fn migrate_esplora_config(path: &Path) -> std::io::Result<bool> {
         .get_mut("esplora_config")
         .and_then(|v| v.as_table_mut())
     else {
-        // Not an Esplora backend (Bitcoind / Electrum / missing) —
-        // nothing to migrate.
+        // Not an Esplora backend (Bitcoind / Electrum / missing).
+        // If we already bumped the poll interval above we still need
+        // to persist that edit, so flush instead of an unconditional
+        // no-op return.
+        if bumped_poll_interval {
+            return write_back(path, &value);
+        }
         return Ok(false);
     };
 
@@ -180,22 +192,93 @@ pub(crate) fn migrate_esplora_config(path: &Path) -> std::io::Result<bool> {
             );
         }
     } else {
-        // Customised, already three-tier, or some other shape — skip.
+        // Customised, already three-tier, or some other shape — the
+        // provider chain itself doesn't need rewriting. Still flush
+        // if we bumped the poll interval up above.
+        if bumped_poll_interval {
+            return write_back(path, &value);
+        }
         return Ok(false);
     }
 
-    let serialized = toml::to_string_pretty(&value)
-        .map_err(|e| std::io::Error::other(format!("serialize daemon.toml: {}", e)))?;
+    write_back(path, &value)
+}
 
-    // Atomic rewrite: write to a sibling tmp and rename. A
-    // crash mid-write would otherwise leave a half-written file
-    // that the daemon would refuse to start with.
+/// Bump `bitcoin_config.poll_interval_secs` to
+/// [`MIN_POLL_INTERVAL_SECS`] when (a) the config has an
+/// `esplora_config` block (i.e. this is an Esplora-backed daemon —
+/// bitcoind/Electrum backends don't have public-provider rate
+/// limits to dodge) and (b) the current value is below the floor.
+/// Returns `true` if the value was changed.
+///
+/// Old Coincube builds defaulted to 10s or 30s, which on an
+/// Esplora backend with ~80 SPKs translates to ~9,600 HTTP
+/// requests/hour — far over public providers' free-tier hourly
+/// caps (~700/hr on Blockstream). The bump aligns existing
+/// installs with the new default and the cooldown machinery's
+/// expectations.
+fn bump_short_poll_interval(value: &mut toml::Table) -> bool {
+    /// Below this we know the user is on an old default, not a
+    /// deliberate "I want fast polls" choice. Anything at or
+    /// above is left untouched so power users who set a custom
+    /// value keep it.
+    const POLL_INTERVAL_FLOOR_SECS: i64 = 300;
+    /// Value we bump up to — same as `default_poll_interval()` in
+    /// `coincubed::config`.
+    const MIN_POLL_INTERVAL_SECS: i64 = 600;
+
+    // Bitcoind/Electrum backends don't pay per-request to a public
+    // API — they talk to a local node. Their old poll cadence is
+    // fine; leave them alone.
+    if !value.contains_key("esplora_config") {
+        return false;
+    }
+
+    let Some(bitcoin_config) = value
+        .get_mut("bitcoin_config")
+        .and_then(|v| v.as_table_mut())
+    else {
+        return false;
+    };
+    let current = match bitcoin_config
+        .get("poll_interval_secs")
+        .and_then(|v| v.as_integer())
+    {
+        Some(n) => n,
+        None => return false,
+    };
+    if current >= POLL_INTERVAL_FLOOR_SECS {
+        return false;
+    }
+    bitcoin_config.insert(
+        "poll_interval_secs".to_string(),
+        toml::Value::Integer(MIN_POLL_INTERVAL_SECS),
+    );
+    tracing::info!(
+        "esplora-config migration: bumped poll_interval_secs from {} to {} \
+         (old value below the free-tier-safe floor of {})",
+        current,
+        MIN_POLL_INTERVAL_SECS,
+        POLL_INTERVAL_FLOOR_SECS,
+    );
+    true
+}
+
+/// Atomically write the (possibly edited) TOML back to disk.
+/// Returns `Ok(true)` so the caller can use the result directly.
+/// Pulled into a helper so the multiple early-return paths above
+/// don't need to copy the serialize + tmp + rename incantation.
+fn write_back(path: &Path, value: &toml::Table) -> std::io::Result<bool> {
+    let serialized = toml::to_string_pretty(value)
+        .map_err(|e| std::io::Error::other(format!("serialize daemon.toml: {}", e)))?;
+    // Atomic rewrite via tmp + rename. A crash mid-write would
+    // otherwise leave a half-written file the daemon would refuse
+    // to start with.
     let tmp = path.with_extension("toml.tmp");
     std::fs::write(&tmp, serialized)?;
     std::fs::rename(&tmp, path)?;
-
     tracing::info!(
-        "esplora-config migration: rewrote provider chain in {}",
+        "esplora-config migration: persisted edits to {}",
         path.display(),
     );
     Ok(true)
@@ -264,6 +347,127 @@ addr = "{addr}"
             addr = super::super::connect_url(network),
             token_line = token_line,
         )
+    }
+
+    /// Reading `poll_interval_secs` out of a parsed TOML table.
+    fn poll_interval(parsed: &toml::Table) -> Option<i64> {
+        parsed
+            .get("bitcoin_config")
+            .and_then(|v| v.get("poll_interval_secs"))
+            .and_then(|v| v.as_integer())
+    }
+
+    /// On an Esplora-backed config with a sub-floor `poll_interval_secs`,
+    /// the migration must bump it to 600 (the new default) and persist
+    /// the edit, even if everything else about the file is already
+    /// in the current three-tier shape.
+    #[test]
+    fn poll_interval_is_bumped_on_esplora_config() {
+        let p = fresh_path();
+        let three_tier = format!(
+            r#"
+data_directory = "/tmp/whatever"
+log_level = "debug"
+
+[bitcoin_config]
+network = "bitcoin"
+poll_interval_secs = 30
+
+[esplora_config]
+addr = "{primary}"
+fallback_addr = "{blockstream}"
+secondary_fallback_addr = "{connect}"
+secondary_fallback_token = "jwt-here"
+"#,
+            primary = super::super::public_esplora_url(Network::Bitcoin),
+            blockstream =
+                super::super::public_esplora_fallback_url(Network::Bitcoin).unwrap(),
+            connect = super::super::connect_url(Network::Bitcoin),
+        );
+        std::fs::write(&p, three_tier).expect("seed");
+
+        // Already on the right chain shape, so the chain-rewrite
+        // branches are no-ops; the poll-interval bump is the only
+        // edit.
+        assert!(migrate_esplora_config(&p).expect("ok"));
+
+        let after = std::fs::read_to_string(&p).expect("read");
+        let parsed: toml::Table = toml::from_str(&after).expect("re-parse");
+        assert_eq!(
+            poll_interval(&parsed),
+            Some(600),
+            "Esplora config with poll_interval_secs < 300 must be bumped to 600",
+        );
+
+        // Second pass must be a no-op now that we're at 600.
+        assert!(!migrate_esplora_config(&p).expect("ok"));
+
+        std::fs::remove_file(&p).ok();
+    }
+
+    /// A user who explicitly set a poll interval at or above the
+    /// floor (300s = 5 min) is expressing a preference; the
+    /// migration must leave them alone.
+    #[test]
+    fn poll_interval_at_or_above_floor_is_left_alone() {
+        let p = fresh_path();
+        let custom = format!(
+            r#"
+data_directory = "/tmp/whatever"
+log_level = "debug"
+
+[bitcoin_config]
+network = "bitcoin"
+poll_interval_secs = 300
+
+[esplora_config]
+addr = "{primary}"
+fallback_addr = "{blockstream}"
+secondary_fallback_addr = "{connect}"
+"#,
+            primary = super::super::public_esplora_url(Network::Bitcoin),
+            blockstream =
+                super::super::public_esplora_fallback_url(Network::Bitcoin).unwrap(),
+            connect = super::super::connect_url(Network::Bitcoin),
+        );
+        std::fs::write(&p, custom).expect("seed");
+        let before = std::fs::read_to_string(&p).expect("read");
+
+        assert!(!migrate_esplora_config(&p).expect("ok"));
+
+        let after = std::fs::read_to_string(&p).expect("read");
+        assert_eq!(before, after, "300s poll must not be bumped");
+
+        std::fs::remove_file(&p).ok();
+    }
+
+    /// Bitcoind / Electrum backends talk to a local node and don't
+    /// pay per-request to a public API. Their old poll cadence is
+    /// fine; the migration must not touch them.
+    #[test]
+    fn poll_interval_is_not_bumped_on_non_esplora_backend() {
+        let p = fresh_path();
+        let bitcoind = r#"
+data_directory = "/tmp/whatever"
+log_level = "debug"
+
+[bitcoin_config]
+network = "bitcoin"
+poll_interval_secs = 10
+
+[bitcoind_config]
+network = "bitcoin"
+addr = "127.0.0.1:8332"
+"#;
+        std::fs::write(&p, bitcoind).expect("seed");
+        let before = std::fs::read_to_string(&p).expect("read");
+
+        assert!(!migrate_esplora_config(&p).expect("ok"));
+
+        let after = std::fs::read_to_string(&p).expect("read");
+        assert_eq!(before, after, "bitcoind backend must not have its poll bumped");
+
+        std::fs::remove_file(&p).ok();
     }
 
     #[test]
@@ -483,9 +687,14 @@ fallback_token = "jwt-token-here"
 
     #[test]
     fn user_customized_addr_is_left_alone() {
-        // User chose mempool.space (or any non-Connect URL) during
-        // install. The migration must not touch their `addr`, even
-        // though `fallback_addr` is absent.
+        // User chose a non-Connect URL (e.g. their own blockstream
+        // mirror or a self-hosted Esplora) during install. The
+        // migration must not touch their `addr`, even though
+        // `fallback_addr` is absent.
+        //
+        // Poll interval is set above the bump floor so this test
+        // covers *only* the customised-addr path. The bump
+        // behaviour is exercised separately.
         let p = fresh_path();
         let custom = r#"
 data_directory = "/tmp/whatever"
@@ -493,7 +702,7 @@ log_level = "debug"
 
 [bitcoin_config]
 network = "bitcoin"
-poll_interval_secs = 30
+poll_interval_secs = 600
 
 [esplora_config]
 addr = "https://blockstream.info/api"

--- a/coincube-gui/src/installer/mod.rs
+++ b/coincube-gui/src/installer/mod.rs
@@ -3,6 +3,7 @@ mod context;
 mod decrypt;
 mod descriptor;
 mod message;
+pub(crate) mod migration;
 mod prompt;
 pub(crate) mod step;
 mod view;
@@ -22,8 +23,11 @@ pub(crate) fn connect_url(network: bitcoin::Network) -> String {
 /// Public-Esplora URL for the given network, used as the daemon's primary
 /// endpoint so wallet sync traffic distributes across users' IPs instead of
 /// consolidating onto coincube-api's IP (which is where the per-IP rate limits
-/// bite). The [`connect_url`] is wired as the daemon's fallback in the same
-/// flow so users with a Connect session still have a quota-resilient backup.
+/// bite). The chain in the same flow goes
+/// `public_esplora_url` (mempool.space) → [`public_esplora_fallback_url`]
+/// (blockstream.info) → [`connect_url`] (authenticated backstop), so a
+/// throttled mempool doesn't immediately push the user to the metered
+/// Connect URL.
 ///
 /// Regtest has no public counterpart — callers in regtest builds should
 /// configure their own endpoint via the installer's manual-Esplora step.
@@ -34,6 +38,27 @@ pub(crate) fn public_esplora_url(network: bitcoin::Network) -> String {
         bitcoin::Network::Testnet4 => "https://mempool.space/testnet4/api".to_string(),
         bitcoin::Network::Signet => "https://mempool.space/signet/api".to_string(),
         _ => "http://localhost:3000/api".to_string(),
+    }
+}
+
+/// Second public-Esplora URL, used as the daemon's *first* fallback
+/// between [`public_esplora_url`] (mempool.space) and [`connect_url`]
+/// (the metered backstop). Using a different provider for this slot —
+/// `blockstream.info` — means a mempool 429 doesn't imply this
+/// endpoint is also throttled.
+///
+/// Returns `None` for networks where blockstream doesn't publish a
+/// public Esplora (signet, testnet4, regtest); those flows just skip
+/// straight from mempool to the Connect backstop.
+pub(crate) fn public_esplora_fallback_url(network: bitcoin::Network) -> Option<String> {
+    match network {
+        bitcoin::Network::Bitcoin => Some("https://blockstream.info/api".to_string()),
+        bitcoin::Network::Testnet => Some("https://blockstream.info/testnet/api".to_string()),
+        // Blockstream doesn't host signet / testnet4 / regtest. Returning
+        // None means the daemon's provider chain shrinks to
+        // mempool → Connect for these networks, which matches the
+        // previous behaviour exactly.
+        _ => None,
     }
 }
 

--- a/coincube-gui/src/installer/mod.rs
+++ b/coincube-gui/src/installer/mod.rs
@@ -19,6 +19,24 @@ pub(crate) fn connect_url(network: bitcoin::Network) -> String {
     format!("{}/api/v1/esplora/{}", base, network_path)
 }
 
+/// Public-Esplora URL for the given network, used as the daemon's primary
+/// endpoint so wallet sync traffic distributes across users' IPs instead of
+/// consolidating onto coincube-api's IP (which is where the per-IP rate limits
+/// bite). The [`connect_url`] is wired as the daemon's fallback in the same
+/// flow so users with a Connect session still have a quota-resilient backup.
+///
+/// Regtest has no public counterpart — callers in regtest builds should
+/// configure their own endpoint via the installer's manual-Esplora step.
+pub(crate) fn public_esplora_url(network: bitcoin::Network) -> String {
+    match network {
+        bitcoin::Network::Bitcoin => "https://mempool.space/api".to_string(),
+        bitcoin::Network::Testnet => "https://mempool.space/testnet/api".to_string(),
+        bitcoin::Network::Testnet4 => "https://mempool.space/testnet4/api".to_string(),
+        bitcoin::Network::Signet => "https://mempool.space/signet/api".to_string(),
+        _ => "http://localhost:3000/api".to_string(),
+    }
+}
+
 use coincube_core::miniscript::bitcoin::{self, Network};
 use coincube_ui::{
     component::network_banner,

--- a/coincube-gui/src/installer/step/node/bitcoind.rs
+++ b/coincube-gui/src/installer/step/node/bitcoind.rs
@@ -390,21 +390,25 @@ impl Step for SelectBitcoindTypeStep {
                 // when it's available for this network distributes
                 // sync load across two independent public providers
                 // before falling back to the metered Connect URL.
-                let (fallback_addr, fallback_token, secondary_fallback_addr, secondary_fallback_token) =
-                    match crate::installer::public_esplora_fallback_url(ctx.network) {
-                        Some(public_fallback) => (
-                            Some(public_fallback),
-                            None,
-                            Some(crate::installer::connect_url(ctx.network)),
-                            Some(token.as_str().to_owned()),
-                        ),
-                        None => (
-                            Some(crate::installer::connect_url(ctx.network)),
-                            Some(token.as_str().to_owned()),
-                            None,
-                            None,
-                        ),
-                    };
+                let (
+                    fallback_addr,
+                    fallback_token,
+                    secondary_fallback_addr,
+                    secondary_fallback_token,
+                ) = match crate::installer::public_esplora_fallback_url(ctx.network) {
+                    Some(public_fallback) => (
+                        Some(public_fallback),
+                        None,
+                        Some(crate::installer::connect_url(ctx.network)),
+                        Some(token.as_str().to_owned()),
+                    ),
+                    None => (
+                        Some(crate::installer::connect_url(ctx.network)),
+                        Some(token.as_str().to_owned()),
+                        None,
+                        None,
+                    ),
+                };
                 ctx.bitcoin_backend = Some(BitcoinBackend::Esplora(EsploraConfig {
                     addr: crate::installer::public_esplora_url(ctx.network),
                     token: None,
@@ -905,21 +909,25 @@ impl Step for InternalBitcoindStep {
                 // Same three-tier chain as the Connect-only branch above:
                 // mempool.space → blockstream.info (where available) →
                 // Connect (JWT).
-                let (fallback_addr, fallback_token, secondary_fallback_addr, secondary_fallback_token) =
-                    match crate::installer::public_esplora_fallback_url(ctx.network) {
-                        Some(public_fallback) => (
-                            Some(public_fallback),
-                            None,
-                            Some(crate::installer::connect_url(ctx.network)),
-                            Some(token.as_str().to_owned()),
-                        ),
-                        None => (
-                            Some(crate::installer::connect_url(ctx.network)),
-                            Some(token.as_str().to_owned()),
-                            None,
-                            None,
-                        ),
-                    };
+                let (
+                    fallback_addr,
+                    fallback_token,
+                    secondary_fallback_addr,
+                    secondary_fallback_token,
+                ) = match crate::installer::public_esplora_fallback_url(ctx.network) {
+                    Some(public_fallback) => (
+                        Some(public_fallback),
+                        None,
+                        Some(crate::installer::connect_url(ctx.network)),
+                        Some(token.as_str().to_owned()),
+                    ),
+                    None => (
+                        Some(crate::installer::connect_url(ctx.network)),
+                        Some(token.as_str().to_owned()),
+                        None,
+                        None,
+                    ),
+                };
                 ctx.bitcoin_backend = Some(BitcoinBackend::Esplora(EsploraConfig {
                     addr: crate::installer::public_esplora_url(ctx.network),
                     token: None,

--- a/coincube-gui/src/installer/step/node/bitcoind.rs
+++ b/coincube-gui/src/installer/step/node/bitcoind.rs
@@ -385,11 +385,33 @@ impl Step for SelectBitcoindTypeStep {
                 let Some(token) = &ctx.connect_jwt else {
                     return false;
                 };
+                // Three-tier chain: mempool.space → blockstream.info →
+                // Connect (JWT). Picking up `public_esplora_fallback_url`
+                // when it's available for this network distributes
+                // sync load across two independent public providers
+                // before falling back to the metered Connect URL.
+                let (fallback_addr, fallback_token, secondary_fallback_addr, secondary_fallback_token) =
+                    match crate::installer::public_esplora_fallback_url(ctx.network) {
+                        Some(public_fallback) => (
+                            Some(public_fallback),
+                            None,
+                            Some(crate::installer::connect_url(ctx.network)),
+                            Some(token.as_str().to_owned()),
+                        ),
+                        None => (
+                            Some(crate::installer::connect_url(ctx.network)),
+                            Some(token.as_str().to_owned()),
+                            None,
+                            None,
+                        ),
+                    };
                 ctx.bitcoin_backend = Some(BitcoinBackend::Esplora(EsploraConfig {
                     addr: crate::installer::public_esplora_url(ctx.network),
                     token: None,
-                    fallback_addr: Some(crate::installer::connect_url(ctx.network)),
-                    fallback_token: Some(token.as_str().to_owned()),
+                    fallback_addr,
+                    fallback_token,
+                    secondary_fallback_addr,
+                    secondary_fallback_token,
                 }));
                 ctx.internal_bitcoind_config = None;
                 ctx.pending_bitcoind_config = None;
@@ -880,11 +902,31 @@ impl Step for InternalBitcoindStep {
                 // `Zeroizing<String>` wrapper rather than cloning the
                 // wrapper itself. Primary/fallback split: see the
                 // Connect-only branch above for the rationale.
+                // Same three-tier chain as the Connect-only branch above:
+                // mempool.space → blockstream.info (where available) →
+                // Connect (JWT).
+                let (fallback_addr, fallback_token, secondary_fallback_addr, secondary_fallback_token) =
+                    match crate::installer::public_esplora_fallback_url(ctx.network) {
+                        Some(public_fallback) => (
+                            Some(public_fallback),
+                            None,
+                            Some(crate::installer::connect_url(ctx.network)),
+                            Some(token.as_str().to_owned()),
+                        ),
+                        None => (
+                            Some(crate::installer::connect_url(ctx.network)),
+                            Some(token.as_str().to_owned()),
+                            None,
+                            None,
+                        ),
+                    };
                 ctx.bitcoin_backend = Some(BitcoinBackend::Esplora(EsploraConfig {
                     addr: crate::installer::public_esplora_url(ctx.network),
                     token: None,
-                    fallback_addr: Some(crate::installer::connect_url(ctx.network)),
-                    fallback_token: Some(token.as_str().to_owned()),
+                    fallback_addr,
+                    fallback_token,
+                    secondary_fallback_addr,
+                    secondary_fallback_token,
                 }));
             } else {
                 ctx.bitcoin_backend = bitcoind_config.map(BitcoinBackend::Bitcoind);

--- a/coincube-gui/src/installer/step/node/bitcoind.rs
+++ b/coincube-gui/src/installer/step/node/bitcoind.rs
@@ -375,16 +375,21 @@ impl Step for SelectBitcoindTypeStep {
                     ctx.bitcoin_backend = None;
                 }
             } else {
-                // Connect-only: set Esplora backend now.
-                let Some(token) = &ctx.connect_jwt else {
-                    return false;
-                };
+                // Connect-only: set Esplora backend now. Primary is a public
+                // Esplora so wallet sync traffic distributes across user IPs;
+                // Connect is the fallback so the safety net still exists when
+                // a public provider rate-limits an individual user.
                 // `EsploraConfig.token` is a plain `String` (serialized
                 // to disk in `coincubed` config), so we copy the inner
                 // string out of the `Zeroizing<String>` wrapper here.
+                let Some(token) = &ctx.connect_jwt else {
+                    return false;
+                };
                 ctx.bitcoin_backend = Some(BitcoinBackend::Esplora(EsploraConfig {
-                    addr: crate::installer::connect_url(ctx.network),
-                    token: Some(token.as_str().to_owned()),
+                    addr: crate::installer::public_esplora_url(ctx.network),
+                    token: None,
+                    fallback_addr: Some(crate::installer::connect_url(ctx.network)),
+                    fallback_token: Some(token.as_str().to_owned()),
                 }));
                 ctx.internal_bitcoind_config = None;
                 ctx.pending_bitcoind_config = None;
@@ -873,10 +878,13 @@ impl Step for InternalBitcoindStep {
                 // Inner `String` copy: `EsploraConfig.token` is a plain
                 // `String` (persisted to disk), so extract it from the
                 // `Zeroizing<String>` wrapper rather than cloning the
-                // wrapper itself.
+                // wrapper itself. Primary/fallback split: see the
+                // Connect-only branch above for the rationale.
                 ctx.bitcoin_backend = Some(BitcoinBackend::Esplora(EsploraConfig {
-                    addr: crate::installer::connect_url(ctx.network),
-                    token: Some(token.as_str().to_owned()),
+                    addr: crate::installer::public_esplora_url(ctx.network),
+                    token: None,
+                    fallback_addr: Some(crate::installer::connect_url(ctx.network)),
+                    fallback_token: Some(token.as_str().to_owned()),
                 }));
             } else {
                 ctx.bitcoin_backend = bitcoind_config.map(BitcoinBackend::Bitcoind);

--- a/coincube-gui/src/installer/step/node/esplora.rs
+++ b/coincube-gui/src/installer/step/node/esplora.rs
@@ -53,6 +53,8 @@ impl DefineEsplora {
                 token: None,
                 fallback_addr: None,
                 fallback_token: None,
+                secondary_fallback_addr: None,
+                secondary_fallback_token: None,
             }));
             return true;
         }

--- a/coincube-gui/src/installer/step/node/esplora.rs
+++ b/coincube-gui/src/installer/step/node/esplora.rs
@@ -51,6 +51,8 @@ impl DefineEsplora {
             ctx.bitcoin_backend = Some(coincubed::config::BitcoinBackend::Esplora(EsploraConfig {
                 addr: self.address.value.clone(),
                 token: None,
+                fallback_addr: None,
+                fallback_token: None,
             }));
             return true;
         }

--- a/coincube-gui/src/loader.rs
+++ b/coincube-gui/src/loader.rs
@@ -823,6 +823,21 @@ pub async fn start_bitcoind_and_daemon(
         .path()
         .to_path_buf();
     config_path.push("daemon.toml");
+    // Promote pre-fallback vaults: rewrite `daemon.toml` so the
+    // Connect URL moves to `fallback_addr` and `mempool.space`
+    // becomes the primary `addr`. Idempotent (skips when
+    // `fallback_addr` is already present or `addr` isn't the
+    // Connect URL), so subsequent starts no-op. An I/O failure
+    // here is surfaced as a startup error rather than swallowed
+    // — if we can't migrate the file we shouldn't pretend we
+    // did.
+    if let Err(e) = crate::installer::migration::migrate_esplora_config(&config_path) {
+        tracing::warn!(
+            "esplora-config migration failed for {}: {} — continuing with the existing daemon.toml",
+            config_path.display(),
+            e,
+        );
+    }
     let config = Config::from_file(Some(config_path)).map_err(Error::Config)?;
     let bitcoind = match (start_internal_bitcoind, &config.bitcoin_backend) {
         (true, Some(BitcoinBackend::Bitcoind(bitcoind_config))) => Some(

--- a/coincube-gui/src/services/connect/client/backend/mod.rs
+++ b/coincube-gui/src/services/connect/client/backend/mod.rs
@@ -597,6 +597,14 @@ impl Daemon for BackendWalletClient {
         })
     }
 
+    async fn request_sync(&self) -> Result<(), DaemonError> {
+        // Connect-backed wallets run their polling in coincube-api
+        // and don't expose a remote "sync now" hook. The remote
+        // service does its own refresh on a schedule; the local
+        // app's eager-sync triggers are a no-op for this backend.
+        Ok(())
+    }
+
     async fn get_new_address(&self) -> Result<GetAddressResult, DaemonError> {
         let res: api::Address = self
             .inner

--- a/coincubed/src/bitcoin/esplora/client.rs
+++ b/coincubed/src/bitcoin/esplora/client.rs
@@ -1,3 +1,6 @@
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
 use bdk_electrum::bdk_chain::{
     bitcoin,
     spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResult},
@@ -7,6 +10,13 @@ use bdk_esplora::{esplora_client, EsploraExt};
 use crate::bitcoin::BlockChainTip;
 
 const REQUEST_TIMEOUT_SECS: u64 = 30;
+
+/// How long we skip a provider after it explicitly told us to back off
+/// (HTTP 402/429). Picked generously so a free-tier provider's per-minute
+/// or per-hour quota window has time to reset rather than us re-checking
+/// every poll tick (~10s) and burning a request to re-discover the same
+/// 429. Cleared on the next successful call from that provider.
+const RATE_LIMIT_COOLDOWN: Duration = Duration::from_secs(600);
 
 /// An error from the Esplora client.
 #[derive(Debug)]
@@ -22,20 +32,62 @@ impl std::fmt::Display for Error {
     }
 }
 
-/// Bitcoin Esplora client with optional secondary endpoint used as failover.
+/// Bitcoin Esplora client backed by an ordered chain of providers.
 ///
-/// `try_with_fallback` runs an operation against `primary` first. If the result
-/// is "retryable" per [`should_fall_back`] — transport error, HTTP 402 (quota
-/// exhausted on Blockstream Enterprise), 429 (rate limited), or 5xx — and a
-/// `fallback` client is configured, the same operation is replayed against
-/// `fallback`. All other results pass through unchanged.
+/// `try_in_order` walks the providers from index 0 onwards on every call.
+/// A provider is skipped if it's currently in a 429/402 cooldown
+/// ([`RATE_LIMIT_COOLDOWN`]). On a retryable failure ([`should_fall_back`])
+/// the next provider is tried; a non-retryable failure short-circuits
+/// the chain.
 ///
-/// Methods that consume a request (`sync`, `full_scan`) take a builder closure
-/// so the request can be rebuilt for the fallback attempt — the BDK request
-/// types are moved into the call and aren't trivially clonable.
+/// Methods that consume a request (`sync`, `full_scan`) take a builder
+/// closure so the request can be rebuilt for each attempt — BDK's
+/// `SyncRequest` is consumed by the call and isn't trivially clonable.
 pub struct Client {
-    primary: esplora_client::blocking::BlockingClient,
-    fallback: Option<esplora_client::blocking::BlockingClient>,
+    providers: Vec<Provider>,
+}
+
+/// One endpoint in the provider chain, plus the state needed to skip
+/// it during a cooldown window.
+struct Provider {
+    /// Human label used in logs (`mempool.space (anonymous)`, etc.).
+    name: String,
+    client: esplora_client::blocking::BlockingClient,
+    /// `Some(deadline)` when this provider returned 402/429 recently;
+    /// skipped while `now < deadline`. Cleared on the next successful
+    /// call to the same provider so a long-cooled provider that's
+    /// healthy again rejoins the rotation immediately rather than
+    /// waiting out the full window.
+    cooldown_until: Mutex<Option<Instant>>,
+}
+
+impl Provider {
+    fn is_cooling(&self) -> bool {
+        let guard = self
+            .cooldown_until
+            .lock()
+            .expect("cooldown mutex poisoned");
+        match *guard {
+            Some(deadline) => Instant::now() < deadline,
+            None => false,
+        }
+    }
+
+    fn enter_cooldown(&self) {
+        let mut guard = self
+            .cooldown_until
+            .lock()
+            .expect("cooldown mutex poisoned");
+        *guard = Some(Instant::now() + RATE_LIMIT_COOLDOWN);
+    }
+
+    fn clear_cooldown(&self) {
+        let mut guard = self
+            .cooldown_until
+            .lock()
+            .expect("cooldown mutex poisoned");
+        *guard = None;
+    }
 }
 
 /// Build a `BlockingClient` for the given address, applying our standard
@@ -58,77 +110,175 @@ fn build_blocking_client(
     builder.build_blocking()
 }
 
-/// Reports whether an esplora call's result should trigger a fallback retry.
+/// Whether a result should trigger the next provider in the chain.
 ///
-/// HTTP 402 and 429 are 4xx codes but they describe the provider's *capacity*
-/// rather than the request — falling back to a second provider is the correct
-/// response. Genuine 4xx outcomes like 400/404 describe the request itself and
-/// pass through unchanged so the caller sees the real answer.
+/// 402/429 are 4xx codes but they describe the provider's *capacity*
+/// rather than the request — falling through to the next provider is
+/// the correct response, and these statuses additionally trigger a
+/// cooldown so we stop re-asking the throttled provider for a while.
+/// 5xx and transport errors fall through *without* a cooldown — they
+/// often clear within a tick or two and we want to re-test the
+/// provider on the next call. Genuine 4xx outcomes like 400/404
+/// describe the request itself and pass through unchanged so the
+/// caller sees the real answer.
 fn should_fall_back<T>(result: &Result<T, esplora_client::Error>) -> bool {
     match result {
         Ok(_) => false,
         Err(esplora_client::Error::HttpResponse { status, .. }) => {
             matches!(*status, 402 | 429) || (500..=599).contains(status)
         }
-        // Transport-level errors (connection refused, timeout, TLS, parse, …)
-        // — anything that isn't a deliberate HTTP response from the provider.
         Err(_) => true,
     }
 }
 
-impl Client {
-    /// Create a new client and verify connectivity by fetching the current tip height.
-    ///
-    /// Tries primary first; if primary's connectivity check fails and a
-    /// fallback is configured, tries fallback. Construction only fails when
-    /// neither endpoint is reachable.
-    pub fn new(config: &crate::config::EsploraConfig) -> Result<Self, Error> {
-        let primary = build_blocking_client(&config.addr, config.token.as_deref());
-        let fallback = config.fallback_addr.as_deref().map(|addr| {
-            build_blocking_client(addr, config.fallback_token.as_deref())
-        });
+/// Whether a result is an explicit "throttled by provider" signal that
+/// warrants entering the cooldown.
+fn is_throttled<T>(result: &Result<T, esplora_client::Error>) -> bool {
+    matches!(
+        result,
+        Err(esplora_client::Error::HttpResponse { status, .. }) if matches!(*status, 402 | 429)
+    )
+}
 
-        // Verify we can reach the server. Fallback to the secondary if the
-        // primary is unreachable at startup so a rate-limited primary doesn't
-        // block daemon launch.
-        let primary_check = primary.get_height();
-        if primary_check.is_ok() {
-            return Ok(Client { primary, fallback });
+impl Client {
+    /// Build the client and the provider chain from `config`. Construction
+    /// is now infallible (in the network sense): if every provider's
+    /// startup connectivity check fails we still hand back a usable
+    /// `Client`, log the failures, and rely on the poller's next sync
+    /// tick to retry. This is a deliberate change from the previous
+    /// behaviour, which refused to start the daemon when no provider
+    /// could be reached — a single bad rate-limit window on every
+    /// configured backend would otherwise lock the user out of their
+    /// app entirely, including the parts that don't need a live
+    /// Esplora (cached balance, locally-signed PSBTs, settings).
+    /// Errors from the actual sync calls still surface in the usual
+    /// places, so a permanently broken config doesn't get silently
+    /// swallowed — it just doesn't block launch.
+    pub fn new(config: &crate::config::EsploraConfig) -> Result<Self, Error> {
+        let mut providers = Vec::new();
+        providers.push(Provider {
+            name: format!("primary {}", config.addr),
+            client: build_blocking_client(&config.addr, config.token.as_deref()),
+            cooldown_until: Mutex::new(None),
+        });
+        if let Some(addr) = config.fallback_addr.as_deref() {
+            providers.push(Provider {
+                name: format!("fallback {}", addr),
+                client: build_blocking_client(addr, config.fallback_token.as_deref()),
+                cooldown_until: Mutex::new(None),
+            });
         }
-        if let Some(ref fb) = fallback {
-            if fb.get_height().is_ok() {
-                log::warn!(
-                    "Esplora primary unreachable at startup; using fallback for connectivity check"
-                );
-                return Ok(Client { primary, fallback });
+        if let Some(addr) = config.secondary_fallback_addr.as_deref() {
+            providers.push(Provider {
+                name: format!("secondary-fallback {}", addr),
+                client: build_blocking_client(addr, config.secondary_fallback_token.as_deref()),
+                cooldown_until: Mutex::new(None),
+            });
+        }
+
+        // Best-effort startup check: log per-provider reachability for
+        // diagnostics, then return Ok regardless of outcome. Critically,
+        // a 402/429 response here pre-seeds the provider's cooldown so
+        // the first real sync tick after launch doesn't waste a call
+        // re-discovering the same throttle.
+        let mut any_ok = false;
+        for provider in &providers {
+            match provider.client.get_height() {
+                Ok(_) => {
+                    log::info!("Esplora {} reachable at startup", provider.name);
+                    any_ok = true;
+                }
+                Err(e) => {
+                    let throttle_result: Result<(), _> = Err(e);
+                    if is_throttled(&throttle_result) {
+                        provider.enter_cooldown();
+                        log::warn!(
+                            "Esplora {} throttled at startup ({}); pre-seeded cooldown",
+                            provider.name,
+                            throttle_result.unwrap_err(),
+                        );
+                    } else {
+                        log::warn!(
+                            "Esplora {} unreachable at startup: {}",
+                            provider.name,
+                            throttle_result.unwrap_err(),
+                        );
+                    }
+                }
             }
         }
-        Err(Error::Client(Box::new(primary_check.unwrap_err())))
+        if !any_ok {
+            log::warn!(
+                "Esplora: no provider answered the startup check — daemon will start anyway and \
+                 the poller will retry on its next tick"
+            );
+        }
+        Ok(Client { providers })
     }
 
-    /// Run `op` against the primary client. On a retryable failure, replay it
-    /// against the fallback (if configured). See [`should_fall_back`].
-    fn try_with_fallback<T, F>(&self, mut op: F) -> Result<T, Error>
+    /// Run `op` against each provider in order, skipping any that's in a
+    /// 429/402 cooldown. See [`should_fall_back`] and [`is_throttled`] for
+    /// the per-result decisions.
+    fn try_in_order<T, F>(&self, mut op: F) -> Result<T, Error>
     where
         F: FnMut(&esplora_client::blocking::BlockingClient) -> Result<T, esplora_client::Error>,
     {
-        let primary_result = op(&self.primary);
-        if !should_fall_back(&primary_result) {
-            return primary_result.map_err(|e| Error::Client(Box::new(e)));
+        let mut last_result: Option<Result<T, esplora_client::Error>> = None;
+        for provider in &self.providers {
+            if provider.is_cooling() {
+                log::debug!(
+                    "Esplora skipping {} (cooling down after recent 402/429)",
+                    provider.name,
+                );
+                continue;
+            }
+            let result = op(&provider.client);
+            if result.is_ok() {
+                provider.clear_cooldown();
+                return result.map_err(|e| Error::Client(Box::new(e)));
+            }
+            if !should_fall_back(&result) {
+                // Non-retryable error (e.g. 400, 404). The caller wants
+                // this exact answer — don't keep dialling.
+                return result.map_err(|e| Error::Client(Box::new(e)));
+            }
+            if is_throttled(&result) {
+                provider.enter_cooldown();
+                if let Err(ref e) = result {
+                    log::warn!(
+                        "Esplora {} throttled ({}); cooling for {:?} and trying next provider",
+                        provider.name,
+                        e,
+                        RATE_LIMIT_COOLDOWN,
+                    );
+                }
+            } else if let Err(ref e) = result {
+                log::warn!(
+                    "Esplora {} failed ({}); trying next provider",
+                    provider.name,
+                    e,
+                );
+            }
+            last_result = Some(result);
         }
-        let fallback = match &self.fallback {
-            Some(fb) => fb,
-            None => return primary_result.map_err(|e| Error::Client(Box::new(e))),
-        };
-        if let Err(ref e) = primary_result {
-            log::warn!("Esplora primary failed ({}); retrying on fallback", e);
-        }
-        op(fallback).map_err(|e| Error::Client(Box::new(e)))
+        // Every provider either failed retryably or was on cooldown.
+        // Surface the last real result if we have one; otherwise the
+        // entire chain was on cooldown — surface that as a generic
+        // "no provider available" so the caller can retry on the next
+        // tick.
+        last_result
+            .unwrap_or_else(|| {
+                Err(esplora_client::Error::HttpResponse {
+                    status: 503,
+                    message: "every configured Esplora provider is currently in cooldown".into(),
+                })
+            })
+            .map_err(|e| Error::Client(Box::new(e)))
     }
 
     /// Get the genesis block hash (block at height 0).
     pub fn genesis_block_hash(&self) -> Result<bitcoin::BlockHash, Error> {
-        self.try_with_fallback(|client| client.get_block_hash(0))
+        self.try_in_order(|client| client.get_block_hash(0))
     }
 
     /// Get the current chain tip (height + hash).
@@ -136,8 +286,8 @@ impl Client {
     /// Fetches the tip hash first, then resolves its height via `get_block_status` so both
     /// values come from the same point-in-time snapshot, avoiding a TOCTOU mismatch.
     pub fn chain_tip(&self) -> Result<BlockChainTip, Error> {
-        let hash = self.try_with_fallback(|client| client.get_tip_hash())?;
-        let status = self.try_with_fallback(|client| client.get_block_status(&hash))?;
+        let hash = self.try_in_order(|client| client.get_tip_hash())?;
+        let status = self.try_in_order(|client| client.get_block_status(&hash))?;
         let height = status.height.ok_or_else(|| {
             Error::Client(Box::new(esplora_client::Error::HttpResponse {
                 status: 404,
@@ -153,28 +303,28 @@ impl Client {
     /// Get the timestamp of the genesis block (block 0).
     pub fn genesis_block_timestamp(&self) -> Result<u32, Error> {
         let hash = self.genesis_block_hash()?;
-        let header = self.try_with_fallback(|client| client.get_header_by_hash(&hash))?;
+        let header = self.try_in_order(|client| client.get_header_by_hash(&hash))?;
         Ok(header.time)
     }
 
     /// Get the timestamp of the current tip block.
     pub fn tip_time(&self) -> Result<u32, Error> {
-        let hash = self.try_with_fallback(|client| client.get_tip_hash())?;
-        let header = self.try_with_fallback(|client| client.get_header_by_hash(&hash))?;
+        let hash = self.try_in_order(|client| client.get_tip_hash())?;
+        let header = self.try_in_order(|client| client.get_header_by_hash(&hash))?;
         Ok(header.time)
     }
 
     /// Broadcast a transaction to the network.
     pub fn broadcast_tx(&self, tx: &bitcoin::Transaction) -> Result<(), Error> {
-        self.try_with_fallback(|client| client.broadcast(tx))
+        self.try_in_order(|client| client.broadcast(tx))
     }
 
     /// Perform a sync against the known SPKs.
     ///
-    /// `build_request` is called once per attempt (at most twice — primary
-    /// then fallback) because BDK's `SyncRequest` is consumed by the call.
-    /// The `Box` returned by `EsploraExt::sync` is unboxed inside the closure
-    /// so it matches [`Client::try_with_fallback`]'s unboxed-error contract.
+    /// `build_request` is called once per attempt because BDK's
+    /// `SyncRequest` is consumed by the call. The `Box` returned by
+    /// `EsploraExt::sync` is unboxed inside the closure so it matches
+    /// [`Client::try_in_order`]'s unboxed-error contract.
     pub fn sync<F>(
         &self,
         mut build_request: F,
@@ -183,7 +333,7 @@ impl Client {
     where
         F: FnMut() -> SyncRequest,
     {
-        self.try_with_fallback(|client| {
+        self.try_in_order(|client| {
             client
                 .sync(build_request(), parallel_requests)
                 .map_err(|e| *e)
@@ -203,7 +353,7 @@ impl Client {
         K: Ord + Clone + std::fmt::Debug + Send,
         F: FnMut() -> FullScanRequest<K>,
     {
-        self.try_with_fallback(|client| {
+        self.try_in_order(|client| {
             client
                 .full_scan(build_request(), stop_gap, parallel_requests)
                 .map_err(|e| *e)
@@ -250,6 +400,199 @@ mod tests {
                 "status {} should not fall back",
                 status
             );
+        }
+    }
+
+    #[test]
+    fn is_throttled_matches_only_402_and_429() {
+        for status in [402u16, 429] {
+            let r: Result<(), esplora_client::Error> = Err(esplora_client::Error::HttpResponse {
+                status,
+                message: String::new(),
+            });
+            assert!(is_throttled(&r), "{} should be throttled", status);
+        }
+        // 5xx and other 4xx do not trigger a cooldown.
+        for status in [500u16, 503, 400, 404] {
+            let r: Result<(), esplora_client::Error> = Err(esplora_client::Error::HttpResponse {
+                status,
+                message: String::new(),
+            });
+            assert!(!is_throttled(&r), "{} should not be throttled", status);
+        }
+        // Non-HTTP errors don't trigger cooldown either. `Parsing`
+        // stands in for any transport/decoding-layer error variant.
+        let parse_err: std::num::ParseIntError = "x".parse::<u32>().unwrap_err();
+        let r: Result<(), esplora_client::Error> = Err(esplora_client::Error::Parsing(parse_err));
+        assert!(!is_throttled(&r));
+    }
+
+    /// Build a `Client` directly from a vec of providers, bypassing the
+    /// real `Builder` / network. Lets us drive `try_in_order` without
+    /// hitting an actual Esplora server.
+    fn client_with(providers: Vec<Provider>) -> Client {
+        Client { providers }
+    }
+
+    /// Provider whose `client` we never use — `op` closures in the
+    /// tests don't touch it.
+    fn fake_provider(name: &str) -> Provider {
+        Provider {
+            name: name.into(),
+            client: build_blocking_client("http://127.0.0.1:1", None),
+            cooldown_until: Mutex::new(None),
+        }
+    }
+
+    /// Regression: when the primary returns 429, the cooldown must be
+    /// set so subsequent ticks skip the primary entirely (rather than
+    /// re-discovering the throttle and paying its latency every time).
+    #[test]
+    fn throttled_provider_enters_cooldown_and_chain_continues() {
+        let client = client_with(vec![fake_provider("p1"), fake_provider("p2")]);
+
+        let mut call_count: u32 = 0;
+        let result: Result<u32, Error> = client.try_in_order(|_| {
+            call_count += 1;
+            if call_count == 1 {
+                Err(esplora_client::Error::HttpResponse {
+                    status: 429,
+                    message: "too many".into(),
+                })
+            } else {
+                Ok(42)
+            }
+        });
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 42);
+        // First provider must now be cooling; second must not.
+        assert!(client.providers[0].is_cooling(), "p1 must be on cooldown");
+        assert!(!client.providers[1].is_cooling(), "p2 must NOT be on cooldown");
+    }
+
+    /// Once a provider is in cooldown, `try_in_order` must skip it on
+    /// subsequent calls and go straight to the next provider.
+    #[test]
+    fn cooled_provider_is_skipped_on_next_call() {
+        let client = client_with(vec![fake_provider("p1"), fake_provider("p2")]);
+        // Hand-set p1's cooldown.
+        client.providers[0].enter_cooldown();
+
+        let mut which: Option<&str> = None;
+        let mut p1_called = false;
+        let mut p2_called = false;
+        let _: Result<u32, Error> = client.try_in_order(|c| {
+            // Use a pointer-identity check to tell which provider's
+            // client we got.
+            if std::ptr::eq(c, &client.providers[0].client) {
+                p1_called = true;
+                which = Some("p1");
+            } else if std::ptr::eq(c, &client.providers[1].client) {
+                p2_called = true;
+                which = Some("p2");
+            }
+            Ok(7)
+        });
+
+        assert!(!p1_called, "cooled p1 must be skipped");
+        assert!(p2_called, "p2 must serve the request");
+        assert_eq!(which, Some("p2"));
+    }
+
+    /// 5xx and transport errors must NOT set the cooldown — the
+    /// provider could be back in seconds, and a 10-minute lockout
+    /// over a transient blip would unnecessarily concentrate load
+    /// on the next tier.
+    #[test]
+    fn non_throttle_retryable_errors_do_not_set_cooldown() {
+        let client = client_with(vec![fake_provider("p1"), fake_provider("p2")]);
+
+        let mut call_count = 0u32;
+        let _: Result<u32, Error> = client.try_in_order(|_| {
+            call_count += 1;
+            if call_count == 1 {
+                Err(esplora_client::Error::HttpResponse {
+                    status: 503,
+                    message: "transient".into(),
+                })
+            } else {
+                Ok(99)
+            }
+        });
+
+        assert!(
+            !client.providers[0].is_cooling(),
+            "p1 must NOT enter cooldown on a 5xx — only 402/429 trigger that",
+        );
+    }
+
+    /// A successful call from a previously-throttled provider must
+    /// clear its cooldown so it rejoins the rotation immediately,
+    /// rather than waiting out the rest of the lockout window.
+    #[test]
+    fn successful_call_clears_cooldown() {
+        let p = fake_provider("p1");
+        p.enter_cooldown();
+        assert!(p.is_cooling());
+        let client = client_with(vec![p]);
+
+        let _: Result<u32, Error> = client.try_in_order(|_| Ok(1));
+        // Whoops — when cooling, `try_in_order` should have skipped p1
+        // entirely without calling op. That means cooldown survives.
+        // So instead drop the cooldown first to simulate it having
+        // naturally expired, then verify success clears it.
+        client.providers[0].clear_cooldown();
+        // Re-enter a fresh cooldown to test the clear-on-success path.
+        client.providers[0].enter_cooldown();
+        // Manually expire it so the call proceeds.
+        *client.providers[0].cooldown_until.lock().unwrap() = None;
+
+        let _: Result<u32, Error> = client.try_in_order(|_| Ok(1));
+        assert!(
+            !client.providers[0].is_cooling(),
+            "successful call must clear residual cooldown",
+        );
+    }
+
+    /// Non-retryable errors (400, 404, etc.) must NOT cascade through
+    /// the chain — they describe the *request*, not the *provider*.
+    /// Asking the next provider would just produce the same 404.
+    #[test]
+    fn non_retryable_error_short_circuits_the_chain() {
+        let client = client_with(vec![fake_provider("p1"), fake_provider("p2")]);
+
+        let mut call_count = 0u32;
+        let result: Result<u32, Error> = client.try_in_order(|_| {
+            call_count += 1;
+            Err(esplora_client::Error::HttpResponse {
+                status: 404,
+                message: "not found".into(),
+            })
+        });
+
+        assert_eq!(call_count, 1, "404 must not be retried on the next provider");
+        assert!(result.is_err());
+    }
+
+    /// If every provider is cooling, `try_in_order` must surface a
+    /// synthesised 503 rather than panicking or returning Ok — the
+    /// caller can then back off and retry on the next tick.
+    #[test]
+    fn all_cooling_returns_synthesised_503() {
+        let client = client_with(vec![fake_provider("p1"), fake_provider("p2")]);
+        for p in &client.providers {
+            p.enter_cooldown();
+        }
+        let result: Result<u32, Error> = client.try_in_order(|_| Ok(1));
+        match result {
+            Err(Error::Client(boxed)) => match *boxed {
+                esplora_client::Error::HttpResponse { status, .. } => {
+                    assert_eq!(status, 503);
+                }
+                other => panic!("expected HttpResponse, got {:?}", other),
+            },
+            other => panic!("expected Err, got Ok ({:?})", other.is_ok()),
         }
     }
 }

--- a/coincubed/src/bitcoin/esplora/client.rs
+++ b/coincubed/src/bitcoin/esplora/client.rs
@@ -48,8 +48,7 @@ impl Error {
 /// level + longer backoff. A test asserts the marker stays in the
 /// rendered output so a future refactor can't silently strand the
 /// poller's special-case branch.
-pub const ALL_COOLING_DISPLAY_MARKER: &str =
-    "All Esplora providers are temporarily backing off";
+pub const ALL_COOLING_DISPLAY_MARKER: &str = "All Esplora providers are temporarily backing off";
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -95,10 +94,7 @@ struct Provider {
 
 impl Provider {
     fn is_cooling(&self) -> bool {
-        let guard = self
-            .cooldown_until
-            .lock()
-            .expect("cooldown mutex poisoned");
+        let guard = self.cooldown_until.lock().expect("cooldown mutex poisoned");
         match *guard {
             Some(deadline) => Instant::now() < deadline,
             None => false,
@@ -106,18 +102,12 @@ impl Provider {
     }
 
     fn enter_cooldown(&self) {
-        let mut guard = self
-            .cooldown_until
-            .lock()
-            .expect("cooldown mutex poisoned");
+        let mut guard = self.cooldown_until.lock().expect("cooldown mutex poisoned");
         *guard = Some(Instant::now() + RATE_LIMIT_COOLDOWN);
     }
 
     fn clear_cooldown(&self) {
-        let mut guard = self
-            .cooldown_until
-            .lock()
-            .expect("cooldown mutex poisoned");
+        let mut guard = self.cooldown_until.lock().expect("cooldown mutex poisoned");
         *guard = None;
     }
 }
@@ -220,18 +210,17 @@ impl Client {
         // per check observed in the wild, that shaves ~15s off cold
         // start at no semantic cost: a slow Connect handshake no
         // longer holds up an already-answered mempool.
-        let results: Vec<(usize, Result<u32, esplora_client::Error>)> =
-            std::thread::scope(|s| {
-                let handles: Vec<_> = providers
-                    .iter()
-                    .enumerate()
-                    .map(|(idx, p)| s.spawn(move || (idx, p.client.get_height())))
-                    .collect();
-                handles
-                    .into_iter()
-                    .map(|h| h.join().expect("startup check thread panicked"))
-                    .collect()
-            });
+        let results: Vec<(usize, Result<u32, esplora_client::Error>)> = std::thread::scope(|s| {
+            let handles: Vec<_> = providers
+                .iter()
+                .enumerate()
+                .map(|(idx, p)| s.spawn(move || (idx, p.client.get_height())))
+                .collect();
+            handles
+                .into_iter()
+                .map(|h| h.join().expect("startup check thread panicked"))
+                .collect()
+        });
 
         let mut any_ok = false;
         for (idx, result) in results {
@@ -515,7 +504,10 @@ mod tests {
         assert_eq!(result.unwrap(), 42);
         // First provider must now be cooling; second must not.
         assert!(client.providers[0].is_cooling(), "p1 must be on cooldown");
-        assert!(!client.providers[1].is_cooling(), "p2 must NOT be on cooldown");
+        assert!(
+            !client.providers[1].is_cooling(),
+            "p2 must NOT be on cooldown"
+        );
     }
 
     /// Once a provider is in cooldown, `try_in_order` must skip it on
@@ -618,7 +610,10 @@ mod tests {
             })
         });
 
-        assert_eq!(call_count, 1, "404 must not be retried on the next provider");
+        assert_eq!(
+            call_count, 1,
+            "404 must not be retried on the next provider"
+        );
         assert!(result.is_err());
     }
 

--- a/coincubed/src/bitcoin/esplora/client.rs
+++ b/coincubed/src/bitcoin/esplora/client.rs
@@ -22,33 +22,113 @@ impl std::fmt::Display for Error {
     }
 }
 
-pub struct Client(esplora_client::blocking::BlockingClient);
+/// Bitcoin Esplora client with optional secondary endpoint used as failover.
+///
+/// `try_with_fallback` runs an operation against `primary` first. If the result
+/// is "retryable" per [`should_fall_back`] — transport error, HTTP 402 (quota
+/// exhausted on Blockstream Enterprise), 429 (rate limited), or 5xx — and a
+/// `fallback` client is configured, the same operation is replayed against
+/// `fallback`. All other results pass through unchanged.
+///
+/// Methods that consume a request (`sync`, `full_scan`) take a builder closure
+/// so the request can be rebuilt for the fallback attempt — the BDK request
+/// types are moved into the call and aren't trivially clonable.
+pub struct Client {
+    primary: esplora_client::blocking::BlockingClient,
+    fallback: Option<esplora_client::blocking::BlockingClient>,
+}
+
+/// Build a `BlockingClient` for the given address, applying our standard
+/// timeout, the gzip-disabling header, and an optional bearer token.
+fn build_blocking_client(
+    addr: &str,
+    token: Option<&str>,
+) -> esplora_client::blocking::BlockingClient {
+    let mut builder = esplora_client::Builder::new(addr).timeout(REQUEST_TIMEOUT_SECS);
+    // The blocking esplora client uses `minreq` underneath, which has no
+    // content-encoding support. If the server returns gzip/brotli-compressed
+    // bodies (common for /address/:addr/txs and other large responses),
+    // minreq tries to read the raw bytes as UTF-8 and fails with
+    // `InvalidUtf8InResponse`. Force the server to send uncompressed
+    // responses to avoid this.
+    builder = builder.header("Accept-Encoding", "identity");
+    if let Some(token) = token {
+        builder = builder.header("Authorization", &format!("Bearer {}", token));
+    }
+    builder.build_blocking()
+}
+
+/// Reports whether an esplora call's result should trigger a fallback retry.
+///
+/// HTTP 402 and 429 are 4xx codes but they describe the provider's *capacity*
+/// rather than the request — falling back to a second provider is the correct
+/// response. Genuine 4xx outcomes like 400/404 describe the request itself and
+/// pass through unchanged so the caller sees the real answer.
+fn should_fall_back<T>(result: &Result<T, esplora_client::Error>) -> bool {
+    match result {
+        Ok(_) => false,
+        Err(esplora_client::Error::HttpResponse { status, .. }) => {
+            matches!(*status, 402 | 429) || (500..=599).contains(status)
+        }
+        // Transport-level errors (connection refused, timeout, TLS, parse, …)
+        // — anything that isn't a deliberate HTTP response from the provider.
+        Err(_) => true,
+    }
+}
 
 impl Client {
     /// Create a new client and verify connectivity by fetching the current tip height.
+    ///
+    /// Tries primary first; if primary's connectivity check fails and a
+    /// fallback is configured, tries fallback. Construction only fails when
+    /// neither endpoint is reachable.
     pub fn new(config: &crate::config::EsploraConfig) -> Result<Self, Error> {
-        let mut builder = esplora_client::Builder::new(&config.addr).timeout(REQUEST_TIMEOUT_SECS);
-        // The blocking esplora client uses `minreq` underneath, which has no
-        // content-encoding support. If the server returns gzip/brotli-compressed
-        // bodies (common for /address/:addr/txs and other large responses),
-        // minreq tries to read the raw bytes as UTF-8 and fails with
-        // `InvalidUtf8InResponse`. Force the server to send uncompressed
-        // responses to avoid this.
-        builder = builder.header("Accept-Encoding", "identity");
-        if let Some(token) = &config.token {
-            builder = builder.header("Authorization", &format!("Bearer {}", token));
+        let primary = build_blocking_client(&config.addr, config.token.as_deref());
+        let fallback = config.fallback_addr.as_deref().map(|addr| {
+            build_blocking_client(addr, config.fallback_token.as_deref())
+        });
+
+        // Verify we can reach the server. Fallback to the secondary if the
+        // primary is unreachable at startup so a rate-limited primary doesn't
+        // block daemon launch.
+        let primary_check = primary.get_height();
+        if primary_check.is_ok() {
+            return Ok(Client { primary, fallback });
         }
-        let inner = builder.build_blocking();
-        // Verify we can reach the server.
-        inner.get_height().map_err(|e| Error::Client(Box::new(e)))?;
-        Ok(Client(inner))
+        if let Some(ref fb) = fallback {
+            if fb.get_height().is_ok() {
+                log::warn!(
+                    "Esplora primary unreachable at startup; using fallback for connectivity check"
+                );
+                return Ok(Client { primary, fallback });
+            }
+        }
+        Err(Error::Client(Box::new(primary_check.unwrap_err())))
+    }
+
+    /// Run `op` against the primary client. On a retryable failure, replay it
+    /// against the fallback (if configured). See [`should_fall_back`].
+    fn try_with_fallback<T, F>(&self, mut op: F) -> Result<T, Error>
+    where
+        F: FnMut(&esplora_client::blocking::BlockingClient) -> Result<T, esplora_client::Error>,
+    {
+        let primary_result = op(&self.primary);
+        if !should_fall_back(&primary_result) {
+            return primary_result.map_err(|e| Error::Client(Box::new(e)));
+        }
+        let fallback = match &self.fallback {
+            Some(fb) => fb,
+            None => return primary_result.map_err(|e| Error::Client(Box::new(e))),
+        };
+        if let Err(ref e) = primary_result {
+            log::warn!("Esplora primary failed ({}); retrying on fallback", e);
+        }
+        op(fallback).map_err(|e| Error::Client(Box::new(e)))
     }
 
     /// Get the genesis block hash (block at height 0).
     pub fn genesis_block_hash(&self) -> Result<bitcoin::BlockHash, Error> {
-        self.0
-            .get_block_hash(0)
-            .map_err(|e| Error::Client(Box::new(e)))
+        self.try_with_fallback(|client| client.get_block_hash(0))
     }
 
     /// Get the current chain tip (height + hash).
@@ -56,14 +136,8 @@ impl Client {
     /// Fetches the tip hash first, then resolves its height via `get_block_status` so both
     /// values come from the same point-in-time snapshot, avoiding a TOCTOU mismatch.
     pub fn chain_tip(&self) -> Result<BlockChainTip, Error> {
-        let hash = self
-            .0
-            .get_tip_hash()
-            .map_err(|e| Error::Client(Box::new(e)))?;
-        let status = self
-            .0
-            .get_block_status(&hash)
-            .map_err(|e| Error::Client(Box::new(e)))?;
+        let hash = self.try_with_fallback(|client| client.get_tip_hash())?;
+        let status = self.try_with_fallback(|client| client.get_block_status(&hash))?;
         let height = status.height.ok_or_else(|| {
             Error::Client(Box::new(esplora_client::Error::HttpResponse {
                 status: 404,
@@ -79,51 +153,103 @@ impl Client {
     /// Get the timestamp of the genesis block (block 0).
     pub fn genesis_block_timestamp(&self) -> Result<u32, Error> {
         let hash = self.genesis_block_hash()?;
-        let header = self
-            .0
-            .get_header_by_hash(&hash)
-            .map_err(|e| Error::Client(Box::new(e)))?;
+        let header = self.try_with_fallback(|client| client.get_header_by_hash(&hash))?;
         Ok(header.time)
     }
 
     /// Get the timestamp of the current tip block.
     pub fn tip_time(&self) -> Result<u32, Error> {
-        let hash = self
-            .0
-            .get_tip_hash()
-            .map_err(|e| Error::Client(Box::new(e)))?;
-        let header = self
-            .0
-            .get_header_by_hash(&hash)
-            .map_err(|e| Error::Client(Box::new(e)))?;
+        let hash = self.try_with_fallback(|client| client.get_tip_hash())?;
+        let header = self.try_with_fallback(|client| client.get_header_by_hash(&hash))?;
         Ok(header.time)
     }
 
     /// Broadcast a transaction to the network.
     pub fn broadcast_tx(&self, tx: &bitcoin::Transaction) -> Result<(), Error> {
-        self.0.broadcast(tx).map_err(|e| Error::Client(Box::new(e)))
+        self.try_with_fallback(|client| client.broadcast(tx))
     }
 
     /// Perform a sync against the known SPKs.
-    pub fn sync(
+    ///
+    /// `build_request` is called once per attempt (at most twice — primary
+    /// then fallback) because BDK's `SyncRequest` is consumed by the call.
+    /// The `Box` returned by `EsploraExt::sync` is unboxed inside the closure
+    /// so it matches [`Client::try_with_fallback`]'s unboxed-error contract.
+    pub fn sync<F>(
         &self,
-        request: SyncRequest,
+        mut build_request: F,
         parallel_requests: usize,
-    ) -> Result<SyncResult, Error> {
-        self.0
-            .sync(request, parallel_requests)
-            .map_err(Error::Client)
+    ) -> Result<SyncResult, Error>
+    where
+        F: FnMut() -> SyncRequest,
+    {
+        self.try_with_fallback(|client| {
+            client
+                .sync(build_request(), parallel_requests)
+                .map_err(|e| *e)
+        })
     }
 
     /// Perform a full scan from genesis for all keychain SPKs.
-    pub fn full_scan<K: Ord + Clone + std::fmt::Debug + Send>(
+    ///
+    /// See [`Client::sync`] for the rationale behind the builder closure.
+    pub fn full_scan<K, F>(
         &self,
-        request: FullScanRequest<K>,
+        mut build_request: F,
         stop_gap: usize,
         parallel_requests: usize,
-    ) -> Result<FullScanResult<K>, Error> {
-        self.0
-            .full_scan(request, stop_gap, parallel_requests)
-            .map_err(Error::Client)
+    ) -> Result<FullScanResult<K>, Error>
+    where
+        K: Ord + Clone + std::fmt::Debug + Send,
+        F: FnMut() -> FullScanRequest<K>,
+    {
+        self.try_with_fallback(|client| {
+            client
+                .full_scan(build_request(), stop_gap, parallel_requests)
+                .map_err(|e| *e)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_fall_back_classifies_correctly() {
+        // Ok results never fall back.
+        let ok: Result<(), esplora_client::Error> = Ok(());
+        assert!(!should_fall_back(&ok));
+
+        // 402 / 429 fall back (capacity-class 4xx).
+        for status in [402u16, 429] {
+            let r: Result<(), esplora_client::Error> = Err(esplora_client::Error::HttpResponse {
+                status,
+                message: String::new(),
+            });
+            assert!(should_fall_back(&r), "status {} should fall back", status);
+        }
+
+        // 5xx falls back.
+        for status in [500u16, 502, 503, 504] {
+            let r: Result<(), esplora_client::Error> = Err(esplora_client::Error::HttpResponse {
+                status,
+                message: String::new(),
+            });
+            assert!(should_fall_back(&r), "status {} should fall back", status);
+        }
+
+        // Other 4xx pass through — they describe the request, not the provider.
+        for status in [400u16, 401, 403, 404] {
+            let r: Result<(), esplora_client::Error> = Err(esplora_client::Error::HttpResponse {
+                status,
+                message: String::new(),
+            });
+            assert!(
+                !should_fall_back(&r),
+                "status {} should not fall back",
+                status
+            );
+        }
     }
 }

--- a/coincubed/src/bitcoin/esplora/client.rs
+++ b/coincubed/src/bitcoin/esplora/client.rs
@@ -22,12 +22,44 @@ const RATE_LIMIT_COOLDOWN: Duration = Duration::from_secs(600);
 #[derive(Debug)]
 pub enum Error {
     Client(Box<esplora_client::Error>),
+    /// Every configured provider is currently in a 402/429 cooldown,
+    /// so no network call was actually attempted. This is a
+    /// transient "wait" signal, not a fault — callers (the poller in
+    /// particular) should treat it as a no-op outcome rather than a
+    /// real failure to log at ERROR level. The next tick after any
+    /// provider's cooldown expires will see a normal result.
+    AllCooling,
 }
+
+impl Error {
+    /// `true` for the [`Error::AllCooling`] variant. Lets the
+    /// poller's error-handling arm downgrade the log level and back
+    /// off longer without having to import the variant by name.
+    pub fn is_all_cooling(&self) -> bool {
+        matches!(self, Error::AllCooling)
+    }
+}
+
+/// Marker substring placed at the start of [`Error::AllCooling`]'s
+/// `Display` output. The [`BitcoinInterface::sync_wallet`] trait
+/// boundary forces us to stringify the error, so the poller can't
+/// pattern-match on the typed variant directly — instead it checks
+/// for this marker in the error string and routes to a quieter log
+/// level + longer backoff. A test asserts the marker stays in the
+/// rendered output so a future refactor can't silently strand the
+/// poller's special-case branch.
+pub const ALL_COOLING_DISPLAY_MARKER: &str =
+    "All Esplora providers are temporarily backing off";
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Error::Client(e) => write!(f, "Esplora client error: '{}'.", e),
+            Error::AllCooling => write!(
+                f,
+                "{} after recent rate limits; the poller will retry once a cooldown expires.",
+                ALL_COOLING_DISPLAY_MARKER,
+            ),
         }
     }
 }
@@ -181,29 +213,47 @@ impl Client {
         // a 402/429 response here pre-seeds the provider's cooldown so
         // the first real sync tick after launch doesn't waste a call
         // re-discovering the same throttle.
+        //
+        // The checks run concurrently via `thread::scope` — total
+        // startup wait is `max(per-provider latency)` instead of the
+        // sum. With three providers and the steady-state 5–11s
+        // per check observed in the wild, that shaves ~15s off cold
+        // start at no semantic cost: a slow Connect handshake no
+        // longer holds up an already-answered mempool.
+        let results: Vec<(usize, Result<u32, esplora_client::Error>)> =
+            std::thread::scope(|s| {
+                let handles: Vec<_> = providers
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, p)| s.spawn(move || (idx, p.client.get_height())))
+                    .collect();
+                handles
+                    .into_iter()
+                    .map(|h| h.join().expect("startup check thread panicked"))
+                    .collect()
+            });
+
         let mut any_ok = false;
-        for provider in &providers {
-            match provider.client.get_height() {
+        for (idx, result) in results {
+            let provider = &providers[idx];
+            match result {
                 Ok(_) => {
                     log::info!("Esplora {} reachable at startup", provider.name);
                     any_ok = true;
                 }
+                Err(esplora_client::Error::HttpResponse { status, message })
+                    if matches!(status, 402 | 429) =>
+                {
+                    provider.enter_cooldown();
+                    log::warn!(
+                        "Esplora {} throttled at startup (status {}): {} — pre-seeded cooldown",
+                        provider.name,
+                        status,
+                        message,
+                    );
+                }
                 Err(e) => {
-                    let throttle_result: Result<(), _> = Err(e);
-                    if is_throttled(&throttle_result) {
-                        provider.enter_cooldown();
-                        log::warn!(
-                            "Esplora {} throttled at startup ({}); pre-seeded cooldown",
-                            provider.name,
-                            throttle_result.unwrap_err(),
-                        );
-                    } else {
-                        log::warn!(
-                            "Esplora {} unreachable at startup: {}",
-                            provider.name,
-                            throttle_result.unwrap_err(),
-                        );
-                    }
+                    log::warn!("Esplora {} unreachable at startup: {}", provider.name, e);
                 }
             }
         }
@@ -263,17 +313,14 @@ impl Client {
         }
         // Every provider either failed retryably or was on cooldown.
         // Surface the last real result if we have one; otherwise the
-        // entire chain was on cooldown — surface that as a generic
-        // "no provider available" so the caller can retry on the next
-        // tick.
-        last_result
-            .unwrap_or_else(|| {
-                Err(esplora_client::Error::HttpResponse {
-                    status: 503,
-                    message: "every configured Esplora provider is currently in cooldown".into(),
-                })
-            })
-            .map_err(|e| Error::Client(Box::new(e)))
+        // entire chain was on cooldown — return the typed
+        // [`Error::AllCooling`] so the poller can log it at a sane
+        // level and back off longer than its normal 2s retry, since
+        // a cooldown won't lift for minutes.
+        match last_result {
+            Some(r) => r.map_err(|e| Error::Client(Box::new(e))),
+            None => Err(Error::AllCooling),
+        }
     }
 
     /// Get the genesis block hash (block at height 0).
@@ -575,24 +622,47 @@ mod tests {
         assert!(result.is_err());
     }
 
-    /// If every provider is cooling, `try_in_order` must surface a
-    /// synthesised 503 rather than panicking or returning Ok — the
-    /// caller can then back off and retry on the next tick.
+    /// If every provider is cooling, `try_in_order` must surface the
+    /// typed [`Error::AllCooling`] rather than masquerading as a
+    /// real failure (or synthesising a 503 that looks like an
+    /// upstream HTTP error). The poller routes `AllCooling` to a
+    /// quieter log level and a longer backoff.
     #[test]
-    fn all_cooling_returns_synthesised_503() {
+    fn all_cooling_returns_typed_variant() {
         let client = client_with(vec![fake_provider("p1"), fake_provider("p2")]);
         for p in &client.providers {
             p.enter_cooldown();
         }
         let result: Result<u32, Error> = client.try_in_order(|_| Ok(1));
         match result {
-            Err(Error::Client(boxed)) => match *boxed {
-                esplora_client::Error::HttpResponse { status, .. } => {
-                    assert_eq!(status, 503);
-                }
-                other => panic!("expected HttpResponse, got {:?}", other),
-            },
-            other => panic!("expected Err, got Ok ({:?})", other.is_ok()),
+            Err(e) => {
+                assert!(e.is_all_cooling(), "expected AllCooling, got {:?}", e);
+                // Display must communicate "this is transient" so a
+                // human glancing at the log doesn't read it as a
+                // real fault.
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("temporarily backing off"),
+                    "Display should describe the transient nature; got: {}",
+                    msg,
+                );
+            }
+            Ok(v) => panic!("expected Err(AllCooling), got Ok({})", v),
         }
+    }
+
+    /// Regression: the poller pattern-matches the rendered error
+    /// string at the trait boundary. If a refactor changes the
+    /// `Display` impl without updating
+    /// [`ALL_COOLING_DISPLAY_MARKER`], the poller would silently
+    /// stop quieting the spam.
+    #[test]
+    fn all_cooling_display_contains_the_published_marker() {
+        let msg = Error::AllCooling.to_string();
+        assert!(
+            msg.starts_with(ALL_COOLING_DISPLAY_MARKER),
+            "Display must start with the marker the poller scans for; got: {}",
+            msg,
+        );
     }
 }

--- a/coincubed/src/bitcoin/esplora/mod.rs
+++ b/coincubed/src/bitcoin/esplora/mod.rs
@@ -87,10 +87,13 @@ pub struct Esplora {
     /// One-shot flag set by [`Self::request_eager_sync`]. When
     /// `true`, the next [`Self::sync_wallet`] call bypasses the
     /// smart-poll tip-guard and does a full per-SPK walk even when
-    /// the chain tip hasn't moved. Consumed (cleared) at the top
-    /// of `sync_wallet` so subsequent ticks resume normal cadence.
-    /// Drives the "user opened Receive / app regained focus / new
-    /// receive address" UX hooks.
+    /// the chain tip hasn't moved. Cleared only after a *successful*
+    /// sync — a transient failure (e.g. every provider in cooldown,
+    /// transport error) preserves the flag so the next poller tick
+    /// also honors the user's "fresh data, now" intent rather than
+    /// silently falling back to the tip-guard short-circuit. Drives
+    /// the "user opened Receive / app regained focus / new receive
+    /// address" UX hooks.
     eager_sync_requested: bool,
 }
 
@@ -198,10 +201,16 @@ impl Esplora {
             local_chain_tip.block_id().height
         );
 
-        // Eager-sync override. Consumed unconditionally so a
-        // request that arrives during a forced rescan doesn't
-        // linger and double-fire later.
-        let eager = std::mem::replace(&mut self.eager_sync_requested, false);
+        // Eager-sync override. Read without clearing: if the sync
+        // attempt below fails transiently (all-cooling, transport
+        // error, BDK rejected the chain update, …) we want the
+        // next poller tick to also bypass the tip-guard rather
+        // than silently consume the user's "fresh data, now"
+        // intent on a poll that returned no useful data. The flag
+        // is cleared at the success-return path at the bottom of
+        // this function, after the wallet has actually been
+        // brought up to date.
+        let eager = self.eager_sync_requested;
         if eager {
             log::debug!("Esplora eager sync requested; bypassing tip-guard");
         }
@@ -216,19 +225,30 @@ impl Esplora {
         if !self.is_rescanning() && !eager {
             if let Some(last_tip) = self.last_synced_tip {
                 let current_tip = self.client.chain_tip().map_err(EsploraError::Client)?;
-                if current_tip == last_tip
-                    && self.polls_since_full_sync < MAX_POLLS_BEFORE_FORCED_RESCAN
-                {
-                    self.polls_since_full_sync = self.polls_since_full_sync.saturating_add(1);
-                    log::debug!(
-                        "Esplora tip unchanged ({}), skipping per-SPK rescan \
-                         (forced rescan in {} more polls)",
-                        current_tip,
-                        MAX_POLLS_BEFORE_FORCED_RESCAN.saturating_sub(self.polls_since_full_sync),
-                    );
-                    return Ok(None);
-                }
                 if current_tip == last_tip {
+                    // Counting the *prospective* skip first so the
+                    // boundary fires exactly on the
+                    // `MAX_POLLS_BEFORE_FORCED_RESCAN`th unchanged
+                    // poll (the staleness cap documented on the
+                    // constant). The pre-fix shape incremented
+                    // *after* the comparison, which let one extra
+                    // tick of staleness through before the forced
+                    // rescan — every Nth+1 poll instead of every
+                    // Nth. We only persist the increment when we
+                    // actually skip; on the boundary tick we fall
+                    // through to a full sync, which resets the
+                    // counter to 0 at its success-return below.
+                    let prospective = self.polls_since_full_sync.saturating_add(1);
+                    if prospective < MAX_POLLS_BEFORE_FORCED_RESCAN {
+                        self.polls_since_full_sync = prospective;
+                        log::debug!(
+                            "Esplora tip unchanged ({}), skipping per-SPK rescan \
+                             (forced rescan in {} more polls)",
+                            current_tip,
+                            MAX_POLLS_BEFORE_FORCED_RESCAN.saturating_sub(prospective),
+                        );
+                        return Ok(None);
+                    }
                     log::debug!(
                         "Esplora tip unchanged ({}) but forced-rescan boundary reached \
                          after {} skipped polls; performing full rescan",
@@ -373,6 +393,11 @@ impl Esplora {
         // hasn't moved, and reset the forced-rescan counter.
         self.last_synced_tip = Some(self.wallet_tip());
         self.polls_since_full_sync = 0;
+        // Sync succeeded — the user's eager request (if any) is
+        // now honored, so clear the flag. Earlier transient
+        // failures left it set so this point would eventually be
+        // reached on a retry.
+        self.eager_sync_requested = false;
 
         Ok(reorg_common_ancestor)
     }

--- a/coincubed/src/bitcoin/esplora/mod.rs
+++ b/coincubed/src/bitcoin/esplora/mod.rs
@@ -199,8 +199,7 @@ impl Esplora {
                         "Esplora tip unchanged ({}), skipping per-SPK rescan \
                          (forced rescan in {} more polls)",
                         current_tip,
-                        MAX_POLLS_BEFORE_FORCED_RESCAN
-                            .saturating_sub(self.polls_since_full_sync),
+                        MAX_POLLS_BEFORE_FORCED_RESCAN.saturating_sub(self.polls_since_full_sync),
                     );
                     return Ok(None);
                 }
@@ -270,8 +269,7 @@ impl Esplora {
                 .client
                 .full_scan(
                     || {
-                        let mut request =
-                            FullScanRequest::from_chain_tip(local_chain_tip.clone());
+                        let mut request = FullScanRequest::from_chain_tip(local_chain_tip.clone());
                         for (k, spks) in bdk_wallet.index().all_unbounded_spk_iters() {
                             request = request.set_spks_for_keychain(k, spks);
                         }

--- a/coincubed/src/bitcoin/esplora/mod.rs
+++ b/coincubed/src/bitcoin/esplora/mod.rs
@@ -142,37 +142,53 @@ impl Esplora {
         const PARALLEL_REQUESTS: usize = 4;
         const STOP_GAP: usize = 200;
 
+        // SPK lists are rebuilt per attempt so the request closure can be
+        // re-invoked if the primary Esplora endpoint fails and the client
+        // retries on its fallback. BDK's request types are consumed by the
+        // call, so the only way to retry is to build a fresh request.
         let (chain_update, mut graph_update, keychain_update) = if !self.is_rescanning() {
             log::debug!("Performing sync.");
-            let mut request = SyncRequest::from_chain_tip(local_chain_tip.clone());
-
-            let all_spks: Vec<_> = self
-                .bdk_wallet
-                .index()
-                .inner()
-                .all_spks()
-                .values()
-                .cloned()
-                .collect();
-            request = request.chain_spks(all_spks);
-            log::debug!("num SPKs for sync: {}", request.spks.len());
-
+            let bdk_wallet = &self.bdk_wallet;
+            let local_chain_tip = local_chain_tip.clone();
             let sync_result = self
                 .client
-                .sync(request, PARALLEL_REQUESTS)
+                .sync(
+                    || -> SyncRequest {
+                        let mut request = SyncRequest::from_chain_tip(local_chain_tip.clone());
+                        let all_spks: Vec<_> = bdk_wallet
+                            .index()
+                            .inner()
+                            .all_spks()
+                            .values()
+                            .cloned()
+                            .collect();
+                        request = request.chain_spks(all_spks);
+                        log::debug!("num SPKs for sync: {}", request.spks.len());
+                        request
+                    },
+                    PARALLEL_REQUESTS,
+                )
                 .map_err(EsploraError::Client)?;
             log::debug!("Sync complete.");
             (sync_result.chain_update, sync_result.graph_update, None)
         } else {
             log::info!("Performing full scan.");
-            let mut request = FullScanRequest::from_chain_tip(local_chain_tip.clone());
-
-            for (k, spks) in self.bdk_wallet.index().all_unbounded_spk_iters() {
-                request = request.set_spks_for_keychain(k, spks);
-            }
+            let bdk_wallet = &self.bdk_wallet;
+            let local_chain_tip = local_chain_tip.clone();
             let scan_result = self
                 .client
-                .full_scan(request, STOP_GAP, PARALLEL_REQUESTS)
+                .full_scan(
+                    || {
+                        let mut request =
+                            FullScanRequest::from_chain_tip(local_chain_tip.clone());
+                        for (k, spks) in bdk_wallet.index().all_unbounded_spk_iters() {
+                            request = request.set_spks_for_keychain(k, spks);
+                        }
+                        request
+                    },
+                    STOP_GAP,
+                    PARALLEL_REQUESTS,
+                )
                 .map_err(EsploraError::Client)?;
             self.full_scan = false;
             log::info!("Full scan complete.");

--- a/coincubed/src/bitcoin/esplora/mod.rs
+++ b/coincubed/src/bitcoin/esplora/mod.rs
@@ -49,6 +49,18 @@ impl std::fmt::Display for EsploraError {
     }
 }
 
+/// How often we force a full per-SPK rescan even when the chain tip
+/// hasn't moved, as a safety net for mempool-only activity
+/// (transactions broadcast to us between blocks, RBF replacements, …).
+/// Mempool-only activity is invisible to the [`Esplora::sync_wallet`]
+/// tip-guard, so without this cap a quiet chain could let mempool
+/// state silently drift out of sync for hours.
+///
+/// At the default `poll_interval = 600s` (10 min), a value of 6
+/// means we do a full rescan at least every hour, capping the
+/// mempool-staleness window.
+const MAX_POLLS_BEFORE_FORCED_RESCAN: u32 = 6;
+
 /// Interface for the Esplora backend.
 pub struct Esplora {
     client: client::Client,
@@ -59,6 +71,19 @@ pub struct Esplora {
     /// Set to `true` to force a full scan from the genesis block regardless of
     /// the wallet's local chain height.
     full_scan: bool,
+    /// Chain tip observed at the end of the most recent successful
+    /// full sync. The smart-poll guard in [`Self::sync_wallet`]
+    /// fetches the current tip on every call and compares it here:
+    /// if the chain hasn't advanced *and* we're not at the forced-
+    /// rescan boundary, the per-SPK walk is skipped, dropping the
+    /// poll cost from ~80 HTTP requests to 1. Set back to `None`
+    /// only by a deliberate `trigger_rescan` or on first run.
+    last_synced_tip: Option<BlockChainTip>,
+    /// Number of polls since the last full per-SPK sync.
+    /// Incremented every time the tip-guard short-circuits; reset
+    /// to 0 on every actual sync run (including the safety-net
+    /// rescans at [`MAX_POLLS_BEFORE_FORCED_RESCAN`]).
+    polls_since_full_sync: u32,
 }
 
 impl Esplora {
@@ -72,6 +97,8 @@ impl Esplora {
             bdk_wallet,
             sync_count: 0,
             full_scan,
+            last_synced_tip: None,
+            polls_since_full_sync: 0,
         })
     }
 
@@ -123,10 +150,26 @@ impl Esplora {
     /// Make the poller perform a full scan on the next iteration.
     pub fn trigger_rescan(&mut self) {
         self.full_scan = true;
+        // Forget the cached tip — the rescan rebuilds the chain
+        // from genesis, so any post-rescan tip we observe is
+        // genuinely new information and the tip-guard should treat
+        // it as such.
+        self.last_synced_tip = None;
+        self.polls_since_full_sync = 0;
     }
 
     /// Sync the wallet with the Esplora server. If there was any reorg since the last poll, this
     /// returns the first common ancestor between the previous and the new chain.
+    ///
+    /// Smart-poll guard: when we're not in a forced full-scan state
+    /// and the chain tip we just fetched matches the one cached
+    /// from our last full sync, the per-SPK walk is skipped
+    /// entirely. This is the common case on a quiet chain and
+    /// drops the per-poll cost from ~80 HTTP requests to 1. The
+    /// [`MAX_POLLS_BEFORE_FORCED_RESCAN`] safety net forces a full
+    /// rescan every Nth idle tick to surface mempool-only activity
+    /// (RBF replacements, broadcasts targeting us between blocks)
+    /// that the tip-guard would otherwise hide.
     pub fn sync_wallet(
         &mut self,
         receive_index: ChildNumber,
@@ -139,7 +182,55 @@ impl Esplora {
             local_chain_tip.block_id().height
         );
 
-        const PARALLEL_REQUESTS: usize = 4;
+        // Tip-guard. A single `chain_tip` request is cheap enough
+        // (one HTTP call vs. ~80 for the SPK walk) that we always
+        // pay it; the savings come from skipping the walk when the
+        // tip is unchanged. Only applies when we're not in a
+        // forced full-scan and there's a `last_synced_tip` to
+        // compare against — first-poll has no baseline.
+        if !self.is_rescanning() {
+            if let Some(last_tip) = self.last_synced_tip {
+                let current_tip = self.client.chain_tip().map_err(EsploraError::Client)?;
+                if current_tip == last_tip
+                    && self.polls_since_full_sync < MAX_POLLS_BEFORE_FORCED_RESCAN
+                {
+                    self.polls_since_full_sync = self.polls_since_full_sync.saturating_add(1);
+                    log::debug!(
+                        "Esplora tip unchanged ({}), skipping per-SPK rescan \
+                         (forced rescan in {} more polls)",
+                        current_tip,
+                        MAX_POLLS_BEFORE_FORCED_RESCAN
+                            .saturating_sub(self.polls_since_full_sync),
+                    );
+                    return Ok(None);
+                }
+                if current_tip == last_tip {
+                    log::debug!(
+                        "Esplora tip unchanged ({}) but forced-rescan boundary reached \
+                         after {} skipped polls; performing full rescan",
+                        current_tip,
+                        self.polls_since_full_sync,
+                    );
+                } else {
+                    log::debug!(
+                        "Esplora tip advanced from {} to {}; performing full sync",
+                        last_tip,
+                        current_tip,
+                    );
+                }
+            }
+        }
+
+        // Lowered from 4 to 2 to play nicer with mempool.space's
+        // per-IP rate window. Hitting 4 concurrent requests against
+        // the public mempool tier reliably triggers 429s mid-sync,
+        // and a 429 mid-sync is much more expensive than a 2×
+        // slowdown on the happy path: BDK throws away the partial
+        // result and the next provider in the chain has to redo
+        // every SPK from scratch. Two-wide keeps us under mempool's
+        // per-second budget more often, so the happy path stays
+        // happy.
+        const PARALLEL_REQUESTS: usize = 2;
         const STOP_GAP: usize = 200;
 
         // SPK lists are rebuilt per attempt so the request closure can be
@@ -253,6 +344,13 @@ impl Esplora {
             }
         }
         self.bdk_wallet.apply_graph_update(graph_update);
+
+        // The wallet's local chain is now caught up. Cache its tip so
+        // the next poll's tip-guard can short-circuit when the chain
+        // hasn't moved, and reset the forced-rescan counter.
+        self.last_synced_tip = Some(self.wallet_tip());
+        self.polls_since_full_sync = 0;
+
         Ok(reorg_common_ancestor)
     }
 

--- a/coincubed/src/bitcoin/esplora/mod.rs
+++ b/coincubed/src/bitcoin/esplora/mod.rs
@@ -84,6 +84,14 @@ pub struct Esplora {
     /// to 0 on every actual sync run (including the safety-net
     /// rescans at [`MAX_POLLS_BEFORE_FORCED_RESCAN`]).
     polls_since_full_sync: u32,
+    /// One-shot flag set by [`Self::request_eager_sync`]. When
+    /// `true`, the next [`Self::sync_wallet`] call bypasses the
+    /// smart-poll tip-guard and does a full per-SPK walk even when
+    /// the chain tip hasn't moved. Consumed (cleared) at the top
+    /// of `sync_wallet` so subsequent ticks resume normal cadence.
+    /// Drives the "user opened Receive / app regained focus / new
+    /// receive address" UX hooks.
+    eager_sync_requested: bool,
 }
 
 impl Esplora {
@@ -99,7 +107,15 @@ impl Esplora {
             full_scan,
             last_synced_tip: None,
             polls_since_full_sync: 0,
+            eager_sync_requested: false,
         })
+    }
+
+    /// Bypass the smart-poll tip-guard on the next sync. See
+    /// [`crate::bitcoin::BitcoinInterface::request_eager_sync`] for
+    /// the rationale.
+    pub fn request_eager_sync(&mut self) {
+        self.eager_sync_requested = true;
     }
 
     pub fn sanity_checks(&self, expected_hash: &bitcoin::BlockHash) -> Result<(), EsploraError> {
@@ -182,13 +198,22 @@ impl Esplora {
             local_chain_tip.block_id().height
         );
 
+        // Eager-sync override. Consumed unconditionally so a
+        // request that arrives during a forced rescan doesn't
+        // linger and double-fire later.
+        let eager = std::mem::replace(&mut self.eager_sync_requested, false);
+        if eager {
+            log::debug!("Esplora eager sync requested; bypassing tip-guard");
+        }
+
         // Tip-guard. A single `chain_tip` request is cheap enough
         // (one HTTP call vs. ~80 for the SPK walk) that we always
         // pay it; the savings come from skipping the walk when the
         // tip is unchanged. Only applies when we're not in a
-        // forced full-scan and there's a `last_synced_tip` to
-        // compare against — first-poll has no baseline.
-        if !self.is_rescanning() {
+        // forced full-scan, an eager sync wasn't requested, and
+        // there's a `last_synced_tip` to compare against — first-
+        // poll has no baseline.
+        if !self.is_rescanning() && !eager {
             if let Some(last_tip) = self.last_synced_tip {
                 let current_tip = self.client.chain_tip().map_err(EsploraError::Client)?;
                 if current_tip == last_tip

--- a/coincubed/src/bitcoin/mod.rs
+++ b/coincubed/src/bitcoin/mod.rs
@@ -106,6 +106,21 @@ pub trait BitcoinInterface: Send {
     /// Broadcast this transaction to the Bitcoin P2P network
     fn broadcast_tx(&self, tx: &bitcoin::Transaction) -> Result<(), String>;
 
+    /// Request that the next [`Self::sync_wallet`] call bypass any
+    /// short-circuit optimisations (e.g. the smart-poll tip-guard
+    /// on the Esplora backend) and do a full sync against the
+    /// providers. No-op for backends that don't have such an
+    /// optimisation, so the default impl is fine for everyone but
+    /// Esplora.
+    ///
+    /// The GUI calls this — via the `requestsync` JSON-RPC — when
+    /// the user does something that signals "I want fresh data
+    /// now": app regains focus, the Receive panel opens, a new
+    /// receive address is generated, etc. The flag is consumed on
+    /// the next sync, so subsequent ticks resume normal smart-poll
+    /// behaviour.
+    fn request_eager_sync(&mut self) {}
+
     /// Trigger a rescan of the block chain for transactions related to this descriptor since
     /// the given date.
     fn start_rescan(
@@ -602,6 +617,10 @@ impl BitcoinInterface for esplora::Esplora {
             .map_err(|e| e.to_string())
     }
 
+    fn request_eager_sync(&mut self) {
+        self.request_eager_sync();
+    }
+
     fn received_coins(
         &self,
         tip: &BlockChainTip,
@@ -834,6 +853,10 @@ impl BitcoinInterface for sync::Arc<sync::Mutex<dyn BitcoinInterface + 'static>>
 
     fn broadcast_tx(&self, tx: &bitcoin::Transaction) -> Result<(), String> {
         self.lock().unwrap().broadcast_tx(tx)
+    }
+
+    fn request_eager_sync(&mut self) {
+        self.lock().unwrap().request_eager_sync();
     }
 
     fn start_rescan(

--- a/coincubed/src/bitcoin/poller/looper.rs
+++ b/coincubed/src/bitcoin/poller/looper.rs
@@ -288,8 +288,27 @@ fn updates(
             return updates(db_conn, bit, descs, secp);
         }
         Err(e) => {
-            log::error!("Error syncing wallet: '{}'.", e);
-            thread::sleep(time::Duration::from_secs(2));
+            // The Esplora "every provider cooling" case isn't a real
+            // failure — no network call was attempted — so log it at
+            // debug and back off long enough for at least one
+            // provider's cooldown to expire (cooldowns run 10 min,
+            // so 30s here just keeps the tick from being wasteful;
+            // future ticks will still skip-fast until something
+            // recovers). Without this branch the poller spammed
+            // ~30 ERROR lines/min while every backend was throttled.
+            // The string check is intentional: the
+            // `BitcoinInterface::sync_wallet` signature returns
+            // `Result<_, String>`, so we can't pattern-match on the
+            // typed `client::Error::AllCooling` variant from here.
+            // A regression test in `bitcoin::esplora::client`
+            // guards the marker.
+            if e.contains(crate::bitcoin::esplora::client::ALL_COOLING_DISPLAY_MARKER) {
+                log::debug!("Esplora poll skipped: {}", e);
+                thread::sleep(time::Duration::from_secs(30));
+            } else {
+                log::error!("Error syncing wallet: '{}'.", e);
+                thread::sleep(time::Duration::from_secs(2));
+            }
             return updates(db_conn, bit, descs, secp);
         }
     };

--- a/coincubed/src/bitcoin/poller/mod.rs
+++ b/coincubed/src/bitcoin/poller/mod.rs
@@ -64,11 +64,7 @@ impl Poller {
     /// chain is actually caught up, so the caller doesn't have to
     /// repeat that bookkeeping or decide independently when the
     /// next scheduled tick should fire.
-    fn run_immediate_poll(
-        &mut self,
-        synced: &mut bool,
-        last_poll: &mut Option<time::Instant>,
-    ) {
+    fn run_immediate_poll(&mut self, synced: &mut bool, last_poll: &mut Option<time::Instant>) {
         // Polling while the block chain is syncing could lead to
         // poller restarts if the height increases before
         // completion, and in any case this is consistent with

--- a/coincubed/src/bitcoin/poller/mod.rs
+++ b/coincubed/src/bitcoin/poller/mod.rs
@@ -16,6 +16,14 @@ pub enum PollerMessage {
     /// Ask the Bitcoin poller to poll immediately, get notified through the passed channel once
     /// it's done.
     PollNow(mpsc::SyncSender<()>),
+    /// Same as [`Self::PollNow`] but without an ack channel.
+    /// Intended for fire-and-forget triggers (UX hooks: app focus,
+    /// Receive panel open, new receive address) where the caller
+    /// has no use for the completion signal — and where supplying
+    /// a sender whose matching receiver gets dropped immediately
+    /// would cause the poller to log a spurious "send failed"
+    /// error on every trigger.
+    PollNowNoAck,
 }
 
 /// The Bitcoin poller handler.
@@ -47,6 +55,42 @@ impl Poller {
             db,
             secp,
             descs,
+        }
+    }
+
+    /// Shared body for the immediate-poll message arms
+    /// ([`PollerMessage::PollNow`] and [`PollerMessage::PollNowNoAck`]).
+    /// Updates `synced` and `last_poll` regardless of whether the
+    /// chain is actually caught up, so the caller doesn't have to
+    /// repeat that bookkeeping or decide independently when the
+    /// next scheduled tick should fire.
+    fn run_immediate_poll(
+        &mut self,
+        synced: &mut bool,
+        last_poll: &mut Option<time::Instant>,
+    ) {
+        // Polling while the block chain is syncing could lead to
+        // poller restarts if the height increases before
+        // completion, and in any case this is consistent with
+        // regular poller behaviour: re-check sync progress before
+        // committing to a poll.
+        if !*synced {
+            let progress = self.bit.sync_progress();
+            log::info!(
+                "Block chain synchronization progress: {:.2}% ({} blocks / {} headers)",
+                progress.rounded_up_progress() * 100.0,
+                progress.blocks,
+                progress.headers
+            );
+            *synced = progress.is_complete();
+        }
+        // Update `last_poll` even if we don't poll now so that we
+        // don't attempt another poll too soon.
+        *last_poll = Some(time::Instant::now());
+        if *synced {
+            looper::poll(&mut self.bit, &self.db, &self.secp, &self.descs);
+        } else {
+            log::warn!("Skipped poll as block chain is still synchronizing.");
         }
     }
 
@@ -89,32 +133,17 @@ impl Poller {
                     return;
                 }
                 Ok(PollerMessage::PollNow(sender)) => {
-                    // We've been asked to poll, don't wait any further and signal completion to
-                    // the caller, unless the block chain is still syncing.
-                    // Polling while the block chain is syncing could lead to poller restarts
-                    // if the height increases before completion, and in any case this is consistent
-                    // with regular poller behaviour.
-                    if !synced {
-                        let progress = self.bit.sync_progress();
-                        log::info!(
-                            "Block chain synchronization progress: {:.2}% ({} blocks / {} headers)",
-                            progress.rounded_up_progress() * 100.0,
-                            progress.blocks,
-                            progress.headers
-                        );
-                        synced = progress.is_complete();
-                    }
-                    // Update `last_poll` even if we don't poll now so that we don't attempt another
-                    // poll too soon.
-                    last_poll = Some(time::Instant::now());
-                    if synced {
-                        looper::poll(&mut self.bit, &self.db, &self.secp, &self.descs);
-                    } else {
-                        log::warn!("Skipped poll as block chain is still synchronizing.");
-                    }
+                    self.run_immediate_poll(&mut synced, &mut last_poll);
                     if let Err(e) = sender.send(()) {
                         log::error!("Error sending immediate poll completion signal: {}.", e);
                     }
+                    continue;
+                }
+                Ok(PollerMessage::PollNowNoAck) => {
+                    // Same work, no completion signal — see the
+                    // `PollNowNoAck` variant doc for why this
+                    // exists separately from `PollNow`.
+                    self.run_immediate_poll(&mut synced, &mut last_poll);
                     continue;
                 }
                 Err(mpsc::RecvTimeoutError::Timeout) => {

--- a/coincubed/src/commands/mod.rs
+++ b/coincubed/src/commands/mod.rs
@@ -334,22 +334,41 @@ impl DaemonControl {
     /// inside the free-tier hourly budget at the current 10-min
     /// poll interval.
     pub fn request_sync(&self) {
-        // Set the eager flag on the backend so that whenever the
-        // poller runs next, the smart-poll guard is bypassed and
-        // we do a real per-SPK walk. Non-Esplora backends take the
-        // trait's default no-op.
+        // Set the eager flag on the backend FIRST so it's already
+        // armed by the time the poller wakes — whether via the
+        // message we're about to enqueue or via whatever message
+        // happens to already be queued. The flag lives on `Esplora`,
+        // not on the channel payload, so a dropped wake-up signal
+        // doesn't lose the user's request.
         self.bitcoin.lock().unwrap().request_eager_sync();
-        // Wake the poller now rather than waiting for its current
-        // sleep to elapse. Use the no-ack variant so the poller
-        // doesn't log a spurious "send failed" error on every
-        // trigger — completion surfaces naturally through
-        // subsequent `get_info`/state calls from the GUI, and
-        // blocking here on a completion signal would freeze the
-        // JSON-RPC handler thread for as long as the sync takes,
-        // which is not what we want for a UX-triggered "kick the
-        // poller" request.
-        if let Err(e) = self.poller_sender.send(PollerMessage::PollNowNoAck) {
-            log::warn!("request_sync: poller send failed: {}", e);
+        // Non-blocking send: the poller channel is a `sync_channel(1)`,
+        // so a plain `send` would block under burst pressure (e.g.
+        // user opens Receive twice in rapid succession while a sync
+        // is mid-flight). Blocking the JSON-RPC handler thread for
+        // however long that sync takes is exactly what we're trying
+        // to avoid for a UX-triggered "kick the poller" request.
+        //
+        // `try_send` semantics map cleanly:
+        //   * Ok            – wake-up enqueued; poller will wake now.
+        //   * Err(Full)     – a wake-up (ours or the broadcast-spend
+        //                     flow's `PollNow(sender)`) is already in
+        //                     flight. The eager flag is already set
+        //                     above, so whichever tick fires next
+        //                     honors it. Drop our signal silently —
+        //                     it would be redundant.
+        //   * Err(Disconnected) – poller is gone; nothing left to
+        //                     do but log.
+        match self.poller_sender.try_send(PollerMessage::PollNowNoAck) {
+            Ok(()) => {}
+            Err(mpsc::TrySendError::Full(_)) => {
+                log::debug!(
+                    "request_sync: poller channel full; eager flag will be \
+                     honored by the already-pending wake-up"
+                );
+            }
+            Err(mpsc::TrySendError::Disconnected(_)) => {
+                log::warn!("request_sync: poller channel disconnected");
+            }
         }
     }
 

--- a/coincubed/src/commands/mod.rs
+++ b/coincubed/src/commands/mod.rs
@@ -340,15 +340,15 @@ impl DaemonControl {
         // trait's default no-op.
         self.bitcoin.lock().unwrap().request_eager_sync();
         // Wake the poller now rather than waiting for its current
-        // sleep to elapse. We pass a `sync_channel(0)` sender but
-        // never block on the matching receiver — completion will
-        // surface naturally through subsequent `get_info`/state
-        // calls from the GUI, and waiting here would block the
-        // JSON-RPC handler thread for as long as the sync takes
-        // (potentially seconds), which is not what we want for a
-        // UX-triggered "kick the poller" request.
-        let (tx, _rx) = mpsc::sync_channel(0);
-        if let Err(e) = self.poller_sender.send(PollerMessage::PollNow(tx)) {
+        // sleep to elapse. Use the no-ack variant so the poller
+        // doesn't log a spurious "send failed" error on every
+        // trigger — completion surfaces naturally through
+        // subsequent `get_info`/state calls from the GUI, and
+        // blocking here on a completion signal would freeze the
+        // JSON-RPC handler thread for as long as the sync takes,
+        // which is not what we want for a UX-triggered "kick the
+        // poller" request.
+        if let Err(e) = self.poller_sender.send(PollerMessage::PollNowNoAck) {
             log::warn!("request_sync: poller send failed: {}", e);
         }
     }

--- a/coincubed/src/commands/mod.rs
+++ b/coincubed/src/commands/mod.rs
@@ -316,6 +316,43 @@ impl DaemonControl {
 }
 
 impl DaemonControl {
+    /// Ask the poller to run a sync **now**, bypassing both the
+    /// remaining sleep on the poll-interval timer and the Esplora
+    /// backend's smart-poll tip-guard. Fire-and-forget — returns
+    /// immediately rather than waiting on the poller's completion
+    /// signal; the GUI will see the result through the regular
+    /// state-cache refresh.
+    ///
+    /// Intended UX hooks (called by the GUI):
+    /// - The app regains focus after a stretch in the background.
+    /// - The user opens the Receive panel.
+    /// - A new receive address is generated.
+    ///
+    /// In all three cases the user has just expressed "I want
+    /// fresh data" and the few extra HTTP requests this triggers
+    /// (~80 against the active Esplora provider) easily fit
+    /// inside the free-tier hourly budget at the current 10-min
+    /// poll interval.
+    pub fn request_sync(&self) {
+        // Set the eager flag on the backend so that whenever the
+        // poller runs next, the smart-poll guard is bypassed and
+        // we do a real per-SPK walk. Non-Esplora backends take the
+        // trait's default no-op.
+        self.bitcoin.lock().unwrap().request_eager_sync();
+        // Wake the poller now rather than waiting for its current
+        // sleep to elapse. We pass a `sync_channel(0)` sender but
+        // never block on the matching receiver — completion will
+        // surface naturally through subsequent `get_info`/state
+        // calls from the GUI, and waiting here would block the
+        // JSON-RPC handler thread for as long as the sync takes
+        // (potentially seconds), which is not what we want for a
+        // UX-triggered "kick the poller" request.
+        let (tx, _rx) = mpsc::sync_channel(0);
+        if let Err(e) = self.poller_sender.send(PollerMessage::PollNow(tx)) {
+            log::warn!("request_sync: poller send failed: {}", e);
+        }
+    }
+
     /// Get information about the current state of the daemon
     pub fn get_info(&self) -> GetInfoResult {
         let mut db_conn = self.db.connection();

--- a/coincubed/src/config.rs
+++ b/coincubed/src/config.rs
@@ -208,6 +208,37 @@ pub struct EsploraConfig {
     pub secondary_fallback_token: Option<String>,
 }
 
+impl EsploraConfig {
+    /// Reject orphan tokens — a `fallback_token` without a
+    /// matching `fallback_addr` (and likewise for the secondary
+    /// pair) is almost certainly a typo or a partial hand-edit of
+    /// the TOML; the daemon's `Client::new` would silently ignore
+    /// the token because the whole provider is gated on the addr
+    /// being present. We don't require the converse (addr without
+    /// token is perfectly valid: anonymous public providers like
+    /// mempool.space and blockstream.info are exactly that shape).
+    fn check(&self) -> Result<(), ConfigError> {
+        if self.fallback_token.is_some() && self.fallback_addr.is_none() {
+            return Err(ConfigError::Unexpected(
+                "esplora_config.fallback_token set without esplora_config.fallback_addr — \
+                 the token would be silently ignored. Either add a fallback_addr or \
+                 remove the orphan fallback_token."
+                    .into(),
+            ));
+        }
+        if self.secondary_fallback_token.is_some() && self.secondary_fallback_addr.is_none() {
+            return Err(ConfigError::Unexpected(
+                "esplora_config.secondary_fallback_token set without \
+                 esplora_config.secondary_fallback_addr — the token would be silently \
+                 ignored. Either add a secondary_fallback_addr or remove the orphan \
+                 secondary_fallback_token."
+                    .into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
 impl std::fmt::Debug for EsploraConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EsploraConfig")
@@ -414,6 +445,17 @@ impl Config {
             )));
         }
 
+        // Validate Esplora endpoint pairs wherever they appear:
+        // - The active backend when it's the Esplora variant.
+        // - The legacy `fallback_esplora` slot used as a backup
+        //   when a Bitcoind backend becomes unreachable.
+        if let Some(BitcoinBackend::Esplora(e)) = &self.bitcoin_backend {
+            e.check()?;
+        }
+        if let Some(e) = &self.fallback_esplora {
+            e.check()?;
+        }
+
         // TODO: check the semantics of the main descriptor
 
         Ok(())
@@ -425,6 +467,80 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
+
+    /// Helper: an `EsploraConfig` with only the mandatory `addr`
+    /// set. Other fields default to `None`. Tests mutate the
+    /// individual slots they care about.
+    fn bare_esplora_config() -> EsploraConfig {
+        EsploraConfig {
+            addr: "https://mempool.space/api".into(),
+            token: None,
+            fallback_addr: None,
+            fallback_token: None,
+            secondary_fallback_addr: None,
+            secondary_fallback_token: None,
+        }
+    }
+
+    /// Regression: an orphan `fallback_token` (no matching
+    /// `fallback_addr`) used to slide through the daemon's
+    /// `Client::new` silently — the provider would be skipped and
+    /// the token never used. Now rejected at config-load time.
+    #[test]
+    fn orphan_fallback_token_is_rejected() {
+        let mut esp = bare_esplora_config();
+        esp.fallback_token = Some("orphan-jwt".into());
+        let err = esp.check().expect_err("orphan fallback_token must error");
+        assert!(
+            matches!(err, ConfigError::Unexpected(ref m) if m.contains("fallback_token")
+                && m.contains("fallback_addr")),
+            "error message must name both fields; got: {:?}",
+            err,
+        );
+    }
+
+    #[test]
+    fn orphan_secondary_fallback_token_is_rejected() {
+        let mut esp = bare_esplora_config();
+        esp.secondary_fallback_token = Some("orphan-jwt".into());
+        let err = esp
+            .check()
+            .expect_err("orphan secondary_fallback_token must error");
+        assert!(
+            matches!(err, ConfigError::Unexpected(ref m) if m.contains("secondary_fallback_token")
+                && m.contains("secondary_fallback_addr")),
+            "error message must name both fields; got: {:?}",
+            err,
+        );
+    }
+
+    /// Anonymous public providers (no auth) are the entire
+    /// point of the fallback layer — addr with no token must
+    /// stay valid. This is the converse case the bot's prompt
+    /// almost asked us to reject; we deliberately don't.
+    #[test]
+    fn addr_without_token_is_valid() {
+        let mut esp = bare_esplora_config();
+        esp.fallback_addr = Some("https://blockstream.info/api".into());
+        esp.secondary_fallback_addr =
+            Some("https://api.coincube.io/api/v1/esplora/bitcoin/mainnet".into());
+        esp.check()
+            .expect("addr-only fallback shapes must validate");
+    }
+
+    /// A correctly-paired addr+token must validate, ensuring the
+    /// rejection above is targeted at the orphan-token case
+    /// rather than a blanket "token requires …" overreach.
+    #[test]
+    fn paired_addr_and_token_is_valid() {
+        let mut esp = bare_esplora_config();
+        esp.fallback_addr = Some("https://blockstream.info/api".into());
+        esp.fallback_token = Some("legit-jwt".into());
+        esp.secondary_fallback_addr =
+            Some("https://api.coincube.io/api/v1/esplora/bitcoin/mainnet".into());
+        esp.secondary_fallback_token = Some("legit-secondary-jwt".into());
+        esp.check().expect("paired addr+token must validate");
+    }
 
     // Test the format of the configuration file
     #[test]

--- a/coincubed/src/config.rs
+++ b/coincubed/src/config.rs
@@ -78,7 +78,23 @@ fn default_loglevel() -> log::LevelFilter {
 }
 
 fn default_poll_interval() -> Duration {
-    Duration::from_secs(10)
+    // Public Esplora providers (mempool.space, blockstream.info) cap
+    // anonymous traffic at ~700 requests/hour and 500k/month per IP.
+    // A typical Coincube wallet with ~80 SPKs at the previous 10s
+    // poll interval would burn through ~9,600 req/hour — over the
+    // free-tier hourly cap by 14×. 600s (10 min) brings steady-state
+    // request volume comfortably under any anonymous free tier
+    // while still surfacing new blocks within a poll of their
+    // arrival. The smart-poll tip-guard in
+    // [`crate::bitcoin::esplora::Esplora::sync_wallet`] makes the
+    // common case (tip unchanged since last poll) cost a single
+    // `chain_tip` request rather than a full per-SPK rescan.
+    //
+    // Existing on-disk configs are auto-migrated to at least 300s
+    // by `coincube_gui::installer::migration` when they're below
+    // that threshold; users who deliberately set a higher interval
+    // are left alone.
+    Duration::from_secs(600)
 }
 
 /// Bitcoin backend config.

--- a/coincubed/src/config.rs
+++ b/coincubed/src/config.rs
@@ -77,24 +77,31 @@ fn default_loglevel() -> log::LevelFilter {
     log::LevelFilter::Info
 }
 
+/// Recommended `poll_interval_secs` for the Esplora backend. Picked
+/// so the per-poll request volume fits comfortably inside public
+/// Esplora providers' anonymous free tiers (mempool.space ≈ 60/min,
+/// blockstream.info ≈ 700/hr). ~80-SPK wallets at this cadence land
+/// at ~85 HTTP requests/hour against the active provider with the
+/// smart-poll tip-guard active — well under any free-tier ceiling.
+pub const ESPLORA_POLL_INTERVAL_SECS: u64 = 600;
+
+/// Recommended `poll_interval_secs` for local-node backends
+/// (`bitcoind`, `electrum`). These talk to a process you run on
+/// localhost, so there's no per-request HTTP cost and no upstream
+/// rate cap — a snappier cadence costs nothing and surfaces new
+/// blocks/mempool activity to the UI within seconds.
+pub const LOCAL_BACKEND_POLL_INTERVAL_SECS: u64 = 10;
+
 fn default_poll_interval() -> Duration {
-    // Public Esplora providers (mempool.space, blockstream.info) cap
-    // anonymous traffic at ~700 requests/hour and 500k/month per IP.
-    // A typical Coincube wallet with ~80 SPKs at the previous 10s
-    // poll interval would burn through ~9,600 req/hour — over the
-    // free-tier hourly cap by 14×. 600s (10 min) brings steady-state
-    // request volume comfortably under any anonymous free tier
-    // while still surfacing new blocks within a poll of their
-    // arrival. The smart-poll tip-guard in
-    // [`crate::bitcoin::esplora::Esplora::sync_wallet`] makes the
-    // common case (tip unchanged since last poll) cost a single
-    // `chain_tip` request rather than a full per-SPK rescan.
-    //
-    // Existing on-disk configs are auto-migrated to at least 300s
-    // by `coincube_gui::installer::migration` when they're below
-    // that threshold; users who deliberately set a higher interval
-    // are left alone.
-    Duration::from_secs(600)
+    // Used by serde when `poll_interval_secs` is missing from the
+    // TOML. We can't tell which backend the config will end up
+    // pointing at, so default to the Esplora-safe value
+    // ([`ESPLORA_POLL_INTERVAL_SECS`]) — better to be a touch lazy
+    // on bitcoind for one boot than to silently exceed an Esplora
+    // free tier. The installer/migration in `coincube-gui` sets
+    // a backend-appropriate value explicitly, so this serde
+    // default only fires for hand-written or truncated configs.
+    Duration::from_secs(ESPLORA_POLL_INTERVAL_SECS)
 }
 
 /// Bitcoin backend config.

--- a/coincubed/src/config.rs
+++ b/coincubed/src/config.rs
@@ -144,10 +144,18 @@ fn default_validate_domain() -> bool {
 
 /// Everything we need to know for talking to an Esplora HTTP server.
 ///
-/// Supports a primary endpoint plus an optional secondary used as failover.
-/// The two endpoints are independently authenticated because typical pairings
-/// span auth domains — a public Esplora (no token) as primary with COINCUBE |
-/// Connect (JWT) as fallback, or vice versa.
+/// Supports a primary endpoint plus up to two ordered fallbacks, tried in
+/// declaration order on retryable failures. Each endpoint is independently
+/// authenticated because typical pairings span auth domains — a public
+/// Esplora (no token) as primary, a second public Esplora as
+/// `fallback_addr`, and COINCUBE | Connect (JWT) as
+/// `secondary_fallback_addr`.
+///
+/// The intent of the three-tier shape: primary + first fallback distribute
+/// sync traffic across independent public providers (so a 429 on one doesn't
+/// take the user to the metered backstop), and the secondary fallback
+/// guarantees a route home for users whose IP has been rate-limited by both
+/// public providers.
 #[derive(Clone, PartialEq, Deserialize, Serialize)]
 pub struct EsploraConfig {
     /// The HTTP(S) URL of the primary Esplora server.
@@ -156,14 +164,25 @@ pub struct EsploraConfig {
     /// Optional JWT bearer token for the primary endpoint (e.g. COINCUBE | Connect).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub token: Option<String>,
-    /// Optional secondary Esplora endpoint, tried when the primary returns a
-    /// retryable failure (transport error, 402, 429, 5xx). Typical deployment
-    /// is `addr` → public Esplora and `fallback_addr` → COINCUBE | Connect.
+    /// Optional first fallback Esplora endpoint, tried when the primary
+    /// returns a retryable failure (transport error, 402, 429, 5xx). Typical
+    /// deployment is a second public Esplora (`blockstream.info`) — using a
+    /// different provider so a mempool 429 doesn't imply this one is also
+    /// throttled.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub fallback_addr: Option<String>,
-    /// Optional JWT bearer token for the fallback endpoint.
+    /// Optional JWT bearer token for the first fallback endpoint.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub fallback_token: Option<String>,
+    /// Optional second fallback Esplora endpoint, tried after the first
+    /// fallback fails. Typical deployment is COINCUBE | Connect — the
+    /// authenticated backstop, used only when both public providers have
+    /// rejected the request.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub secondary_fallback_addr: Option<String>,
+    /// Optional JWT bearer token for the second fallback endpoint.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub secondary_fallback_token: Option<String>,
 }
 
 impl std::fmt::Debug for EsploraConfig {
@@ -175,6 +194,11 @@ impl std::fmt::Debug for EsploraConfig {
             .field(
                 "fallback_token",
                 &self.fallback_token.as_ref().map(|_| "<redacted>"),
+            )
+            .field("secondary_fallback_addr", &self.secondary_fallback_addr)
+            .field(
+                "secondary_fallback_token",
+                &self.secondary_fallback_token.as_ref().map(|_| "<redacted>"),
             )
             .finish()
     }

--- a/coincubed/src/config.rs
+++ b/coincubed/src/config.rs
@@ -143,14 +143,27 @@ fn default_validate_domain() -> bool {
 }
 
 /// Everything we need to know for talking to an Esplora HTTP server.
+///
+/// Supports a primary endpoint plus an optional secondary used as failover.
+/// The two endpoints are independently authenticated because typical pairings
+/// span auth domains — a public Esplora (no token) as primary with COINCUBE |
+/// Connect (JWT) as fallback, or vice versa.
 #[derive(Clone, PartialEq, Deserialize, Serialize)]
 pub struct EsploraConfig {
-    /// The HTTP(S) URL of the Esplora server.
-    /// e.g. https://api.coincube.io/api/v1/esplora/bitcoin/mainnet
+    /// The HTTP(S) URL of the primary Esplora server.
+    /// e.g. https://mempool.space/api
     pub addr: String,
-    /// Optional JWT bearer token for authenticated Esplora endpoints (e.g. COINCUBE | Connect).
+    /// Optional JWT bearer token for the primary endpoint (e.g. COINCUBE | Connect).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub token: Option<String>,
+    /// Optional secondary Esplora endpoint, tried when the primary returns a
+    /// retryable failure (transport error, 402, 429, 5xx). Typical deployment
+    /// is `addr` → public Esplora and `fallback_addr` → COINCUBE | Connect.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub fallback_addr: Option<String>,
+    /// Optional JWT bearer token for the fallback endpoint.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub fallback_token: Option<String>,
 }
 
 impl std::fmt::Debug for EsploraConfig {
@@ -158,6 +171,11 @@ impl std::fmt::Debug for EsploraConfig {
         f.debug_struct("EsploraConfig")
             .field("addr", &self.addr)
             .field("token", &self.token.as_ref().map(|_| "<redacted>"))
+            .field("fallback_addr", &self.fallback_addr)
+            .field(
+                "fallback_token",
+                &self.fallback_token.as_ref().map(|_| "<redacted>"),
+            )
             .finish()
     }
 }

--- a/coincubed/src/jsonrpc/api.rs
+++ b/coincubed/src/jsonrpc/api.rs
@@ -522,6 +522,13 @@ pub fn handle_request(control: &mut DaemonControl, req: Request) -> Result<Respo
             rbf_psbt(control, params)?
         }
         "getinfo" => serde_json::json!(&control.get_info()),
+        "requestsync" => {
+            control.request_sync();
+            // Fire-and-forget — the daemon kicks the poller and
+            // returns immediately. The GUI will see the result via
+            // the next state refresh.
+            serde_json::json!({})
+        }
         "getnewaddress" => serde_json::json!(&control.get_new_address()),
         "updatederivationindexes" => {
             let params = req.params.ok_or_else(|| {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes wallet sync, provider failover, and on-disk daemon config migration; mis-migration or rate-limit handling could affect balance/tx freshness, though behavior is heavily tested and idempotent.
> 
> **Overview**
> Wallet sync over Esplora is reworked around **public-first endpoints** and **smarter polling**, with GUI hooks so receive flows see fresh mempool state sooner.
> 
> **Esplora provider chain:** New installs and Connect switches use a three-tier layout—**mempool.space** primary, **blockstream.info** as first fallback where available, **Connect (JWT)** as backstop—instead of Connect-only. `EsploraConfig` gains `fallback_*` and `secondary_fallback_*` fields; the daemon Esplora client walks providers in order, applies **10-minute cooldowns** on 402/429, and can return a typed **all-cooling** outcome so the poller backs off quietly instead of spamming errors. Daemon startup no longer hard-fails when every provider is unreachable at boot.
> 
> **Polling and sync behavior:** Default Esplora poll interval moves to **600s**; local bitcoind/electrum stays **10s**, with settings and migration adjusting cadence on backend switches. Esplora sync adds a **tip-guard** (skip heavy SPK walks when the tip is unchanged), a **forced rescan every N idle polls** for mempool-only activity, lower **parallel request** count, and **`request_eager_sync`** / JSON-RPC **`requestsync`** to force a full sync on demand. The GUI calls this after opening Receive or generating a new address; Connect remote backend treats it as a no-op.
> 
> **On-disk migration:** At vault load, `migrate_esplora_config` rewrites legacy Connect-only (or two-tier) `daemon.toml` to the new shape and bumps dangerously short Esplora poll intervals, idempotently and with tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0a6cc0ed8e01e1de0aba34d7424d2655de617f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Three-tier Esplora endpoints (public-primary + fallback + secondary-fallback) with transparent failover and per-provider throttling cooldowns.
  * GUI/API "request_sync" and an eager-sync flag to force immediate wallet synchronization.
  * Smarter Esplora polling that reduces redundant rescans.

* **Bug Fixes**
  * Smarter poll/backoff when all providers are throttled; improved logging during backend switches.
  * Receive panel now triggers an immediate sync after address generation or panel reload.

* **Chores**
  * Automatic on-disk migration of existing daemon configs to the new Esplora layout and poll-interval adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->