### PR TITLE
Cleanup authentication flows

### DIFF
--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -2393,7 +2393,9 @@ fn cubes_list_item<'a>(
         )
     } else if signed_in {
         (
-            icon::cloud_slash_icon().style(theme::text::secondary).into(),
+            icon::cloud_slash_icon()
+                .style(theme::text::secondary)
+                .into(),
             "Not yet synced to Connect. It will sync automatically in a moment.",
         )
     } else {

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1758,14 +1758,19 @@ impl Home {
                                             &self.error,
                                             self.creating_cube,
                                             self.passkey_mode,
+                                            self.connect_account.authenticated_client().is_some(),
                                         )
                                     } else {
                                         let current_net_str =
                                             settings::network_to_api_string(self.network);
+                                        let signed_in =
+                                            self.connect_account.authenticated_client().is_some();
                                         let mut col =
                                             cubes.iter().enumerate().fold(
                                                 Column::new().spacing(20),
-                                                |col, (i, cube)| col.push(cubes_list_item(cube, i)),
+                                                |col, (i, cube)| {
+                                                    col.push(cubes_list_item(cube, i, signed_in))
+                                                },
                                             );
                                         // Show remote-only cubes (on server but not local)
                                         for rc in self
@@ -1858,6 +1863,7 @@ impl Home {
                                             &self.error,
                                             self.creating_cube,
                                             self.passkey_mode,
+                                            self.connect_account.authenticated_client().is_some(),
                                         ));
                                     }
                                     col.into()
@@ -2193,6 +2199,7 @@ fn create_cube_form<'a>(
     error: &'a Option<String>,
     creating_cube: bool,
     passkey_mode: bool,
+    signed_in: bool,
 ) -> Element<'a, ViewMessage> {
     use coincube_ui::component::form;
     use std::time::Duration;
@@ -2208,6 +2215,50 @@ fn create_cube_form<'a>(
             )
             .style(theme::text::secondary),
         );
+
+    // When signed out, the cube is created and stored locally but is NOT
+    // registered with the Connect server (see the `authenticated_client()`
+    // gate in the CreateCube handler). It therefore won't appear on paired
+    // mobile signers (the Keychain app) until the user signs in, which
+    // triggers the catch-up sync. Surface that up front so the absence on
+    // mobile isn't a surprise.
+    if !signed_in {
+        column = column.push(
+            Container::new(
+                Column::new()
+                    .spacing(10)
+                    .push(
+                        Row::new()
+                            .spacing(10)
+                            .align_y(Alignment::Center)
+                            .push(icon::cloud_slash_icon().style(theme::text::warning))
+                            .push(
+                                p2_regular(
+                                    "You're signed out. This Cube will be saved on this device \
+                                     only. Sign in to Connect to sync it to your other devices \
+                                     and the Keychain mobile app.",
+                                )
+                                .style(theme::text::secondary),
+                            ),
+                    )
+                    .push(
+                        Row::new()
+                            .align_y(Alignment::Center)
+                            .push(Space::new().width(Length::Fill))
+                            .push(
+                                button::secondary(None, "Sign In")
+                                    .on_press(ViewMessage::GoToSection(HomeSection::Connect(
+                                        app::menu::ConnectSubMenu::Overview,
+                                    )))
+                                    .width(Length::Fixed(140.0)),
+                            ),
+                    ),
+            )
+            .padding(12)
+            .width(Length::Fill)
+            .style(theme::card::simple),
+        );
+    }
 
     // Passkey toggle — hidden entirely when the passkey feature is disabled
     // via the COINCUBE_ENABLE_PASSKEY env var. The surrounding PIN flow
@@ -2326,12 +2377,40 @@ fn create_cube_form<'a>(
         .into()
 }
 
-fn cubes_list_item<'a>(cube: &'a CubeSettings, i: usize) -> Element<'a, ViewMessage> {
-    let sync_indicator = if cube.remote_synced {
-        icon::cloud_check_icon().style(theme::text::success)
+fn cubes_list_item<'a>(
+    cube: &'a CubeSettings,
+    i: usize,
+    signed_in: bool,
+) -> Element<'a, ViewMessage> {
+    // Hover hint on the cloud icon explains the sync state. When the user
+    // is signed out, an unsynced Cube is local-only and the tooltip points
+    // them at sign-in; when signed in, an unsynced Cube is mid-sync (the
+    // catch-up sync registers it on reload) so the wording differs.
+    let (sync_icon, sync_hint): (Element<'a, ViewMessage>, &'static str) = if cube.remote_synced {
+        (
+            icon::cloud_check_icon().style(theme::text::success).into(),
+            "Synced to Connect and available on your other devices.",
+        )
+    } else if signed_in {
+        (
+            icon::cloud_slash_icon().style(theme::text::secondary).into(),
+            "Not yet synced to Connect. It will sync automatically in a moment.",
+        )
     } else {
-        icon::cloud_slash_icon().style(theme::text::secondary)
+        (
+            icon::cloud_slash_icon().style(theme::text::warning).into(),
+            "Saved on this device only. Sign in to Connect to sync this Cube to \
+             your other devices and the Keychain mobile app.",
+        )
     };
+    let sync_indicator = iced_tooltip::Tooltip::new(
+        sync_icon,
+        Container::new(p2_regular(sync_hint))
+            .padding(8)
+            .max_width(260)
+            .style(theme::card::simple),
+        iced_tooltip::Position::Bottom,
+    );
 
     Container::new(
         Row::new()

--- a/coincube-gui/src/installer/step/coincube_connect.rs
+++ b/coincube-gui/src/installer/step/coincube_connect.rs
@@ -31,6 +31,13 @@ pub struct CoincubeConnectStep {
     processing: bool,
     error: Option<String>,
     skipped: bool,
+    /// Set by `load_context` when the installer was launched with an
+    /// already-authenticated Connect session (e.g. Vault setup started
+    /// from Home while signed in). Tells `load()` to fire `Message::Next`
+    /// so the step auto-advances past the redundant email + OTP form,
+    /// adopting the existing token instead of asking the user to
+    /// re-authenticate the same account.
+    preauthenticated: bool,
 }
 
 impl CoincubeConnectStep {
@@ -49,6 +56,7 @@ impl CoincubeConnectStep {
             processing: false,
             error: None,
             skipped: false,
+            preauthenticated: false,
         }
     }
 }
@@ -76,6 +84,51 @@ async fn send_otp(client: CoincubeClient, email: String, is_signup: bool) -> Res
 }
 
 impl Step for CoincubeConnectStep {
+    /// Adopt an already-authenticated Connect session forwarded from the
+    /// app (`ctx.coincube_client`) the first time this step becomes
+    /// active. When a Vault is set up from Home while signed in, the
+    /// home's session is threaded into the installer; without this hook
+    /// the step would start at the email form and force a second
+    /// email + OTP round on the same account — the redundant-login bug.
+    ///
+    /// Guards:
+    ///   * `self.jwt.is_some()` / `self.otp_sent` — the user has already
+    ///     captured a token or started the in-step OTP flow; don't
+    ///     override their in-progress auth.
+    ///   * `self.preauthenticated` — only adopt once; avoids re-arming
+    ///     the auto-advance if `load_context` runs again.
+    ///   * `client.token().is_some()` — an unauthenticated client is
+    ///     useless here and would just 401 downstream.
+    fn load_context(&mut self, ctx: &Context) {
+        if self.jwt.is_some() || self.otp_sent || self.preauthenticated {
+            return;
+        }
+        let Some(client) = &ctx.coincube_client else {
+            return;
+        };
+        let Some(token) = client.token() else {
+            return;
+        };
+        // Clone the client (not just the token) to inherit the base URL /
+        // HTTP plumbing the app already configured. Stash the JWT in
+        // `Zeroizing` so it's scrubbed on drop — same handling as the
+        // in-step OTP path. `apply()` moves it into `ctx.connect_jwt`.
+        self.client = client.clone();
+        self.jwt = Some(Zeroizing::new(token.to_string()));
+        self.preauthenticated = true;
+    }
+
+    /// When pre-authenticated, fire `Message::Next` so the step machine
+    /// runs `apply()` (which moves the adopted token into
+    /// `ctx.connect_jwt`) and advances — skipping the auth UI entirely.
+    fn load(&self) -> Task<Message> {
+        if self.preauthenticated && self.jwt.is_some() {
+            Task::done(Message::Next)
+        } else {
+            Task::none()
+        }
+    }
+
     fn skip(&self, ctx: &Context) -> bool {
         ctx.network == coincube_core::miniscript::bitcoin::Network::Regtest
             || ctx.remote_backend.is_some()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI copy/tooltips and installer step auto-skip only; no changes to core auth or cube registration logic beyond reusing an existing token.
> 
> **Overview**
> **Connect auth UX** on Home now reflects whether the user is signed in: the create-Cube flow shows a warning (device-only until sign-in) with a **Sign In** shortcut when logged out, and cube list cloud icons use **tooltips** that distinguish synced, pending sync (signed in), vs local-only (signed out).
> 
> The installer **`CoincubeConnectStep`** reuses an existing Home session via `load_context` / `load()`: when `ctx.coincube_client` already has a token, it adopts the client and JWT and **auto-advances** past email/OTP instead of forcing a second login.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 922efccd8e6fd7365a65ea59d2f8dab3cc845c78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->