### PR TITLE
Desktop billing work

### DIFF
--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1049,8 +1049,13 @@ impl ConnectAccountPanel {
                 // The view dispatches the body off `active_sub`, so flipping
                 // it here switches the visible sub-view to the picker. Used
                 // by the expired-state renew CTA (D3), which opens the
-                // picker rather than pre-filling an invoice.
+                // picker rather than pre-filling an invoice. Clear the
+                // billing-history toggle so the picker actually renders —
+                // `plan_billing_ux` shows history ahead of the picker, and a
+                // session-stale `show_billing_history` would otherwise route
+                // "View plans" to the history list instead.
                 self.active_sub = ConnectSubMenu::PlanBilling;
+                self.show_billing_history = false;
             }
 
             ConnectAccountMessage::RenewCurrentPlan => {
@@ -1062,6 +1067,10 @@ impl ConnectAccountPanel {
                 let tier = plan.plan.clone();
                 let cycle = plan.billing_cycle;
                 self.active_sub = ConnectSubMenu::PlanBilling;
+                // Same routing concern as OpenPlanBilling: a stale history
+                // toggle would mask the picker on the Free/lapsed fallback
+                // path below (where no checkout is started).
+                self.show_billing_history = false;
                 // A Free/lapsed plan has no tier to pre-fill an invoice for
                 // — fall back to the picker.
                 if matches!(tier, PlanTier::Free) {
@@ -2767,6 +2776,29 @@ mod plan_lifecycle_tests {
         assert!(panel.renewal_banner_dismissed);
         // Dismissed banner never shows, regardless of lifecycle.
         assert!(!panel.show_renewal_banner());
+    }
+
+    #[test]
+    fn open_plan_billing_clears_stale_history_toggle() {
+        // Regression: "View plans" must land on the picker even if the user
+        // left billing history open earlier in the session — `plan_billing_ux`
+        // renders history ahead of the picker.
+        let mut panel = ConnectAccountPanel::new();
+        panel.show_billing_history = true;
+        let _ = panel.update_message(ConnectAccountMessage::OpenPlanBilling);
+        assert_eq!(panel.active_sub, ConnectSubMenu::PlanBilling);
+        assert!(!panel.show_billing_history);
+    }
+
+    #[test]
+    fn renew_current_plan_clears_stale_history_toggle() {
+        // The Free/lapsed fallback path starts no checkout, so a stale
+        // history toggle would otherwise mask the picker there too.
+        let mut panel = panel_with_plan(plan(PlanTier::Free, PlanStatus::Active, None, None));
+        panel.show_billing_history = true;
+        let _ = panel.update_message(ConnectAccountMessage::RenewCurrentPlan);
+        assert_eq!(panel.active_sub, ConnectSubMenu::PlanBilling);
+        assert!(!panel.show_billing_history);
     }
 
     // ── Pricing schema soft-update note (D4) ──────────────────────────

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -2744,8 +2744,12 @@ mod plan_lifecycle_tests {
     #[test]
     fn paid_plan_without_renewal_date_is_active() {
         // No renewal_at to reason about — treat as active (not in-window).
-        let panel =
-            panel_with_plan(plan(PlanTier::Pro, PlanStatus::Active, None, Some(BillingCycle::Monthly)));
+        let panel = panel_with_plan(plan(
+            PlanTier::Pro,
+            PlanStatus::Active,
+            None,
+            Some(BillingCycle::Monthly),
+        ));
         assert_eq!(panel.plan_lifecycle_at(at(NOW)), PlanLifecycle::Active);
     }
 

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -10,7 +10,7 @@ use crate::{
         BillingCycle, BillingHistoryEntry, ChargeStatus, CheckoutRequest, CheckoutResponse,
         CoincubeClient, ConnectPlan, Contact, ContactCube, ContactRole, CreateInviteRequest,
         FeaturesResponse, Invite, LoginActivity, LoginResponse, OtpRequest, OtpVerifyRequest,
-        ReceivedInvite, User, VerifiedDevice,
+        PlanStatus, PlanTier, ReceivedInvite, User, VerifiedDevice,
     },
 };
 
@@ -49,6 +49,36 @@ pub struct CheckoutState {
     pub checkout: Option<CheckoutResponse>,
     pub lightning_qr: Option<qr_code::Data>,
     pub poll_errors: u8,
+}
+
+// ── Plan lifecycle (renewal banner / expired state) ─────────────────────────
+
+/// Number of days before `renewal_at` at which the pre-expiry renewal
+/// banner begins showing (PLAN-billing-desktop D1).
+pub const PLAN_RENEWAL_BANNER_DAYS: i64 = 7;
+
+/// Highest pricing-schema version this build can fully render. A
+/// `/connect/features` payload advertising a higher version triggers the
+/// soft "update available" note in the plan picker (D4).
+pub const SUPPORTED_PRICING_SCHEMA_VERSION: u32 = 1;
+
+/// Where the user's plan sits in its lifecycle, derived from the
+/// `/connect/plan` response plus the current time. Drives the renewal
+/// banner (D1) and the expired-state UX (D3); kept as a pure projection
+/// so that branching stays unit-testable without a running clock.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlanLifecycle {
+    /// Free tier with no lapsed paid plan — the ordinary free experience.
+    Free,
+    /// Active paid plan, comfortably before its renewal date.
+    Active,
+    /// Active paid plan within `PLAN_RENEWAL_BANNER_DAYS` of renewal.
+    /// `days_remaining` is clamped at 0 (today, or just past but not yet
+    /// demoted, reads as "0 days").
+    RenewalDue { days_remaining: i64 },
+    /// A paid plan that lapsed — the backend demoted it (reported as
+    /// `past_due`, typically alongside the Free tier).
+    Expired,
 }
 
 /// Which sub-view of the Contacts section is shown.
@@ -261,6 +291,10 @@ pub struct ConnectAccountPanel {
     pub billing_history: Option<Vec<BillingHistoryEntry>>,
     /// Whether the billing history sub-view is shown.
     pub show_billing_history: bool,
+    /// Whether the user dismissed the pre-expiry renewal banner this
+    /// session (D1). Not persisted — re-shows on next launch while the
+    /// plan is still within its renewal window.
+    pub renewal_banner_dismissed: bool,
 }
 
 impl ConnectAccountPanel {
@@ -281,6 +315,7 @@ impl ConnectAccountPanel {
             checkout: None,
             billing_history: None,
             show_billing_history: false,
+            renewal_banner_dismissed: false,
         }
     }
 
@@ -535,6 +570,7 @@ impl ConnectAccountPanel {
                 self.checkout = None;
                 self.billing_history = None;
                 self.show_billing_history = false;
+                self.renewal_banner_dismissed = false;
                 self.selected_billing_cycle = BillingCycle::Monthly;
                 self.contacts_state.clear();
                 self.clear_keyring_session();
@@ -1000,6 +1036,45 @@ impl ConnectAccountPanel {
 
             ConnectAccountMessage::OpenCheckoutUrl(url) => {
                 return iced::Task::done(Message::View(view::Message::OpenUrl(url)));
+            }
+
+            ConnectAccountMessage::DismissRenewalBanner => {
+                // Per-session only — `renewal_banner_dismissed` resets on
+                // logout and isn't persisted, so the banner re-shows on the
+                // next launch while the plan is still in-window.
+                self.renewal_banner_dismissed = true;
+            }
+
+            ConnectAccountMessage::OpenPlanBilling => {
+                // The view dispatches the body off `active_sub`, so flipping
+                // it here switches the visible sub-view to the picker. Used
+                // by the expired-state renew CTA (D3), which opens the
+                // picker rather than pre-filling an invoice.
+                self.active_sub = ConnectSubMenu::PlanBilling;
+            }
+
+            ConnectAccountMessage::RenewCurrentPlan => {
+                // D1 banner CTA: jump to Plan & Billing and open checkout
+                // pre-selected to the user's current tier + cycle.
+                let Some(plan) = self.plan.as_ref() else {
+                    return iced::Task::none();
+                };
+                let tier = plan.plan.clone();
+                let cycle = plan.billing_cycle;
+                self.active_sub = ConnectSubMenu::PlanBilling;
+                // A Free/lapsed plan has no tier to pre-fill an invoice for
+                // — fall back to the picker.
+                if matches!(tier, PlanTier::Free) {
+                    return iced::Task::none();
+                }
+                if let Some(cycle) = cycle {
+                    self.selected_billing_cycle = cycle;
+                }
+                // Reuse the existing StartCheckout path so the invoice
+                // creation + polling stay in one place.
+                return iced::Task::done(Message::View(view::Message::ConnectAccount(
+                    ConnectAccountMessage::StartCheckout(tier),
+                )));
             }
 
             ConnectAccountMessage::ToggleBillingHistory => {
@@ -1657,6 +1732,66 @@ impl ConnectAccountPanel {
 impl Default for ConnectAccountPanel {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// ── Plan lifecycle / pricing-schema helpers (D1 / D3 / D4) ──────────────────
+impl ConnectAccountPanel {
+    /// Classify the current plan against `now`. Pure (takes the clock as
+    /// an argument) so the banner/expired-state branching is unit-testable.
+    pub fn plan_lifecycle_at(&self, now: chrono::DateTime<chrono::Utc>) -> PlanLifecycle {
+        let Some(plan) = self.plan.as_ref() else {
+            return PlanLifecycle::Free;
+        };
+        // The backend demotes a lapsed paid plan and reports it as
+        // `past_due` — surface that as Expired regardless of the tier it
+        // was reset to.
+        if matches!(plan.status, PlanStatus::PastDue) {
+            return PlanLifecycle::Expired;
+        }
+        if matches!(plan.plan, PlanTier::Free) {
+            return PlanLifecycle::Free;
+        }
+        // Paid + active: decide on the renewal window.
+        let Some(renewal_raw) = plan.renewal_at.as_deref() else {
+            return PlanLifecycle::Active;
+        };
+        let Ok(renewal) = chrono::DateTime::parse_from_rfc3339(renewal_raw) else {
+            return PlanLifecycle::Active;
+        };
+        let days_remaining = (renewal.with_timezone(&chrono::Utc) - now).num_days();
+        if days_remaining <= PLAN_RENEWAL_BANNER_DAYS {
+            PlanLifecycle::RenewalDue {
+                days_remaining: days_remaining.max(0),
+            }
+        } else {
+            PlanLifecycle::Active
+        }
+    }
+
+    /// Lifecycle against the wall clock — used by the view layer.
+    pub fn plan_lifecycle(&self) -> PlanLifecycle {
+        self.plan_lifecycle_at(chrono::Utc::now())
+    }
+
+    /// Whether the pre-expiry renewal banner should render: the plan is
+    /// within its renewal window AND the user hasn't dismissed it this
+    /// session. The expired state has its own dedicated UX (D3), so the
+    /// banner intentionally does not cover `Expired`.
+    pub fn show_renewal_banner(&self) -> bool {
+        !self.renewal_banner_dismissed
+            && matches!(self.plan_lifecycle(), PlanLifecycle::RenewalDue { .. })
+    }
+
+    /// True when `/connect/features` advertised a pricing schema newer
+    /// than this build understands — drives the soft "update available"
+    /// note in the plan picker (D4).
+    pub fn pricing_schema_outdated(&self) -> bool {
+        self.features
+            .as_ref()
+            .and_then(|f| f.pricing_schema_version)
+            .map(|v| v > SUPPORTED_PRICING_SCHEMA_VERSION)
+            .unwrap_or(false)
     }
 }
 
@@ -2458,5 +2593,210 @@ mod add_to_cube_tests {
             sample_contact_cube(42, "bitcoin"),
         ]);
         assert!(panel.contacts_state.contact_is_in_active_cube(7));
+    }
+}
+
+// =============================================================================
+// Plan lifecycle / pricing-schema tests (PLAN-billing-desktop §3)
+// =============================================================================
+//
+// Cover the pure `plan_lifecycle_at` projection across renewal-date windows
+// (outside window, within window, expired), the `past_due` → Expired branch,
+// banner visibility/dismissal, and the schema-version soft-update trigger.
+#[cfg(test)]
+mod plan_lifecycle_tests {
+    use super::*;
+    use crate::services::coincube::{PlanEntitlements, PlanFeatureInfo};
+
+    /// Parse a fixed RFC-3339 instant for deterministic `now`/renewal math.
+    fn at(iso: &str) -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::parse_from_rfc3339(iso)
+            .unwrap()
+            .with_timezone(&chrono::Utc)
+    }
+
+    fn plan(
+        tier: PlanTier,
+        status: PlanStatus,
+        renewal_at: Option<&str>,
+        cycle: Option<BillingCycle>,
+    ) -> ConnectPlan {
+        ConnectPlan {
+            plan: tier,
+            status,
+            renewal_at: renewal_at.map(|s| s.to_string()),
+            entitlements: PlanEntitlements {
+                free_signing_key_count: 0,
+                policy_editing: false,
+                legacy_invites: false,
+                linked_keychains: false,
+                duress_remote_lock: false,
+                business_orgs: false,
+            },
+            billing_cycle: cycle,
+        }
+    }
+
+    fn panel_with_plan(plan: ConnectPlan) -> ConnectAccountPanel {
+        let mut panel = ConnectAccountPanel::new();
+        panel.plan = Some(plan);
+        panel
+    }
+
+    const NOW: &str = "2026-06-08T00:00:00Z";
+
+    #[test]
+    fn no_plan_is_free() {
+        let panel = ConnectAccountPanel::new();
+        assert_eq!(panel.plan_lifecycle_at(at(NOW)), PlanLifecycle::Free);
+    }
+
+    #[test]
+    fn free_active_plan_is_free() {
+        let panel = panel_with_plan(plan(PlanTier::Free, PlanStatus::Active, None, None));
+        assert_eq!(panel.plan_lifecycle_at(at(NOW)), PlanLifecycle::Free);
+    }
+
+    #[test]
+    fn paid_plan_outside_window_is_active() {
+        // Renewal a month out — well beyond the 7-day banner threshold.
+        let panel = panel_with_plan(plan(
+            PlanTier::Pro,
+            PlanStatus::Active,
+            Some("2026-07-08T00:00:00Z"),
+            Some(BillingCycle::Monthly),
+        ));
+        assert_eq!(panel.plan_lifecycle_at(at(NOW)), PlanLifecycle::Active);
+    }
+
+    #[test]
+    fn paid_plan_within_window_is_renewal_due() {
+        // Renewal 5 days out → inside the window, days_remaining == 5.
+        let panel = panel_with_plan(plan(
+            PlanTier::Pro,
+            PlanStatus::Active,
+            Some("2026-06-13T00:00:00Z"),
+            Some(BillingCycle::Annual),
+        ));
+        assert_eq!(
+            panel.plan_lifecycle_at(at(NOW)),
+            PlanLifecycle::RenewalDue { days_remaining: 5 }
+        );
+    }
+
+    #[test]
+    fn paid_plan_exactly_at_threshold_is_renewal_due() {
+        // Boundary: renewal exactly PLAN_RENEWAL_BANNER_DAYS out is in-window.
+        let panel = panel_with_plan(plan(
+            PlanTier::Estate,
+            PlanStatus::Active,
+            Some("2026-06-15T00:00:00Z"),
+            Some(BillingCycle::Monthly),
+        ));
+        assert_eq!(
+            panel.plan_lifecycle_at(at(NOW)),
+            PlanLifecycle::RenewalDue {
+                days_remaining: PLAN_RENEWAL_BANNER_DAYS
+            }
+        );
+    }
+
+    #[test]
+    fn paid_plan_past_renewal_but_not_yet_demoted_clamps_to_zero() {
+        // Renewal already elapsed but the backend hasn't demoted yet —
+        // days_remaining clamps at 0 rather than going negative.
+        let panel = panel_with_plan(plan(
+            PlanTier::Pro,
+            PlanStatus::Active,
+            Some("2026-06-06T00:00:00Z"),
+            Some(BillingCycle::Monthly),
+        ));
+        assert_eq!(
+            panel.plan_lifecycle_at(at(NOW)),
+            PlanLifecycle::RenewalDue { days_remaining: 0 }
+        );
+    }
+
+    #[test]
+    fn free_past_due_is_expired() {
+        // The D3 case: backend demoted a lapsed paid plan to Free + past_due.
+        let panel = panel_with_plan(plan(
+            PlanTier::Free,
+            PlanStatus::PastDue,
+            Some("2026-06-01T00:00:00Z"),
+            None,
+        ));
+        assert_eq!(panel.plan_lifecycle_at(at(NOW)), PlanLifecycle::Expired);
+    }
+
+    #[test]
+    fn paid_past_due_is_expired() {
+        // Defensive: a paid tier still flagged past_due also reads Expired.
+        let panel = panel_with_plan(plan(
+            PlanTier::Pro,
+            PlanStatus::PastDue,
+            Some("2026-06-01T00:00:00Z"),
+            Some(BillingCycle::Monthly),
+        ));
+        assert_eq!(panel.plan_lifecycle_at(at(NOW)), PlanLifecycle::Expired);
+    }
+
+    #[test]
+    fn paid_plan_without_renewal_date_is_active() {
+        // No renewal_at to reason about — treat as active (not in-window).
+        let panel =
+            panel_with_plan(plan(PlanTier::Pro, PlanStatus::Active, None, Some(BillingCycle::Monthly)));
+        assert_eq!(panel.plan_lifecycle_at(at(NOW)), PlanLifecycle::Active);
+    }
+
+    // ── Banner visibility / dismissal ─────────────────────────────────
+    #[test]
+    fn dismiss_renewal_banner_sets_flag() {
+        let mut panel = panel_with_plan(plan(
+            PlanTier::Pro,
+            PlanStatus::Active,
+            Some("2026-06-13T00:00:00Z"),
+            Some(BillingCycle::Monthly),
+        ));
+        assert!(!panel.renewal_banner_dismissed);
+        let _ = panel.update_message(ConnectAccountMessage::DismissRenewalBanner);
+        assert!(panel.renewal_banner_dismissed);
+        // Dismissed banner never shows, regardless of lifecycle.
+        assert!(!panel.show_renewal_banner());
+    }
+
+    // ── Pricing schema soft-update note (D4) ──────────────────────────
+    fn features(version: Option<u32>) -> FeaturesResponse {
+        FeaturesResponse {
+            plans: vec![PlanFeatureInfo {
+                name: "pro".to_string(),
+                price: None,
+                features: Vec::new(),
+                included_linked_participants: None,
+            }],
+            pricing_schema_version: version,
+        }
+    }
+
+    #[test]
+    fn schema_not_outdated_when_features_absent() {
+        let panel = ConnectAccountPanel::new();
+        assert!(!panel.pricing_schema_outdated());
+    }
+
+    #[test]
+    fn schema_not_outdated_at_or_below_supported_version() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.features = Some(features(None));
+        assert!(!panel.pricing_schema_outdated());
+        panel.features = Some(features(Some(SUPPORTED_PRICING_SCHEMA_VERSION)));
+        assert!(!panel.pricing_schema_outdated());
+    }
+
+    #[test]
+    fn schema_outdated_above_supported_version() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.features = Some(features(Some(SUPPORTED_PRICING_SCHEMA_VERSION + 1)));
+        assert!(panel.pricing_schema_outdated());
     }
 }

--- a/coincube-gui/src/app/state/connect/mod.rs
+++ b/coincube-gui/src/app/state/connect/mod.rs
@@ -83,7 +83,7 @@ pub(crate) fn delete_connect_secret(user_key: &str) {
 
 pub use account::{
     AddToCubeDialog, CheckoutPhase, CheckoutState, ConnectAccountPanel, ConnectFlowStep,
-    ContactsState, ContactsStep, InviteCubeOption,
+    ContactsState, ContactsStep, InviteCubeOption, PlanLifecycle,
 };
 pub use cube::ConnectCubePanel;
 pub use cube_members::ConnectCubeMembersState;

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -403,52 +403,50 @@ fn overview_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccount
     }
 
     col.push(
-            container(
-                Column::new()
-                    .push(
-                        Row::new()
-                            .push(text::p1_medium("Email").color(color::GREY_3))
-                            .push(iced::widget::Space::new().width(Length::Fill))
-                            .push(text::p1_regular(email).style(theme::text::primary))
-                            .align_y(Alignment::Center),
-                    )
-                    .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
-                    .push(
-                        Row::new()
-                            .push(text::p1_medium("Status").color(color::GREY_3))
-                            .push(iced::widget::Space::new().width(Length::Fill))
-                            .push(verification_badge)
-                            .align_y(Alignment::Center),
-                    )
-                    .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
-                    .push(
-                        Row::new()
-                            .push(text::p1_medium("Plan").color(color::GREY_3))
-                            .push(iced::widget::Space::new().width(Length::Fill))
-                            .push(text::p1_bold(plan_label).color(color::ORANGE))
-                            .align_y(Alignment::Center),
-                    )
-                    .push(iced::widget::Space::new().height(Length::Fixed(20.0)))
-                    .push(
-                        button::secondary(None, "Sign Out").on_press(ConnectAccountMessage::LogOut),
-                    )
-                    .padding(20)
-                    .spacing(2),
-            )
-            .style(|t| container::Style {
-                background: Some(iced::Background::Color(t.colors.cards.simple.background)),
-                border: iced::Border {
-                    color: color::ORANGE,
-                    width: 0.2,
-                    radius: 20.0.into(),
-                },
-                ..Default::default()
-            })
-            .width(Length::Fill),
+        container(
+            Column::new()
+                .push(
+                    Row::new()
+                        .push(text::p1_medium("Email").color(color::GREY_3))
+                        .push(iced::widget::Space::new().width(Length::Fill))
+                        .push(text::p1_regular(email).style(theme::text::primary))
+                        .align_y(Alignment::Center),
+                )
+                .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+                .push(
+                    Row::new()
+                        .push(text::p1_medium("Status").color(color::GREY_3))
+                        .push(iced::widget::Space::new().width(Length::Fill))
+                        .push(verification_badge)
+                        .align_y(Alignment::Center),
+                )
+                .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+                .push(
+                    Row::new()
+                        .push(text::p1_medium("Plan").color(color::GREY_3))
+                        .push(iced::widget::Space::new().width(Length::Fill))
+                        .push(text::p1_bold(plan_label).color(color::ORANGE))
+                        .align_y(Alignment::Center),
+                )
+                .push(iced::widget::Space::new().height(Length::Fixed(20.0)))
+                .push(button::secondary(None, "Sign Out").on_press(ConnectAccountMessage::LogOut))
+                .padding(20)
+                .spacing(2),
         )
-        .spacing(0)
-        .width(Length::Fill)
-        .into()
+        .style(|t| container::Style {
+            background: Some(iced::Background::Color(t.colors.cards.simple.background)),
+            border: iced::Border {
+                color: color::ORANGE,
+                width: 0.2,
+                radius: 20.0.into(),
+            },
+            ..Default::default()
+        })
+        .width(Length::Fill),
+    )
+    .spacing(0)
+    .width(Length::Fill)
+    .into()
 }
 
 fn plan_tier_color(tier: &PlanTier) -> iced::Color {
@@ -470,16 +468,17 @@ fn cube_limit_for(tier: &PlanTier) -> usize {
 // ── Renewal reminder / expired prompt banner (D1 / D3) ──────────────────────
 
 /// Pre-expiry renewal reminder (D1) or, for a lapsed plan, an expired
-/// prompt (D3). Returns `None` when the plan is comfortably active, free,
-/// or the user dismissed the banner this session. Shared by the account
-/// overview and the plan view; the renewal CTA opens checkout pre-selected
-/// to the current tier + cycle, while the expired CTA opens the picker.
+/// prompt (D3). Returns `None` when the plan is comfortably active or free.
+/// Shared by the account overview and the plan view; the renewal CTA opens
+/// checkout pre-selected to the current tier + cycle, while the expired CTA
+/// opens the picker.
+///
+/// The per-session dismissal applies *only* to the pre-expiry reminder —
+/// the expired prompt is not dismissible, so dismissing the reminder and
+/// then lapsing in the same session still surfaces the expired state.
 fn renewal_banner<'a>(
     state: &'a ConnectAccountPanel,
 ) -> Option<Element<'a, ConnectAccountMessage>> {
-    if state.renewal_banner_dismissed {
-        return None;
-    }
     let (title, accent, copy, cta_label, cta_msg): (
         &str,
         iced::Color,
@@ -488,6 +487,9 @@ fn renewal_banner<'a>(
         ConnectAccountMessage,
     ) = match state.plan_lifecycle() {
         PlanLifecycle::RenewalDue { .. } => {
+            if state.renewal_banner_dismissed {
+                return None;
+            }
             let plan = state.plan.as_ref()?;
             let date = plan
                 .renewal_at
@@ -523,7 +525,10 @@ fn renewal_banner<'a>(
                 "Plan expired",
                 color::RED,
                 copy,
-                "Renew",
+                // Routes to the picker, not a direct checkout — a lapsed
+                // plan reports as Free, so the prior tier is gone and there's
+                // nothing to pre-fill an invoice with. Label reflects that.
+                "View plans",
                 ConnectAccountMessage::OpenPlanBilling,
             )
         }
@@ -1761,4 +1766,57 @@ fn avatar_settings_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectCub
     .style(card_style)
     .width(Length::Fill)
     .into()
+}
+
+#[cfg(test)]
+mod renewal_banner_tests {
+    //! Visibility tests for `renewal_banner`. The function returns an
+    //! `Option<Element>` and its `style`/`on_press` closures are deferred,
+    //! so we can construct it headless and assert only Some/None.
+    use super::*;
+    use crate::services::coincube::{ConnectPlan, PlanEntitlements, PlanStatus};
+
+    fn plan(tier: PlanTier, status: PlanStatus, renewal_at: Option<&str>) -> ConnectPlan {
+        ConnectPlan {
+            plan: tier,
+            status,
+            renewal_at: renewal_at.map(|s| s.to_string()),
+            entitlements: PlanEntitlements {
+                free_signing_key_count: 0,
+                policy_editing: false,
+                legacy_invites: false,
+                linked_keychains: false,
+                duress_remote_lock: false,
+                business_orgs: false,
+            },
+            billing_cycle: Some(BillingCycle::Monthly),
+        }
+    }
+
+    /// Regression: dismissing the pre-expiry reminder must NOT suppress the
+    /// expired prompt once the plan lapses in the same session.
+    #[test]
+    fn expired_banner_shows_even_after_reminder_dismissed() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.renewal_banner_dismissed = true;
+        // Free + past_due is the backend's demoted/expired shape.
+        panel.plan = Some(plan(
+            PlanTier::Free,
+            PlanStatus::PastDue,
+            Some("2026-06-01T00:00:00Z"),
+        ));
+        assert!(matches!(panel.plan_lifecycle(), PlanLifecycle::Expired));
+        assert!(
+            renewal_banner(&panel).is_some(),
+            "expired prompt must render regardless of the reminder dismissal"
+        );
+    }
+
+    /// A free, never-paid account shows no banner.
+    #[test]
+    fn no_banner_for_plain_free_account() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.plan = Some(plan(PlanTier::Free, PlanStatus::Active, None));
+        assert!(renewal_banner(&panel).is_none());
+    }
 }

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -21,7 +21,7 @@ use crate::{
         settings::global::AccountTier,
         state::connect::{
             AvatarFlowStep, CheckoutPhase, ConnectAccountPanel, ConnectCubePanel, ConnectFlowStep,
-            ConnectPanel,
+            ConnectPanel, PlanLifecycle,
         },
         view::{AvatarMessage, ConnectAccountMessage, ConnectCubeMessage},
     },
@@ -391,10 +391,18 @@ fn overview_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccount
         text::p2_regular("✗ Unverified").color(color::GREY_3).into()
     };
 
-    Column::new()
+    let mut col = Column::new()
         .push(text::h4_bold("Account Overview").style(theme::text::primary))
-        .push(iced::widget::Space::new().height(Length::Fixed(15.0)))
-        .push(
+        .push(iced::widget::Space::new().height(Length::Fixed(15.0)));
+
+    // Pre-expiry renewal reminder (D1) / expired prompt (D3).
+    if let Some(banner) = renewal_banner(state) {
+        col = col
+            .push(banner)
+            .push(iced::widget::Space::new().height(Length::Fixed(12.0)));
+    }
+
+    col.push(
             container(
                 Column::new()
                     .push(
@@ -457,6 +465,132 @@ fn cube_limit_for(tier: &PlanTier) -> usize {
         PlanTier::Pro => AccountTier::Pro.cube_limit(),
         PlanTier::Estate => AccountTier::Estate.cube_limit(),
     }
+}
+
+// ── Renewal reminder / expired prompt banner (D1 / D3) ──────────────────────
+
+/// Pre-expiry renewal reminder (D1) or, for a lapsed plan, an expired
+/// prompt (D3). Returns `None` when the plan is comfortably active, free,
+/// or the user dismissed the banner this session. Shared by the account
+/// overview and the plan view; the renewal CTA opens checkout pre-selected
+/// to the current tier + cycle, while the expired CTA opens the picker.
+fn renewal_banner<'a>(
+    state: &'a ConnectAccountPanel,
+) -> Option<Element<'a, ConnectAccountMessage>> {
+    if state.renewal_banner_dismissed {
+        return None;
+    }
+    let (title, accent, copy, cta_label, cta_msg): (
+        &str,
+        iced::Color,
+        String,
+        &str,
+        ConnectAccountMessage,
+    ) = match state.plan_lifecycle() {
+        PlanLifecycle::RenewalDue { .. } => {
+            let plan = state.plan.as_ref()?;
+            let date = plan
+                .renewal_at
+                .as_deref()
+                .map(format_date)
+                .unwrap_or_else(|| "soon".to_string());
+            (
+                "Renewal reminder",
+                color::ORANGE,
+                format!(
+                    "Your {} plan renews on {}. Renew now to keep your features.",
+                    plan.tier(),
+                    date
+                ),
+                "Renew",
+                ConnectAccountMessage::RenewCurrentPlan,
+            )
+        }
+        PlanLifecycle::Expired => {
+            let copy = match state
+                .plan
+                .as_ref()
+                .and_then(|p| p.renewal_at.as_deref())
+                .map(format_date)
+            {
+                Some(d) => format!(
+                    "Your plan expired on {} — renew to restore premium features.",
+                    d
+                ),
+                None => "Your plan expired — renew to restore premium features.".to_string(),
+            };
+            (
+                "Plan expired",
+                color::RED,
+                copy,
+                "Renew",
+                ConnectAccountMessage::OpenPlanBilling,
+            )
+        }
+        PlanLifecycle::Active | PlanLifecycle::Free => return None,
+    };
+
+    let body = Row::new()
+        .push(
+            Column::new()
+                .push(text::p2_bold(title).color(accent))
+                .push(iced::widget::Space::new().height(Length::Fixed(2.0)))
+                .push(text::p2_regular(copy).style(theme::text::primary))
+                .width(Length::Fill),
+        )
+        .push(iced::widget::Space::new().width(Length::Fixed(10.0)))
+        .push(
+            Column::new()
+                .push(button::primary(None, cta_label).on_press(cta_msg))
+                .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+                .push(
+                    button::secondary(None, "Dismiss")
+                        .on_press(ConnectAccountMessage::DismissRenewalBanner),
+                )
+                .align_x(Alignment::End),
+        )
+        .align_y(Alignment::Center);
+
+    Some(
+        container(body)
+            .padding(14)
+            .width(Length::Fill)
+            .style(move |t| container::Style {
+                background: Some(iced::Background::Color(t.colors.cards.simple.background)),
+                border: iced::Border {
+                    color: accent,
+                    width: 1.0,
+                    radius: 14.0.into(),
+                },
+                ..Default::default()
+            })
+            .into(),
+    )
+}
+
+/// Soft "update available" note shown in the plan picker when the
+/// backend's pricing schema version exceeds what this build supports
+/// (D4). Non-blocking — the picker still renders the plans it understands.
+fn schema_update_note<'a>() -> Element<'a, ConnectAccountMessage> {
+    container(
+        text::p2_regular(
+            "A newer pricing update is available. Some plan details may be \
+             incomplete — update Coincube to see the latest plans and prices.",
+        )
+        .color(color::GREY_3),
+    )
+    .padding(12)
+    .width(Length::Fill)
+    .style(|t| container::Style {
+        background: Some(iced::Background::Color(t.colors.cards.simple.background)),
+        border: iced::Border {
+            color: color::ORANGE,
+            width: 0.5,
+            radius: 10.0.into(),
+        },
+        ..Default::default()
+    })
+    .into()
 }
 
 // ── Plan & Billing — top-level router ───────────────────────────────────────
@@ -577,7 +711,25 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
 
     let mut col = Column::new()
         .push(text::h4_bold("Plan & Billing").style(theme::text::primary))
-        .push(iced::widget::Space::new().height(Length::Fixed(15.0)))
+        .push(iced::widget::Space::new().height(Length::Fixed(15.0)));
+
+    // Renewal reminder (D1) / expired prompt (D3). On the plan view the
+    // expired prompt sits above the picker so the user can renew in place.
+    if let Some(banner) = renewal_banner(state) {
+        col = col
+            .push(banner)
+            .push(iced::widget::Space::new().height(Length::Fixed(15.0)));
+    }
+
+    // Soft "update available" note when the backend advertises a pricing
+    // schema newer than this build understands (D4).
+    if state.pricing_schema_outdated() {
+        col = col
+            .push(schema_update_note())
+            .push(iced::widget::Space::new().height(Length::Fixed(12.0)));
+    }
+
+    col = col
         .push(cycle_toggle)
         .push(iced::widget::Space::new().height(Length::Fixed(15.0)));
 

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -717,6 +717,14 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
                 .push(banner)
                 .push(iced::widget::Space::new().height(Length::Fixed(15.0)));
         }
+        // A newer schema can rename tiers so every card is filtered out,
+        // landing here — exactly when the "update available" note is most
+        // relevant, so surface it on this path too (D4).
+        if state.pricing_schema_outdated() {
+            col = col
+                .push(schema_update_note())
+                .push(iced::widget::Space::new().height(Length::Fixed(12.0)));
+        }
         col = col.push(
             text::p1_regular(
                 "Pricing temporarily unavailable.\n\

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -479,12 +479,16 @@ fn cube_limit_for(tier: &PlanTier) -> usize {
 fn renewal_banner<'a>(
     state: &'a ConnectAccountPanel,
 ) -> Option<Element<'a, ConnectAccountMessage>> {
-    let (title, accent, copy, cta_label, cta_msg): (
+    // `dismissible` gates the Dismiss control: only the pre-expiry reminder
+    // honours `renewal_banner_dismissed`, so the expired prompt omits the
+    // button entirely rather than rendering a no-op.
+    let (title, accent, copy, cta_label, cta_msg, dismissible): (
         &str,
         iced::Color,
         String,
         &str,
         ConnectAccountMessage,
+        bool,
     ) = match state.plan_lifecycle() {
         PlanLifecycle::RenewalDue { .. } => {
             if state.renewal_banner_dismissed {
@@ -506,6 +510,7 @@ fn renewal_banner<'a>(
                 ),
                 "Renew",
                 ConnectAccountMessage::RenewCurrentPlan,
+                true,
             )
         }
         PlanLifecycle::Expired => {
@@ -530,10 +535,21 @@ fn renewal_banner<'a>(
                 // nothing to pre-fill an invoice with. Label reflects that.
                 "View plans",
                 ConnectAccountMessage::OpenPlanBilling,
+                false,
             )
         }
         PlanLifecycle::Active | PlanLifecycle::Free => return None,
     };
+
+    let mut actions = Column::new().push(button::primary(None, cta_label).on_press(cta_msg));
+    if dismissible {
+        actions = actions
+            .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+            .push(
+                button::secondary(None, "Dismiss")
+                    .on_press(ConnectAccountMessage::DismissRenewalBanner),
+            );
+    }
 
     let body = Row::new()
         .push(
@@ -544,16 +560,7 @@ fn renewal_banner<'a>(
                 .width(Length::Fill),
         )
         .push(iced::widget::Space::new().width(Length::Fixed(10.0)))
-        .push(
-            Column::new()
-                .push(button::primary(None, cta_label).on_press(cta_msg))
-                .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
-                .push(
-                    button::secondary(None, "Dismiss")
-                        .on_press(ConnectAccountMessage::DismissRenewalBanner),
-                )
-                .align_x(Alignment::End),
-        )
+        .push(actions.align_x(Alignment::End))
         .align_y(Alignment::Center);
 
     Some(

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -705,20 +705,26 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
         .unwrap_or_default();
 
     if cards.is_empty() {
-        return container(
-            Column::new()
-                .push(text::h4_bold("Plan & Billing").style(theme::text::primary))
-                .push(iced::widget::Space::new().height(Length::Fixed(20.0)))
-                .push(
-                    text::p1_regular(
-                        "Pricing temporarily unavailable.\n\
-                         Reconnect to the internet to view current plans and features.",
-                    )
-                    .color(color::GREY_3),
-                ),
-        )
-        .padding(16)
-        .into();
+        // Features failed to load, but the renewal/expired prompt is driven
+        // by `/connect/plan` (not features), so still surface it here —
+        // otherwise an expired user routed to Plan & Billing only sees the
+        // generic "unavailable" copy and loses the renew messaging.
+        let mut col = Column::new()
+            .push(text::h4_bold("Plan & Billing").style(theme::text::primary))
+            .push(iced::widget::Space::new().height(Length::Fixed(20.0)));
+        if let Some(banner) = renewal_banner(state) {
+            col = col
+                .push(banner)
+                .push(iced::widget::Space::new().height(Length::Fixed(15.0)));
+        }
+        col = col.push(
+            text::p1_regular(
+                "Pricing temporarily unavailable.\n\
+                 Reconnect to the internet to view current plans and features.",
+            )
+            .color(color::GREY_3),
+        );
+        return container(col).padding(16).into();
     }
 
     let mut col = Column::new()

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1075,6 +1075,14 @@ pub enum ConnectAccountMessage {
     ),
     DismissCheckout,
     OpenCheckoutUrl(String),
+    /// User dismissed the pre-expiry renewal banner for this session (D1).
+    DismissRenewalBanner,
+    /// Renewal banner CTA — open Plan & Billing checkout pre-selected to
+    /// the current tier + cycle (D1).
+    RenewCurrentPlan,
+    /// Navigate to the Plan & Billing picker (e.g. the expired-state renew
+    /// CTA, D3).
+    OpenPlanBilling,
     BillingHistoryLoaded(
         Result<Vec<crate::services::coincube::BillingHistoryEntry>, String>,
         u64,

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1467,6 +1467,20 @@ impl Home {
             }
 
             Message::View(ViewMessage::ConnectAccount(msg)) => {
+                // The banner CTAs navigate the panel to Plan & Billing by
+                // setting its `active_sub`, but the sidebar highlight follows
+                // the host's `active_section`. Mirror the move here so the two
+                // stay in sync (otherwise the rail keeps highlighting Overview
+                // while the pane shows the picker/checkout, and re-selecting
+                // Overview would silently reset `active_sub`).
+                if matches!(
+                    msg,
+                    ConnectAccountMessage::OpenPlanBilling
+                        | ConnectAccountMessage::RenewCurrentPlan
+                ) {
+                    self.active_section =
+                        HomeSection::Connect(app::menu::ConnectSubMenu::PlanBilling);
+                }
                 let was_authenticated = self.connect_account.is_authenticated();
                 let task = map_connect_task(self.connect_account.update_message(msg));
                 let now_authenticated = self.connect_account.is_authenticated();

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -1458,6 +1458,20 @@ impl Launcher {
             }
 
             Message::View(ViewMessage::ConnectAccount(msg)) => {
+                // The banner CTAs navigate the panel to Plan & Billing by
+                // setting its `active_sub`, but the sidebar highlight follows
+                // the host's `active_section`. Mirror the move here so the two
+                // stay in sync (otherwise the rail keeps highlighting Overview
+                // while the pane shows the picker/checkout, and re-selecting
+                // Overview would silently reset `active_sub`).
+                if matches!(
+                    msg,
+                    ConnectAccountMessage::OpenPlanBilling
+                        | ConnectAccountMessage::RenewCurrentPlan
+                ) {
+                    self.active_section =
+                        LauncherSection::Connect(app::menu::ConnectSubMenu::PlanBilling);
+                }
                 let was_authenticated = self.connect_account.is_authenticated();
                 let task = map_connect_task(self.connect_account.update_message(msg));
                 let now_authenticated = self.connect_account.is_authenticated();

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -331,6 +331,19 @@ pub struct PlanFeatureInfo {
 #[derive(Debug, Clone, Deserialize)]
 pub struct FeaturesResponse {
     pub plans: Vec<PlanFeatureInfo>,
+    /// Version of the pricing schema the backend emitted. The desktop
+    /// build understands up to `SUPPORTED_PRICING_SCHEMA_VERSION`; a
+    /// higher value means the server is describing plans/prices with a
+    /// newer contract this build can't fully render, so the picker shows
+    /// a soft "update available" note. `None`/absent (older backends, or
+    /// the field unset) is treated as version 0 — never outdated.
+    #[serde(
+        default,
+        alias = "schemaVersion",
+        alias = "pricingSchemaVersion",
+        alias = "pricing_schema_version"
+    )]
+    pub pricing_schema_version: Option<u32>,
 }
 
 // ── Checkout / Billing ──────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly UI and local state around existing checkout/plan APIs; no auth or payment logic changes beyond reusing StartCheckout.
> 
> **Overview**
> Adds **desktop Connect plan lifecycle UX**: a pure `PlanLifecycle` projection from `/connect/plan` (free, active, renewal within 7 days, expired via `past_due`) drives shared **renewal reminder** and **expired** banners on Account Overview and Plan & Billing.
> 
> **Renew** opens Plan & Billing and starts checkout with the current tier/cycle; **View plans** / expired flows open the picker and clear a stale billing-history toggle so the picker actually shows. Per-session **Dismiss** only hides the pre-expiry banner (resets on logout).
> 
> Parses **`pricing_schema_version`** from `/connect/features` and shows a non-blocking “update available” note when the server schema exceeds `SUPPORTED_PRICING_SCHEMA_VERSION`. **Home** and **launcher** mirror sidebar highlight to Plan & Billing when banner CTAs fire.
> 
> Unit tests cover lifecycle math, banner dismissal vs expired visibility, routing regressions, and schema detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75ff5ba0ebe020c5d6c882d680f92a9bf34f795d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-expiry renewal reminders with a per-session dismiss option
  * Visible plan lifecycle states (Free, Active, Renewal Due with days remaining, Expired)
  * Quick actions to open Plan & Billing or start renewal/checkout flows
  * Detection and non-blocking notice when a newer pricing schema is available

* **Tests**
  * Unit tests covering plan lifecycle, banner dismissal behavior, expiration handling, and pricing-schema detection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->