### PR TITLE
Live confirmation count and other cleanup

### DIFF
--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -3369,6 +3369,7 @@ impl App {
                 &self.received_celebration_amount,
                 &self.received_celebration_quote,
                 &self.received_celebration_image,
+                "has arrived.",
                 view::Message::DismissReceivedCelebration,
             );
             view::dashboard(&self.panels.current, &self.cache, celebration)

--- a/coincube-gui/src/app/state/spark/esplora.rs
+++ b/coincube-gui/src/app/state/spark/esplora.rs
@@ -49,6 +49,14 @@ fn esplora_base(network: Network) -> Option<&'static str> {
     }
 }
 
+/// Whether [`fetch_confirmations`] has anywhere to query for `network`.
+/// Callers short-circuit on `false` to avoid scheduling work that's
+/// guaranteed to come back empty (and to suppress the 30s poll
+/// subscription on regtest).
+pub fn is_supported(network: Network) -> bool {
+    esplora_base(network).is_some()
+}
+
 /// Fetch the current confirmation count for each `(txid, vout)` against
 /// the given network's Esplora.
 ///

--- a/coincube-gui/src/app/state/spark/esplora.rs
+++ b/coincube-gui/src/app/state/spark/esplora.rs
@@ -1,0 +1,130 @@
+//! Thin Esplora client used to surface live confirmation counts for
+//! pending Spark on-chain deposits.
+//!
+//! The Breez Spark SDK only exposes `is_mature: bool` on each
+//! `DepositInfo` — it never reports the *count* of confirmations a
+//! deposit currently has. To render "1 / 3 confirmations" in the
+//! Pending Deposits card we query a public Esplora REST endpoint
+//! ourselves: one GET per pending txid plus one GET for the chain tip,
+//! turning `(tip - block_height + 1)` into a confirmation count (`0`
+//! when the tx is still in mempool).
+//!
+//! Mainnet → mempool.space's Esplora. Regtest has no public Esplora,
+//! so the helper returns an empty map there and the view falls back to
+//! the SDK's plain "Waiting for confirmation" wording.
+//!
+//! All errors are swallowed (logged at `warn`) and the affected
+//! deposit simply omits its confirmation count from the result map —
+//! the row degrades gracefully to the SDK-driven status text.
+//!
+//! The 3-confirmation maturity threshold comes from Breez's own docs
+//! (`docs/breez-sdk/src/guide/onchain_claims.md`): "after **3 on-chain
+//! confirmations** the deposit has sufficient confirmations".
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use coincube_core::miniscript::bitcoin::Network;
+use serde::Deserialize;
+
+/// Number of on-chain confirmations the Spark SDK requires before
+/// `is_mature` flips and the SDK auto-claims the deposit.
+pub const DEPOSIT_MATURITY_CONFIRMATIONS: u32 = 3;
+
+const ESPLORA_TIMEOUT: Duration = Duration::from_secs(8);
+
+#[derive(Debug, Deserialize)]
+struct TxStatus {
+    confirmed: bool,
+    block_height: Option<u32>,
+}
+
+fn esplora_base(network: Network) -> Option<&'static str> {
+    match network {
+        Network::Bitcoin => Some("https://mempool.space/api"),
+        // Spark only supports Mainnet + Regtest in this Cube. Regtest
+        // runs against a local SDK fixture chain with no public
+        // Esplora — skip the fetch entirely there.
+        _ => None,
+    }
+}
+
+/// Fetch the current confirmation count for each `(txid, vout)` against
+/// the given network's Esplora.
+///
+/// Returns a map keyed by `(txid, vout)`. Missing entries mean the
+/// fetch failed for that deposit (network error, tx not found, …) —
+/// the caller renders the SDK's fallback status text in that case.
+pub async fn fetch_confirmations(
+    network: Network,
+    deposits: Vec<(String, u32)>,
+) -> HashMap<(String, u32), u32> {
+    let mut out = HashMap::new();
+    if deposits.is_empty() {
+        return out;
+    }
+    let Some(base) = esplora_base(network) else {
+        return out;
+    };
+
+    let client = match reqwest::Client::builder().timeout(ESPLORA_TIMEOUT).build() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("esplora: failed to build reqwest client: {e}");
+            return out;
+        }
+    };
+
+    let tip_height: u32 = match client
+        .get(format!("{base}/blocks/tip/height"))
+        .send()
+        .await
+        .and_then(|r| r.error_for_status())
+    {
+        Ok(resp) => match resp.text().await {
+            Ok(body) => match body.trim().parse() {
+                Ok(h) => h,
+                Err(e) => {
+                    tracing::warn!("esplora: tip height parse failed ({body:?}): {e}");
+                    return out;
+                }
+            },
+            Err(e) => {
+                tracing::warn!("esplora: tip height body read failed: {e}");
+                return out;
+            }
+        },
+        Err(e) => {
+            tracing::warn!("esplora: tip height fetch failed: {e}");
+            return out;
+        }
+    };
+
+    for (txid, vout) in deposits {
+        let url = format!("{base}/tx/{txid}/status");
+        match client
+            .get(&url)
+            .send()
+            .await
+            .and_then(|r| r.error_for_status())
+        {
+            Ok(resp) => match resp.json::<TxStatus>().await {
+                Ok(status) => {
+                    let confs = if status.confirmed {
+                        status
+                            .block_height
+                            .map(|h| tip_height.saturating_sub(h).saturating_add(1))
+                            .unwrap_or(1)
+                    } else {
+                        0
+                    };
+                    out.insert((txid, vout), confs);
+                }
+                Err(e) => tracing::warn!("esplora: status decode failed for {txid}: {e}"),
+            },
+            Err(e) => tracing::warn!("esplora: status fetch failed for {txid}: {e}"),
+        }
+    }
+
+    out
+}

--- a/coincube-gui/src/app/state/spark/mod.rs
+++ b/coincube-gui/src/app/state/spark/mod.rs
@@ -5,6 +5,7 @@
 //! (None when the cube has no Spark signer or the bridge subprocess
 //! failed to spawn) and renders an "unavailable" stub in that case.
 
+pub mod esplora;
 pub mod overview;
 pub mod receive;
 pub mod send;

--- a/coincube-gui/src/app/state/spark/receive.rs
+++ b/coincube-gui/src/app/state/spark/receive.rs
@@ -484,22 +484,22 @@ impl State for SparkReceive {
                 // deposit's GET failed) shouldn't wipe the confirmation
                 // count for the others.
                 //
-                // Take the max of stored vs. incoming per key — if the
-                // 30s subscription tick fires a second fetch before the
-                // first completes (possible when many immature deposits
-                // serialize through the 8s per-request Esplora
-                // timeout), an older slower response can land after a
-                // newer one. Confirmations only ever go up between
-                // reorgs, so `max` keeps the freshest count without
-                // needing a nonce/cancellation handshake; reorg-driven
-                // decreases reach us via the SDK's `DepositsChanged`
-                // event, which clears stale entries by way of the
-                // `live_keys` retain in `PendingDepositsLoaded`.
+                // Plain overwrite per key — we deliberately do NOT
+                // `max` here. A reorg can legitimately drop a
+                // deposit's confirmation count (the block at height
+                // H got replaced, so the tx is back in the mempool
+                // until it re-confirms), and the user should see
+                // that reflected. The cost is that if the 30s
+                // subscription tick fires a second fetch before the
+                // first completes (possible when many immature
+                // deposits serialize through Esplora's 8s per-request
+                // timeout) and the slower one lands after the faster
+                // one, the displayed count can briefly flicker
+                // backward until the next tick corrects it — but
+                // both responses are valid past-chain snapshots, so
+                // it's stale display, not wrong data.
                 for (key, confs) in map {
-                    self.pending_deposit_confirmations
-                        .entry(key)
-                        .and_modify(|v| *v = (*v).max(confs))
-                        .or_insert(confs);
+                    self.pending_deposit_confirmations.insert(key, confs);
                 }
                 Task::none()
             }

--- a/coincube-gui/src/app/state/spark/receive.rs
+++ b/coincube-gui/src/app/state/spark/receive.rs
@@ -20,12 +20,13 @@
 //! Lightning Address display, and the on-chain claim lifecycle all
 //! land in Phase 4d.
 
+use std::collections::HashMap;
 use std::convert::TryInto;
 use std::sync::Arc;
 
 use coincube_spark_protocol::{DepositInfo, ReceivePaymentOk};
 use coincube_ui::widget::Element;
-use iced::{widget::qr_code, Task};
+use iced::{widget::qr_code, Subscription, Task};
 
 use crate::app::cache::Cache;
 use crate::app::menu::{Menu, SparkSubMenu};
@@ -63,16 +64,12 @@ pub enum SparkReceivePhase {
     /// RPC succeeded — `payment_request` is the copyable result.
     Generated(ReceivePaymentOk),
     /// A `PaymentSucceeded` event arrived while the panel was in
-    /// `Generated` state. Carries the amount from the event so the
-    /// confirmation screen can show it directly (saves a follow-up
-    /// `list_payments` round-trip).
-    ///
-    /// Phase 4d treats "any payment succeeded while an invoice is
-    /// on screen" as matching the displayed invoice. That's wrong in
-    /// the edge case where multiple channels settle at once, but
-    /// it's the simplest MVP. Phase 4e can correlate via the
-    /// payment's bolt11 field when we plumb richer event payloads.
-    Received { amount_sat: i64 },
+    /// `Generated` state. Carries the running sum of all qualifying
+    /// `PaymentReceived` events that have arrived since this phase
+    /// was entered, plus a `count` so the celebration label can say
+    /// "(2 deposits)" when multiple back-to-back receives stack up
+    /// before the user dismisses the screen.
+    Received { amount_sat: i64, count: u32 },
     /// RPC failed — user-visible error.
     Error(String),
 }
@@ -107,6 +104,14 @@ pub struct SparkReceive {
     /// Phase 4f: surface a transient claim error to the user. Cleared
     /// on the next reload or successful claim.
     pub claim_error: Option<String>,
+    /// Live on-chain confirmation count per pending deposit, fetched
+    /// from a public Esplora ([`esplora::fetch_confirmations`]). The
+    /// SDK only tells us `is_mature: bool`, so we query Esplora
+    /// ourselves to surface progress like "1 / 3 confirmations" on
+    /// rows that haven't matured yet. Entries are dropped when the
+    /// deposit list refreshes; missing keys render the SDK's plain
+    /// "Waiting for confirmations" fallback text.
+    pub pending_deposit_confirmations: HashMap<(String, u32), u32>,
     /// Phase 4f: the BOLT11 invoice string of the currently-displayed
     /// generated invoice, captured at `GenerateSucceeded` time. Used
     /// by the auto-advance handler to correlate `PaymentSucceeded`
@@ -138,6 +143,7 @@ impl SparkReceive {
             pending_deposits: Vec::new(),
             claiming: None,
             claim_error: None,
+            pending_deposit_confirmations: HashMap::new(),
             displayed_invoice: None,
             received_amount_display: String::new(),
             received_celebration_context: "lightning-receive".to_string(),
@@ -176,6 +182,8 @@ impl State for SparkReceive {
                 pending_deposits: &self.pending_deposits,
                 claiming: self.claiming.as_ref(),
                 claim_error: self.claim_error.as_deref(),
+                pending_deposit_confirmations: &self.pending_deposit_confirmations,
+                network: cache.network,
                 received_amount_display: &self.received_amount_display,
                 received_celebration_context: &self.received_celebration_context,
                 received_quote: &self.received_quote,
@@ -201,6 +209,25 @@ impl State for SparkReceive {
             fetch_deposits_task(self.backend.clone()),
             fetch_payments_task(self.backend.clone()),
         ])
+    }
+
+    fn subscription(&self) -> Subscription<Message> {
+        // Esplora doesn't push — we poll on a fixed cadence while at
+        // least one immature deposit is on screen so the "X / 3
+        // confirmations" badge keeps ticking between block arrivals
+        // (the SDK only re-emits `DepositsChanged` at maturity /
+        // refund-status transitions, not on every new confirmation).
+        // The poll stops automatically the moment the list is empty
+        // or every deposit has matured.
+        let has_immature = self.pending_deposits.iter().any(|d| !d.is_mature);
+        if !has_immature {
+            return Subscription::none();
+        }
+        iced::time::every(std::time::Duration::from_secs(30)).map(|_| {
+            Message::View(crate::app::view::Message::SparkReceive(
+                crate::app::view::SparkReceiveMessage::RefreshConfirmations,
+            ))
+        })
     }
 
     fn update(
@@ -323,10 +350,14 @@ impl State for SparkReceive {
                 Task::none()
             }
             SparkReceiveMessage::PaymentReceived { amount_sat, bolt11 } => {
-                // Only react if the user is actually looking at an
-                // invoice — events that arrive while the panel is
-                // idle or showing an error are no-ops.
-                if !matches!(self.phase, SparkReceivePhase::Generated(_)) {
+                // Accept events while either showing an invoice
+                // (`Generated`) — first arrival — or already on the
+                // celebration screen (`Received`) — back-to-back
+                // deposits accumulate into the running total instead
+                // of being silently dropped. Idle / error / generating
+                // phases stay no-op.
+                let already_celebrating = matches!(self.phase, SparkReceivePhase::Received { .. });
+                if !already_celebrating && !matches!(self.phase, SparkReceivePhase::Generated(_)) {
                     return Task::none();
                 }
 
@@ -354,13 +385,22 @@ impl State for SparkReceive {
                 //
                 // BOLT11 comparison is case-insensitive — canonical
                 // form is lowercase but some SDKs hand back mixed case.
-                let matches_invoice = match (&self.displayed_invoice, &bolt11) {
-                    (Some(displayed), Some(event_bolt11)) => {
-                        displayed.eq_ignore_ascii_case(event_bolt11)
+                //
+                // For follow-ups during the celebration we only
+                // aggregate non-BOLT11 events — a BOLT11 invoice is
+                // single-use, so any second BOLT11 must be unrelated
+                // and is skipped.
+                let matches_invoice = if already_celebrating {
+                    bolt11.is_none()
+                } else {
+                    match (&self.displayed_invoice, &bolt11) {
+                        (Some(displayed), Some(event_bolt11)) => {
+                            displayed.eq_ignore_ascii_case(event_bolt11)
+                        }
+                        (Some(_), None) => false,
+                        (None, None) => true,
+                        (None, Some(_)) => false,
                     }
-                    (Some(_), None) => false,
-                    (None, None) => true,
-                    (None, Some(_)) => false,
                 };
                 if !matches_invoice {
                     return Task::none();
@@ -368,18 +408,42 @@ impl State for SparkReceive {
 
                 self.qr_data = None;
                 self.displayed_invoice = None;
-                self.received_amount_display = format!("+{} sats", amount_sat.unsigned_abs());
-                // Pick celebration image based on receive method.
-                let context = if self.method == SparkReceiveMethod::Bolt11 {
-                    "lightning-receive"
-                } else {
-                    "spark-receive"
+                let (running_total, count) = match self.phase {
+                    SparkReceivePhase::Received {
+                        amount_sat: prev,
+                        count,
+                    } => (prev.saturating_add(amount_sat), count.saturating_add(1)),
+                    _ => (amount_sat, 1),
                 };
-                self.received_celebration_context = context.to_string();
-                self.received_quote = coincube_ui::component::quote_display::random_quote(context);
-                self.received_image_handle =
-                    coincube_ui::component::quote_display::image_handle_for_context(context);
-                self.phase = SparkReceivePhase::Received { amount_sat };
+                self.received_amount_display = if count > 1 {
+                    format!(
+                        "+{} sats ({} deposits)",
+                        running_total.unsigned_abs(),
+                        count
+                    )
+                } else {
+                    format!("+{} sats", running_total.unsigned_abs())
+                };
+                // Pick celebration image based on receive method.
+                // Only re-roll the quote on the first arrival so the
+                // imagery doesn't flicker when a follow-up deposit
+                // bumps the total.
+                if !already_celebrating {
+                    let context = if self.method == SparkReceiveMethod::Bolt11 {
+                        "lightning-receive"
+                    } else {
+                        "spark-receive"
+                    };
+                    self.received_celebration_context = context.to_string();
+                    self.received_quote =
+                        coincube_ui::component::quote_display::random_quote(context);
+                    self.received_image_handle =
+                        coincube_ui::component::quote_display::image_handle_for_context(context);
+                }
+                self.phase = SparkReceivePhase::Received {
+                    amount_sat: running_total,
+                    count,
+                };
                 // Surface the just-received payment in the Last
                 // Transactions list the moment it arrives.
                 fetch_payments_task(self.backend.clone())
@@ -387,14 +451,40 @@ impl State for SparkReceive {
             SparkReceiveMessage::PendingDepositsLoaded(deposits) => {
                 self.pending_deposits = deposits;
                 self.claim_error = None;
-                Task::none()
+                // Drop confirmation entries for deposits that left
+                // the list (claimed or refunded), then kick off a
+                // fresh Esplora fetch for any immature deposit still
+                // in the list. Mature deposits skip the fetch — they
+                // already have a Claim button and the per-confirmation
+                // count is no longer useful.
+                let live_keys: std::collections::HashSet<(String, u32)> = self
+                    .pending_deposits
+                    .iter()
+                    .map(|d| (d.txid.clone(), d.vout))
+                    .collect();
+                self.pending_deposit_confirmations
+                    .retain(|k, _| live_keys.contains(k));
+                refresh_confirmations_task(cache.network, &self.pending_deposits)
             }
             SparkReceiveMessage::PendingDepositsFailed(err) => {
                 tracing::warn!("Spark list_unclaimed_deposits failed: {}", err);
                 // Don't surface as a hard error — the rest of the
                 // panel still works. Just clear the displayed list.
                 self.pending_deposits.clear();
+                self.pending_deposit_confirmations.clear();
                 Task::none()
+            }
+            SparkReceiveMessage::DepositConfirmationsUpdated(map) => {
+                // Merge rather than replace: a partial fetch (one
+                // deposit's GET failed) shouldn't wipe the confirmation
+                // count for the others.
+                for (key, confs) in map {
+                    self.pending_deposit_confirmations.insert(key, confs);
+                }
+                Task::none()
+            }
+            SparkReceiveMessage::RefreshConfirmations => {
+                refresh_confirmations_task(cache.network, &self.pending_deposits)
             }
             SparkReceiveMessage::ClaimDepositRequested { txid, vout } => {
                 let Some(backend) = self.backend.clone() else {
@@ -487,6 +577,32 @@ fn fetch_payments_task(backend: Option<Arc<SparkBackend>>) -> Task<Message> {
         |err| {
             Message::View(crate::app::view::Message::SparkReceive(
                 crate::app::view::SparkReceiveMessage::PaymentsFailed(err),
+            ))
+        },
+    )
+}
+
+/// Kick off an Esplora confirmation-count fetch for every immature
+/// deposit in `deposits`. Returns `Task::none()` when there's nothing
+/// to fetch — keeps the call site at `PendingDepositsLoaded` /
+/// `RefreshConfirmations` branch-free.
+fn refresh_confirmations_task(
+    network: coincube_core::miniscript::bitcoin::Network,
+    deposits: &[DepositInfo],
+) -> Task<Message> {
+    let targets: Vec<(String, u32)> = deposits
+        .iter()
+        .filter(|d| !d.is_mature)
+        .map(|d| (d.txid.clone(), d.vout))
+        .collect();
+    if targets.is_empty() {
+        return Task::none();
+    }
+    Task::perform(
+        super::esplora::fetch_confirmations(network, targets),
+        |map| {
+            Message::View(crate::app::view::Message::SparkReceive(
+                crate::app::view::SparkReceiveMessage::DepositConfirmationsUpdated(map),
             ))
         },
     )

--- a/coincube-gui/src/app/state/spark/receive.rs
+++ b/coincube-gui/src/app/state/spark/receive.rs
@@ -387,11 +387,16 @@ impl State for SparkReceive {
                 // form is lowercase but some SDKs hand back mixed case.
                 //
                 // For follow-ups during the celebration we only
-                // aggregate non-BOLT11 events — a BOLT11 invoice is
-                // single-use, so any second BOLT11 must be unrelated
-                // and is skipped.
+                // aggregate when the panel was generating an on-chain /
+                // Spark address AND the event has no bolt11 — a BOLT11
+                // invoice is single-use and unrelated Lightning
+                // activity that happens to settle while the on-chain
+                // celebration is on screen would otherwise inflate the
+                // running total. For BOLT11 celebrations we never
+                // aggregate: a second event after invoice settlement
+                // is by definition a different payment.
                 let matches_invoice = if already_celebrating {
-                    bolt11.is_none()
+                    self.method != SparkReceiveMethod::Bolt11 && bolt11.is_none()
                 } else {
                     match (&self.displayed_invoice, &bolt11) {
                         (Some(displayed), Some(event_bolt11)) => {
@@ -478,8 +483,23 @@ impl State for SparkReceive {
                 // Merge rather than replace: a partial fetch (one
                 // deposit's GET failed) shouldn't wipe the confirmation
                 // count for the others.
+                //
+                // Take the max of stored vs. incoming per key — if the
+                // 30s subscription tick fires a second fetch before the
+                // first completes (possible when many immature deposits
+                // serialize through the 8s per-request Esplora
+                // timeout), an older slower response can land after a
+                // newer one. Confirmations only ever go up between
+                // reorgs, so `max` keeps the freshest count without
+                // needing a nonce/cancellation handshake; reorg-driven
+                // decreases reach us via the SDK's `DepositsChanged`
+                // event, which clears stale entries by way of the
+                // `live_keys` retain in `PendingDepositsLoaded`.
                 for (key, confs) in map {
-                    self.pending_deposit_confirmations.insert(key, confs);
+                    self.pending_deposit_confirmations
+                        .entry(key)
+                        .and_modify(|v| *v = (*v).max(confs))
+                        .or_insert(confs);
                 }
                 Task::none()
             }
@@ -584,12 +604,16 @@ fn fetch_payments_task(backend: Option<Arc<SparkBackend>>) -> Task<Message> {
 
 /// Kick off an Esplora confirmation-count fetch for every immature
 /// deposit in `deposits`. Returns `Task::none()` when there's nothing
-/// to fetch — keeps the call site at `PendingDepositsLoaded` /
-/// `RefreshConfirmations` branch-free.
+/// to fetch, or when `network` has no public Esplora to hit — keeps
+/// the call site at `PendingDepositsLoaded` / `RefreshConfirmations`
+/// branch-free.
 fn refresh_confirmations_task(
     network: coincube_core::miniscript::bitcoin::Network,
     deposits: &[DepositInfo],
 ) -> Task<Message> {
+    if !super::esplora::is_supported(network) {
+        return Task::none();
+    }
     let targets: Vec<(String, u32)> = deposits
         .iter()
         .filter(|d| !d.is_mature)

--- a/coincube-gui/src/app/view/liquid/receive.rs
+++ b/coincube-gui/src/app/view/liquid/receive.rs
@@ -1172,6 +1172,7 @@ pub fn received_celebration_page<'a>(
         amount_display,
         quote,
         image_handle,
+        "has arrived.",
         LiquidReceiveMessage::DismissCelebration,
     )
 }

--- a/coincube-gui/src/app/view/spark/mod.rs
+++ b/coincube-gui/src/app/view/spark/mod.rs
@@ -170,6 +170,17 @@ pub enum SparkReceiveMessage {
     /// Phase 4f: app-level signal that the bridge emitted a
     /// `DepositsChanged` event. The panel re-fetches the list.
     DepositsChanged,
+    /// An Esplora `/tx/<txid>/status` + tip query batch came back with
+    /// per-deposit confirmation counts. Map key is `(txid, vout)`,
+    /// value is `0` for mempool / unconfirmed and `>= 1` once mined.
+    /// Used to render "X / 3 confirmations" on immature rows.
+    DepositConfirmationsUpdated(std::collections::HashMap<(String, u32), u32>),
+    /// 30s subscription tick while immature deposits are on screen —
+    /// fires a fresh Esplora batch so the confirmation counts update
+    /// between block arrivals without waiting for a `DepositsChanged`
+    /// event (the SDK only re-emits at mature/refund-status boundaries,
+    /// not on every new confirmation).
+    RefreshConfirmations,
     Reset,
     /// A `list_payments` RPC completed — used to populate the Last
     /// Transactions section under the Receive form.

--- a/coincube-gui/src/app/view/spark/receive.rs
+++ b/coincube-gui/src/app/view/spark/receive.rs
@@ -1,11 +1,8 @@
 //! View renderer for [`crate::app::state::spark::receive::SparkReceive`].
-//!
-//! Phase 4c ships the minimum viable Receive UI: method radio buttons,
-//! BOLT11 amount/description inputs (hidden for on-chain), a Generate
-//! button, and a result card that shows the invoice/address as a
-//! selectable text field. QR codes, copy animations, Lightning Address
-//! display, and the on-chain claim-deposit lifecycle land in Phase 4d.
 
+use std::collections::HashMap;
+
+use coincube_core::miniscript::bitcoin::Network;
 use coincube_ui::{
     component::{
         amount::BitcoinDisplayUnit,
@@ -22,6 +19,7 @@ use iced::{
 
 use coincube_spark_protocol::DepositInfo;
 
+use crate::app::state::spark::esplora::DEPOSIT_MATURITY_CONFIRMATIONS;
 use crate::app::state::spark::receive::{SparkReceiveMethod, SparkReceivePhase};
 use crate::app::view::spark::{last_tx::last_transactions_section, SparkRecentTransaction};
 use crate::app::view::{Message, SparkReceiveMessage};
@@ -42,6 +40,13 @@ pub struct SparkReceiveView<'a> {
     pub claiming: Option<&'a (String, u32)>,
     /// Phase 4f: transient error from the most recent claim attempt.
     pub claim_error: Option<&'a str>,
+    /// Live on-chain confirmation count per pending deposit, keyed by
+    /// `(txid, vout)`. Sourced from a public Esplora and refreshed on a
+    /// 30s tick; missing keys render the SDK's plain fallback text.
+    pub pending_deposit_confirmations: &'a HashMap<(String, u32), u32>,
+    /// Bitcoin network the cube is running on. Drives the Pending
+    /// Deposits explanatory copy (live counts only available on mainnet).
+    pub network: Network,
     pub received_amount_display: &'a str,
     pub received_celebration_context: &'a str,
     pub received_quote: &'a coincube_ui::component::quote_display::Quote,
@@ -135,21 +140,21 @@ impl<'a> SparkReceiveView<'a> {
             .style(theme::card::simple);
             content = content.push(form_card);
         } else if self.method == SparkReceiveMethod::OnchainBitcoin {
-            // On-chain: nothing to configure in Phase 4c. Explain the
-            // deposit model so the user knows what to expect.
+            // On-chain: nothing to configure. Explain the deposit
+            // model so the user knows what to expect.
             let info_card = Container::new(
                 Column::new()
                     .spacing(8)
                     .push(h4_bold("Spark on-chain receive"))
-                    .push(p2_regular(
-                        "Spark uses a deposit-address model — the user sends \
-                         BTC to the address below, the bridge notices the \
-                         incoming tx, and the funds become spendable after \
-                         the SDK claims the deposit (automatic background \
-                         process in a future phase; today the user may need \
-                         to restart the cube to surface the claim). Phase \
-                         4d wires the explicit claim lifecycle into the UI.",
-                    )),
+                    .push(p2_regular(format!(
+                        "Spark uses a deposit-address model — send BTC to \
+                         the address below and Spark will notice the \
+                         incoming transaction automatically. The deposit \
+                         becomes spendable once it has {} on-chain \
+                         confirmations, at which point the SDK claims it \
+                         into your wallet.",
+                        DEPOSIT_MATURITY_CONFIRMATIONS,
+                    ))),
             )
             .padding(16)
             .style(theme::card::simple);
@@ -188,6 +193,8 @@ impl<'a> SparkReceiveView<'a> {
                 self.pending_deposits,
                 self.claiming,
                 self.claim_error,
+                self.pending_deposit_confirmations,
+                self.network,
             ));
         }
 
@@ -208,21 +215,28 @@ fn pending_deposits_card<'a>(
     deposits: &'a [DepositInfo],
     claiming: Option<&'a (String, u32)>,
     claim_error: Option<&'a str>,
+    confirmations: &'a HashMap<(String, u32), u32>,
+    network: Network,
 ) -> Element<'a, Message> {
     let mut card = Column::new()
         .spacing(12)
         .push(h4_bold("Pending deposits"))
-        .push(p2_regular(
+        .push(p2_regular(format!(
             "Spark notices incoming on-chain transactions automatically. \
-             Mature deposits can be claimed into your wallet below.",
-        ));
+             Each deposit becomes claimable after {} on-chain confirmations, \
+             at which point the SDK claims it into your wallet.",
+            DEPOSIT_MATURITY_CONFIRMATIONS,
+        )));
 
     if let Some(err) = claim_error {
         card = card.push(p2_regular(format!("Claim failed: {}", err)));
     }
 
     for deposit in deposits {
-        card = card.push(deposit_row(deposit, claiming));
+        let confs = confirmations
+            .get(&(deposit.txid.clone(), deposit.vout))
+            .copied();
+        card = card.push(deposit_row(deposit, claiming, confs, network));
     }
 
     Container::new(card)
@@ -234,6 +248,8 @@ fn pending_deposits_card<'a>(
 fn deposit_row<'a>(
     deposit: &'a DepositInfo,
     claiming: Option<&'a (String, u32)>,
+    confirmations: Option<u32>,
+    network: Network,
 ) -> Element<'a, Message> {
     let is_being_claimed = claiming
         .map(|(txid, vout)| txid == &deposit.txid && *vout == deposit.vout)
@@ -262,8 +278,20 @@ fn deposit_row<'a>(
             .width(Length::Fixed(140.0))
             .into()
     } else if !deposit.is_mature {
-        // Immature — show waiting status, no button.
-        p2_regular("Waiting for confirmation").into()
+        // Immature — show "X / N confirmations" if Esplora has
+        // answered, otherwise the SDK-driven fallback wording. The
+        // fallback also applies on networks where no public Esplora
+        // is available (regtest).
+        let label = match confirmations {
+            Some(c) if network == Network::Bitcoin => {
+                format!("{} / {} confirmations", c, DEPOSIT_MATURITY_CONFIRMATIONS)
+            }
+            _ => format!(
+                "Waiting for confirmations ({} required)",
+                DEPOSIT_MATURITY_CONFIRMATIONS
+            ),
+        };
+        p2_regular(label).into()
     } else if let Some(err) = &deposit.claim_error {
         // Previous claim attempt failed for a reason the SDK
         // surfaces. Show a short hint + Retry button.

--- a/coincube-gui/src/app/view/spark/receive.rs
+++ b/coincube-gui/src/app/view/spark/receive.rs
@@ -69,12 +69,18 @@ impl<'a> SparkReceiveView<'a> {
         }
 
         // ── Full-screen celebration for received payments ─────────────
-        if matches!(self.phase, SparkReceivePhase::Received { .. }) {
+        if let SparkReceivePhase::Received { count, .. } = self.phase {
+            let verb_phrase = if *count > 1 {
+                "have arrived."
+            } else {
+                "has arrived."
+            };
             return coincube_ui::component::received_celebration_page(
                 self.received_celebration_context,
                 self.received_amount_display,
                 self.received_quote,
                 self.received_image_handle,
+                verb_phrase,
                 Message::SparkReceive(SparkReceiveMessage::Reset),
             );
         }

--- a/coincube-gui/src/app/view/vault/overview.rs
+++ b/coincube-gui/src/app/view/vault/overview.rs
@@ -536,6 +536,7 @@ pub fn received_celebration_page<'a>(
         amount_display,
         quote,
         image_handle,
+        "has arrived.",
         Message::DismissReceivedCelebration,
     )
 }

--- a/coincube-ui/src/component/mod.rs
+++ b/coincube-ui/src/component/mod.rs
@@ -40,6 +40,7 @@ pub fn received_celebration_page<'a, M: Clone + 'a>(
     amount_display: &'a str,
     quote: &'a quote_display::Quote,
     image_handle: &'a iced::widget::image::Handle,
+    verb_phrase: &'a str,
     on_dismiss: M,
 ) -> Element<'a, M> {
     use quote_display::{self as qd, QuoteDisplayProps};
@@ -65,14 +66,10 @@ pub fn received_celebration_page<'a, M: Clone + 'a>(
                             ..Default::default()
                         }),
                 )
-                .push(
-                    iced::widget::text("has arrived.")
-                        .size(20)
-                        .font(iced::Font {
-                            style: iced::font::Style::Italic,
-                            ..Default::default()
-                        }),
-                ),
+                .push(iced::widget::text(verb_phrase).size(20).font(iced::Font {
+                    style: iced::font::Style::Italic,
+                    ..Default::default()
+                })),
         )
         .push(iced::widget::Space::new().height(Length::Fixed(10.0)))
         .push(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI and optional mainnet HTTP polling only; failures degrade to existing SDK wording with no wallet or auth changes.
> 
> **Overview**
> Adds a **mainnet Esplora** helper (`mempool.space`) so Spark Receive can show **live on-chain confirmation progress** (e.g. `1 / 3 confirmations`) for immature pending deposits, since the SDK only exposes `is_mature`. The panel **polls every 30s** while immature deposits exist, refreshes counts when the deposit list reloads, and **falls back** to generic copy on regtest or fetch failures.
> 
> **Receive celebration** now **stacks back-to-back on-chain/Spark receives** into one screen (running total + deposit count, singular/plural “has/have arrived”), with tighter rules so unrelated Lightning events don’t inflate the total during on-chain celebration.
> 
> Shared **`received_celebration_page`** takes a configurable **verb phrase**; on-chain deposit copy references the **3-confirmation** maturity constant in the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71af7b1978482a7f2ed27f418faa2f2ce3845e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pending Spark deposits now show live on-chain confirmation counts (e.g., "X / 3 confirmations") and network-aware copy for Bitcoin deposits.
  * Automatic blockchain polling (~30s) updates confirmations while immature deposits exist; refreshes on deposit list changes.
  * Receive panel celebration now aggregates back-to-back payments into a cumulative count and updates the display accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->