### PR TITLE
Duress/00 plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ audit-report.json
 audit-sonar.json
 clippy-sonar.json
 wildcard-cleanup-plan.md
+# Understand-Anything: keep architecture graph local (public repo)
+.understand-anything/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]

--- a/coincube-gui/Cargo.toml
+++ b/coincube-gui/Cargo.toml
@@ -77,7 +77,7 @@ log = "0.4"
 dirs = "6"
 toml = "0.9"
 rand = "0.8"
-chrono = "0.4.38"
+chrono = { version = "0.4.38", features = ["serde"] }
 mostro-core = "0.7"
 nostr-sdk = { version = "0.43.0", features = ["nip06", "nip59"] }
 bip39 = { version = "2.1.0", features = ["rand"] }

--- a/coincube-gui/src/app/message.rs
+++ b/coincube-gui/src/app/message.rs
@@ -198,6 +198,30 @@ pub enum Message {
         email: String,
         cube_uuid: Option<String>,
     },
+    /// Persist a completed duress enrollment (Phases 2 & 8). Emitted by the
+    /// Connect panel, which lacks Cube/datadir context; handled by the App,
+    /// which writes the active Cube's duress PIN hash and this device's
+    /// encrypted duress code into `DuressLocalState`.
+    CompleteDuressEnrollment(DuressEnrollmentPayload),
+}
+
+/// Sensitive payload for [`Message::CompleteDuressEnrollment`]. `Debug` is
+/// hand-written to redact the plaintext duress PIN and code so they never reach
+/// a tracing snapshot of the parent message.
+pub struct DuressEnrollmentPayload {
+    pub duress_pin: String,
+    pub duress_code: String,
+    pub gen: u64,
+}
+
+impl std::fmt::Debug for DuressEnrollmentPayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DuressEnrollmentPayload")
+            .field("duress_pin", &"<redacted>")
+            .field("duress_code", &"<redacted>")
+            .field("gen", &self.gen)
+            .finish()
+    }
 }
 
 #[derive(Debug)]

--- a/coincube-gui/src/app/message.rs
+++ b/coincube-gui/src/app/message.rs
@@ -207,7 +207,10 @@ pub enum Message {
 
 /// Sensitive payload for [`Message::CompleteDuressEnrollment`]. `Debug` is
 /// hand-written to redact the plaintext duress PIN and code so they never reach
-/// a tracing snapshot of the parent message.
+/// a tracing snapshot of the parent message. `Clone` is required because the
+/// Home/Launcher `Message` enums (which relay this from their Connect panels)
+/// derive `Clone`.
+#[derive(Clone)]
 pub struct DuressEnrollmentPayload {
     pub duress_pin: String,
     pub duress_code: String,

--- a/coincube-gui/src/app/message.rs
+++ b/coincube-gui/src/app/message.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use zeroize::Zeroizing;
+
 use coincube_core::miniscript::bitcoin::{
     address::NetworkUnchecked,
     bip32::{ChildNumber, Fingerprint},
@@ -205,15 +207,16 @@ pub enum Message {
     CompleteDuressEnrollment(DuressEnrollmentPayload),
 }
 
-/// Sensitive payload for [`Message::CompleteDuressEnrollment`]. `Debug` is
-/// hand-written to redact the plaintext duress PIN and code so they never reach
-/// a tracing snapshot of the parent message. `Clone` is required because the
-/// Home/Launcher `Message` enums (which relay this from their Connect panels)
-/// derive `Clone`.
+/// Sensitive payload for [`Message::CompleteDuressEnrollment`]. The duress PIN
+/// and code are wrapped in `Zeroizing` so their heap bytes are scrubbed on
+/// drop (the message is cloned/relayed across the App/Home/Launcher surfaces).
+/// `Debug` is also hand-written to redact them so they never reach a tracing
+/// snapshot of the parent message. `Clone` is required because the Home/Launcher
+/// `Message` enums (which relay this from their Connect panels) derive `Clone`.
 #[derive(Clone)]
 pub struct DuressEnrollmentPayload {
-    pub duress_pin: String,
-    pub duress_code: String,
+    pub duress_pin: Zeroizing<String>,
+    pub duress_code: Zeroizing<String>,
     /// Connect account id, persisted so the unauth activation POST can address
     /// it later. `None` for sovereign (no-Connect) enrollment.
     pub account_id: Option<String>,

--- a/coincube-gui/src/app/message.rs
+++ b/coincube-gui/src/app/message.rs
@@ -215,6 +215,10 @@ pub enum Message {
 /// `Message` enums (which relay this from their Connect panels) derive `Clone`.
 #[derive(Clone)]
 pub struct DuressEnrollmentPayload {
+    /// The user's re-typed regular PIN. Carried so the persist step can verify
+    /// it against each Cube's ACTUAL stored PIN (the wizard can only check the
+    /// re-typed value) before arming the duress PIN.
+    pub regular_pin: Zeroizing<String>,
     pub duress_pin: Zeroizing<String>,
     pub duress_code: Zeroizing<String>,
     /// Connect account id, persisted so the unauth activation POST can address
@@ -226,6 +230,7 @@ pub struct DuressEnrollmentPayload {
 impl std::fmt::Debug for DuressEnrollmentPayload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DuressEnrollmentPayload")
+            .field("regular_pin", &"<redacted>")
             .field("duress_pin", &"<redacted>")
             .field("duress_code", &"<redacted>")
             .field("gen", &self.gen)

--- a/coincube-gui/src/app/message.rs
+++ b/coincube-gui/src/app/message.rs
@@ -214,6 +214,9 @@ pub enum Message {
 pub struct DuressEnrollmentPayload {
     pub duress_pin: String,
     pub duress_code: String,
+    /// Connect account id, persisted so the unauth activation POST can address
+    /// it later. `None` for sovereign (no-Connect) enrollment.
+    pub account_id: Option<String>,
     pub gen: u64,
 }
 

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -786,6 +786,47 @@ fn is_daemon_unreachable(e: &Error) -> bool {
     )
 }
 
+/// Persist a completed duress enrollment locally (Phases 2 & 8). Writes the
+/// duress PIN hash onto **every** Cube in `network` — a duress wipe takes all
+/// Cubes on the device, so the duress PIN must trip from any Cube's unlock —
+/// and stores this device's ChaCha20-encrypted duress code in
+/// `DuressLocalState` (data-dir root, outside the wiped tree). Shared by the
+/// App, Home, and Launcher surfaces, all of which can host the Connect Duress
+/// panel. Hashing happens inside this async task so the UI thread never blocks
+/// on argon2.
+pub(crate) async fn persist_duress_enrollment(
+    datadir: CoincubeDirectory,
+    network: bitcoin::Network,
+    duress_pin: String,
+    duress_code: String,
+) {
+    // 1. Duress PIN hash → every Cube in the network settings.
+    if let Ok(hash) = crate::services::duress::enroll::hash_duress_secret(&duress_pin) {
+        let network_dir = datadir.network_directory(network);
+        let _ = crate::app::settings::update_settings_file(&network_dir, move |mut s| {
+            for cube in s.cubes.iter_mut() {
+                cube.duress_pin_hash = Some(hash.clone());
+            }
+            Some(s)
+        })
+        .await;
+    }
+    // 2. Encrypted device code → DuressLocalState. Skipped when empty (the
+    //    server-enroll path re-enters with an empty code once already stored).
+    if !duress_code.is_empty() {
+        let root = datadir.path().to_path_buf();
+        if let Ok(key) = crate::services::duress::cipher::DeviceKey::load_or_create(&root) {
+            if let Ok(enc) = key.encrypt(&duress_code) {
+                let mut st =
+                    crate::services::duress::DuressLocalState::load(&root).unwrap_or_default();
+                st.enrolled = true;
+                st.duress_code = Some(enc);
+                let _ = st.save(&root);
+            }
+        }
+    }
+}
+
 /// Poll the local bitcoind's IBD progress via its JSON-RPC interface.
 /// Returns `(verificationprogress, initialblockdownload)` or an error string.
 async fn check_bitcoind_sync_progress(
@@ -2416,58 +2457,19 @@ impl App {
             Message::CompleteDuressEnrollment(payload) => {
                 // Phases 2 & 8: the Connect panel collected + validated the
                 // credentials and (for Connect tiers) enrolled on the server;
-                // persist the per-Cube duress PIN and this device's encrypted
-                // duress code here, where the Cube + datadir context lives.
+                // persist the duress PIN + this device's encrypted code here,
+                // where the Cube + datadir context lives. Shared with the Home
+                // and Launcher surfaces, which also host the Connect Duress
+                // panel (see `persist_duress_enrollment`).
                 let crate::app::message::DuressEnrollmentPayload {
                     duress_pin,
                     duress_code,
                     ..
                 } = payload;
-                let pin_hash =
-                    crate::services::duress::enroll::hash_duress_secret(&duress_pin).ok();
-                // Reflect immediately in the in-memory cube so this session's
-                // unlock screen recognises the duress PIN without a reload.
-                if let Some(h) = &pin_hash {
-                    self.cube_settings.duress_pin_hash = Some(h.clone());
-                }
                 let datadir = self.datadir.clone();
                 let network = self.cache.network;
-                let cube_id = self.cube_settings.id.clone();
-                let root = self.datadir.path().to_path_buf();
                 return Task::perform(
-                    async move {
-                        // 1. Persist the duress PIN hash on the active Cube.
-                        if let Some(hash) = pin_hash {
-                            let network_dir = datadir.network_directory(network);
-                            let _ = crate::app::settings::update_settings_file(
-                                &network_dir,
-                                move |mut s| {
-                                    if let Some(cube) = s.cubes.iter_mut().find(|c| c.id == cube_id)
-                                    {
-                                        cube.duress_pin_hash = Some(hash.clone());
-                                    }
-                                    Some(s)
-                                },
-                            )
-                            .await;
-                        }
-                        // 2. Persist this device's encrypted duress code in
-                        //    DuressLocalState (data-dir root, survives the wipe).
-                        if !duress_code.is_empty() {
-                            if let Ok(key) =
-                                crate::services::duress::cipher::DeviceKey::load_or_create(&root)
-                            {
-                                if let Ok(enc) = key.encrypt(&duress_code) {
-                                    let mut st =
-                                        crate::services::duress::DuressLocalState::load(&root)
-                                            .unwrap_or_default();
-                                    st.enrolled = true;
-                                    st.duress_code = Some(enc);
-                                    let _ = st.save(&root);
-                                }
-                            }
-                        }
-                    },
+                    persist_duress_enrollment(datadir, network, duress_pin, duress_code),
                     |_| Message::CacheUpdated,
                 );
             }

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -830,6 +830,8 @@ pub(crate) async fn persist_duress_enrollment(
     //    real one. If the user mistyped their PIN (so the wizard's check was
     //    meaningless) or the duress PIN is within one edit of a real unlock
     //    PIN, refuse — otherwise a fat-fingered unlock could trip a wipe.
+    let mut prior_settings: Vec<crate::app::settings::Settings> =
+        Vec::with_capacity(network_dirs.len());
     for network_dir in &network_dirs {
         // We enumerated this dir because it HAS a settings.json. If it now
         // can't be read (corrupt/parse/IO, or a race), fail loud rather than
@@ -849,20 +851,44 @@ pub(crate) async fn persist_duress_enrollment(
                 crate::services::duress::enroll::validate_duress_pin(&regular_pin, &duress_pin)?;
             }
         }
+        // Snapshot the pre-write state so a later failure can roll back.
+        prior_settings.push(settings);
     }
 
-    // 1. Duress PIN hash → every Cube on every network.
+    // 1. Duress PIN hash → every Cube on every network. Sequential file writes
+    //    have no cross-file transaction, so if a later network fails, roll back
+    //    the networks already written to their snapshot — the device must never
+    //    end up with some networks armed and others not.
     let hash = crate::services::duress::enroll::hash_duress_secret(&duress_pin)?;
-    for network_dir in &network_dirs {
-        let hash = hash.clone();
-        crate::app::settings::update_settings_file(network_dir, move |mut s| {
+    let mut written = 0usize;
+    for (i, network_dir) in network_dirs.iter().enumerate() {
+        let h = hash.clone();
+        let write = crate::app::settings::update_settings_file(network_dir, move |mut s| {
             for cube in s.cubes.iter_mut() {
-                cube.duress_pin_hash = Some(hash.clone());
+                cube.duress_pin_hash = Some(h.clone());
             }
             Some(s)
         })
-        .await
-        .map_err(|e| e.to_string())?;
+        .await;
+        match write {
+            Ok(()) => written = i + 1,
+            Err(e) => {
+                for j in 0..written {
+                    let restore = prior_settings[j].clone();
+                    if let Err(re) =
+                        crate::app::settings::update_settings_file(&network_dirs[j], move |_| {
+                            Some(restore)
+                        })
+                        .await
+                    {
+                        log::error!("duress: rollback of network {j} settings failed: {re}");
+                    }
+                }
+                return Err(format!(
+                    "Couldn't arm the duress PIN on all your Cubes ({e}); no changes were kept."
+                ));
+            }
+        }
     }
 
     // 2. Encrypted device code + account id → DuressLocalState. The encrypted

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -831,22 +831,22 @@ pub(crate) async fn persist_duress_enrollment(
     //    meaningless) or the duress PIN is within one edit of a real unlock
     //    PIN, refuse — otherwise a fat-fingered unlock could trip a wipe.
     for network_dir in &network_dirs {
-        if let Ok(settings) = crate::app::settings::Settings::from_file(network_dir) {
-            for cube in &settings.cubes {
-                if cube.has_pin() {
-                    if !cube.verify_pin(&regular_pin) {
-                        return Err(
-                            "That PIN doesn't match your Cube PIN. Enter your real PIN so the \
-                             duress PIN can be safely checked against it. (All your Cubes must \
-                             share the same PIN to enable duress.)"
-                                .to_string(),
-                        );
-                    }
-                    crate::services::duress::enroll::validate_duress_pin(
-                        &regular_pin,
-                        &duress_pin,
-                    )?;
+        // We enumerated this dir because it HAS a settings.json. If it now
+        // can't be read (corrupt/parse/IO, or a race), fail loud rather than
+        // skip the safety check and arm an unverified duress PIN anyway.
+        let settings = crate::app::settings::Settings::from_file(network_dir)
+            .map_err(|e| format!("Couldn't read your Cube settings to verify your PIN: {e}"))?;
+        for cube in &settings.cubes {
+            if cube.has_pin() {
+                if !cube.verify_pin(&regular_pin) {
+                    return Err(
+                        "That PIN doesn't match your Cube PIN. Enter your real PIN so the \
+                         duress PIN can be safely checked against it. (All your Cubes must \
+                         share the same PIN to enable duress.)"
+                            .to_string(),
+                    );
                 }
+                crate::services::duress::enroll::validate_duress_pin(&regular_pin, &duress_pin)?;
             }
         }
     }

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -2569,6 +2569,14 @@ impl App {
                 }
             },
             Message::CompleteDuressEnrollment(payload) => {
+                // Drop a completion that outlived its Connect session: a logout
+                // or session reset bumps `session_generation`, and persisting
+                // now would arm the duress PIN + DuressLocalState for an account
+                // the user is no longer signed into.
+                if payload.gen != self.panels.connect.account.session_generation() {
+                    log::warn!("duress: ignoring enrollment completion from a stale session");
+                    return Task::none();
+                }
                 // Phases 2 & 8: the Connect panel collected + validated the
                 // credentials and (for Connect tiers) enrolled on the server;
                 // persist the duress PIN + this device's encrypted code here,

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -2413,6 +2413,64 @@ impl App {
                     }
                 }
             },
+            Message::CompleteDuressEnrollment(payload) => {
+                // Phases 2 & 8: the Connect panel collected + validated the
+                // credentials and (for Connect tiers) enrolled on the server;
+                // persist the per-Cube duress PIN and this device's encrypted
+                // duress code here, where the Cube + datadir context lives.
+                let crate::app::message::DuressEnrollmentPayload {
+                    duress_pin,
+                    duress_code,
+                    ..
+                } = payload;
+                let pin_hash =
+                    crate::services::duress::enroll::hash_duress_secret(&duress_pin).ok();
+                // Reflect immediately in the in-memory cube so this session's
+                // unlock screen recognises the duress PIN without a reload.
+                if let Some(h) = &pin_hash {
+                    self.cube_settings.duress_pin_hash = Some(h.clone());
+                }
+                let datadir = self.datadir.clone();
+                let network = self.cache.network;
+                let cube_id = self.cube_settings.id.clone();
+                let root = self.datadir.path().to_path_buf();
+                return Task::perform(
+                    async move {
+                        // 1. Persist the duress PIN hash on the active Cube.
+                        if let Some(hash) = pin_hash {
+                            let network_dir = datadir.network_directory(network);
+                            let _ = crate::app::settings::update_settings_file(
+                                &network_dir,
+                                move |mut s| {
+                                    if let Some(cube) = s.cubes.iter_mut().find(|c| c.id == cube_id)
+                                    {
+                                        cube.duress_pin_hash = Some(hash.clone());
+                                    }
+                                    Some(s)
+                                },
+                            )
+                            .await;
+                        }
+                        // 2. Persist this device's encrypted duress code in
+                        //    DuressLocalState (data-dir root, survives the wipe).
+                        if !duress_code.is_empty() {
+                            if let Ok(key) =
+                                crate::services::duress::cipher::DeviceKey::load_or_create(&root)
+                            {
+                                if let Ok(enc) = key.encrypt(&duress_code) {
+                                    let mut st =
+                                        crate::services::duress::DuressLocalState::load(&root)
+                                            .unwrap_or_default();
+                                    st.enrolled = true;
+                                    st.duress_code = Some(enc);
+                                    let _ = st.save(&root);
+                                }
+                            }
+                        }
+                    },
+                    |_| Message::CacheUpdated,
+                );
+            }
             Message::CacheUpdated => {
                 // Cube (Home) Settings lives on every cube, vault or not,
                 // so its cache update must fire independently of the

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -861,6 +861,7 @@ pub(crate) async fn persist_duress_enrollment(
     //    PIN, refuse — otherwise a fat-fingered unlock could trip a wipe.
     let mut prior_settings: Vec<crate::app::settings::Settings> =
         Vec::with_capacity(network_dirs.len());
+    let mut total_cubes = 0usize;
     for network_dir in &network_dirs {
         // We enumerated this dir because it HAS a settings.json. If it now
         // can't be read (corrupt/parse/IO, or a race), fail loud rather than
@@ -868,6 +869,7 @@ pub(crate) async fn persist_duress_enrollment(
         let settings = crate::app::settings::Settings::from_file(network_dir)
             .map_err(|e| format!("Couldn't read your Cube settings to verify your PIN: {e}"))?;
         for cube in &settings.cubes {
+            total_cubes += 1;
             if cube.has_pin() {
                 if !cube.verify_pin(&regular_pin) {
                     return Err(
@@ -882,6 +884,14 @@ pub(crate) async fn persist_duress_enrollment(
         }
         // Snapshot the pre-write state so a later failure can roll back.
         prior_settings.push(settings);
+    }
+    // Settings files exist but hold no Cubes — the write below would set
+    // duress_pin_hash on nothing. Don't mark duress "enabled" when no Cube is
+    // actually armed and no PIN path can trip a wipe.
+    if total_cubes == 0 {
+        return Err(
+            "Couldn't find any Cubes on this device to protect with duress mode.".to_string(),
+        );
     }
 
     // 1. Duress PIN hash → every Cube on every network. Sequential file writes

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -800,22 +800,26 @@ pub(crate) async fn persist_duress_enrollment(
     duress_pin: zeroize::Zeroizing<String>,
     duress_code: zeroize::Zeroizing<String>,
     account_id: Option<String>,
-) {
+) -> Result<(), String> {
     // 1. Duress PIN hash → every Cube in the network settings.
-    if let Ok(hash) = crate::services::duress::enroll::hash_duress_secret(&duress_pin) {
-        let network_dir = datadir.network_directory(network);
-        let _ = crate::app::settings::update_settings_file(&network_dir, move |mut s| {
-            for cube in s.cubes.iter_mut() {
-                cube.duress_pin_hash = Some(hash.clone());
-            }
-            Some(s)
-        })
-        .await;
-    }
+    let hash = crate::services::duress::enroll::hash_duress_secret(&duress_pin)?;
+    let network_dir = datadir.network_directory(network);
+    crate::app::settings::update_settings_file(&network_dir, move |mut s| {
+        for cube in s.cubes.iter_mut() {
+            cube.duress_pin_hash = Some(hash.clone());
+        }
+        Some(s)
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
     // 2. Encrypted device code + account id → DuressLocalState. The encrypted
     //    code is skipped when empty (the server-enroll path re-enters with an
     //    empty code once it's already stored), but the account id is always
     //    recorded so the activation POST can address the right account.
+    //    `load` is resilient (missing → default); only `save` and the
+    //    encryption are fail-loud, since a silent failure here would leave the
+    //    user believing duress is armed when its PIN won't trigger.
     let root = datadir.path().to_path_buf();
     let mut st = crate::services::duress::DuressLocalState::load(&root).unwrap_or_default();
     st.enrolled = true;
@@ -823,13 +827,12 @@ pub(crate) async fn persist_duress_enrollment(
         st.account_id = account_id;
     }
     if !duress_code.is_empty() {
-        if let Ok(key) = crate::services::duress::cipher::DeviceKey::load_or_create(&root) {
-            if let Ok(enc) = key.encrypt(&duress_code) {
-                st.duress_code = Some(enc);
-            }
-        }
+        let key = crate::services::duress::cipher::DeviceKey::load_or_create(&root)
+            .map_err(|e| e.to_string())?;
+        st.duress_code = Some(key.encrypt(&duress_code)?);
     }
-    let _ = st.save(&root);
+    st.save(&root).map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 /// Poll the local bitcoind's IBD progress via its JSON-RPC interface.
@@ -2485,7 +2488,15 @@ impl App {
                         duress_code,
                         account_id,
                     ),
-                    |_| Message::CacheUpdated,
+                    |res| match res {
+                        Ok(()) => Message::CacheUpdated,
+                        Err(e) => {
+                            log::error!("duress: failed to persist enrollment: {e}");
+                            Message::View(view::Message::ShowError(format!(
+                                "Couldn't finish enabling duress mode: {e}. Please try again."
+                            )))
+                        }
+                    },
                 );
             }
             Message::CacheUpdated => {

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -949,7 +949,11 @@ pub(crate) async fn persist_duress_enrollment(
     //    hashes, roll those back too — otherwise Cubes stay armed (and would
     //    wipe on the duress PIN) while the matching enrollment state is missing.
     let local: Result<(), String> = (|| {
-        let mut st = crate::services::duress::DuressLocalState::load(&root).unwrap_or_default();
+        // load() already maps a missing file to Ok(default); a real parse/IO
+        // error must NOT be papered over with a default that save() then writes
+        // back, clobbering valid state. Propagate it (rolling back step 1).
+        let mut st = crate::services::duress::DuressLocalState::load(&root)
+            .map_err(|e| format!("Couldn't read existing duress state: {e}"))?;
         st.enrolled = true;
         st.account_id = account_id;
         if !duress_code.is_empty() {
@@ -2004,8 +2008,23 @@ impl App {
                 let root = self.datadir.path().to_path_buf();
                 Task::perform(
                     async move {
-                        let mut st = crate::services::duress::DuressLocalState::load(&root)
-                            .unwrap_or_default();
+                        // load() already maps a missing file to Ok(default); a
+                        // real parse/IO error must NOT be papered over with a
+                        // default that save() then writes back, clobbering valid
+                        // state (enrolled / account_id / encrypted code). Skip
+                        // the persist on a real read error — the UI still locks
+                        // below, and the DuressLockRemote backstop / session-check
+                        // re-sync handle durability.
+                        let mut st = match crate::services::duress::DuressLocalState::load(&root) {
+                            Ok(st) => st,
+                            Err(e) => {
+                                log::warn!(
+                                    "[CONNECT GRPC] reading duress state failed; \
+                                     not overwriting: {e}"
+                                );
+                                return;
+                            }
+                        };
                         st.active = true;
                         st.unlock_at = unlock_at;
                         // Retry: a failed persist would let a relaunch reconcile
@@ -2031,8 +2050,20 @@ impl App {
                 let root = self.datadir.path().to_path_buf();
                 Task::perform(
                     async move {
-                        let mut st = crate::services::duress::DuressLocalState::load(&root)
-                            .unwrap_or_default();
+                        // As above: skip on a real read error so a transient
+                        // failure can't clobber valid state with a default. The
+                        // cryptic screen's own server poll re-syncs the cleared
+                        // state on the next check.
+                        let mut st = match crate::services::duress::DuressLocalState::load(&root) {
+                            Ok(st) => st,
+                            Err(e) => {
+                                log::warn!(
+                                    "[CONNECT GRPC] reading duress state failed; \
+                                     not overwriting: {e}"
+                                );
+                                return;
+                            }
+                        };
                         st.active = false;
                         st.unlock_at = None;
                         if let Err(e) = st.save(&root) {

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -822,6 +822,14 @@ pub(crate) async fn persist_duress_enrollment(
     // all per-network settings, not just the active one.
     let root = datadir.path().to_path_buf();
     let network_dirs = duress_enroll_network_dirs(&root);
+    // No per-network settings.json found — there are no Cubes to arm (or the
+    // data directory couldn't be read). Fail loud instead of marking duress
+    // "enabled" with no duress PIN written anywhere.
+    if network_dirs.is_empty() {
+        return Err(
+            "Couldn't find any Cubes on this device to protect with duress mode.".to_string(),
+        );
+    }
 
     // 0. Guard against arming a near-miss duress PIN, across ALL networks,
     //    BEFORE writing anything. The wizard could only check the duress PIN

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1808,6 +1808,46 @@ impl App {
                 ));
                 Task::batch([persist_task, dispatch_task])
             }
+            M::DuressActivated { unlock_at, source } => {
+                // Phase 7b: remote duress activation. Persist active state to
+                // DuressLocalState (at the data-dir root) WITHOUT wiping —
+                // remote activation can be accidental, so local Cube data is
+                // left intact. The launch-time reconcile (and a future live
+                // bubble-up to the tab shell) routes into the cryptic screen.
+                log::warn!(
+                    "[CONNECT GRPC] Duress activated remotely (source={})",
+                    source
+                );
+                let root = self.datadir.path().to_path_buf();
+                Task::perform(
+                    async move {
+                        let mut st = crate::services::duress::DuressLocalState::load(&root)
+                            .unwrap_or_default();
+                        st.active = true;
+                        st.unlock_at = unlock_at;
+                        if let Err(e) = st.save(&root) {
+                            log::warn!("[CONNECT GRPC] Failed to persist remote duress state: {e}");
+                        }
+                    },
+                    |_| Message::CacheUpdated,
+                )
+            }
+            M::DuressCleared => {
+                log::info!("[CONNECT GRPC] Duress cleared remotely");
+                let root = self.datadir.path().to_path_buf();
+                Task::perform(
+                    async move {
+                        let mut st = crate::services::duress::DuressLocalState::load(&root)
+                            .unwrap_or_default();
+                        st.active = false;
+                        st.unlock_at = None;
+                        if let Err(e) = st.save(&root) {
+                            log::warn!("[CONNECT GRPC] Failed to clear remote duress state: {e}");
+                        }
+                    },
+                    |_| Message::CacheUpdated,
+                )
+            }
         }
     }
 

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1858,14 +1858,15 @@ impl App {
                 // Phase 7b: remote duress activation. Persist active state to
                 // DuressLocalState (at the data-dir root) WITHOUT wiping —
                 // remote activation can be accidental, so local Cube data is
-                // left intact. The launch-time reconcile (and a future live
-                // bubble-up to the tab shell) routes into the cryptic screen.
+                // left intact. Then bubble up to the tab shell to lock the
+                // RUNNING app into the cryptic screen immediately (not just on
+                // next launch).
                 log::warn!(
                     "[CONNECT GRPC] Duress activated remotely (source={})",
                     source
                 );
                 let root = self.datadir.path().to_path_buf();
-                Task::perform(
+                let persist = Task::perform(
                     async move {
                         let mut st = crate::services::duress::DuressLocalState::load(&root)
                             .unwrap_or_default();
@@ -1876,7 +1877,9 @@ impl App {
                         }
                     },
                     |_| Message::CacheUpdated,
-                )
+                );
+                let lock = Task::done(Message::View(view::Message::DuressLockRemote));
+                Task::batch([persist, lock])
             }
             M::DuressCleared => {
                 log::info!("[CONNECT GRPC] Duress cleared remotely");

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1990,8 +1990,19 @@ impl App {
                             .unwrap_or_default();
                         st.active = true;
                         st.unlock_at = unlock_at;
-                        if let Err(e) = st.save(&root) {
-                            log::warn!("[CONNECT GRPC] Failed to persist remote duress state: {e}");
+                        // Retry: a failed persist would let a relaunch reconcile
+                        // (which keys off st.active) drop back to the normal Home
+                        // flow with Cube data intact while the server is still in
+                        // duress. The DuressLockRemote handler re-persists as a
+                        // final backstop tied to the UI lock.
+                        for attempt in 1..=3 {
+                            match st.save(&root) {
+                                Ok(()) => break,
+                                Err(e) => log::warn!(
+                                    "[CONNECT GRPC] persist remote duress state \
+                                     attempt {attempt}/3 failed: {e}"
+                                ),
+                            }
                         }
                     },
                     |_| Message::View(view::Message::DuressLockRemote),

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -797,8 +797,8 @@ fn is_daemon_unreachable(e: &Error) -> bool {
 pub(crate) async fn persist_duress_enrollment(
     datadir: CoincubeDirectory,
     network: bitcoin::Network,
-    duress_pin: String,
-    duress_code: String,
+    duress_pin: zeroize::Zeroizing<String>,
+    duress_code: zeroize::Zeroizing<String>,
     account_id: Option<String>,
 ) {
     // 1. Duress PIN hash → every Cube in the network settings.

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -797,13 +797,37 @@ fn is_daemon_unreachable(e: &Error) -> bool {
 pub(crate) async fn persist_duress_enrollment(
     datadir: CoincubeDirectory,
     network: bitcoin::Network,
+    regular_pin: zeroize::Zeroizing<String>,
     duress_pin: zeroize::Zeroizing<String>,
     duress_code: zeroize::Zeroizing<String>,
     account_id: Option<String>,
 ) -> Result<(), String> {
+    let network_dir = datadir.network_directory(network);
+
+    // 0. Guard against arming a near-miss duress PIN. The wizard could only
+    //    check the duress PIN against the *re-typed* regular PIN; verify that
+    //    re-typed value against each Cube's ACTUAL stored PIN, and re-check
+    //    distinctness against the real one. If the user mistyped their PIN (so
+    //    the wizard's check was meaningless) or the duress PIN is within one
+    //    edit of a real unlock PIN, refuse — otherwise a fat-fingered unlock
+    //    could trip an accidental wipe.
+    if let Ok(settings) = crate::app::settings::Settings::from_file(&network_dir) {
+        for cube in &settings.cubes {
+            if cube.has_pin() {
+                if !cube.verify_pin(&regular_pin) {
+                    return Err(
+                        "That PIN doesn't match your current Cube PIN. Enter your real \
+                         PIN so the duress PIN can be safely checked against it."
+                            .to_string(),
+                    );
+                }
+                crate::services::duress::enroll::validate_duress_pin(&regular_pin, &duress_pin)?;
+            }
+        }
+    }
+
     // 1. Duress PIN hash → every Cube in the network settings.
     let hash = crate::services::duress::enroll::hash_duress_secret(&duress_pin)?;
-    let network_dir = datadir.network_directory(network);
     crate::app::settings::update_settings_file(&network_dir, move |mut s| {
         for cube in s.cubes.iter_mut() {
             cube.duress_pin_hash = Some(hash.clone());
@@ -2473,6 +2497,7 @@ impl App {
                 // and Launcher surfaces, which also host the Connect Duress
                 // panel (see `persist_duress_enrollment`).
                 let crate::app::message::DuressEnrollmentPayload {
+                    regular_pin,
                     duress_pin,
                     duress_code,
                     account_id,
@@ -2484,6 +2509,7 @@ impl App {
                     persist_duress_enrollment(
                         datadir,
                         network,
+                        regular_pin,
                         duress_pin,
                         duress_code,
                         account_id,

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -900,12 +900,21 @@ pub(crate) async fn persist_duress_enrollment(
     //    end up with some networks armed and others not.
     let hash = crate::services::duress::enroll::hash_duress_secret(&duress_pin)?;
     let mut written = 0usize;
+    // Count the Cubes that actually had a duress_pin_hash written, at write
+    // time. update_settings_file re-reads each settings file under its lock, so
+    // this is authoritative even if the on-disk Cube set changed since the
+    // step-0 snapshot — we never mark enrolled when zero hashes were written.
+    let armed = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     for (i, network_dir) in network_dirs.iter().enumerate() {
         let h = hash.clone();
+        let armed = armed.clone();
         let write = crate::app::settings::update_settings_file(network_dir, move |mut s| {
+            let mut n = 0usize;
             for cube in s.cubes.iter_mut() {
                 cube.duress_pin_hash = Some(h.clone());
+                n += 1;
             }
+            armed.fetch_add(n, std::sync::atomic::Ordering::Relaxed);
             Some(s)
         })
         .await;
@@ -918,6 +927,15 @@ pub(crate) async fn persist_duress_enrollment(
                 ));
             }
         }
+    }
+    // Settings files were present but held no Cubes at write time — no
+    // duress_pin_hash was set anywhere. Roll the (content-unchanged) writes back
+    // and abort rather than mark duress enabled with no PIN that can trip a wipe.
+    if armed.load(std::sync::atomic::Ordering::Relaxed) == 0 {
+        rollback_duress_pin_writes(&network_dirs, &prior_settings, written).await;
+        return Err(
+            "Couldn't find any Cubes on this device to protect with duress mode.".to_string(),
+        );
     }
 
     // 2. Encrypted device code + account id → DuressLocalState. The encrypted

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -867,16 +867,16 @@ pub(crate) async fn persist_duress_enrollment(
 
     // 2. Encrypted device code + account id → DuressLocalState. The encrypted
     //    code is skipped when empty (the server-enroll path re-enters with an
-    //    empty code once it's already stored), but the account id is always
-    //    recorded so the activation POST can address the right account.
+    //    empty code once it's already stored). The account id is set
+    //    unconditionally — including to `None` for a sovereign enrollment — so
+    //    re-enrolling sovereign clears any previously stored Connect account id
+    //    and local activation can't trigger-with-code against a stale account.
     //    `load` is resilient (missing → default); only `save` and the
     //    encryption are fail-loud, since a silent failure here would leave the
     //    user believing duress is armed when its PIN won't trigger.
     let mut st = crate::services::duress::DuressLocalState::load(&root).unwrap_or_default();
     st.enrolled = true;
-    if account_id.is_some() {
-        st.account_id = account_id;
-    }
+    st.account_id = account_id;
     if !duress_code.is_empty() {
         let key = crate::services::duress::cipher::DeviceKey::load_or_create(&root)
             .map_err(|e| e.to_string())?;

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -794,48 +794,76 @@ fn is_daemon_unreachable(e: &Error) -> bool {
 /// App, Home, and Launcher surfaces, all of which can host the Connect Duress
 /// panel. Hashing happens inside this async task so the UI thread never blocks
 /// on argon2.
+/// Every per-network directory under the datadir root that holds a
+/// `settings.json` (i.e. has Cubes). A duress enrollment verifies + writes the
+/// duress PIN across all of these, matching the all-networks scope of the wipe.
+fn duress_enroll_network_dirs(root: &std::path::Path) -> Vec<crate::dir::NetworkDirectory> {
+    let mut dirs = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() && p.join(crate::app::settings::SETTINGS_FILE_NAME).is_file() {
+                dirs.push(crate::dir::NetworkDirectory::new(p));
+            }
+        }
+    }
+    dirs
+}
+
 pub(crate) async fn persist_duress_enrollment(
     datadir: CoincubeDirectory,
-    network: bitcoin::Network,
     regular_pin: zeroize::Zeroizing<String>,
     duress_pin: zeroize::Zeroizing<String>,
     duress_code: zeroize::Zeroizing<String>,
     account_id: Option<String>,
 ) -> Result<(), String> {
-    let network_dir = datadir.network_directory(network);
+    // A duress wipe takes every Cube on EVERY network under the datadir, so the
+    // duress PIN must trip from any of them — set it (and verify against it) on
+    // all per-network settings, not just the active one.
+    let root = datadir.path().to_path_buf();
+    let network_dirs = duress_enroll_network_dirs(&root);
 
-    // 0. Guard against arming a near-miss duress PIN. The wizard could only
-    //    check the duress PIN against the *re-typed* regular PIN; verify that
-    //    re-typed value against each Cube's ACTUAL stored PIN, and re-check
-    //    distinctness against the real one. If the user mistyped their PIN (so
-    //    the wizard's check was meaningless) or the duress PIN is within one
-    //    edit of a real unlock PIN, refuse — otherwise a fat-fingered unlock
-    //    could trip an accidental wipe.
-    if let Ok(settings) = crate::app::settings::Settings::from_file(&network_dir) {
-        for cube in &settings.cubes {
-            if cube.has_pin() {
-                if !cube.verify_pin(&regular_pin) {
-                    return Err(
-                        "That PIN doesn't match your current Cube PIN. Enter your real \
-                         PIN so the duress PIN can be safely checked against it."
-                            .to_string(),
-                    );
+    // 0. Guard against arming a near-miss duress PIN, across ALL networks,
+    //    BEFORE writing anything. The wizard could only check the duress PIN
+    //    against the *re-typed* regular PIN; verify that re-typed value against
+    //    each Cube's ACTUAL stored PIN and re-check distinctness against the
+    //    real one. If the user mistyped their PIN (so the wizard's check was
+    //    meaningless) or the duress PIN is within one edit of a real unlock
+    //    PIN, refuse — otherwise a fat-fingered unlock could trip a wipe.
+    for network_dir in &network_dirs {
+        if let Ok(settings) = crate::app::settings::Settings::from_file(network_dir) {
+            for cube in &settings.cubes {
+                if cube.has_pin() {
+                    if !cube.verify_pin(&regular_pin) {
+                        return Err(
+                            "That PIN doesn't match your Cube PIN. Enter your real PIN so the \
+                             duress PIN can be safely checked against it. (All your Cubes must \
+                             share the same PIN to enable duress.)"
+                                .to_string(),
+                        );
+                    }
+                    crate::services::duress::enroll::validate_duress_pin(
+                        &regular_pin,
+                        &duress_pin,
+                    )?;
                 }
-                crate::services::duress::enroll::validate_duress_pin(&regular_pin, &duress_pin)?;
             }
         }
     }
 
-    // 1. Duress PIN hash → every Cube in the network settings.
+    // 1. Duress PIN hash → every Cube on every network.
     let hash = crate::services::duress::enroll::hash_duress_secret(&duress_pin)?;
-    crate::app::settings::update_settings_file(&network_dir, move |mut s| {
-        for cube in s.cubes.iter_mut() {
-            cube.duress_pin_hash = Some(hash.clone());
-        }
-        Some(s)
-    })
-    .await
-    .map_err(|e| e.to_string())?;
+    for network_dir in &network_dirs {
+        let hash = hash.clone();
+        crate::app::settings::update_settings_file(network_dir, move |mut s| {
+            for cube in s.cubes.iter_mut() {
+                cube.duress_pin_hash = Some(hash.clone());
+            }
+            Some(s)
+        })
+        .await
+        .map_err(|e| e.to_string())?;
+    }
 
     // 2. Encrypted device code + account id → DuressLocalState. The encrypted
     //    code is skipped when empty (the server-enroll path re-enters with an
@@ -844,7 +872,6 @@ pub(crate) async fn persist_duress_enrollment(
     //    `load` is resilient (missing → default); only `save` and the
     //    encryption are fail-loud, since a silent failure here would leave the
     //    user believing duress is armed when its PIN won't trigger.
-    let root = datadir.path().to_path_buf();
     let mut st = crate::services::duress::DuressLocalState::load(&root).unwrap_or_default();
     st.enrolled = true;
     if account_id.is_some() {
@@ -2504,11 +2531,9 @@ impl App {
                     ..
                 } = payload;
                 let datadir = self.datadir.clone();
-                let network = self.cache.network;
                 return Task::perform(
                     persist_duress_enrollment(
                         datadir,
-                        network,
                         regular_pin,
                         duress_pin,
                         duress_code,

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1912,15 +1912,17 @@ impl App {
                 // Phase 7b: remote duress activation. Persist active state to
                 // DuressLocalState (at the data-dir root) WITHOUT wiping —
                 // remote activation can be accidental, so local Cube data is
-                // left intact. Then bubble up to the tab shell to lock the
-                // RUNNING app into the cryptic screen immediately (not just on
-                // next launch).
+                // left intact. The UI lock is sequenced AFTER the persist (it's
+                // the task's completion message, not a parallel batch) so the
+                // cryptic screen never appears before `active` is durable; if
+                // the app exits right after seeing the lock, the relaunch
+                // reconcile still routes back into duress.
                 log::warn!(
                     "[CONNECT GRPC] Duress activated remotely (source={})",
                     source
                 );
                 let root = self.datadir.path().to_path_buf();
-                let persist = Task::perform(
+                Task::perform(
                     async move {
                         let mut st = crate::services::duress::DuressLocalState::load(&root)
                             .unwrap_or_default();
@@ -1930,10 +1932,8 @@ impl App {
                             log::warn!("[CONNECT GRPC] Failed to persist remote duress state: {e}");
                         }
                     },
-                    |_| Message::CacheUpdated,
-                );
-                let lock = Task::done(Message::View(view::Message::DuressLockRemote));
-                Task::batch([persist, lock])
+                    |_| Message::View(view::Message::DuressLockRemote),
+                )
             }
             M::DuressCleared => {
                 log::info!("[CONNECT GRPC] Duress cleared remotely");

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -799,6 +799,7 @@ pub(crate) async fn persist_duress_enrollment(
     network: bitcoin::Network,
     duress_pin: String,
     duress_code: String,
+    account_id: Option<String>,
 ) {
     // 1. Duress PIN hash → every Cube in the network settings.
     if let Ok(hash) = crate::services::duress::enroll::hash_duress_secret(&duress_pin) {
@@ -811,20 +812,24 @@ pub(crate) async fn persist_duress_enrollment(
         })
         .await;
     }
-    // 2. Encrypted device code → DuressLocalState. Skipped when empty (the
-    //    server-enroll path re-enters with an empty code once already stored).
+    // 2. Encrypted device code + account id → DuressLocalState. The encrypted
+    //    code is skipped when empty (the server-enroll path re-enters with an
+    //    empty code once it's already stored), but the account id is always
+    //    recorded so the activation POST can address the right account.
+    let root = datadir.path().to_path_buf();
+    let mut st = crate::services::duress::DuressLocalState::load(&root).unwrap_or_default();
+    st.enrolled = true;
+    if account_id.is_some() {
+        st.account_id = account_id;
+    }
     if !duress_code.is_empty() {
-        let root = datadir.path().to_path_buf();
         if let Ok(key) = crate::services::duress::cipher::DeviceKey::load_or_create(&root) {
             if let Ok(enc) = key.encrypt(&duress_code) {
-                let mut st =
-                    crate::services::duress::DuressLocalState::load(&root).unwrap_or_default();
-                st.enrolled = true;
                 st.duress_code = Some(enc);
-                let _ = st.save(&root);
             }
         }
     }
+    let _ = st.save(&root);
 }
 
 /// Poll the local bitcoind's IBD progress via its JSON-RPC interface.
@@ -2464,12 +2469,19 @@ impl App {
                 let crate::app::message::DuressEnrollmentPayload {
                     duress_pin,
                     duress_code,
+                    account_id,
                     ..
                 } = payload;
                 let datadir = self.datadir.clone();
                 let network = self.cache.network;
                 return Task::perform(
-                    persist_duress_enrollment(datadir, network, duress_pin, duress_code),
+                    persist_duress_enrollment(
+                        datadir,
+                        network,
+                        duress_pin,
+                        duress_code,
+                        account_id,
+                    ),
                     |_| Message::CacheUpdated,
                 );
             }

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -810,6 +810,27 @@ fn duress_enroll_network_dirs(root: &std::path::Path) -> Vec<crate::dir::Network
     dirs
 }
 
+/// Best-effort restore of the first `count` networks' settings to their
+/// pre-enrollment snapshot, undoing the duress PIN hashes written in step 1.
+/// Used when a later step (another network, or the local-state save) fails, so
+/// the device never ends up with Cubes armed but the matching enrollment state
+/// missing.
+async fn rollback_duress_pin_writes(
+    network_dirs: &[crate::dir::NetworkDirectory],
+    prior_settings: &[crate::app::settings::Settings],
+    count: usize,
+) {
+    for j in 0..count {
+        let restore = prior_settings[j].clone();
+        if let Err(re) =
+            crate::app::settings::update_settings_file(&network_dirs[j], move |_| Some(restore))
+                .await
+        {
+            log::error!("duress: rollback of network {j} settings failed: {re}");
+        }
+    }
+}
+
 pub(crate) async fn persist_duress_enrollment(
     datadir: CoincubeDirectory,
     regular_pin: zeroize::Zeroizing<String>,
@@ -881,17 +902,7 @@ pub(crate) async fn persist_duress_enrollment(
         match write {
             Ok(()) => written = i + 1,
             Err(e) => {
-                for j in 0..written {
-                    let restore = prior_settings[j].clone();
-                    if let Err(re) =
-                        crate::app::settings::update_settings_file(&network_dirs[j], move |_| {
-                            Some(restore)
-                        })
-                        .await
-                    {
-                        log::error!("duress: rollback of network {j} settings failed: {re}");
-                    }
-                }
+                rollback_duress_pin_writes(&network_dirs, &prior_settings, written).await;
                 return Err(format!(
                     "Couldn't arm the duress PIN on all your Cubes ({e}); no changes were kept."
                 ));
@@ -906,17 +917,24 @@ pub(crate) async fn persist_duress_enrollment(
     //    re-enrolling sovereign clears any previously stored Connect account id
     //    and local activation can't trigger-with-code against a stale account.
     //    `load` is resilient (missing → default); only `save` and the
-    //    encryption are fail-loud, since a silent failure here would leave the
-    //    user believing duress is armed when its PIN won't trigger.
-    let mut st = crate::services::duress::DuressLocalState::load(&root).unwrap_or_default();
-    st.enrolled = true;
-    st.account_id = account_id;
-    if !duress_code.is_empty() {
-        let key = crate::services::duress::cipher::DeviceKey::load_or_create(&root)
-            .map_err(|e| e.to_string())?;
-        st.duress_code = Some(key.encrypt(&duress_code)?);
+    //    encryption are fail-loud. If this fails AFTER step 1 armed the PIN
+    //    hashes, roll those back too — otherwise Cubes stay armed (and would
+    //    wipe on the duress PIN) while the matching enrollment state is missing.
+    let local: Result<(), String> = (|| {
+        let mut st = crate::services::duress::DuressLocalState::load(&root).unwrap_or_default();
+        st.enrolled = true;
+        st.account_id = account_id;
+        if !duress_code.is_empty() {
+            let key = crate::services::duress::cipher::DeviceKey::load_or_create(&root)
+                .map_err(|e| e.to_string())?;
+            st.duress_code = Some(key.encrypt(&duress_code)?);
+        }
+        st.save(&root).map_err(|e| e.to_string())
+    })();
+    if let Err(e) = local {
+        rollback_duress_pin_writes(&network_dirs, &prior_settings, network_dirs.len()).await;
+        return Err(e);
     }
-    st.save(&root).map_err(|e| e.to_string())?;
     Ok(())
 }
 

--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -268,6 +268,12 @@ pub struct CubeSettings {
     /// Optional security PIN (stored as Argon2id hash with salt in PHC format)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub security_pin_hash: Option<String>,
+    /// Optional duress PIN (Argon2id PHC hash). Entering this PIN at Cube
+    /// unlock activates duress mode (Phase 3) instead of unlocking. Distinct
+    /// from `security_pin_hash`; enrollment enforces a Levenshtein distance of
+    /// at least 2 between them so it can't be triggered by accident.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duress_pin_hash: Option<String>,
     /// Fingerprint of this Cube's master seed MasterSigner.
     /// All wallets (Vault, Liquid, Spark) derive from this single seed.
     /// The serde aliases keep existing settings.json files readable without migration.
@@ -329,6 +335,7 @@ impl CubeSettings {
             created_at: chrono::Utc::now().timestamp(),
             vault_wallet_id: None,
             security_pin_hash: None,
+            duress_pin_hash: None,
             master_signer_fingerprint: None,
             backed_up: false,
             mfa_done: false,
@@ -406,6 +413,33 @@ impl CubeSettings {
         } else {
             // No PIN set, allow access
             true
+        }
+    }
+
+    /// Sets this Cube's duress PIN (Argon2id PHC hash). Callers must have
+    /// already validated distinctness from the regular PIN via
+    /// [`services::duress::enroll::validate_duress_pin`].
+    pub fn with_duress_pin(mut self, pin: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        self.duress_pin_hash = Some(Self::hash_pin(pin)?);
+        Ok(self)
+    }
+
+    pub fn has_duress_pin(&self) -> bool {
+        self.duress_pin_hash.is_some()
+    }
+
+    /// Verifies a candidate PIN against the stored duress-PIN hash.
+    ///
+    /// Returns `false` when no duress PIN is configured — the opposite default
+    /// from [`verify_pin`](Self::verify_pin), which *allows* access when unset.
+    /// A duress match must only ever happen on an explicit, deliberate
+    /// configuration. Callers MUST run [`verify_pin`](Self::verify_pin) first
+    /// and only consult this on a regular-PIN miss, so the regular unlock path
+    /// is never shadowed and the two argon2 verifies take comparable time.
+    pub fn verify_duress_pin(&self, pin: &str) -> bool {
+        match &self.duress_pin_hash {
+            Some(stored_hash) => Self::verify_argon2_pin(pin, stored_hash),
+            None => false,
         }
     }
 
@@ -1385,6 +1419,32 @@ mod test {
         // as Sovereign — registration is the gating signal.
         cube.remote_synced = false;
         assert_eq!(cube.connect_state(), CubeConnectState::Sovereign);
+    }
+
+    #[test]
+    fn duress_pin_verify_is_independent_of_regular_pin() {
+        use super::CubeSettings;
+        use coincube_core::miniscript::bitcoin::Network;
+
+        // No duress PIN set → never matches (opposite default from verify_pin).
+        let plain = CubeSettings::new("No duress".to_string(), Network::Bitcoin)
+            .with_pin("1234")
+            .unwrap();
+        assert!(!plain.has_duress_pin());
+        assert!(!plain.verify_duress_pin("1234"));
+        assert!(!plain.verify_duress_pin("0000"));
+
+        // With a duress PIN: only the duress PIN matches verify_duress_pin, and
+        // only the regular PIN matches verify_pin.
+        let cube = CubeSettings::new("Both".to_string(), Network::Bitcoin)
+            .with_pin("1234")
+            .unwrap()
+            .with_duress_pin("8765")
+            .unwrap();
+        assert!(cube.verify_pin("1234"));
+        assert!(!cube.verify_pin("8765"));
+        assert!(cube.verify_duress_pin("8765"));
+        assert!(!cube.verify_duress_pin("1234"));
     }
 
     #[test]

--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -234,6 +234,19 @@ pub fn derive_master_signer_fingerprint(
     })
 }
 
+/// A Cube's relationship to Connect, rendered as a single tri-state cube icon
+/// on the Cubes list (Phase 1 of duress mode). The progression
+/// Sovereign → Registered → Backed up mirrors increasing recoverability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CubeConnectState {
+    /// Not registered with Connect — local-only, no server-side recovery.
+    Sovereign,
+    /// Registered with Connect but no Cube Recovery Kit uploaded yet.
+    Registered,
+    /// Registered with Connect and a Cube Recovery Kit is present.
+    BackedUp,
+}
+
 /// Cubes represent user accounts that can contain multiple features (Vault, Liquid wallet, etc.)
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CubeSettings {
@@ -352,6 +365,30 @@ impl CubeSettings {
     /// Whether this Cube uses a passkey-derived master key (no PIN, no stored seed).
     pub fn is_passkey_cube(&self) -> bool {
         self.passkey_metadata.is_some()
+    }
+
+    /// True when this Cube has a Cube Recovery Kit pushed to Connect. We treat
+    /// a recorded backed-up descriptor fingerprint as the CRK-presence signal
+    /// (`recovery_kit_last_backed_up_descriptor_fingerprint` is set on a
+    /// successful kit upload and cleared on delete). Distinct from
+    /// [`backed_up`](Self::backed_up), which tracks the *local* seed-phrase
+    /// backup, not the server-side recovery kit.
+    pub fn has_recovery_kit(&self) -> bool {
+        self.recovery_kit_last_backed_up_descriptor_fingerprint
+            .is_some()
+    }
+
+    /// Classifies this Cube's relationship to Connect for the card indicator
+    /// (Phase 1 of duress mode). Users must be able to tell at a glance whether
+    /// a Cube has a recovery kit before they're told what a duress wipe costs.
+    pub fn connect_state(&self) -> CubeConnectState {
+        if !self.remote_synced {
+            CubeConnectState::Sovereign
+        } else if self.has_recovery_kit() {
+            CubeConnectState::BackedUp
+        } else {
+            CubeConnectState::Registered
+        }
     }
 
     pub fn with_pin(mut self, pin: &str) -> Result<Self, Box<dyn std::error::Error>> {
@@ -1321,6 +1358,46 @@ mod test {
             cube.master_signer_fingerprint.map(|f| f.to_string()),
             Some("aabbccdd".to_string()),
             "serde alias should map old field name to master_signer_fingerprint"
+        );
+    }
+
+    #[test]
+    fn connect_state_classifies_three_tiers() {
+        use super::{CubeConnectState, CubeSettings};
+        use coincube_core::miniscript::bitcoin::Network;
+
+        // Sovereign: not registered with Connect.
+        let mut cube = CubeSettings::new("Sovereign".to_string(), Network::Bitcoin);
+        cube.remote_synced = false;
+        assert_eq!(cube.connect_state(), CubeConnectState::Sovereign);
+        assert!(!cube.has_recovery_kit());
+
+        // Registered: synced to Connect, no recovery kit yet.
+        cube.remote_synced = true;
+        assert_eq!(cube.connect_state(), CubeConnectState::Registered);
+
+        // Backed up: synced AND a recovery-kit descriptor has been pushed.
+        cube.recovery_kit_last_backed_up_descriptor_fingerprint = Some("abc123".to_string());
+        assert!(cube.has_recovery_kit());
+        assert_eq!(cube.connect_state(), CubeConnectState::BackedUp);
+
+        // A recovery kit on a Cube that somehow lost remote_synced still reads
+        // as Sovereign — registration is the gating signal.
+        cube.remote_synced = false;
+        assert_eq!(cube.connect_state(), CubeConnectState::Sovereign);
+    }
+
+    #[test]
+    fn backed_up_flag_is_not_recovery_kit() {
+        use super::CubeSettings;
+        use coincube_core::miniscript::bitcoin::Network;
+
+        // `backed_up` is the local seed-phrase backup, not the server CRK.
+        let mut cube = CubeSettings::new("Seed only".to_string(), Network::Bitcoin);
+        cube.backed_up = true;
+        assert!(
+            !cube.has_recovery_kit(),
+            "local seed backup must not be mistaken for a Connect recovery kit"
         );
     }
 }

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1389,10 +1389,12 @@ impl ConnectAccountPanel {
 
                 if tier == EnrollTier::Sovereign {
                     // No Connect call — local wipe + cryptic only. Persist now.
+                    let regular_pin = e.regular_pin.clone();
                     let duress_pin = e.duress_pin.clone();
                     self.duress_enroll = None;
                     return iced::Task::done(Message::CompleteDuressEnrollment(
                         crate::app::message::DuressEnrollmentPayload {
+                            regular_pin: zeroize::Zeroizing::new(regular_pin),
                             duress_pin: zeroize::Zeroizing::new(duress_pin),
                             duress_code: zeroize::Zeroizing::new(code),
                             account_id: None,
@@ -1466,6 +1468,7 @@ impl ConnectAccountPanel {
                         if let Some(e) = self.duress_enroll.take() {
                             return iced::Task::done(Message::CompleteDuressEnrollment(
                                 crate::app::message::DuressEnrollmentPayload {
+                                    regular_pin: zeroize::Zeroizing::new(e.regular_pin),
                                     duress_pin: zeroize::Zeroizing::new(e.duress_pin),
                                     duress_code: zeroize::Zeroizing::new(
                                         e.pending_code.unwrap_or_default(),

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -682,9 +682,7 @@ impl ConnectAccountPanel {
                 // passphrases, generated code) and the recovery all-clear
                 // passphrase before dropping them, so they don't survive the
                 // session reset.
-                if let Some(mut wizard) = self.duress_enroll.take() {
-                    wizard.zeroize_secrets();
-                }
+                self.clear_duress_enroll();
                 self.scrub_recovery_passphrase();
                 self.clear_keyring_session();
                 self.client = CoincubeClient::new();
@@ -1382,6 +1380,9 @@ impl ConnectAccountPanel {
     /// Opens the duress enrollment wizard at `step` for `tier`, resetting all
     /// inputs. Shared by the Tier 1 / Tier 2 / Sovereign entry points.
     fn open_enroll_wizard(&mut self, tier: EnrollTier, step: DuressEnrollStep) {
+        // Scrub any wizard already in flight before replacing it, so re-opening
+        // never drops its secrets unzeroized.
+        self.clear_duress_enroll();
         self.duress_enroll = Some(DuressEnrollState {
             tier,
             step,
@@ -1405,6 +1406,17 @@ impl ConnectAccountPanel {
     fn scrub_recovery_passphrase(&mut self) {
         if let ConnectFlowStep::DuressRecovery { passphrase, .. } = &mut self.step {
             zeroize::Zeroize::zeroize(passphrase);
+        }
+    }
+
+    /// The single teardown path for the enrollment wizard: zeroize its secrets
+    /// (PINs, passphrases, pending code) before dropping it, so no branch that
+    /// cancels, completes, or replaces `duress_enroll` leaves them on the heap.
+    /// Completion paths clone the few values they forward into a `Zeroizing`
+    /// payload first, then call this to scrub the originals.
+    fn clear_duress_enroll(&mut self) {
+        if let Some(mut wizard) = self.duress_enroll.take() {
+            wizard.zeroize_secrets();
         }
     }
 
@@ -1503,21 +1515,14 @@ impl ConnectAccountPanel {
                 self.open_enroll_wizard(EnrollTier::Tier2, DuressEnrollStep::SetDuressPin);
             }
             DuressMessage::SignUpForConnect => {
-                // Scrub the wizard's secrets (PINs, passphrases, pending code)
-                // before dropping it, like logout does — leaving the flow must
-                // not leave them on the heap.
-                if let Some(mut wizard) = self.duress_enroll.take() {
-                    wizard.zeroize_secrets();
-                }
+                self.clear_duress_enroll();
                 self.step = ConnectFlowStep::Register {
                     email: String::new(),
                     loading: false,
                 };
             }
             DuressMessage::CancelEnrollment => {
-                if let Some(mut wizard) = self.duress_enroll.take() {
-                    wizard.zeroize_secrets();
-                }
+                self.clear_duress_enroll();
             }
             DuressMessage::RegularPinChanged(v) => {
                 if let Some(e) = &mut self.duress_enroll {
@@ -1591,7 +1596,7 @@ impl ConnectAccountPanel {
                     // No Connect call — local wipe + cryptic only. Persist now.
                     let regular_pin = e.regular_pin.clone();
                     let duress_pin = e.duress_pin.clone();
-                    self.duress_enroll = None;
+                    self.clear_duress_enroll();
                     return iced::Task::done(Message::CompleteDuressEnrollment(
                         crate::app::message::DuressEnrollmentPayload {
                             regular_pin: zeroize::Zeroizing::new(regular_pin),
@@ -1607,7 +1612,11 @@ impl ConnectAccountPanel {
                 // code are persisted locally only after a successful
                 // EnrollResult, so a server failure can't leave a half-armed
                 // duress PIN on disk. Stash the code for that success handler.
-                e.pending_code = Some(code.clone());
+                // Zeroize any code stashed by a prior submit (retry) before
+                // replacing it, so the superseded plaintext doesn't linger.
+                if let Some(mut old) = e.pending_code.replace(code.clone()) {
+                    zeroize::Zeroize::zeroize(&mut old);
+                }
                 let all_clear_hash = enroll::hash_duress_secret(&e.all_clear);
                 let crk_hash = if tier == EnrollTier::Tier1 {
                     Some(enroll::hash_duress_secret(&e.crk_password))
@@ -1676,18 +1685,24 @@ impl ConnectAccountPanel {
                         // Doing this only on success means a server failure
                         // never leaves a half-armed duress PIN on disk.
                         let account_id = self.user.as_ref().map(|u| u.id.to_string());
-                        if let Some(e) = self.duress_enroll.take() {
-                            return iced::Task::done(Message::CompleteDuressEnrollment(
-                                crate::app::message::DuressEnrollmentPayload {
-                                    regular_pin: zeroize::Zeroizing::new(e.regular_pin),
-                                    duress_pin: zeroize::Zeroizing::new(e.duress_pin),
-                                    duress_code: zeroize::Zeroizing::new(
-                                        e.pending_code.unwrap_or_default(),
-                                    ),
-                                    account_id,
-                                    gen,
-                                },
-                            ));
+                        // Clone the forwarded secrets into the Zeroizing payload,
+                        // then scrub the wizard via the shared helper — this path
+                        // must not drop the leftover fields (all_clear, CRK
+                        // password, sovereign_confirm) unzeroized.
+                        let payload = self.duress_enroll.as_ref().map(|e| {
+                            crate::app::message::DuressEnrollmentPayload {
+                                regular_pin: zeroize::Zeroizing::new(e.regular_pin.clone()),
+                                duress_pin: zeroize::Zeroizing::new(e.duress_pin.clone()),
+                                duress_code: zeroize::Zeroizing::new(
+                                    e.pending_code.clone().unwrap_or_default(),
+                                ),
+                                account_id,
+                                gen,
+                            }
+                        });
+                        if let Some(payload) = payload {
+                            self.clear_duress_enroll();
+                            return iced::Task::done(Message::CompleteDuressEnrollment(payload));
                         }
                     }
                     Err(msg) => {

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1381,8 +1381,8 @@ impl ConnectAccountPanel {
                 let code = enroll::generate_duress_code();
                 let local_persist = iced::Task::done(Message::CompleteDuressEnrollment(
                     crate::app::message::DuressEnrollmentPayload {
-                        duress_pin,
-                        duress_code: code.clone(),
+                        duress_pin: zeroize::Zeroizing::new(duress_pin),
+                        duress_code: zeroize::Zeroizing::new(code.clone()),
                         account_id,
                         gen,
                     },

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -2545,11 +2545,6 @@ fn register_device_duress_task(client: CoincubeClient, account_id: String) -> ic
             };
             let root = datadir.path();
             let mut st = DuressLocalState::load(root).unwrap_or_default();
-            // Idempotent: this device already minted a code (enrollment or a
-            // prior registration). Nothing to do.
-            if st.duress_code.is_some() {
-                return;
-            }
             let fingerprint = match crate::services::duress::device_fingerprint(root) {
                 Ok(f) => f,
                 Err(e) => {
@@ -2557,23 +2552,6 @@ fn register_device_duress_task(client: CoincubeClient, account_id: String) -> ic
                     return;
                 }
             };
-            let code = enroll::generate_duress_code();
-            let code_hash = match enroll::hash_duress_secret(&code) {
-                Ok(h) => h,
-                Err(e) => {
-                    log::warn!("[CONNECT] device duress register: hash error: {e}");
-                    return;
-                }
-            };
-            if let Err(e) = client
-                .register_device_duress_code(&fingerprint, &code_hash)
-                .await
-            {
-                log::warn!("[CONNECT] register_device_duress_code failed: {e}");
-                return;
-            }
-            // Persist the plaintext code (encrypted at rest) + account id so
-            // local activation can address the right account offline.
             let key = match DeviceKey::load_or_create(root) {
                 Ok(k) => k,
                 Err(e) => {
@@ -2581,16 +2559,56 @@ fn register_device_duress_task(client: CoincubeClient, account_id: String) -> ic
                     return;
                 }
             };
-            match key.encrypt(&code) {
-                Ok(enc) => {
-                    st.enrolled = true;
-                    st.account_id = Some(account_id);
-                    st.duress_code = Some(enc);
-                    if let Err(e) = st.save(root) {
-                        log::warn!("[CONNECT] device duress register: save error: {e}");
+            // Reuse an existing local code (re-hash it for the server) when one
+            // is already held, so a re-fire after a failed registration — or a
+            // stale `this_device_registered` from the server — re-registers the
+            // SAME code instead of churning it. Otherwise mint a fresh one.
+            let (enc, code_hash) = match st.duress_code.as_ref().and_then(|e| key.decrypt(e).ok()) {
+                Some(existing) => match enroll::hash_duress_secret(&existing) {
+                    Ok(h) => (st.duress_code.clone().unwrap(), h),
+                    Err(e) => {
+                        log::warn!("[CONNECT] device duress register: hash error: {e}");
+                        return;
                     }
+                },
+                None => {
+                    let code = enroll::generate_duress_code();
+                    let enc = match key.encrypt(&code) {
+                        Ok(enc) => enc,
+                        Err(e) => {
+                            log::warn!("[CONNECT] device duress register: encrypt error: {e}");
+                            return;
+                        }
+                    };
+                    let hash = match enroll::hash_duress_secret(&code) {
+                        Ok(h) => h,
+                        Err(e) => {
+                            log::warn!("[CONNECT] device duress register: hash error: {e}");
+                            return;
+                        }
+                    };
+                    (enc, hash)
                 }
-                Err(e) => log::warn!("[CONNECT] device duress register: encrypt error: {e}"),
+            };
+            // Persist the code locally BEFORE registering with the server, so
+            // the server never marks this device registered while this install
+            // lacks the matching code — which would block both activation's
+            // trigger-with-code and the auto re-registration retry (gated on the
+            // server's `!this_device_registered`). If the local save fails the
+            // server is left untouched; if the server register fails, local
+            // keeps the code and the next sign-in re-registers it.
+            st.enrolled = true;
+            st.account_id = Some(account_id);
+            st.duress_code = Some(enc);
+            if let Err(e) = st.save(root) {
+                log::warn!("[CONNECT] device duress register: local save failed: {e}");
+                return;
+            }
+            if let Err(e) = client
+                .register_device_duress_code(&fingerprint, &code_hash)
+                .await
+            {
+                log::warn!("[CONNECT] register_device_duress_code failed: {e}");
             }
         },
         |_| {

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -235,6 +235,15 @@ pub enum ConnectFlowStep {
         is_signup: bool,
         cooldown: u8,
     },
+    /// Post-auth, pre-dashboard gate (Phase 6): block on `get_duress_state` so
+    /// the dashboard is never shown to a possibly-in-duress account. `failed`
+    /// is set once retries are exhausted, switching the view to an error +
+    /// Retry affordance. We fail CLOSED here (no dashboard) rather than open —
+    /// the whole Connect dashboard is server-backed, so if this check is
+    /// unreachable the dashboard is non-functional anyway.
+    CheckingDuress {
+        failed: bool,
+    },
     Dashboard,
     /// Post-lockout recovery (Phase 6). Shown as the FIRST thing after sign-in
     /// when the account is in duress — there is no normal dashboard until the
@@ -576,7 +585,9 @@ impl ConnectAccountPanel {
                 self.session_generation += 1;
                 self.user = Some(user);
                 self.plan = plan;
-                self.step = ConnectFlowStep::Dashboard;
+                // Phase 6: gate on the duress check FIRST — don't reveal the
+                // dashboard until we've confirmed the account isn't in duress.
+                self.step = ConnectFlowStep::CheckingDuress { failed: false };
                 self.error = None;
                 // Fetch plan + features in background (non-blocking)
                 let gen = self.session_generation;
@@ -1179,8 +1190,9 @@ impl ConnectAccountPanel {
                 self.error = Some(error);
             }
             ConnectAccountMessage::DuressStateChecked(state, gen, attempt) => {
-                // Phase 6: post-sign-in gate. If the account is in duress,
-                // replace the dashboard with the recovery flow.
+                // Phase 6: post-sign-in gate. We sit in `CheckingDuress` until
+                // this resolves, so the dashboard is never shown to a possibly-
+                // in-duress account.
                 if gen != self.session_generation {
                     return iced::Task::none();
                 }
@@ -1193,26 +1205,31 @@ impl ConnectAccountPanel {
                             cleared: false,
                         };
                     }
-                    // Confirmed not in duress — stay on the dashboard.
-                    Some(_) => {}
-                    // Failed / unreachable check. Don't silently leave a duress
-                    // account on the dashboard: retry with a short delay, up to
-                    // a bounded number of attempts. (We deliberately do NOT
-                    // fail-closed into the recovery gate, which would wrongly
-                    // block a non-duress account during a transient outage; the
-                    // gRPC stream and the relaunch reconcile are the other
-                    // safety nets.)
+                    // Confirmed not in duress — NOW reveal the dashboard.
+                    Some(_) => self.step = ConnectFlowStep::Dashboard,
+                    // Failed / unreachable check — retry with backoff.
                     None if attempt + 1 < DURESS_CHECK_MAX_ATTEMPTS => {
                         return duress_state_check_task(self.client.clone(), gen, attempt + 1);
                     }
+                    // Retries exhausted. Fail CLOSED: do not reveal the
+                    // dashboard. Show an error + Retry on the checking screen.
+                    // (The dashboard is server-backed anyway, so it would be
+                    // non-functional during this outage.)
                     None => {
                         log::warn!(
                             "[CONNECT] duress state check failed after {} attempts; \
-                             leaving dashboard (live stream / relaunch will reconcile)",
+                             holding at the verification gate",
                             attempt + 1
                         );
+                        self.step = ConnectFlowStep::CheckingDuress { failed: true };
                     }
                 }
+            }
+            ConnectAccountMessage::RetryDuressCheck => {
+                // From the CheckingDuress error screen.
+                self.step = ConnectFlowStep::CheckingDuress { failed: false };
+                let gen = self.session_generation;
+                return duress_state_check_task(self.client.clone(), gen, 0);
             }
             ConnectAccountMessage::Duress(m) => return self.update_duress(m),
         }

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -2506,7 +2506,11 @@ fn duress_state_check_task(client: CoincubeClient, gen: u64, attempt: u8) -> ice
 /// the stability guarantee, so the wizard surfaces the failure and lets the
 /// user retry instead.
 fn device_fingerprint() -> Result<String, String> {
-    let dir = crate::dir::CoincubeDirectory::new_default()
+    // Use the process's ACTIVE data directory (honours a custom `--datadir`),
+    // not the OS default — otherwise the fingerprint would be persisted at a
+    // different path than the Cubes / DuressLocalState and diverge from what the
+    // server was told.
+    let dir = crate::dir::CoincubeDirectory::active()
         .map_err(|e| format!("data directory unavailable: {e}"))?;
     crate::services::duress::device_fingerprint(dir.path())
         .map_err(|e| format!("device fingerprint unavailable: {e}"))

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1285,12 +1285,47 @@ impl ConnectAccountPanel {
                 }
                 match state {
                     Some(s) if s.active => {
+                        let unlock_at = s.unlock_at;
                         self.step = ConnectFlowStep::DuressRecovery {
-                            unlock_at: s.unlock_at,
+                            unlock_at,
                             passphrase: String::new(),
                             submitting: false,
                             cleared: false,
                         };
+                        // The gRPC stream that persists a remote activation only
+                        // runs inside the in-Cube App. On Home/Launcher (and on
+                        // any sign-in) this check IS the source of truth, so
+                        // mirror an active duress into DuressLocalState — no
+                        // wipe, matching the remote handler, since a remote
+                        // trigger can be accidental — so the Cube-launch
+                        // reconcile locks into the cryptic screen instead of
+                        // opening an unlocked Cube. That screen re-polls the
+                        // server and self-clears once duress is lifted.
+                        return iced::Task::perform(
+                            async move {
+                                if let Ok(dir) = crate::dir::CoincubeDirectory::active() {
+                                    let root = dir.path();
+                                    let mut st =
+                                        crate::services::duress::DuressLocalState::load(root)
+                                            .unwrap_or_default();
+                                    if !st.active {
+                                        st.active = true;
+                                        st.unlock_at = unlock_at;
+                                        if let Err(e) = st.save(root) {
+                                            log::warn!(
+                                                "[CONNECT] failed to persist remote duress \
+                                                 active state: {e}"
+                                            );
+                                        }
+                                    }
+                                }
+                            },
+                            |_| {
+                                Message::View(view::Message::ConnectAccount(
+                                    ConnectAccountMessage::DuressDeviceRegistered,
+                                ))
+                            },
+                        );
                     }
                     // Confirmed not in duress — NOW reveal the dashboard.
                     Some(s) => {
@@ -1335,7 +1370,8 @@ impl ConnectAccountPanel {
                 return duress_state_check_task(self.client.clone(), gen, 0);
             }
             ConnectAccountMessage::DuressDeviceRegistered => {
-                // Side-effect-only task completed (Phase 0 device-code register).
+                // Side-effect-only task completed (Phase 0 device-code register,
+                // or mirroring a remote-active duress into DuressLocalState).
             }
             ConnectAccountMessage::Duress(m) => return self.update_duress(m),
         }

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -298,6 +298,11 @@ pub struct DuressEnrollState {
     pub memorized: bool,
     pub submitting: bool,
     pub error: Option<String>,
+    /// This device's generated duress code, held between SubmitEnrollment and a
+    /// successful server EnrollResult. For Connect tiers the code is NOT
+    /// persisted locally until the server confirms enrollment, so a server
+    /// failure can't leave a half-armed duress PIN on disk.
+    pub pending_code: Option<String>,
 }
 
 pub struct ConnectAccountPanel {
@@ -1207,6 +1212,7 @@ impl ConnectAccountPanel {
             memorized: false,
             submitting: false,
             error: None,
+            pending_code: None,
         });
     }
 
@@ -1365,10 +1371,6 @@ impl ConnectAccountPanel {
                 }
             }
             DuressMessage::SubmitEnrollment => {
-                // Read the Connect account id before borrowing `duress_enroll`
-                // mutably (disjoint-field borrows don't extend across the `e`
-                // binding once we hold an owned copy).
-                let user_account_id = self.user.as_ref().map(|u| u.id.to_string());
                 let Some(e) = &mut self.duress_enroll else {
                     return iced::Task::none();
                 };
@@ -1380,34 +1382,30 @@ impl ConnectAccountPanel {
                 e.error = None;
                 let tier = e.tier;
                 let gen = self.session_generation;
-                let duress_pin = e.duress_pin.clone();
-                let account_id = if tier == EnrollTier::Sovereign {
-                    None
-                } else {
-                    user_account_id
-                };
 
                 // Generate this device's duress code ONCE: its hash goes to the
-                // server, the same plaintext is persisted (encrypted) locally by
-                // the App. The local persist is the wipe anchor and always
-                // fires; the server enroll is best-effort on top.
+                // server, the same plaintext is persisted (encrypted) locally.
                 let code = enroll::generate_duress_code();
-                let local_persist = iced::Task::done(Message::CompleteDuressEnrollment(
-                    crate::app::message::DuressEnrollmentPayload {
-                        duress_pin: zeroize::Zeroizing::new(duress_pin),
-                        duress_code: zeroize::Zeroizing::new(code.clone()),
-                        account_id,
-                        gen,
-                    },
-                ));
 
                 if tier == EnrollTier::Sovereign {
-                    // No Connect call — local wipe + cryptic only.
+                    // No Connect call — local wipe + cryptic only. Persist now.
+                    let duress_pin = e.duress_pin.clone();
                     self.duress_enroll = None;
-                    return local_persist;
+                    return iced::Task::done(Message::CompleteDuressEnrollment(
+                        crate::app::message::DuressEnrollmentPayload {
+                            duress_pin: zeroize::Zeroizing::new(duress_pin),
+                            duress_code: zeroize::Zeroizing::new(code),
+                            account_id: None,
+                            gen,
+                        },
+                    ));
                 }
 
-                // Connect tiers: enroll on the server in parallel.
+                // Connect tiers: enroll on the server FIRST. The duress PIN +
+                // code are persisted locally only after a successful
+                // EnrollResult, so a server failure can't leave a half-armed
+                // duress PIN on disk. Stash the code for that success handler.
+                e.pending_code = Some(code.clone());
                 let all_clear_hash = enroll::hash_duress_secret(&e.all_clear);
                 let crk_hash = if tier == EnrollTier::Tier1 {
                     Some(enroll::hash_duress_secret(&e.crk_password))
@@ -1442,7 +1440,7 @@ impl ConnectAccountPanel {
                     device_fingerprint: device_fingerprint(),
                     duress_code_hash: code_hash,
                 };
-                let server_enroll = iced::Task::perform(
+                return iced::Task::perform(
                     async move { client.enroll_duress(req).await },
                     move |res| {
                         Message::View(view::Message::ConnectAccount(
@@ -1453,17 +1451,34 @@ impl ConnectAccountPanel {
                         ))
                     },
                 );
-                return iced::Task::batch([local_persist, server_enroll]);
             }
             DuressMessage::EnrollResult(res, gen) => {
                 if gen != self.session_generation {
                     return iced::Task::none();
                 }
                 match res {
-                    // Server enrolled — close the wizard (the local persist
-                    // already fired in parallel from SubmitEnrollment).
-                    Ok(()) => self.duress_enroll = None,
+                    Ok(()) => {
+                        // Server enrolled — NOW persist locally (PIN hash +
+                        // encrypted code) from the wizard state, then close it.
+                        // Doing this only on success means a server failure
+                        // never leaves a half-armed duress PIN on disk.
+                        let account_id = self.user.as_ref().map(|u| u.id.to_string());
+                        if let Some(e) = self.duress_enroll.take() {
+                            return iced::Task::done(Message::CompleteDuressEnrollment(
+                                crate::app::message::DuressEnrollmentPayload {
+                                    duress_pin: zeroize::Zeroizing::new(e.duress_pin),
+                                    duress_code: zeroize::Zeroizing::new(
+                                        e.pending_code.unwrap_or_default(),
+                                    ),
+                                    account_id,
+                                    gen,
+                                },
+                            ));
+                        }
+                    }
                     Err(msg) => {
+                        // No local state was written — just surface the error
+                        // and keep the wizard open for a retry.
                         if let Some(e) = &mut self.duress_enroll {
                             e.submitting = false;
                             e.error = Some(msg);
@@ -2382,6 +2397,7 @@ mod duress_enroll_tests {
             memorized: false,
             submitting: false,
             error: None,
+            pending_code: None,
         }
     }
 

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1503,14 +1503,21 @@ impl ConnectAccountPanel {
                 self.open_enroll_wizard(EnrollTier::Tier2, DuressEnrollStep::SetDuressPin);
             }
             DuressMessage::SignUpForConnect => {
-                self.duress_enroll = None;
+                // Scrub the wizard's secrets (PINs, passphrases, pending code)
+                // before dropping it, like logout does — leaving the flow must
+                // not leave them on the heap.
+                if let Some(mut wizard) = self.duress_enroll.take() {
+                    wizard.zeroize_secrets();
+                }
                 self.step = ConnectFlowStep::Register {
                     email: String::new(),
                     loading: false,
                 };
             }
             DuressMessage::CancelEnrollment => {
-                self.duress_enroll = None;
+                if let Some(mut wizard) = self.duress_enroll.take() {
+                    wizard.zeroize_secrets();
+                }
             }
             DuressMessage::RegularPinChanged(v) => {
                 if let Some(e) = &mut self.duress_enroll {

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1290,7 +1290,23 @@ impl ConnectAccountPanel {
                         };
                     }
                     // Confirmed not in duress — NOW reveal the dashboard.
-                    Some(_) => self.step = ConnectFlowStep::Dashboard,
+                    Some(s) => {
+                        self.step = ConnectFlowStep::Dashboard;
+                        // Phase 0: a signed-in device on an already-enrolled
+                        // account that isn't yet registered server-side mints +
+                        // registers its OWN duress code (per-device, never
+                        // shared), so it can fire trigger-with-code on its own
+                        // activation. Fire-and-forget; idempotent (skips if this
+                        // device already holds a code).
+                        if s.enrolled && !s.this_device_registered {
+                            if let Some(account_id) = self.user.as_ref().map(|u| u.id.to_string()) {
+                                return register_device_duress_task(
+                                    self.client.clone(),
+                                    account_id,
+                                );
+                            }
+                        }
+                    }
                     // Failed / unreachable check — retry with backoff.
                     None if attempt + 1 < DURESS_CHECK_MAX_ATTEMPTS => {
                         return duress_state_check_task(self.client.clone(), gen, attempt + 1);
@@ -1314,6 +1330,9 @@ impl ConnectAccountPanel {
                 self.step = ConnectFlowStep::CheckingDuress { failed: false };
                 let gen = self.session_generation;
                 return duress_state_check_task(self.client.clone(), gen, 0);
+            }
+            ConnectAccountMessage::DuressDeviceRegistered => {
+                // Side-effect-only task completed (Phase 0 device-code register).
             }
             ConnectAccountMessage::Duress(m) => return self.update_duress(m),
         }
@@ -2490,6 +2509,79 @@ fn duress_state_check_task(client: CoincubeClient, gen: u64, attempt: u8) -> ice
         |(state, g, a)| {
             Message::View(view::Message::ConnectAccount(
                 ConnectAccountMessage::DuressStateChecked(state, g, a),
+            ))
+        },
+    )
+}
+
+/// Phase 0 device-code registration: for a signed-in desktop on an
+/// already-enrolled account that the server doesn't yet recognise, mint a fresh
+/// ~128-bit duress code, send only its argon2id hash via
+/// `register_device_duress_code`, and persist the raw code (encrypted) +
+/// account id into `DuressLocalState` so this device can fire
+/// `trigger-with-code` on its own activation. Per-device — codes are never
+/// shared. Best-effort and idempotent (skips when a code is already held).
+fn register_device_duress_task(client: CoincubeClient, account_id: String) -> iced::Task<Message> {
+    iced::Task::perform(
+        async move {
+            use crate::services::duress::{cipher::DeviceKey, enroll, DuressLocalState};
+            let Ok(datadir) = crate::dir::CoincubeDirectory::active() else {
+                log::warn!("[CONNECT] device duress register skipped: no data directory");
+                return;
+            };
+            let root = datadir.path();
+            let mut st = DuressLocalState::load(root).unwrap_or_default();
+            // Idempotent: this device already minted a code (enrollment or a
+            // prior registration). Nothing to do.
+            if st.duress_code.is_some() {
+                return;
+            }
+            let fingerprint = match crate::services::duress::device_fingerprint(root) {
+                Ok(f) => f,
+                Err(e) => {
+                    log::warn!("[CONNECT] device duress register: fingerprint error: {e}");
+                    return;
+                }
+            };
+            let code = enroll::generate_duress_code();
+            let code_hash = match enroll::hash_duress_secret(&code) {
+                Ok(h) => h,
+                Err(e) => {
+                    log::warn!("[CONNECT] device duress register: hash error: {e}");
+                    return;
+                }
+            };
+            if let Err(e) = client
+                .register_device_duress_code(&fingerprint, &code_hash)
+                .await
+            {
+                log::warn!("[CONNECT] register_device_duress_code failed: {e}");
+                return;
+            }
+            // Persist the plaintext code (encrypted at rest) + account id so
+            // local activation can address the right account offline.
+            let key = match DeviceKey::load_or_create(root) {
+                Ok(k) => k,
+                Err(e) => {
+                    log::warn!("[CONNECT] device duress register: key error: {e}");
+                    return;
+                }
+            };
+            match key.encrypt(&code) {
+                Ok(enc) => {
+                    st.enrolled = true;
+                    st.account_id = Some(account_id);
+                    st.duress_code = Some(enc);
+                    if let Err(e) = st.save(root) {
+                        log::warn!("[CONNECT] device duress register: save error: {e}");
+                    }
+                }
+                Err(e) => log::warn!("[CONNECT] device duress register: encrypt error: {e}"),
+            }
+        },
+        |_| {
+            Message::View(view::Message::ConnectAccount(
+                ConnectAccountMessage::DuressDeviceRegistered,
             ))
         },
     )

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -605,6 +605,7 @@ impl ConnectAccountPanel {
             ConnectAccountMessage::RefreshFailed(err) => {
                 log::warn!("[CONNECT] Session refresh failed (transient): {}", err);
                 self.error = Some(format!("Connection error: {}. Tap to retry.", err));
+                self.scrub_recovery_passphrase();
                 self.step = ConnectFlowStep::Login {
                     email: String::new(),
                     loading: false,
@@ -678,11 +679,13 @@ impl ConnectAccountPanel {
                 self.selected_billing_cycle = BillingCycle::Monthly;
                 self.contacts_state.clear();
                 // Scrub any in-flight enrollment wizard secrets (PINs,
-                // passphrases, generated code) before dropping it, so they
-                // don't survive the session reset.
+                // passphrases, generated code) and the recovery all-clear
+                // passphrase before dropping them, so they don't survive the
+                // session reset.
                 if let Some(mut wizard) = self.duress_enroll.take() {
                     wizard.zeroize_secrets();
                 }
+                self.scrub_recovery_passphrase();
                 self.clear_keyring_session();
                 self.client = CoincubeClient::new();
                 self.step = ConnectFlowStep::Login {
@@ -1359,6 +1362,16 @@ impl ConnectAccountPanel {
         });
     }
 
+    /// Zeroizes the in-memory all-clear passphrase when the panel is in the
+    /// duress recovery flow. Call before replacing `self.step` so the secret
+    /// (it clears duress) doesn't linger on the heap after the user leaves
+    /// recovery. No-op when not in recovery.
+    fn scrub_recovery_passphrase(&mut self) {
+        if let ConnectFlowStep::DuressRecovery { passphrase, .. } = &mut self.step {
+            zeroize::Zeroize::zeroize(passphrase);
+        }
+    }
+
     /// Recovery flow (Phase 6) + enrollment wizard (Phases 2 & 8) dispatcher.
     fn update_duress(&mut self, msg: DuressMessage) -> iced::Task<Message> {
         use crate::services::duress::enroll;
@@ -1423,6 +1436,7 @@ impl ConnectAccountPanel {
                 )));
             }
             DuressMessage::FinishRecovery => {
+                self.scrub_recovery_passphrase();
                 self.step = ConnectFlowStep::Dashboard;
                 self.error = None;
             }

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1474,12 +1474,23 @@ impl ConnectAccountPanel {
                     }
                     None => None,
                 };
+                // A stable device fingerprint is required so the server can
+                // recognise this desktop. If it can't be resolved, fail the
+                // enrollment rather than send an unstable one.
+                let fingerprint = match device_fingerprint() {
+                    Ok(fp) => fp,
+                    Err(msg) => {
+                        e.error = Some(msg);
+                        e.submitting = false;
+                        return iced::Task::none();
+                    }
+                };
                 let client = self.client.clone();
                 let req = crate::services::coincube::EnrollDuressRequest {
                     all_clear_hash,
                     duress_crk_password_hash: crk_hash,
                     unlock_delay_minutes: delay_minutes,
-                    device_fingerprint: device_fingerprint(),
+                    device_fingerprint: fingerprint,
                     duress_code_hash: code_hash,
                 };
                 return iced::Task::perform(
@@ -2344,13 +2355,17 @@ fn duress_state_check_task(client: CoincubeClient, gen: u64, attempt: u8) -> ice
 /// server keys its per-device rows and `this_device_registered` on this value,
 /// so it must be the same across launches, repeat enrollments, and
 /// re-registrations — hence it's loaded from (or minted into) a persisted file
-/// at the data-directory root rather than freshly generated each time. Falls
-/// back to an ephemeral UUID only if the data directory can't be resolved.
-fn device_fingerprint() -> String {
-    crate::dir::CoincubeDirectory::new_default()
-        .ok()
-        .and_then(|dir| crate::services::duress::device_fingerprint(dir.path()).ok())
-        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
+/// at the data-directory root.
+///
+/// Errors are **propagated**, not masked: falling back to a fresh UUID on an
+/// I/O failure would silently send a different fingerprint each time and defeat
+/// the stability guarantee, so the wizard surfaces the failure and lets the
+/// user retry instead.
+fn device_fingerprint() -> Result<String, String> {
+    let dir = crate::dir::CoincubeDirectory::new_default()
+        .map_err(|e| format!("data directory unavailable: {e}"))?;
+    crate::services::duress::device_fingerprint(dir.path())
+        .map_err(|e| format!("device fingerprint unavailable: {e}"))
 }
 
 /// The ordered steps for a tier. Sovereign opens with the Connect

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1337,6 +1337,10 @@ impl ConnectAccountPanel {
                 }
             }
             DuressMessage::SubmitEnrollment => {
+                // Read the Connect account id before borrowing `duress_enroll`
+                // mutably (disjoint-field borrows don't extend across the `e`
+                // binding once we hold an owned copy).
+                let user_account_id = self.user.as_ref().map(|u| u.id.to_string());
                 let Some(e) = &mut self.duress_enroll else {
                     return iced::Task::none();
                 };
@@ -1349,6 +1353,11 @@ impl ConnectAccountPanel {
                 let tier = e.tier;
                 let gen = self.session_generation;
                 let duress_pin = e.duress_pin.clone();
+                let account_id = if tier == EnrollTier::Sovereign {
+                    None
+                } else {
+                    user_account_id
+                };
 
                 // Generate this device's duress code ONCE: its hash goes to the
                 // server, the same plaintext is persisted (encrypted) locally by
@@ -1359,6 +1368,7 @@ impl ConnectAccountPanel {
                     crate::app::message::DuressEnrollmentPayload {
                         duress_pin,
                         duress_code: code.clone(),
+                        account_id,
                         gen,
                     },
                 ));

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1369,7 +1369,8 @@ impl ConnectAccountPanel {
             }
             ConnectAccountMessage::DuressDeviceRegistered => {
                 // Side-effect-only task completed (Phase 0 device-code register,
-                // or mirroring a remote-active duress into DuressLocalState).
+                // or syncing DuressLocalState.active to the server's duress
+                // state — set on the post-sign-in mirror, reset on recovery).
             }
             ConnectAccountMessage::Duress(m) => return self.update_duress(m),
         }
@@ -1465,6 +1466,7 @@ impl ConnectAccountPanel {
                 if gen != self.session_generation {
                     return iced::Task::none();
                 }
+                let mut cleared_ok = false;
                 if let ConnectFlowStep::DuressRecovery {
                     submitting,
                     cleared,
@@ -1473,9 +1475,49 @@ impl ConnectAccountPanel {
                 {
                     *submitting = false;
                     match res {
-                        Ok(()) => *cleared = true,
+                        Ok(()) => {
+                            *cleared = true;
+                            cleared_ok = true;
+                        }
                         Err(e) => self.error = Some(e),
                     }
+                }
+                if cleared_ok {
+                    // The server confirmed the all-clear. The post-sign-in mirror
+                    // may have set DuressLocalState.active = true on this device,
+                    // so reset it durably — otherwise the next launch reconcile
+                    // routes back into the cryptic screen for an account that's
+                    // already been cleared. Mirrors the gRPC DuressCleared and
+                    // cryptic-screen poll resets.
+                    return iced::Task::perform(
+                        async move {
+                            if let Ok(dir) = crate::dir::CoincubeDirectory::active() {
+                                let root = dir.path();
+                                match crate::services::duress::DuressLocalState::load(root) {
+                                    Ok(mut st) if st.active => {
+                                        st.active = false;
+                                        st.unlock_at = None;
+                                        if let Err(e) = st.save(root) {
+                                            log::warn!(
+                                                "[CONNECT] failed to clear local duress \
+                                                 active state: {e}"
+                                            );
+                                        }
+                                    }
+                                    Ok(_) => {}
+                                    Err(e) => log::warn!(
+                                        "[CONNECT] reading duress state failed; \
+                                         not overwriting: {e}"
+                                    ),
+                                }
+                            }
+                        },
+                        |_| {
+                            Message::View(view::Message::ConnectAccount(
+                                ConnectAccountMessage::DuressDeviceRegistered,
+                            ))
+                        },
+                    );
                 }
             }
             DuressMessage::ForgotAllClear => {

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -4,7 +4,7 @@ use crate::{
     app::{
         menu::ConnectSubMenu,
         message::Message,
-        view::{self, ConnectAccountMessage, ContactsMessage},
+        view::{self, ConnectAccountMessage, ContactsMessage, DuressMessage},
     },
     services::coincube::{
         BillingCycle, BillingHistoryEntry, ChargeStatus, CheckoutRequest, CheckoutResponse,
@@ -236,6 +236,68 @@ pub enum ConnectFlowStep {
         cooldown: u8,
     },
     Dashboard,
+    /// Post-lockout recovery (Phase 6). Shown as the FIRST thing after sign-in
+    /// when the account is in duress — there is no normal dashboard until the
+    /// account is cleared from a trusted device.
+    DuressRecovery {
+        /// When the account can be cleared with the all-clear passphrase.
+        unlock_at: Option<chrono::DateTime<chrono::Utc>>,
+        passphrase: String,
+        submitting: bool,
+        /// Set once `clear_duress` succeeds — shows the "download your Cube
+        /// Recovery Kit" hand-off.
+        cleared: bool,
+    },
+}
+
+/// Which credentials the enrollment wizard collects, derived from the account's
+/// duress entitlement (and, for sovereign, the absence of Connect).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnrollTier {
+    /// Connect + recovery kit: full flow incl. the account-level duress CRK
+    /// password (Approach C).
+    Tier1,
+    /// Connect, no recovery kit: same as Tier 1 minus the CRK password, with a
+    /// BIG warning that recovery depends on the seed-phrase backup.
+    Tier2,
+    /// No Connect: local-only wipe; the wizard opens with a Connect-
+    /// encouragement screen and a type-to-confirm friction step.
+    Sovereign,
+}
+
+/// Steps of the duress enrollment wizard. Sovereign opens at `Encourage`;
+/// Connect tiers skip straight to `SetDuressPin`. `SetCrkPassword` is Tier 1
+/// only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DuressEnrollStep {
+    /// Sovereign Step 0 — Connect-encouragement (primary CTA "Sign up for
+    /// Connect", secondary "Continue without Connect").
+    Encourage,
+    /// Sovereign friction — type "I have my seed-phrase backup".
+    SovereignConfirm,
+    SetDuressPin,
+    SetAllClear,
+    SetCrkPassword,
+    PickDelay,
+    Confirm,
+}
+
+/// In-flight enrollment wizard state (Phases 2 & 8). `None` on the panel when
+/// the wizard isn't open.
+#[derive(Debug)]
+pub struct DuressEnrollState {
+    pub tier: EnrollTier,
+    pub step: DuressEnrollStep,
+    /// The user's regular PIN, re-entered so distinctness can be validated.
+    pub regular_pin: String,
+    pub duress_pin: String,
+    pub all_clear: String,
+    pub crk_password: String,
+    pub delay: crate::services::duress::enroll::DuressDelay,
+    pub sovereign_confirm: String,
+    pub memorized: bool,
+    pub submitting: bool,
+    pub error: Option<String>,
 }
 
 pub struct ConnectAccountPanel {
@@ -261,6 +323,8 @@ pub struct ConnectAccountPanel {
     pub billing_history: Option<Vec<BillingHistoryEntry>>,
     /// Whether the billing history sub-view is shown.
     pub show_billing_history: bool,
+    /// Active duress enrollment wizard (Phases 2 & 8); `None` when closed.
+    pub duress_enroll: Option<DuressEnrollState>,
 }
 
 impl ConnectAccountPanel {
@@ -281,6 +345,7 @@ impl ConnectAccountPanel {
             checkout: None,
             billing_history: None,
             show_billing_history: false,
+            duress_enroll: None,
         }
     }
 
@@ -495,6 +560,7 @@ impl ConnectAccountPanel {
                 let gen = self.session_generation;
                 let c1 = self.client.clone();
                 let c2 = self.client.clone();
+                let c3 = self.client.clone();
                 return iced::Task::batch([
                     iced::Task::perform(
                         async move { (c1.get_connect_plan().await.ok(), gen) },
@@ -509,6 +575,16 @@ impl ConnectAccountPanel {
                         |(features, g)| {
                             Message::View(view::Message::ConnectAccount(
                                 ConnectAccountMessage::FeaturesLoaded(features, g),
+                            ))
+                        },
+                    ),
+                    // Phase 6: gate on duress state. If the account is in
+                    // duress, the recovery flow replaces the dashboard.
+                    iced::Task::perform(
+                        async move { (c3.get_duress_state().await.ok(), gen) },
+                        |(state, g)| {
+                            Message::View(view::Message::ConnectAccount(
+                                ConnectAccountMessage::DuressStateChecked(state, g),
                             ))
                         },
                     ),
@@ -1079,8 +1155,285 @@ impl ConnectAccountPanel {
                 // Non-auth error - just show error, don't redirect to login
                 self.error = Some(error);
             }
+            ConnectAccountMessage::DuressStateChecked(state, gen) => {
+                // Phase 6: post-sign-in gate. If the account is in duress,
+                // replace the dashboard with the recovery flow.
+                if gen == self.session_generation {
+                    if let Some(s) = state {
+                        if s.active {
+                            self.step = ConnectFlowStep::DuressRecovery {
+                                unlock_at: s.unlock_at,
+                                passphrase: String::new(),
+                                submitting: false,
+                                cleared: false,
+                            };
+                        }
+                    }
+                }
+            }
+            ConnectAccountMessage::Duress(m) => return self.update_duress(m),
         }
 
+        iced::Task::none()
+    }
+
+    /// Recovery flow (Phase 6) + enrollment wizard (Phases 2 & 8) dispatcher.
+    fn update_duress(&mut self, msg: DuressMessage) -> iced::Task<Message> {
+        use crate::services::duress::enroll;
+        match msg {
+            // ── Recovery (Phase 6) ──
+            DuressMessage::RecoveryPassphraseChanged(text) => {
+                if let ConnectFlowStep::DuressRecovery { passphrase, .. } = &mut self.step {
+                    *passphrase = text;
+                }
+            }
+            DuressMessage::SubmitClear => {
+                let ConnectFlowStep::DuressRecovery {
+                    passphrase,
+                    submitting,
+                    ..
+                } = &mut self.step
+                else {
+                    return iced::Task::none();
+                };
+                let hash = match enroll::hash_duress_secret(passphrase) {
+                    Ok(h) => h,
+                    Err(e) => {
+                        self.error = Some(e);
+                        return iced::Task::none();
+                    }
+                };
+                *submitting = true;
+                let client = self.client.clone();
+                let gen = self.session_generation;
+                return iced::Task::perform(
+                    async move { client.clear_duress(&hash).await },
+                    move |res| {
+                        Message::View(view::Message::ConnectAccount(
+                            ConnectAccountMessage::Duress(DuressMessage::ClearResult(
+                                res.map_err(|e| e.to_string()),
+                                gen,
+                            )),
+                        ))
+                    },
+                );
+            }
+            DuressMessage::ClearResult(res, gen) => {
+                if gen != self.session_generation {
+                    return iced::Task::none();
+                }
+                if let ConnectFlowStep::DuressRecovery {
+                    submitting,
+                    cleared,
+                    ..
+                } = &mut self.step
+                {
+                    *submitting = false;
+                    match res {
+                        Ok(()) => *cleared = true,
+                        Err(e) => self.error = Some(e),
+                    }
+                }
+            }
+            DuressMessage::ForgotAllClear => {
+                return iced::Task::done(Message::View(view::Message::OpenUrl(
+                    "https://coincube.io/support/duress-recovery".to_string(),
+                )));
+            }
+            DuressMessage::FinishRecovery => {
+                self.step = ConnectFlowStep::Dashboard;
+                self.error = None;
+            }
+
+            // ── Enrollment wizard (Phases 2 & 8) ──
+            DuressMessage::StartEnrollment => {
+                let entitled = self
+                    .plan
+                    .as_ref()
+                    .map(|p| p.entitlements.duress_remote_lock)
+                    .unwrap_or(false);
+                // Inside the Connect dashboard the user is signed in, so the
+                // tier is Tier 1/2 when entitled (we can't see per-Cube CRK
+                // state here, so default to Tier 1 and let the CRK step be
+                // optional), else the sovereign-style encouragement flow.
+                let (tier, step) = if entitled {
+                    (EnrollTier::Tier1, DuressEnrollStep::SetDuressPin)
+                } else {
+                    (EnrollTier::Sovereign, DuressEnrollStep::Encourage)
+                };
+                self.duress_enroll = Some(DuressEnrollState {
+                    tier,
+                    step,
+                    regular_pin: String::new(),
+                    duress_pin: String::new(),
+                    all_clear: String::new(),
+                    crk_password: String::new(),
+                    delay: enroll::DuressDelay::default(),
+                    sovereign_confirm: String::new(),
+                    memorized: false,
+                    submitting: false,
+                    error: None,
+                });
+            }
+            DuressMessage::SignUpForConnect => {
+                self.duress_enroll = None;
+                self.step = ConnectFlowStep::Register {
+                    email: String::new(),
+                    loading: false,
+                };
+            }
+            DuressMessage::CancelEnrollment => {
+                self.duress_enroll = None;
+            }
+            DuressMessage::RegularPinChanged(v) => {
+                if let Some(e) = &mut self.duress_enroll {
+                    e.regular_pin = v;
+                }
+            }
+            DuressMessage::DuressPinChanged(v) => {
+                if let Some(e) = &mut self.duress_enroll {
+                    e.duress_pin = v;
+                }
+            }
+            DuressMessage::AllClearChanged(v) => {
+                if let Some(e) = &mut self.duress_enroll {
+                    e.all_clear = v;
+                }
+            }
+            DuressMessage::CrkPasswordChanged(v) => {
+                if let Some(e) = &mut self.duress_enroll {
+                    e.crk_password = v;
+                }
+            }
+            DuressMessage::DelaySelected(d) => {
+                if let Some(e) = &mut self.duress_enroll {
+                    e.delay = d;
+                }
+            }
+            DuressMessage::SovereignConfirmChanged(v) => {
+                if let Some(e) = &mut self.duress_enroll {
+                    e.sovereign_confirm = v;
+                }
+            }
+            DuressMessage::MemorizedToggled(v) => {
+                if let Some(e) = &mut self.duress_enroll {
+                    e.memorized = v;
+                }
+            }
+            DuressMessage::EnrollBack => {
+                if let Some(e) = &mut self.duress_enroll {
+                    e.error = None;
+                    e.step = prev_enroll_step(e.tier, e.step);
+                }
+            }
+            DuressMessage::EnrollNext => {
+                if let Some(e) = &mut self.duress_enroll {
+                    if let Err(msg) = validate_enroll_step(e) {
+                        e.error = Some(msg);
+                    } else {
+                        e.error = None;
+                        e.step = next_enroll_step(e.tier, e.step);
+                    }
+                }
+            }
+            DuressMessage::SubmitEnrollment => {
+                let Some(e) = &mut self.duress_enroll else {
+                    return iced::Task::none();
+                };
+                if let Err(msg) = validate_enroll_step(e) {
+                    e.error = Some(msg);
+                    return iced::Task::none();
+                }
+                e.submitting = true;
+                e.error = None;
+                let tier = e.tier;
+                let gen = self.session_generation;
+                let duress_pin = e.duress_pin.clone();
+
+                // Generate this device's duress code ONCE: its hash goes to the
+                // server, the same plaintext is persisted (encrypted) locally by
+                // the App. The local persist is the wipe anchor and always
+                // fires; the server enroll is best-effort on top.
+                let code = enroll::generate_duress_code();
+                let local_persist = iced::Task::done(Message::CompleteDuressEnrollment(
+                    crate::app::message::DuressEnrollmentPayload {
+                        duress_pin,
+                        duress_code: code.clone(),
+                        gen,
+                    },
+                ));
+
+                if tier == EnrollTier::Sovereign {
+                    // No Connect call — local wipe + cryptic only.
+                    self.duress_enroll = None;
+                    return local_persist;
+                }
+
+                // Connect tiers: enroll on the server in parallel.
+                let all_clear_hash = enroll::hash_duress_secret(&e.all_clear);
+                let crk_hash = if tier == EnrollTier::Tier1 {
+                    Some(enroll::hash_duress_secret(&e.crk_password))
+                } else {
+                    None
+                };
+                let code_hash = enroll::hash_duress_secret(&code);
+                let delay_minutes = e.delay.minutes();
+
+                let (all_clear_hash, code_hash) = match (all_clear_hash, code_hash) {
+                    (Ok(a), Ok(c)) => (a, c),
+                    _ => {
+                        e.error = Some("Failed to hash credentials.".to_string());
+                        e.submitting = false;
+                        return iced::Task::none();
+                    }
+                };
+                let crk_hash = match crk_hash {
+                    Some(Ok(h)) => Some(h),
+                    Some(Err(_)) => {
+                        e.error = Some("Failed to hash credentials.".to_string());
+                        e.submitting = false;
+                        return iced::Task::none();
+                    }
+                    None => None,
+                };
+                let client = self.client.clone();
+                let req = crate::services::coincube::EnrollDuressRequest {
+                    all_clear_hash,
+                    duress_crk_password_hash: crk_hash,
+                    unlock_delay_minutes: delay_minutes,
+                    device_fingerprint: device_fingerprint(),
+                    duress_code_hash: code_hash,
+                };
+                let server_enroll = iced::Task::perform(
+                    async move { client.enroll_duress(req).await },
+                    move |res| {
+                        Message::View(view::Message::ConnectAccount(
+                            ConnectAccountMessage::Duress(DuressMessage::EnrollResult(
+                                res.map_err(|e| e.to_string()),
+                                gen,
+                            )),
+                        ))
+                    },
+                );
+                return iced::Task::batch([local_persist, server_enroll]);
+            }
+            DuressMessage::EnrollResult(res, gen) => {
+                if gen != self.session_generation {
+                    return iced::Task::none();
+                }
+                match res {
+                    // Server enrolled — close the wizard (the local persist
+                    // already fired in parallel from SubmitEnrollment).
+                    Ok(()) => self.duress_enroll = None,
+                    Err(msg) => {
+                        if let Some(e) = &mut self.duress_enroll {
+                            e.submitting = false;
+                            e.error = Some(msg);
+                        }
+                    }
+                }
+            }
+        }
         iced::Task::none()
     }
 }
@@ -1860,6 +2213,173 @@ pub fn load_security_data(client: &CoincubeClient, generation: u64) -> iced::Tas
             },
         ),
     ])
+}
+
+// ── Duress enrollment wizard helpers (Phases 2 & 8) ──
+
+/// A stable-enough per-device fingerprint for duress enrollment. Each device
+/// registers its own row server-side keyed on this value; a fresh UUID at
+/// enrollment time is sufficient since the plaintext code lives only here.
+fn device_fingerprint() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+/// The ordered steps for a tier. Sovereign opens with the Connect
+/// encouragement + friction confirm; Connect tiers skip those. `SetCrkPassword`
+/// is Tier 1 only.
+fn enroll_steps(tier: EnrollTier) -> &'static [DuressEnrollStep] {
+    use DuressEnrollStep::*;
+    match tier {
+        EnrollTier::Tier1 => &[
+            SetDuressPin,
+            SetAllClear,
+            SetCrkPassword,
+            PickDelay,
+            Confirm,
+        ],
+        EnrollTier::Tier2 => &[SetDuressPin, SetAllClear, PickDelay, Confirm],
+        EnrollTier::Sovereign => &[Encourage, SovereignConfirm, SetDuressPin, Confirm],
+    }
+}
+
+fn next_enroll_step(tier: EnrollTier, cur: DuressEnrollStep) -> DuressEnrollStep {
+    let steps = enroll_steps(tier);
+    match steps.iter().position(|s| *s == cur) {
+        Some(i) if i + 1 < steps.len() => steps[i + 1],
+        _ => cur,
+    }
+}
+
+fn prev_enroll_step(tier: EnrollTier, cur: DuressEnrollStep) -> DuressEnrollStep {
+    let steps = enroll_steps(tier);
+    match steps.iter().position(|s| *s == cur) {
+        Some(i) if i > 0 => steps[i - 1],
+        _ => cur,
+    }
+}
+
+/// Validates the current step's inputs before advancing. Returns the spec error
+/// string on failure.
+fn validate_enroll_step(e: &DuressEnrollState) -> Result<(), String> {
+    use crate::services::duress::enroll;
+    match e.step {
+        DuressEnrollStep::Encourage => Ok(()),
+        DuressEnrollStep::SovereignConfirm => {
+            if e.sovereign_confirm.trim() == "I have my seed-phrase backup" {
+                Ok(())
+            } else {
+                Err("Type the confirmation phrase exactly to continue.".to_string())
+            }
+        }
+        DuressEnrollStep::SetDuressPin => {
+            enroll::validate_duress_pin(&e.regular_pin, &e.duress_pin)
+        }
+        DuressEnrollStep::SetAllClear => {
+            enroll::validate_all_clear(&e.all_clear, &e.regular_pin, &e.duress_pin)
+        }
+        DuressEnrollStep::SetCrkPassword => enroll::validate_duress_crk_password(
+            &e.crk_password,
+            &e.regular_pin,
+            &e.duress_pin,
+            &e.all_clear,
+        ),
+        DuressEnrollStep::PickDelay => Ok(()),
+        DuressEnrollStep::Confirm => {
+            if e.memorized {
+                Ok(())
+            } else {
+                Err("Confirm you have memorized all credentials.".to_string())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod duress_enroll_tests {
+    use super::*;
+
+    fn state(tier: EnrollTier, step: DuressEnrollStep) -> DuressEnrollState {
+        DuressEnrollState {
+            tier,
+            step,
+            regular_pin: "1234".to_string(),
+            duress_pin: String::new(),
+            all_clear: String::new(),
+            crk_password: String::new(),
+            delay: crate::services::duress::enroll::DuressDelay::default(),
+            sovereign_confirm: String::new(),
+            memorized: false,
+            submitting: false,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn tier1_step_order() {
+        let mut s = DuressEnrollStep::SetDuressPin;
+        let order = [
+            DuressEnrollStep::SetDuressPin,
+            DuressEnrollStep::SetAllClear,
+            DuressEnrollStep::SetCrkPassword,
+            DuressEnrollStep::PickDelay,
+            DuressEnrollStep::Confirm,
+        ];
+        for expected in &order[1..] {
+            s = next_enroll_step(EnrollTier::Tier1, s);
+            assert_eq!(s, *expected);
+        }
+        // Saturates at the end.
+        assert_eq!(
+            next_enroll_step(EnrollTier::Tier1, DuressEnrollStep::Confirm),
+            DuressEnrollStep::Confirm
+        );
+    }
+
+    #[test]
+    fn tier2_skips_crk_password() {
+        assert_eq!(
+            next_enroll_step(EnrollTier::Tier2, DuressEnrollStep::SetAllClear),
+            DuressEnrollStep::PickDelay
+        );
+    }
+
+    #[test]
+    fn sovereign_opens_with_encourage_and_confirm() {
+        assert_eq!(
+            enroll_steps(EnrollTier::Sovereign)[0],
+            DuressEnrollStep::Encourage
+        );
+        assert_eq!(
+            next_enroll_step(EnrollTier::Sovereign, DuressEnrollStep::Encourage),
+            DuressEnrollStep::SovereignConfirm
+        );
+    }
+
+    #[test]
+    fn validate_rejects_close_duress_pin() {
+        let mut s = state(EnrollTier::Tier1, DuressEnrollStep::SetDuressPin);
+        s.duress_pin = "1235".to_string(); // Levenshtein 1
+        assert!(validate_enroll_step(&s).is_err());
+        s.duress_pin = "8765".to_string();
+        assert!(validate_enroll_step(&s).is_ok());
+    }
+
+    #[test]
+    fn sovereign_confirm_requires_exact_phrase() {
+        let mut s = state(EnrollTier::Sovereign, DuressEnrollStep::SovereignConfirm);
+        s.sovereign_confirm = "nope".to_string();
+        assert!(validate_enroll_step(&s).is_err());
+        s.sovereign_confirm = "I have my seed-phrase backup".to_string();
+        assert!(validate_enroll_step(&s).is_ok());
+    }
+
+    #[test]
+    fn confirm_requires_memorized_checkbox() {
+        let mut s = state(EnrollTier::Tier1, DuressEnrollStep::Confirm);
+        assert!(validate_enroll_step(&s).is_err());
+        s.memorized = true;
+        assert!(validate_enroll_step(&s).is_ok());
+    }
 }
 
 #[cfg(test)]

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1283,47 +1283,20 @@ impl ConnectAccountPanel {
                 }
                 match state {
                     Some(s) if s.active => {
-                        let unlock_at = s.unlock_at;
+                        // This signed-in device is the trusted recovery vehicle:
+                        // show the all-clear entry. Do NOT persist
+                        // DuressLocalState.active here — the launch reconcile
+                        // keys off that flag and would route this device into the
+                        // cryptic dead-end (which has no all-clear entry) on the
+                        // next restart, making recovery impossible. The flag is
+                        // owned by the paths that actually lock this device: the
+                        // local duress PIN and the in-Cube gRPC remote handler.
                         self.step = ConnectFlowStep::DuressRecovery {
-                            unlock_at,
+                            unlock_at: s.unlock_at,
                             passphrase: String::new(),
                             submitting: false,
                             cleared: false,
                         };
-                        // The gRPC stream that persists a remote activation only
-                        // runs inside the in-Cube App. On Home/Launcher (and on
-                        // any sign-in) this check IS the source of truth, so
-                        // mirror an active duress into DuressLocalState — no
-                        // wipe, matching the remote handler, since a remote
-                        // trigger can be accidental — so the Cube-launch
-                        // reconcile locks into the cryptic screen instead of
-                        // opening an unlocked Cube. That screen re-polls the
-                        // server and self-clears once duress is lifted.
-                        return iced::Task::perform(
-                            async move {
-                                if let Ok(dir) = crate::dir::CoincubeDirectory::active() {
-                                    let root = dir.path();
-                                    let mut st =
-                                        crate::services::duress::DuressLocalState::load(root)
-                                            .unwrap_or_default();
-                                    if !st.active {
-                                        st.active = true;
-                                        st.unlock_at = unlock_at;
-                                        if let Err(e) = st.save(root) {
-                                            log::warn!(
-                                                "[CONNECT] failed to persist remote duress \
-                                                 active state: {e}"
-                                            );
-                                        }
-                                    }
-                                }
-                            },
-                            |_| {
-                                Message::View(view::Message::ConnectAccount(
-                                    ConnectAccountMessage::DuressDeviceRegistered,
-                                ))
-                            },
-                        );
                     }
                     // Confirmed not in duress — NOW reveal the dashboard.
                     Some(s) => {

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -2617,7 +2617,19 @@ fn register_device_duress_task(client: CoincubeClient, account_id: String) -> ic
                 return;
             };
             let root = datadir.path();
-            let mut st = DuressLocalState::load(root).unwrap_or_default();
+            // Skip on a real read error (vs a missing file): registering off a
+            // default would overwrite valid state (enrolled / account_id /
+            // existing code) on the save below. Retry happens on the next check.
+            let mut st = match DuressLocalState::load(root) {
+                Ok(st) => st,
+                Err(e) => {
+                    log::warn!(
+                        "[CONNECT] device duress register: reading state failed; \
+                         not overwriting: {e}"
+                    );
+                    return;
+                }
+            };
             let fingerprint = match crate::services::duress::device_fingerprint(root) {
                 Ok(f) => f,
                 Err(e) => {

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -305,6 +305,23 @@ pub struct DuressEnrollState {
     pub pending_code: Option<String>,
 }
 
+impl DuressEnrollState {
+    /// Scrubs the in-memory secret fields (PINs, passphrases, and the generated
+    /// duress code) so they don't linger on the heap after the wizard is torn
+    /// down — e.g. on logout, where the rest of the session is reset.
+    fn zeroize_secrets(&mut self) {
+        use zeroize::Zeroize;
+        self.regular_pin.zeroize();
+        self.duress_pin.zeroize();
+        self.all_clear.zeroize();
+        self.crk_password.zeroize();
+        self.sovereign_confirm.zeroize();
+        if let Some(code) = self.pending_code.as_mut() {
+            code.zeroize();
+        }
+    }
+}
+
 pub struct ConnectAccountPanel {
     pub step: ConnectFlowStep,
     pub active_sub: ConnectSubMenu,
@@ -613,6 +630,12 @@ impl ConnectAccountPanel {
                 self.show_billing_history = false;
                 self.selected_billing_cycle = BillingCycle::Monthly;
                 self.contacts_state.clear();
+                // Scrub any in-flight enrollment wizard secrets (PINs,
+                // passphrases, generated code) before dropping it, so they
+                // don't survive the session reset.
+                if let Some(mut wizard) = self.duress_enroll.take() {
+                    wizard.zeroize_secrets();
+                }
                 self.clear_keyring_session();
                 self.client = CoincubeClient::new();
                 self.step = ConnectFlowStep::Login {
@@ -2402,6 +2425,26 @@ mod duress_enroll_tests {
             error: None,
             pending_code: None,
         }
+    }
+
+    #[test]
+    fn zeroize_secrets_clears_all_sensitive_fields() {
+        let mut s = state(EnrollTier::Tier1, DuressEnrollStep::Confirm);
+        s.regular_pin = "1234".to_string();
+        s.duress_pin = "8765".to_string();
+        s.all_clear = "correct horse battery".to_string();
+        s.crk_password = "a-long-crk-password".to_string();
+        s.sovereign_confirm = "I have my seed-phrase backup".to_string();
+        s.pending_code = Some("deadbeefcafebabe".to_string());
+
+        s.zeroize_secrets();
+
+        assert!(s.regular_pin.is_empty());
+        assert!(s.duress_pin.is_empty());
+        assert!(s.all_clear.is_empty());
+        assert!(s.crk_password.is_empty());
+        assert!(s.sovereign_confirm.is_empty());
+        assert!(s.pending_code.as_deref().unwrap_or("").is_empty());
     }
 
     #[test]

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -579,15 +579,10 @@ impl ConnectAccountPanel {
                         },
                     ),
                     // Phase 6: gate on duress state. If the account is in
-                    // duress, the recovery flow replaces the dashboard.
-                    iced::Task::perform(
-                        async move { (c3.get_duress_state().await.ok(), gen) },
-                        |(state, g)| {
-                            Message::View(view::Message::ConnectAccount(
-                                ConnectAccountMessage::DuressStateChecked(state, g),
-                            ))
-                        },
-                    ),
+                    // duress, the recovery flow replaces the dashboard. A
+                    // failed check retries (see the handler) so a transient
+                    // error doesn't leave a duress account on the dashboard.
+                    duress_state_check_task(c3, gen, 0),
                 ]);
             }
 
@@ -1155,19 +1150,39 @@ impl ConnectAccountPanel {
                 // Non-auth error - just show error, don't redirect to login
                 self.error = Some(error);
             }
-            ConnectAccountMessage::DuressStateChecked(state, gen) => {
+            ConnectAccountMessage::DuressStateChecked(state, gen, attempt) => {
                 // Phase 6: post-sign-in gate. If the account is in duress,
                 // replace the dashboard with the recovery flow.
-                if gen == self.session_generation {
-                    if let Some(s) = state {
-                        if s.active {
-                            self.step = ConnectFlowStep::DuressRecovery {
-                                unlock_at: s.unlock_at,
-                                passphrase: String::new(),
-                                submitting: false,
-                                cleared: false,
-                            };
-                        }
+                if gen != self.session_generation {
+                    return iced::Task::none();
+                }
+                match state {
+                    Some(s) if s.active => {
+                        self.step = ConnectFlowStep::DuressRecovery {
+                            unlock_at: s.unlock_at,
+                            passphrase: String::new(),
+                            submitting: false,
+                            cleared: false,
+                        };
+                    }
+                    // Confirmed not in duress — stay on the dashboard.
+                    Some(_) => {}
+                    // Failed / unreachable check. Don't silently leave a duress
+                    // account on the dashboard: retry with a short delay, up to
+                    // a bounded number of attempts. (We deliberately do NOT
+                    // fail-closed into the recovery gate, which would wrongly
+                    // block a non-duress account during a transient outage; the
+                    // gRPC stream and the relaunch reconcile are the other
+                    // safety nets.)
+                    None if attempt + 1 < DURESS_CHECK_MAX_ATTEMPTS => {
+                        return duress_state_check_task(self.client.clone(), gen, attempt + 1);
+                    }
+                    None => {
+                        log::warn!(
+                            "[CONNECT] duress state check failed after {} attempts; \
+                             leaving dashboard (live stream / relaunch will reconcile)",
+                            attempt + 1
+                        );
                     }
                 }
             }
@@ -2225,7 +2240,34 @@ pub fn load_security_data(client: &CoincubeClient, generation: u64) -> iced::Tas
     ])
 }
 
-// ── Duress enrollment wizard helpers (Phases 2 & 8) ──
+// ── Duress recovery + enrollment helpers (Phases 2, 6 & 8) ──
+
+/// How many times the post-sign-in duress-state check is retried before giving
+/// up (and leaving the dashboard, with the gRPC stream / relaunch reconcile as
+/// the remaining safety nets).
+const DURESS_CHECK_MAX_ATTEMPTS: u8 = 3;
+
+/// Delay before each duress-state-check retry.
+const DURESS_CHECK_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Issues a post-sign-in `get_duress_state` check (Phase 6). `attempt > 0`
+/// sleeps first so a transient failure backs off before retrying. A failed
+/// request collapses to `None`, which the handler turns into a bounded retry.
+fn duress_state_check_task(client: CoincubeClient, gen: u64, attempt: u8) -> iced::Task<Message> {
+    iced::Task::perform(
+        async move {
+            if attempt > 0 {
+                tokio::time::sleep(DURESS_CHECK_RETRY_DELAY).await;
+            }
+            (client.get_duress_state().await.ok(), gen, attempt)
+        },
+        |(state, g, a)| {
+            Message::View(view::Message::ConnectAccount(
+                ConnectAccountMessage::DuressStateChecked(state, g, a),
+            ))
+        },
+    )
+}
 
 /// A stable-enough per-device fingerprint for duress enrollment. Each device
 /// registers its own row server-side keyed on this value; a fresh UUID at

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1192,6 +1192,24 @@ impl ConnectAccountPanel {
         iced::Task::none()
     }
 
+    /// Opens the duress enrollment wizard at `step` for `tier`, resetting all
+    /// inputs. Shared by the Tier 1 / Tier 2 / Sovereign entry points.
+    fn open_enroll_wizard(&mut self, tier: EnrollTier, step: DuressEnrollStep) {
+        self.duress_enroll = Some(DuressEnrollState {
+            tier,
+            step,
+            regular_pin: String::new(),
+            duress_pin: String::new(),
+            all_clear: String::new(),
+            crk_password: String::new(),
+            delay: crate::services::duress::enroll::DuressDelay::default(),
+            sovereign_confirm: String::new(),
+            memorized: false,
+            submitting: false,
+            error: None,
+        });
+    }
+
     /// Recovery flow (Phase 6) + enrollment wizard (Phases 2 & 8) dispatcher.
     fn update_duress(&mut self, msg: DuressMessage) -> iced::Task<Message> {
         use crate::services::duress::enroll;
@@ -1267,28 +1285,23 @@ impl ConnectAccountPanel {
                     .as_ref()
                     .map(|p| p.entitlements.duress_remote_lock)
                     .unwrap_or(false);
-                // Inside the Connect dashboard the user is signed in, so the
-                // tier is Tier 1/2 when entitled (we can't see per-Cube CRK
-                // state here, so default to Tier 1 and let the CRK step be
-                // optional), else the sovereign-style encouragement flow.
-                let (tier, step) = if entitled {
-                    (EnrollTier::Tier1, DuressEnrollStep::SetDuressPin)
+                // Entitled (signed-in) users default to Tier 1, which collects
+                // the account-level duress recovery-kit password — that password
+                // covers current AND future Cubes, so it's safe to collect even
+                // before a CRK exists. A user who explicitly has no recovery kit
+                // takes the Tier 2 path via StartEnrollmentWithoutCrk. Non-
+                // Connect users get the sovereign encouragement flow.
+                if entitled {
+                    self.open_enroll_wizard(EnrollTier::Tier1, DuressEnrollStep::SetDuressPin);
                 } else {
-                    (EnrollTier::Sovereign, DuressEnrollStep::Encourage)
-                };
-                self.duress_enroll = Some(DuressEnrollState {
-                    tier,
-                    step,
-                    regular_pin: String::new(),
-                    duress_pin: String::new(),
-                    all_clear: String::new(),
-                    crk_password: String::new(),
-                    delay: enroll::DuressDelay::default(),
-                    sovereign_confirm: String::new(),
-                    memorized: false,
-                    submitting: false,
-                    error: None,
-                });
+                    self.open_enroll_wizard(EnrollTier::Sovereign, DuressEnrollStep::Encourage);
+                }
+            }
+            DuressMessage::StartEnrollmentWithoutCrk => {
+                // Tier 2 — Connect, no recovery kit: same as Tier 1 minus the
+                // CRK-password step (see `enroll_steps`). The BIG "set up a
+                // recovery kit first" warning is shown on the eligibility gate.
+                self.open_enroll_wizard(EnrollTier::Tier2, DuressEnrollStep::SetDuressPin);
             }
             DuressMessage::SignUpForConnect => {
                 self.duress_enroll = None;

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -2269,11 +2269,17 @@ fn duress_state_check_task(client: CoincubeClient, gen: u64, attempt: u8) -> ice
     )
 }
 
-/// A stable-enough per-device fingerprint for duress enrollment. Each device
-/// registers its own row server-side keyed on this value; a fresh UUID at
-/// enrollment time is sufficient since the plaintext code lives only here.
+/// This device's **stable** per-device fingerprint for duress enrollment. The
+/// server keys its per-device rows and `this_device_registered` on this value,
+/// so it must be the same across launches, repeat enrollments, and
+/// re-registrations — hence it's loaded from (or minted into) a persisted file
+/// at the data-directory root rather than freshly generated each time. Falls
+/// back to an ephemeral UUID only if the data directory can't be resolved.
 fn device_fingerprint() -> String {
-    uuid::Uuid::new_v4().to_string()
+    crate::dir::CoincubeDirectory::new_default()
+        .ok()
+        .and_then(|dir| crate::services::duress::device_fingerprint(dir.path()).ok())
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
 }
 
 /// The ordered steps for a tier. Sovereign opens with the Connect

--- a/coincube-gui/src/app/state/connect/mod.rs
+++ b/coincube-gui/src/app/state/connect/mod.rs
@@ -83,7 +83,7 @@ pub(crate) fn delete_connect_secret(user_key: &str) {
 
 pub use account::{
     AddToCubeDialog, CheckoutPhase, CheckoutState, ConnectAccountPanel, ConnectFlowStep,
-    ContactsState, ContactsStep, InviteCubeOption,
+    ContactsState, ContactsStep, DuressEnrollState, DuressEnrollStep, EnrollTier, InviteCubeOption,
 };
 pub use cube::ConnectCubePanel;
 pub use cube_members::ConnectCubeMembersState;

--- a/coincube-gui/src/app/view/connect/duress_enroll.rs
+++ b/coincube-gui/src/app/view/connect/duress_enroll.rs
@@ -335,10 +335,15 @@ fn delay_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
 }
 
 fn confirm_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
+    // Every tier sets a duress PIN; only Connect tiers collect an all-clear
+    // passphrase, and only Tier 1 a recovery-kit password. Sovereign never
+    // creates an all-clear, so don't tell it to memorize one.
     let mut creds = Column::new()
         .spacing(4)
-        .push(text::p2_regular("• Duress PIN").color(color::GREY_3))
-        .push(text::p2_regular("• All-clear passphrase").color(color::GREY_3));
+        .push(text::p2_regular("• Duress PIN").color(color::GREY_3));
+    if state.tier != EnrollTier::Sovereign {
+        creds = creds.push(text::p2_regular("• All-clear passphrase").color(color::GREY_3));
+    }
     if state.tier == EnrollTier::Tier1 {
         creds = creds.push(text::p2_regular("• Duress recovery-kit password").color(color::GREY_3));
     }

--- a/coincube-gui/src/app/view/connect/duress_enroll.rs
+++ b/coincube-gui/src/app/view/connect/duress_enroll.rs
@@ -1,0 +1,364 @@
+//! Duress recovery flow (Phase 6) and enrollment wizard (Phases 2 & 8) views.
+//!
+//! Both render `Element<ConnectAccountMessage>` and emit
+//! `ConnectAccountMessage::Duress(DuressMessage::…)`. The recovery view is shown
+//! as a [`ConnectFlowStep`](crate::app::state::connect::ConnectFlowStep); the
+//! wizard is shown in place of the duress dashboard panel while
+//! `ConnectAccountPanel::duress_enroll` is `Some`.
+
+use coincube_ui::{
+    color,
+    component::{button, text},
+    theme,
+    widget::*,
+};
+use iced::Length;
+
+use crate::app::state::connect::{DuressEnrollState, DuressEnrollStep, EnrollTier};
+use crate::app::view::{ConnectAccountMessage, DuressMessage};
+use crate::services::duress::enroll::{DuressDelay, MIN_ALL_CLEAR_LEN};
+
+fn msg(m: DuressMessage) -> ConnectAccountMessage {
+    ConnectAccountMessage::Duress(m)
+}
+
+fn card(content: Column<'_, ConnectAccountMessage>) -> Element<'_, ConnectAccountMessage> {
+    Container::new(content.padding(20).spacing(8))
+        .style(theme::card::simple)
+        .width(Length::Fill)
+        .into()
+}
+
+// =============================================================================
+// Phase 6 — post-lockout recovery
+// =============================================================================
+
+/// The recovery screen shown first after sign-in when the account is in duress.
+pub fn recovery_ux<'a>(
+    unlock_at: Option<&chrono::DateTime<chrono::Utc>>,
+    passphrase: &'a str,
+    submitting: bool,
+    cleared: bool,
+) -> Element<'a, ConnectAccountMessage> {
+    let mut col = Column::new()
+        .spacing(16)
+        .max_width(560)
+        .push(text::h4_bold("Duress Mode").style(theme::text::primary));
+
+    if cleared {
+        // Phase 6 Task 6.2 hand-off into the CRK download / restore flow.
+        col = col
+            .push(text::p1_regular(
+                "Duress cleared. Download your Cube Recovery Kit to restore your Cubes.",
+            ))
+            .push(
+                button::primary(None, "Continue")
+                    .width(Length::Fixed(220.0))
+                    .on_press(msg(DuressMessage::FinishRecovery)),
+            );
+        return col.width(Length::Fill).into();
+    }
+
+    let now = chrono::Utc::now();
+    let locked = unlock_at.map(|u| now < *u).unwrap_or(false);
+
+    if locked {
+        let when = unlock_at
+            .map(|u| {
+                u.with_timezone(&chrono::Local)
+                    .format("%b %d, %Y %H:%M %Z")
+                    .to_string()
+            })
+            .unwrap_or_else(|| "later".to_string());
+        col = col.push(card(
+            Column::new()
+                .push(text::p1_bold("Account locked").style(theme::text::primary))
+                .push(
+                    text::p2_regular(format!("Account is locked until {when}. Come back then."))
+                        .color(color::GREY_3),
+                ),
+        ));
+        return col.width(Length::Fill).into();
+    }
+
+    // Window elapsed — collect the all-clear passphrase.
+    let submit: Element<ConnectAccountMessage> = if submitting {
+        button::primary(None, "Clearing…")
+            .width(Length::Fixed(220.0))
+            .into()
+    } else {
+        button::primary(None, "Clear Duress")
+            .width(Length::Fixed(220.0))
+            .on_press(msg(DuressMessage::SubmitClear))
+            .into()
+    };
+
+    col = col.push(card(
+        Column::new()
+            .push(text::p1_bold("Enter your all-clear passphrase").style(theme::text::primary))
+            .push(
+                TextInput::new("All-clear passphrase", passphrase)
+                    .on_input(|v| msg(DuressMessage::RecoveryPassphraseChanged(v)))
+                    .on_submit(msg(DuressMessage::SubmitClear))
+                    .secure(true)
+                    .padding(15),
+            )
+            .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+            .push(submit)
+            .push(
+                button::transparent(None, "Forgot all-clear passphrase?")
+                    .on_press(msg(DuressMessage::ForgotAllClear)),
+            ),
+    ));
+
+    col.width(Length::Fill).into()
+}
+
+// =============================================================================
+// Phases 2 & 8 — enrollment wizard
+// =============================================================================
+
+/// The multi-step enrollment wizard. Tier-aware: sovereign opens with the
+/// Connect-encouragement screen, Connect tiers start at the duress-PIN step.
+pub fn enroll_ux(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
+    let body = match state.step {
+        DuressEnrollStep::Encourage => encourage_step(),
+        DuressEnrollStep::SovereignConfirm => sovereign_confirm_step(state),
+        DuressEnrollStep::SetDuressPin => duress_pin_step(state),
+        DuressEnrollStep::SetAllClear => all_clear_step(state),
+        DuressEnrollStep::SetCrkPassword => crk_password_step(state),
+        DuressEnrollStep::PickDelay => delay_step(state),
+        DuressEnrollStep::Confirm => confirm_step(state),
+    };
+
+    let mut col = Column::new()
+        .spacing(16)
+        .max_width(560)
+        .push(text::h4_bold("Set up Duress Mode").style(theme::text::primary))
+        .push(body);
+
+    if let Some(err) = &state.error {
+        col = col.push(text::p2_regular(err.clone()).color(color::RED));
+    }
+
+    // Navigation row. `Encourage` is special (its own CTAs); every other step
+    // gets Back + (Next | Complete enrollment).
+    if !matches!(state.step, DuressEnrollStep::Encourage) {
+        let is_last = matches!(state.step, DuressEnrollStep::Confirm);
+        let primary = if is_last {
+            if state.submitting {
+                button::primary(None, "Enrolling…").width(Length::Fixed(200.0))
+            } else {
+                button::primary(None, "Complete enrollment")
+                    .width(Length::Fixed(200.0))
+                    .on_press(msg(DuressMessage::SubmitEnrollment))
+            }
+        } else {
+            button::primary(None, "Next")
+                .width(Length::Fixed(120.0))
+                .on_press(msg(DuressMessage::EnrollNext))
+        };
+        col = col.push(
+            Row::new()
+                .spacing(12)
+                .push(
+                    button::secondary(None, "Back")
+                        .width(Length::Fixed(120.0))
+                        .on_press(msg(DuressMessage::EnrollBack)),
+                )
+                .push(iced::widget::Space::new().width(Length::Fill))
+                .push(
+                    button::transparent(None, "Cancel")
+                        .on_press(msg(DuressMessage::CancelEnrollment)),
+                )
+                .push(primary),
+        );
+    }
+
+    col.width(Length::Fill).into()
+}
+
+fn encourage_step<'a>() -> Element<'a, ConnectAccountMessage> {
+    card(
+        Column::new()
+            .push(
+                text::p1_bold("We recommend setting up Connect before enabling duress mode.")
+                    .style(theme::text::primary),
+            )
+            .push(
+                text::p2_regular("Connect makes duress mode safer and more forgiving:")
+                    .color(color::GREY_3),
+            )
+            .push(
+                text::p2_regular(
+                    "• Cube Recovery Kit — restore after a wipe with no paper seed phrase.\n\
+                 • All-clear passphrase — undo an accidental or coerced activation from a \
+                 trusted device. Sovereign duress has no all-clear.\n\
+                 • Lockout window (24h–90d) — buys you time to reach a trusted device.\n\
+                 • Cross-device signaling — the Keychain signer auto-refuses during duress.\n\
+                 • Trusted-device delay on new-device downloads.",
+                )
+                .color(color::GREY_3),
+            )
+            .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
+            .push(
+                button::primary(None, "Sign up for Connect")
+                    .width(Length::Fixed(240.0))
+                    .on_press(msg(DuressMessage::SignUpForConnect)),
+            )
+            .push(
+                button::transparent(None, "Continue without Connect (advanced)")
+                    .on_press(msg(DuressMessage::EnrollNext)),
+            ),
+    )
+}
+
+fn sovereign_confirm_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
+    card(
+        Column::new()
+            .push(text::p1_bold("No server-side recovery").style(theme::text::warning))
+            .push(
+                text::p2_regular(
+                    "Without a Connect account, duress mode will erase your Cubes on this device \
+                 and there is NO server-side recovery path. You will need your seed-phrase \
+                 backup to restore. Continue only if you have a verified offline backup.",
+                )
+                .color(color::GREY_3),
+            )
+            .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+            .push(text::p2_regular("Type: I have my seed-phrase backup").color(color::GREY_3))
+            .push(
+                TextInput::new("I have my seed-phrase backup", &state.sovereign_confirm)
+                    .on_input(|v| msg(DuressMessage::SovereignConfirmChanged(v)))
+                    .padding(15),
+            ),
+    )
+}
+
+fn duress_pin_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
+    card(
+        Column::new()
+            .push(text::p1_bold("Set your duress PIN").style(theme::text::primary))
+            .push(
+                text::p2_regular(
+                    "Your duress PIN must be at least 2 character changes from your regular PIN. \
+                 This prevents accidental activation.",
+                )
+                .color(color::GREY_3),
+            )
+            .push(text::p2_regular("Confirm your regular PIN").color(color::GREY_3))
+            .push(
+                TextInput::new("Regular PIN", &state.regular_pin)
+                    .on_input(|v| msg(DuressMessage::RegularPinChanged(v)))
+                    .secure(true)
+                    .padding(15),
+            )
+            .push(text::p2_regular("New duress PIN").color(color::GREY_3))
+            .push(
+                TextInput::new("Duress PIN", &state.duress_pin)
+                    .on_input(|v| msg(DuressMessage::DuressPinChanged(v)))
+                    .secure(true)
+                    .padding(15),
+            ),
+    )
+}
+
+fn all_clear_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
+    card(
+        Column::new()
+            .push(text::p1_bold("Set your all-clear passphrase").style(theme::text::primary))
+            .push(
+                text::p2_regular(format!(
+                "A memorable phrase, at least {MIN_ALL_CLEAR_LEN} characters. You'll need this \
+                 to recover your account from a trusted device — choose something you can \
+                 remember even after months of disuse.",
+            ))
+                .color(color::GREY_3),
+            )
+            .push(
+                TextInput::new("All-clear passphrase", &state.all_clear)
+                    .on_input(|v| msg(DuressMessage::AllClearChanged(v)))
+                    .secure(true)
+                    .padding(15),
+            ),
+    )
+}
+
+fn crk_password_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
+    card(
+        Column::new()
+            .push(
+                text::p1_bold("Set your duress recovery-kit password").style(theme::text::primary),
+            )
+            .push(
+                text::p2_regular(
+                    "This password applies to all your Cubes. If you ever enter it on a recovery \
+                 screen, the entire account enters duress.",
+                )
+                .color(color::GREY_3),
+            )
+            .push(
+                TextInput::new("Duress recovery-kit password", &state.crk_password)
+                    .on_input(|v| msg(DuressMessage::CrkPasswordChanged(v)))
+                    .secure(true)
+                    .padding(15),
+            ),
+    )
+}
+
+fn delay_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
+    let mut chips = Row::new().spacing(8);
+    for d in DuressDelay::ALL {
+        let selected = d == state.delay;
+        let chip = if selected {
+            button::primary(None, d.label()).width(Length::Fixed(90.0))
+        } else {
+            button::secondary(None, d.label())
+                .width(Length::Fixed(90.0))
+                .on_press(msg(DuressMessage::DelaySelected(d)))
+        };
+        chips = chips.push(chip);
+    }
+    card(
+        Column::new()
+            .push(text::p1_bold("Pick an unlock delay").style(theme::text::primary))
+            .push(
+                text::p2_regular(
+                    "Connect refuses recovery-kit downloads during this window, giving you time \
+                 to reach a trusted device.",
+                )
+                .color(color::GREY_3),
+            )
+            .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+            .push(chips),
+    )
+}
+
+fn confirm_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
+    let mut creds = Column::new()
+        .spacing(4)
+        .push(text::p2_regular("• Duress PIN").color(color::GREY_3))
+        .push(text::p2_regular("• All-clear passphrase").color(color::GREY_3));
+    if state.tier == EnrollTier::Tier1 {
+        creds = creds.push(text::p2_regular("• Duress recovery-kit password").color(color::GREY_3));
+    }
+
+    card(
+        Column::new()
+            .push(text::p1_bold("Memorize your credentials").style(theme::text::primary))
+            .push(
+                text::p2_regular(
+                    "Make sure you have memorized the following. They are never shown again.",
+                )
+                .color(color::GREY_3),
+            )
+            .push(creds)
+            .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+            .push(
+                CheckBox::new(state.memorized)
+                    .label("I have memorized all credentials")
+                    .on_toggle(|v| msg(DuressMessage::MemorizedToggled(v)))
+                    .style(theme::checkbox::primary),
+            ),
+    )
+}

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -64,6 +64,10 @@ pub fn connect_panel<'a>(state: &'a ConnectPanel) -> Element<'a, ViewMessage> {
             ..
         } => otp_ux(email, otp, *sending, *cooldown).map(ViewMessage::ConnectAccount),
 
+        ConnectFlowStep::CheckingDuress { failed } => {
+            checking_duress_ux(*failed).map(ViewMessage::ConnectAccount)
+        }
+
         ConnectFlowStep::DuressRecovery {
             unlock_at,
             passphrase,
@@ -140,6 +144,7 @@ pub fn connect_account_panel<'a>(
             cooldown,
             ..
         } => otp_ux(email, otp, *sending, *cooldown),
+        ConnectFlowStep::CheckingDuress { failed } => checking_duress_ux(*failed),
         ConnectFlowStep::DuressRecovery {
             unlock_at,
             passphrase,
@@ -1089,6 +1094,26 @@ fn security_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccount
         .spacing(0)
         .width(Length::Fill)
         .into()
+}
+
+/// Post-login duress verification gate (Phase 6). Shown after auth while
+/// `get_duress_state` is in flight, so the dashboard isn't revealed to a
+/// possibly-in-duress account. On terminal failure (`failed`) it offers a Retry
+/// rather than falling through to the dashboard.
+fn checking_duress_ux<'a>(failed: bool) -> Element<'a, ConnectAccountMessage> {
+    let mut col = Column::new().spacing(16).align_x(Alignment::Center);
+    if failed {
+        col = col
+            .push(text::p1_regular("Couldn't verify your account status.").color(color::GREY_3))
+            .push(
+                button::primary(None, "Retry")
+                    .width(Length::Fixed(160.0))
+                    .on_press(ConnectAccountMessage::RetryDuressCheck),
+            );
+    } else {
+        col = col.push(text::p1_regular("Checking your account…").color(color::GREY_3));
+    }
+    col.width(Length::Fill).into()
 }
 
 /// Duress enrollment eligibility gate (Phase 2, Task 2.1).

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -1,5 +1,6 @@
 mod contacts;
 pub mod cube_members;
+pub mod duress_enroll;
 pub mod sign_in_prompt;
 
 use coincube_ui::{
@@ -23,7 +24,7 @@ use crate::{
             AvatarFlowStep, CheckoutPhase, ConnectAccountPanel, ConnectCubePanel, ConnectFlowStep,
             ConnectPanel,
         },
-        view::{AvatarMessage, ConnectAccountMessage, ConnectCubeMessage},
+        view::{AvatarMessage, ConnectAccountMessage, ConnectCubeMessage, DuressMessage},
     },
     services::coincube::{
         AvatarAccentMotif, AvatarAgeFeel, AvatarArchetype, AvatarArmorStyle, AvatarDemeanor,
@@ -62,6 +63,14 @@ pub fn connect_panel<'a>(state: &'a ConnectPanel) -> Element<'a, ViewMessage> {
             cooldown,
             ..
         } => otp_ux(email, otp, *sending, *cooldown).map(ViewMessage::ConnectAccount),
+
+        ConnectFlowStep::DuressRecovery {
+            unlock_at,
+            passphrase,
+            submitting,
+            cleared,
+        } => duress_enroll::recovery_ux(unlock_at.as_ref(), passphrase, *submitting, *cleared)
+            .map(ViewMessage::ConnectAccount),
 
         ConnectFlowStep::Dashboard => match &acct.active_sub {
             ConnectSubMenu::Overview => overview_ux(acct).map(ViewMessage::ConnectAccount),
@@ -131,6 +140,12 @@ pub fn connect_account_panel<'a>(
             cooldown,
             ..
         } => otp_ux(email, otp, *sending, *cooldown),
+        ConnectFlowStep::DuressRecovery {
+            unlock_at,
+            passphrase,
+            submitting,
+            cleared,
+        } => duress_enroll::recovery_ux(unlock_at.as_ref(), passphrase, *submitting, *cleared),
         ConnectFlowStep::Dashboard => match &acct.active_sub {
             ConnectSubMenu::Overview => overview_ux(acct),
             ConnectSubMenu::PlanBilling => plan_billing_ux(acct),
@@ -140,7 +155,10 @@ pub fn connect_account_panel<'a>(
         },
     };
 
-    let is_auth_step = !matches!(acct.step, ConnectFlowStep::Dashboard);
+    let is_auth_step = !matches!(
+        acct.step,
+        ConnectFlowStep::Dashboard | ConnectFlowStep::DuressRecovery { .. }
+    );
     let col_align = if is_auth_step {
         Alignment::Center
     } else {
@@ -1084,6 +1102,11 @@ fn security_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccount
 fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMessage> {
     use crate::services::duress::enroll::{DuressDelay, MIN_ALL_CLEAR_LEN};
 
+    // Wizard takes over the panel while enrollment is in progress.
+    if let Some(enroll) = &state.duress_enroll {
+        return duress_enroll::enroll_ux(enroll);
+    }
+
     let entitled = state
         .plan
         .as_ref()
@@ -1201,6 +1224,15 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
         )
         .style(card_style)
         .width(Length::Fill),
+    );
+
+    col = col.push(iced::widget::Space::new().height(Length::Fixed(16.0)));
+    col = col.push(
+        button::primary(None, "Set up Duress Mode")
+            .width(Length::Fixed(240.0))
+            .on_press(ConnectAccountMessage::Duress(
+                DuressMessage::StartEnrollment,
+            )),
     );
 
     col.width(Length::Fill).into()

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -1234,6 +1234,14 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
                 DuressMessage::StartEnrollment,
             )),
     );
+    // Tier 2 (Connect, no recovery kit) — the plan's Task 2.1 secondary path.
+    // The panel can't see per-Cube CRK state, so the user picks: this skips the
+    // duress recovery-kit password step.
+    col = col.push(
+        button::transparent(None, "Continue without a recovery kit (advanced)").on_press(
+            ConnectAccountMessage::Duress(DuressMessage::StartEnrollmentWithoutCrk),
+        ),
+    );
 
     col.width(Length::Fill).into()
 }

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -67,7 +67,7 @@ pub fn connect_panel<'a>(state: &'a ConnectPanel) -> Element<'a, ViewMessage> {
             ConnectSubMenu::Overview => overview_ux(acct).map(ViewMessage::ConnectAccount),
             ConnectSubMenu::PlanBilling => plan_billing_ux(acct).map(ViewMessage::ConnectAccount),
             ConnectSubMenu::Security => security_ux(acct).map(ViewMessage::ConnectAccount),
-            ConnectSubMenu::Duress => duress_ux().map(ViewMessage::ConnectAccount),
+            ConnectSubMenu::Duress => duress_ux(acct).map(ViewMessage::ConnectAccount),
             ConnectSubMenu::Contacts => {
                 contacts::contacts_ux(acct).map(ViewMessage::ConnectAccount)
             }
@@ -135,7 +135,7 @@ pub fn connect_account_panel<'a>(
             ConnectSubMenu::Overview => overview_ux(acct),
             ConnectSubMenu::PlanBilling => plan_billing_ux(acct),
             ConnectSubMenu::Security => security_ux(acct),
-            ConnectSubMenu::Duress => duress_ux(),
+            ConnectSubMenu::Duress => duress_ux(acct),
             ConnectSubMenu::Contacts => contacts::contacts_ux(acct),
         },
     };
@@ -1073,35 +1073,137 @@ fn security_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccount
         .into()
 }
 
-fn duress_ux<'a>() -> Element<'a, ConnectAccountMessage> {
-    Column::new()
-        .push(text::h4_bold("Duress Settings").style(theme::text::primary))
-        .push(iced::widget::Space::new().height(Length::Fixed(15.0)))
-        .push(
-            container(
-                Column::new()
-                    .push(
-                        text::p1_regular(
-                            "Duress protection allows you to lock signing and optionally wipe \
-                             local data under coercion. Configure trusted contacts and escalation \
-                             rules.",
-                        )
-                        .color(color::GREY_3),
-                    )
-                    .push(iced::widget::Space::new().height(Length::Fixed(16.0)))
-                    .push(
-                        text::p2_regular("Coming Soon — requires backend endpoint /connect/duress")
-                            .color(color::GREY_3),
-                    )
-                    .padding(20)
-                    .spacing(2),
+/// Duress enrollment eligibility gate (Phase 2, Task 2.1).
+///
+/// Inside the Connect dashboard the user is already signed in, so the tiers
+/// reduce to Tier 1 (Connect + CRK) and Tier 2 (Connect, no CRK). The sovereign
+/// Tier 3 flow lives behind a separate entry (Phase 8). The interactive
+/// multi-step wizard (`duress_enroll.rs`) builds on the credential rules in
+/// `services::duress::enroll`; this surface explains eligibility and the
+/// credentials the user will set, and surfaces the Tier 2 BIG warning.
+fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMessage> {
+    use crate::services::duress::enroll::{DuressDelay, MIN_ALL_CLEAR_LEN};
+
+    let entitled = state
+        .plan
+        .as_ref()
+        .map(|p| p.entitlements.duress_remote_lock)
+        .unwrap_or(false);
+
+    let mut col = Column::new()
+        .push(text::h4_bold("Duress Mode").style(theme::text::primary))
+        .push(iced::widget::Space::new().height(Length::Fixed(15.0)));
+
+    if !entitled {
+        return col
+            .push(
+                container(
+                    Column::new()
+                        .push(text::p1_regular(
+                            "Duress mode is available on Pro and Estate plans. Upgrade your \
+                             Connect plan to enable it.",
+                        ))
+                        .padding(20),
+                )
+                .style(card_style)
+                .width(Length::Fill),
             )
-            .style(card_style)
-            .width(Length::Fill),
+            .width(Length::Fill)
+            .into();
+    }
+
+    let delays: String = DuressDelay::ALL
+        .iter()
+        .map(|d| d.label())
+        .collect::<Vec<_>>()
+        .join(" · ");
+
+    // What duress activation does — stated plainly, no fine print.
+    col = col.push(
+        container(
+            Column::new()
+                .push(text::p1_bold("What duress mode does").style(theme::text::primary))
+                .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+                .push(
+                    text::p2_regular(
+                        "When you unlock a Cube with your duress PIN, this device erases every \
+                     Cube on it and signals Connect to lock your account. The device then \
+                     shows a dead-end screen until you clear duress from another trusted device.",
+                    )
+                    .color(color::GREY_3),
+                )
+                .padding(20)
+                .spacing(2),
         )
-        .spacing(0)
-        .width(Length::Fill)
-        .into()
+        .style(card_style)
+        .width(Length::Fill),
+    );
+
+    col = col.push(iced::widget::Space::new().height(Length::Fixed(12.0)));
+
+    // Credentials the user will set during enrollment.
+    col = col.push(
+        container(
+            Column::new()
+                .push(text::p1_bold("You'll set").style(theme::text::primary))
+                .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+                .push(
+                    text::p2_regular(
+                        "• A duress PIN — at least 2 character changes from your regular PIN.",
+                    )
+                    .color(color::GREY_3),
+                )
+                .push(
+                    text::p2_regular(format!(
+                        "• An all-clear passphrase — at least {} characters, used to unlock your \
+                     account from a trusted device.",
+                        MIN_ALL_CLEAR_LEN
+                    ))
+                    .color(color::GREY_3),
+                )
+                .push(
+                    text::p2_regular(
+                        "• A duress recovery-kit password (Tier 1) — covers all your Cubes.",
+                    )
+                    .color(color::GREY_3),
+                )
+                .push(
+                    text::p2_regular(format!("• An unlock delay: {}.", delays))
+                        .color(color::GREY_3),
+                )
+                .padding(20)
+                .spacing(4),
+        )
+        .style(card_style)
+        .width(Length::Fill),
+    );
+
+    col = col.push(iced::widget::Space::new().height(Length::Fixed(12.0)));
+
+    // Tier 2 BIG warning — shown whenever the account has no recovery kit yet.
+    // We can't see per-Cube CRK state from this panel, so we surface the
+    // warning unconditionally; the wizard refines it per tier.
+    col = col.push(
+        container(
+            Column::new()
+                .push(
+                    text::p1_bold("Set up a Cube Recovery Kit first")
+                        .style(theme::text::warning),
+                )
+                .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+                .push(text::p2_regular(
+                    "Without a Cube Recovery Kit, a duress wipe is irreversible from Connect — \
+                     you would need your seed-phrase backup to restore. We strongly recommend \
+                     setting up a Cube Recovery Kit before enabling duress mode.",
+                ).color(color::GREY_3))
+                .padding(20)
+                .spacing(2),
+        )
+        .style(card_style)
+        .width(Length::Fill),
+    );
+
+    col.width(Length::Fill).into()
 }
 
 pub fn avatar_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectCubeMessage> {

--- a/coincube-gui/src/app/view/duress/active_screen.rs
+++ b/coincube-gui/src/app/view/duress/active_screen.rs
@@ -4,10 +4,12 @@
 //! This screen replaces every other view. It reveals nothing recoverable and
 //! offers no recovery affordances on this device: no countdown, no remaining
 //! window, no balances, no Cube list, no support link. Its **only** interactive
-//! element is a single "Sign in to Connect" button which, in Phase 5, gates
-//! entirely on server-side duress state — while duress is active it shows an
-//! inline "Try again later" and never a credential prompt.
+//! element is a single "Sign in to Connect" button which gates entirely on
+//! server-side duress state — while duress is active it shows an inline "Try
+//! again later" and **never** a credential prompt. Only when the server reports
+//! duress cleared does the screen exit into the normal flow.
 
+use coincube_core::miniscript::bitcoin::Network;
 use coincube_ui::{
     color,
     component::{button, text},
@@ -15,16 +17,22 @@ use coincube_ui::{
 };
 use iced::{Alignment, Length};
 
+use crate::dir::CoincubeDirectory;
+
 #[derive(Debug, Clone)]
 pub enum Message {
-    /// User tapped "Sign in to Connect". Phase 5 turns this into a
-    /// `get_duress_state` check that either stays (active) or exits (cleared).
+    /// User tapped "Sign in to Connect" — triggers a `get_duress_state` check.
     SignInPressed,
+    /// Result of the check: `Some(true)` still active, `Some(false)` cleared,
+    /// `None` couldn't reach/parse the server. Only `Some(false)` exits the
+    /// screen; everything else stays put with "Try again later".
+    StateChecked(Option<bool>),
 }
 
-/// Cryptic-screen state. Deliberately tiny — it must not cache anything
-/// sensitive.
-#[derive(Debug, Default)]
+/// Cryptic-screen state. Holds just enough context to run the gated Sign-in
+/// check and, on a server-side clear, hand back to the normal launch flow. It
+/// caches nothing sensitive.
+#[derive(Default)]
 pub struct DuressActiveScreen {
     /// Inline error shown beneath the button (e.g. "Duress mode is active.
     /// Try again later.").
@@ -34,11 +42,35 @@ pub struct DuressActiveScreen {
     /// Whether the retry queue still has pending work — drives the subtle
     /// corner dot (Phase 4 Task 4.2). No text, no explanation.
     pub queue_pending: bool,
+    /// Data directory + network, used to locate cached Connect auth
+    /// (`<network>/connect.json`, preserved through the wipe) for the Sign-in
+    /// check and to rebuild the Home flow on exit. `network` is `None` only on
+    /// a launch reconcile where the network wasn't resolved.
+    datadir: Option<CoincubeDirectory>,
+    network: Option<Network>,
 }
 
 impl DuressActiveScreen {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Constructs the screen with the context needed for the gated Sign-in
+    /// check and a clean exit.
+    pub fn with_context(datadir: CoincubeDirectory, network: Option<Network>) -> Self {
+        Self {
+            datadir: Some(datadir),
+            network,
+            ..Self::default()
+        }
+    }
+
+    pub fn datadir(&self) -> Option<&CoincubeDirectory> {
+        self.datadir.as_ref()
+    }
+
+    pub fn network(&self) -> Option<Network> {
+        self.network
     }
 
     pub fn view(&self) -> Element<Message> {

--- a/coincube-gui/src/app/view/duress/active_screen.rs
+++ b/coincube-gui/src/app/view/duress/active_screen.rs
@@ -1,0 +1,80 @@
+//! The cryptic "Duress Mode Activated" screen (Phase 3 emits it; Phase 5 wires
+//! the three exit paths and the gated Sign-in behaviour).
+//!
+//! This screen replaces every other view. It reveals nothing recoverable and
+//! offers no recovery affordances on this device: no countdown, no remaining
+//! window, no balances, no Cube list, no support link. Its **only** interactive
+//! element is a single "Sign in to Connect" button which, in Phase 5, gates
+//! entirely on server-side duress state — while duress is active it shows an
+//! inline "Try again later" and never a credential prompt.
+
+use coincube_ui::{
+    color,
+    component::{button, text},
+    widget::{Column, Container, Element},
+};
+use iced::{Alignment, Length};
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    /// User tapped "Sign in to Connect". Phase 5 turns this into a
+    /// `get_duress_state` check that either stays (active) or exits (cleared).
+    SignInPressed,
+}
+
+/// Cryptic-screen state. Deliberately tiny — it must not cache anything
+/// sensitive.
+#[derive(Debug, Default)]
+pub struct DuressActiveScreen {
+    /// Inline error shown beneath the button (e.g. "Duress mode is active.
+    /// Try again later.").
+    pub error: Option<String>,
+    /// True while a server-side state check is in flight.
+    pub checking: bool,
+    /// Whether the retry queue still has pending work — drives the subtle
+    /// corner dot (Phase 4 Task 4.2). No text, no explanation.
+    pub queue_pending: bool,
+}
+
+impl DuressActiveScreen {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn view(&self) -> Element<Message> {
+        let mut col = Column::new()
+            .width(Length::Fill)
+            .spacing(16)
+            .align_x(Alignment::Center)
+            .push(iced::widget::Space::new().height(Length::Fill))
+            .push(text::h3("Duress Mode Activated"))
+            .push(
+                text::p1_regular(
+                    "Use the COINCUBE app on a trusted device to manage your account.",
+                )
+                .color(color::GREY_3),
+            );
+
+        let sign_in = if self.checking {
+            button::primary(None, "Checking…").width(Length::Fixed(220.0))
+        } else {
+            button::primary(None, "Sign in to Connect")
+                .width(Length::Fixed(220.0))
+                .on_press(Message::SignInPressed)
+        };
+        col = col.push(iced::widget::Space::new().height(Length::Fixed(8.0)));
+        col = col.push(sign_in);
+
+        if let Some(err) = &self.error {
+            col = col.push(text::p2_regular(err).color(color::GREY_3));
+        }
+
+        col = col.push(iced::widget::Space::new().height(Length::Fill));
+
+        Container::new(col)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .center_x(Length::Fill)
+            .into()
+    }
+}

--- a/coincube-gui/src/app/view/duress/active_screen.rs
+++ b/coincube-gui/src/app/view/duress/active_screen.rs
@@ -71,6 +71,17 @@ impl DuressActiveScreen {
 
         col = col.push(iced::widget::Space::new().height(Length::Fill));
 
+        // Subtle pending-work indicator (Phase 4 Task 4.2): a single muted dot,
+        // no text, no explanation — an attacker can infer nothing from it. Only
+        // shown while the activation POST is still queued.
+        if self.queue_pending {
+            col = col.push(
+                Container::new(text::p2_regular("•").color(color::GREY_5))
+                    .width(Length::Fill)
+                    .align_right(Length::Fill),
+            );
+        }
+
         Container::new(col)
             .width(Length::Fill)
             .height(Length::Fill)

--- a/coincube-gui/src/app/view/duress/mod.rs
+++ b/coincube-gui/src/app/view/duress/mod.rs
@@ -1,0 +1,8 @@
+//! Duress-mode UI surfaces.
+//!
+//! [`active_screen`] is the cryptic "Duress Mode Activated" dead-end that
+//! replaces the entire app shell once duress is active (local-PIN wipe path or
+//! remote activation). Its only interactive element is a Sign-in button that
+//! gates entirely on server-side duress state (Phase 5).
+
+pub mod active_screen;

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1107,6 +1107,9 @@ pub enum ConnectAccountMessage {
     /// User tapped Retry on the post-login duress verification gate after the
     /// check failed (retries exhausted).
     RetryDuressCheck,
+    /// Completion of the background "register this device's duress code" task
+    /// (Phase 0). No-op at the UI level — the work is a side effect.
+    DuressDeviceRegistered,
     /// Recovery flow + enrollment wizard messages (nested to keep this enum
     /// tidy).
     Duress(DuressMessage),

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1115,7 +1115,14 @@ pub enum DuressMessage {
     FinishRecovery,
 
     // ── Enrollment wizard (Phases 2 & 8) ──
+    /// Begin enrollment. Entitled users start at Tier 1 (with the account-level
+    /// duress recovery-kit password); non-Connect users get the sovereign flow.
     StartEnrollment,
+    /// Begin enrollment WITHOUT a recovery kit (Tier 2 — the plan's Task 2.1
+    /// "Continue without recovery kit (advanced)"). Skips the CRK-password step.
+    /// Only offered to entitled users, since the panel can't see per-Cube CRK
+    /// state to auto-select the tier.
+    StartEnrollmentWithoutCrk,
     /// Sovereign "Sign up for Connect" CTA → the Register flow.
     SignUpForConnect,
     CancelEnrollment,

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1103,7 +1103,13 @@ pub enum ConnectAccountMessage {
 
 /// Messages for the duress recovery flow (Phase 6) and enrollment wizard
 /// (Phases 2 & 8), nested under [`ConnectAccountMessage::Duress`].
-#[derive(Debug, Clone)]
+///
+/// `Debug` is hand-written (not derived) because the `*Changed` variants carry
+/// secret keystrokes — duress/regular PINs, the all-clear and CRK passwords —
+/// that would otherwise leak into any tracing snapshot of a parent message
+/// (this enum bubbles up through `ConnectAccountMessage` → `view::Message` →
+/// top-level `Message`, all of which derive `Debug`).
+#[derive(Clone)]
 pub enum DuressMessage {
     // ── Recovery (Phase 6) ──
     RecoveryPassphraseChanged(String),
@@ -1137,6 +1143,37 @@ pub enum DuressMessage {
     MemorizedToggled(bool),
     SubmitEnrollment,
     EnrollResult(Result<(), String>, u64),
+}
+
+impl std::fmt::Debug for DuressMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use DuressMessage::*;
+        match self {
+            // Sensitive — never print the typed secret.
+            RecoveryPassphraseChanged(_) => write!(f, "RecoveryPassphraseChanged(<redacted>)"),
+            RegularPinChanged(_) => write!(f, "RegularPinChanged(<redacted>)"),
+            DuressPinChanged(_) => write!(f, "DuressPinChanged(<redacted>)"),
+            AllClearChanged(_) => write!(f, "AllClearChanged(<redacted>)"),
+            CrkPasswordChanged(_) => write!(f, "CrkPasswordChanged(<redacted>)"),
+            SovereignConfirmChanged(_) => write!(f, "SovereignConfirmChanged(<redacted>)"),
+            // Non-sensitive — `ClearResult`/`EnrollResult` carry only an error
+            // string (no secret), so they format normally.
+            SubmitClear => write!(f, "SubmitClear"),
+            ClearResult(res, gen) => write!(f, "ClearResult({:?}, {})", res, gen),
+            ForgotAllClear => write!(f, "ForgotAllClear"),
+            FinishRecovery => write!(f, "FinishRecovery"),
+            StartEnrollment => write!(f, "StartEnrollment"),
+            StartEnrollmentWithoutCrk => write!(f, "StartEnrollmentWithoutCrk"),
+            SignUpForConnect => write!(f, "SignUpForConnect"),
+            CancelEnrollment => write!(f, "CancelEnrollment"),
+            EnrollBack => write!(f, "EnrollBack"),
+            EnrollNext => write!(f, "EnrollNext"),
+            DelaySelected(d) => write!(f, "DelaySelected({:?})", d),
+            MemorizedToggled(b) => write!(f, "MemorizedToggled({})", b),
+            SubmitEnrollment => write!(f, "SubmitEnrollment"),
+            EnrollResult(res, gen) => write!(f, "EnrollResult({:?}, {})", res, gen),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1769,5 +1806,47 @@ mod recovery_kit_upload_outcome_debug_tests {
             rendered
         );
         assert!(rendered.contains("<redacted>"));
+    }
+}
+
+#[cfg(test)]
+mod duress_message_debug_tests {
+    use super::DuressMessage;
+
+    /// Canary string; if it ever shows up in a Debug render the redaction has
+    /// regressed and a typed PIN/passphrase would leak into logs.
+    const CANARY: &str = "canary-secret-XYZZY-do-not-leak";
+
+    #[test]
+    fn sensitive_variants_are_redacted() {
+        let sensitive = [
+            DuressMessage::RecoveryPassphraseChanged(CANARY.to_string()),
+            DuressMessage::RegularPinChanged(CANARY.to_string()),
+            DuressMessage::DuressPinChanged(CANARY.to_string()),
+            DuressMessage::AllClearChanged(CANARY.to_string()),
+            DuressMessage::CrkPasswordChanged(CANARY.to_string()),
+            DuressMessage::SovereignConfirmChanged(CANARY.to_string()),
+        ];
+        for msg in &sensitive {
+            let rendered = format!("{:?}", msg);
+            assert!(
+                !rendered.contains(CANARY),
+                "Debug({:?}) leaked the secret payload",
+                rendered
+            );
+            assert!(rendered.contains("<redacted>"), "got {}", rendered);
+        }
+    }
+
+    #[test]
+    fn non_sensitive_variants_format_normally() {
+        assert_eq!(
+            format!("{:?}", DuressMessage::SubmitEnrollment),
+            "SubmitEnrollment"
+        );
+        assert_eq!(
+            format!("{:?}", DuressMessage::MemorizedToggled(true)),
+            "MemorizedToggled(true)"
+        );
     }
 }

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1084,6 +1084,44 @@ pub enum ConnectAccountMessage {
     UserProfileLoaded(crate::services::coincube::User),
     /// User profile refresh failed (non-auth error)
     UserProfileFailed(String),
+    // --- Duress (Phases 6 & 8) ---
+    /// Result of the post-sign-in `get_duress_state` gate. When `active`,
+    /// the panel replaces the dashboard with the recovery flow.
+    DuressStateChecked(Option<crate::services::coincube::DuressState>, u64),
+    /// Recovery flow + enrollment wizard messages (nested to keep this enum
+    /// tidy).
+    Duress(DuressMessage),
+}
+
+/// Messages for the duress recovery flow (Phase 6) and enrollment wizard
+/// (Phases 2 & 8), nested under [`ConnectAccountMessage::Duress`].
+#[derive(Debug, Clone)]
+pub enum DuressMessage {
+    // ── Recovery (Phase 6) ──
+    RecoveryPassphraseChanged(String),
+    SubmitClear,
+    ClearResult(Result<(), String>, u64),
+    ForgotAllClear,
+    /// After a successful clear, leave recovery and enter the normal dashboard
+    /// (where restore-from-CRK is reachable).
+    FinishRecovery,
+
+    // ── Enrollment wizard (Phases 2 & 8) ──
+    StartEnrollment,
+    /// Sovereign "Sign up for Connect" CTA → the Register flow.
+    SignUpForConnect,
+    CancelEnrollment,
+    EnrollBack,
+    EnrollNext,
+    RegularPinChanged(String),
+    DuressPinChanged(String),
+    AllClearChanged(String),
+    CrkPasswordChanged(String),
+    DelaySelected(crate::services::duress::enroll::DuressDelay),
+    SovereignConfirmChanged(String),
+    MemorizedToggled(bool),
+    SubmitEnrollment,
+    EnrollResult(Result<(), String>, u64),
 }
 
 #[derive(Debug, Clone)]

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1096,6 +1096,9 @@ pub enum ConnectAccountMessage {
     /// transient error doesn't silently leave the user on the dashboard while
     /// the account is in duress.
     DuressStateChecked(Option<crate::services::coincube::DuressState>, u64, u8),
+    /// User tapped Retry on the post-login duress verification gate after the
+    /// check failed (retries exhausted).
+    RetryDuressCheck,
     /// Recovery flow + enrollment wizard messages (nested to keep this enum
     /// tidy).
     Duress(DuressMessage),

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -179,6 +179,11 @@ pub enum Message {
     /// prompt. The Pane intercepts it and focuses the Home tab on its
     /// Connect section.
     OpenConnectSignIn,
+    /// Remote duress activation arrived over the gRPC stream (Phase 7b). The
+    /// tab shell intercepts this and locks the running app into the cryptic
+    /// "Duress Mode Activated" screen — WITHOUT wiping (remote activation can
+    /// be accidental; only a local duress PIN wipes).
+    DuressLockRemote,
     ToggleTheme,
     DismissReceivedCelebration,
     DismissBackupWarning,

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1085,9 +1085,12 @@ pub enum ConnectAccountMessage {
     /// User profile refresh failed (non-auth error)
     UserProfileFailed(String),
     // --- Duress (Phases 6 & 8) ---
-    /// Result of the post-sign-in `get_duress_state` gate. When `active`,
-    /// the panel replaces the dashboard with the recovery flow.
-    DuressStateChecked(Option<crate::services::coincube::DuressState>, u64),
+    /// Result of the post-sign-in `get_duress_state` gate. `Some` switches to
+    /// the recovery flow when `active`; `None` is a failed/unreachable check
+    /// and triggers a bounded retry (the `u8` is the attempt count) so a
+    /// transient error doesn't silently leave the user on the dashboard while
+    /// the account is in duress.
+    DuressStateChecked(Option<crate::services::coincube::DuressState>, u64, u8),
     /// Recovery flow + enrollment wizard messages (nested to keep this enum
     /// tidy).
     Duress(DuressMessage),

--- a/coincube-gui/src/app/view/mod.rs
+++ b/coincube-gui/src/app/view/mod.rs
@@ -2,6 +2,7 @@ mod message;
 
 pub mod buysell;
 pub mod connect;
+pub mod duress;
 pub mod global_home;
 pub mod liquid;
 pub mod nav;

--- a/coincube-gui/src/dir.rs
+++ b/coincube-gui/src/dir.rs
@@ -2,9 +2,16 @@ use crate::app::settings::WalletId;
 use coincube_core::miniscript::bitcoin::Network;
 use coincubed::datadir::DataDirectory;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct CoincubeDirectory(PathBuf);
+
+/// The process-wide active data directory, resolved once at startup from
+/// `--datadir` (or the OS default). Set in `GUI::new`; read by code that runs
+/// outside the datadir-carrying structs (e.g. the account-level Connect panel's
+/// duress-fingerprint helper) so it uses the REAL data path, not the default.
+static ACTIVE_DATADIR: OnceLock<CoincubeDirectory> = OnceLock::new();
 
 impl CoincubeDirectory {
     pub fn new(p: PathBuf) -> Self {
@@ -12,6 +19,21 @@ impl CoincubeDirectory {
     }
     pub fn new_default() -> Result<Self, Box<dyn std::error::Error>> {
         default_datadir().map(CoincubeDirectory::new)
+    }
+
+    /// Records the active data directory for the process (idempotent — only the
+    /// first call wins, which is the startup resolution).
+    pub fn set_active(dir: CoincubeDirectory) {
+        let _ = ACTIVE_DATADIR.set(dir);
+    }
+
+    /// The active data directory, honouring a custom `--datadir`. Falls back to
+    /// the OS default if it was never recorded (e.g. in unit tests).
+    pub fn active() -> Result<CoincubeDirectory, Box<dyn std::error::Error>> {
+        match ACTIVE_DATADIR.get() {
+            Some(dir) => Ok(dir.clone()),
+            None => Self::new_default(),
+        }
     }
 }
 

--- a/coincube-gui/src/gui/mod.rs
+++ b/coincube-gui/src/gui/mod.rs
@@ -120,6 +120,10 @@ impl GUI {
 
     pub fn new((config, log_level): (Config, Option<LevelFilter>)) -> (GUI, Task<Message>) {
         let log_level = log_level.unwrap_or(LevelFilter::INFO);
+        // Record the resolved (possibly `--datadir`-overridden) data directory
+        // process-wide so helpers without a datadir in hand — e.g. the Connect
+        // panel's duress fingerprint — use the real path, not the OS default.
+        CoincubeDirectory::set_active(config.coincube_directory.clone());
         if let Err(e) = setup_logger(log_level, config.coincube_directory.clone()) {
             tracing::warn!("Error while setting error: {}", e);
         }

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -268,8 +268,28 @@ fn activate_local_duress(
     // 4. Wipe (anchor) — runs in parallel with the POST above. Targets EVERY
     //    network's Cube data, matching the launch-time reconcile, so a PIN
     //    unlock on one network can't leave another network's Cubes on disk.
-    if let Err(e) = CubeWiper::new(duress_wipe_targets(root), journal).execute_atomic() {
-        error!("duress: wipe error (continuing to cryptic screen): {e}");
+    //    Retry on failure so a transient lock/IO error doesn't leave Cube seeds
+    //    or PIN material on disk. CubeWiper does NOT clear the journal on a
+    //    failed pass, so even if every attempt here fails, the launch-time
+    //    reconcile (complete_pending_wipe) finishes the wipe on next launch.
+    //    The device still locks into the cryptic screen regardless — showing a
+    //    normal app with Cube data after a duress trigger would be far worse.
+    let wiper = CubeWiper::new(duress_wipe_targets(root), journal);
+    let mut wiped = false;
+    for attempt in 1..=3 {
+        match wiper.execute_atomic() {
+            Ok(()) => {
+                wiped = true;
+                break;
+            }
+            Err(e) => error!("duress: wipe attempt {attempt}/3 failed: {e}"),
+        }
+    }
+    if !wiped {
+        error!(
+            "duress: Cube data may remain on disk; journal retained, wipe will be \
+             retried on next launch"
+        );
     }
 
     // 5. Persist active state so launch-time reconcile re-enters the cryptic

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -74,19 +74,36 @@ impl State {
     }
 }
 
-/// The set of Cube-data directories a duress wipe must obliterate: the `data`
-/// subdir of EVERY per-network directory under the data root. A duress wipe
-/// takes every Cube on the device regardless of which network's Cube triggered
-/// it, so activation and the launch-time reconcile must agree on this set —
-/// otherwise a PIN unlock on one network would leave other networks' Cube data
-/// on disk.
+/// The set of Cube material a duress wipe must obliterate, under EVERY
+/// per-network directory below the data root. A duress wipe takes every Cube on
+/// the device regardless of which network's Cube triggered it, so activation
+/// and the launch-time reconcile must agree on this set.
+///
+/// Per network directory:
+/// - `data/` — wallet databases (BDK, plus breez/spark per-Cube working data
+///   under `data/<wallet_id>/`),
+/// - `mnemonics/` — the master seed phrases (the crown jewels),
+/// - `settings.json` — `security_pin_hash`, `duress_pin_hash`, Cube metadata.
+///
+/// `connect.json` (the cached Connect auth the cryptic screen needs to check
+/// duress state) is deliberately NOT listed, so it survives — as do the
+/// root-level duress stores (`duress-*.json`, `duress.key`, the journal), which
+/// live outside any network directory. Re-checking existence each call makes
+/// this robust to an interrupted wipe: whatever remains is targeted again.
 fn duress_wipe_targets(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    const CUBE_MATERIAL: &[&str] = &["data", "mnemonics", "settings.json"];
     let mut targets = Vec::new();
     if let Ok(entries) = std::fs::read_dir(root) {
         for entry in entries.flatten() {
-            let data = entry.path().join("data");
-            if data.is_dir() {
-                targets.push(data);
+            let net_dir = entry.path();
+            if !net_dir.is_dir() {
+                continue;
+            }
+            for name in CUBE_MATERIAL {
+                let p = net_dir.join(name);
+                if p.exists() {
+                    targets.push(p);
+                }
             }
         }
     }
@@ -1825,4 +1842,67 @@ pub fn create_app_with_remote_backend(
         cube_settings,
         connect_auth,
     ))
+}
+
+#[cfg(test)]
+mod duress_wipe_target_tests {
+    use super::duress_wipe_targets;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+
+    fn touch(path: &std::path::Path) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, b"x").unwrap();
+    }
+
+    #[test]
+    fn wipes_all_cube_material_and_preserves_connect_auth() {
+        let seq = SEQ.fetch_add(1, Ordering::SeqCst);
+        let root = std::env::temp_dir().join(format!(
+            "coincube-wipe-targets-{}-{}",
+            std::process::id(),
+            seq
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+
+        let net = root.join("bitcoin");
+        touch(&net.join("data").join("cube_a").join("wallet.db"));
+        touch(&net.join("mnemonics").join("aabbccdd-master"));
+        touch(&net.join("settings.json"));
+        touch(&net.join("connect.json"));
+        // A second network is covered too.
+        touch(&root.join("testnet").join("mnemonics").join("seed"));
+        // bitcoind (root-level, not a network dir) carries no cube material.
+        touch(&root.join("bitcoind").join("blocks").join("blk0.dat"));
+
+        let targets = duress_wipe_targets(&root);
+
+        assert!(targets.contains(&net.join("data")), "data/ must be wiped");
+        assert!(
+            targets.contains(&net.join("mnemonics")),
+            "mnemonics/ (seeds) must be wiped"
+        );
+        assert!(
+            targets.contains(&net.join("settings.json")),
+            "settings.json (PIN hashes) must be wiped"
+        );
+        assert!(
+            targets.contains(&root.join("testnet").join("mnemonics")),
+            "every network's seeds must be wiped"
+        );
+        // Cached Connect auth and the bitcoind blockchain are preserved.
+        assert!(
+            !targets.iter().any(|t| t.ends_with("connect.json")),
+            "connect.json (cached auth) must survive"
+        );
+        assert!(
+            !targets.iter().any(|t| t.starts_with(root.join("bitcoind"))),
+            "bitcoind blockchain must not be wiped"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
 }

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use iced::{Subscription, Task};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 extern crate serde;
 extern crate serde_json;
 
@@ -123,49 +123,116 @@ fn duress_state_check_task(datadir: CoincubeDirectory, network: bitcoin::Network
     )
 }
 
-/// Performs the on-device duress wipe and returns the cryptic screen to lock
-/// into. The wipe is the trust anchor (the plan's invariant): every byte of
-/// Cube data under `<root>/<network>/data` is obliterated atomically with
-/// respect to the wipe journal, and `DuressLocalState.active` is persisted so a
-/// relaunch routes straight back here. The duress stores at the data-dir root
-/// (`duress-state.json`, `duress-queue.json`, `duress.key`, the journal) are
-/// outside the wiped tree and survive by construction.
+/// Activates duress from the local PIN path and returns the cryptic screen to
+/// lock into. Follows the orchestrator's sacred ordering so the Connect account
+/// lock and offline retry are NOT bypassed on this — the primary — activation
+/// path:
+///
+///   1. journal marker (records the account id for relaunch completion),
+///   2. durable queue commit (Connect tiers) — the source of truth that the
+///      POST eventually fires, committed BEFORE the wipe,
+///   3. fire the unauthenticated `trigger-with-code` POST in the background,
+///   4. atomic wipe IN PARALLEL — never gated on the network,
+///   5. persist `active` for relaunch reconcile.
+///
+/// Sovereign devices (no `account_id`) skip steps 2–3 and wipe locally with no
+/// server signal. The duress stores at the data-dir root (`duress-state.json`,
+/// `duress-queue.json`, `duress.key`, the journal) are outside the wiped tree
+/// and survive by construction, so the queued code + key remain available for
+/// the POST (and the Phase 4 drain loop) after the wipe.
 fn activate_local_duress(
     datadir: CoincubeDirectory,
     network: bitcoin::Network,
 ) -> crate::app::view::duress::active_screen::DuressActiveScreen {
     use crate::app::view::duress::active_screen::DuressActiveScreen;
-    use crate::services::duress::{journal::WipeJournal, wipe::CubeWiper, DuressLocalState};
+    use crate::services::duress::{
+        cipher::DeviceKey, journal::WipeJournal, queue::DuressQueue, wipe::CubeWiper,
+        DuressLocalState, PendingActivation,
+    };
+    use std::time::Duration;
+    use tokio::runtime::Handle;
 
     let root = datadir.path().to_path_buf();
     let root = root.as_path();
+
+    // Load enrollment state up front: the encrypted duress code + Connect
+    // account id drive the server activation POST.
+    let mut st = DuressLocalState::load(root).unwrap_or_default();
+    let account_id = st.account_id.clone();
+    let encrypted_code = st.duress_code.clone();
+
+    // 1. Journal marker FIRST. The recorded account id lets the launch-time
+    //    reconcile finish an interrupted wipe.
     let journal = WipeJournal::new(root);
-    // Mark pending BEFORE enumeration so a crash mid-wipe is completed on the
-    // next launch. The account id is recorded by the orchestrator engine; the
-    // marker's existence is what drives completion.
-    if let Err(e) = journal.mark_pending_activation("") {
+    if let Err(e) = journal.mark_pending_activation(account_id.as_deref().unwrap_or("")) {
         error!("duress: failed to write wipe journal: {e}");
     }
 
+    // 2 + 3. Connect tiers: durably enqueue BEFORE the wipe, then fire the POST
+    //    in the background, in parallel with the wipe.
+    let queue = DuressQueue::new(root);
+    if let (Some(acct), Some(enc)) = (account_id.as_ref(), encrypted_code.as_ref()) {
+        if let Err(e) = queue.enqueue(PendingActivation {
+            account_id: acct.clone(),
+            // Stored encrypted, as everywhere else; the POST decrypts in-flight.
+            duress_code: enc.clone(),
+            enqueued_at: chrono::Utc::now(),
+            attempts: 0,
+        }) {
+            error!("duress: failed to enqueue activation: {e}");
+        }
+
+        let root_buf = root.to_path_buf();
+        let acct = acct.clone();
+        let enc = enc.clone();
+        let post = async move {
+            let code = match DeviceKey::load_or_create(&root_buf).and_then(|k| {
+                k.decrypt(&enc)
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+            }) {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!("duress: cannot recover code for activation POST: {e}");
+                    return;
+                }
+            };
+            let client = crate::services::coincube::CoincubeClient::new();
+            let result = tokio::time::timeout(
+                Duration::from_secs(5),
+                client.trigger_duress_with_code(&acct, &code),
+            )
+            .await;
+            if let Ok(Ok(_)) = result {
+                let _ = DuressQueue::new(&root_buf).dequeue(&acct);
+            }
+            // else: leave in queue; the Phase 4 drain loop retries on next
+            // online launch.
+        };
+        match Handle::try_current() {
+            Ok(handle) => {
+                handle.spawn(post);
+            }
+            // No async runtime in this context — the durable queue entry
+            // remains and the drain loop fires it on next launch.
+            Err(_) => warn!("duress: no runtime for immediate activation POST; queued for drain"),
+        }
+    }
+
+    // 4. Wipe (anchor) — runs in parallel with the POST above.
     let targets = vec![root.join(network.to_string()).join("data")];
-    let wiper = CubeWiper::new(targets, journal);
-    if let Err(e) = wiper.execute_atomic() {
+    if let Err(e) = CubeWiper::new(targets, journal).execute_atomic() {
         error!("duress: wipe error (continuing to cryptic screen): {e}");
     }
 
-    // Persist active state so launch-time reconcile re-enters the cryptic
-    // screen. Load-or-default tolerates a never-enrolled sovereign device.
-    let mut st = DuressLocalState::load(root).unwrap_or_default();
+    // 5. Persist active state so launch-time reconcile re-enters the cryptic
+    //    screen.
     st.active = true;
     st.last_activation_attempt = Some(chrono::Utc::now());
     if let Err(e) = st.save(root) {
         error!("duress: failed to persist active state: {e}");
     }
 
-    let queue_pending = crate::services::duress::queue::DuressQueue::new(root)
-        .is_empty()
-        .map(|empty| !empty)
-        .unwrap_or(false);
+    let queue_pending = queue.is_empty().map(|empty| !empty).unwrap_or(false);
     let mut screen = DuressActiveScreen::with_context(datadir.clone(), Some(network));
     screen.queue_pending = queue_pending;
     screen

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -47,9 +47,80 @@ impl State {
         directory: CoincubeDirectory,
         network: Option<bitcoin::Network>,
     ) -> (Self, Task<Message>) {
+        // Duress launch-time reconcile (Phase 5 Task 5.2, path 1). If this
+        // device is locked into duress — or a wipe was interrupted (journal
+        // marker present) — complete the wipe and route straight to the cryptic
+        // screen. The user clears from another trusted device; the Sign-in
+        // button here only confirms whether that has happened.
+        let root = directory.path().to_path_buf();
+        let st = crate::services::duress::DuressLocalState::load(&root).unwrap_or_default();
+        let journal = crate::services::duress::journal::WipeJournal::new(&root);
+        if st.active || journal.is_pending() {
+            complete_pending_wipe(&root, &journal);
+            let queue_pending = crate::services::duress::queue::DuressQueue::new(&root)
+                .is_empty()
+                .map(|empty| !empty)
+                .unwrap_or(false);
+            let mut screen =
+                crate::app::view::duress::active_screen::DuressActiveScreen::with_context(
+                    directory, network,
+                );
+            screen.queue_pending = queue_pending;
+            return (State::DuressActive(screen), Task::none());
+        }
+
         let (home, command) = Home::new(directory, network);
         (State::Home(home), command.map(Message::Launch))
     }
+}
+
+/// Completes an interrupted duress wipe on launch. Targets the `data` subdir of
+/// every per-network directory under the data root, so a multi-network device
+/// is fully scrubbed regardless of which Cube's PIN triggered duress. No-op
+/// when the journal marker is absent (wipe already finished cleanly).
+fn complete_pending_wipe(
+    root: &std::path::Path,
+    journal: &crate::services::duress::journal::WipeJournal,
+) {
+    use crate::services::duress::wipe::CubeWiper;
+    if !journal.is_pending() {
+        return;
+    }
+    let mut targets = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let data = entry.path().join("data");
+            if data.is_dir() {
+                targets.push(data);
+            }
+        }
+    }
+    let wiper = CubeWiper::new(targets, journal.clone());
+    if let Err(e) = wiper.complete_if_pending() {
+        error!("duress: failed to complete interrupted wipe on launch: {e}");
+    }
+}
+
+/// Builds an authenticated `get_duress_state` check from the Connect auth
+/// cached at `<network>/connect.json` (preserved through the wipe). Returns a
+/// task whose message is `Some(active)` on a successful check, or `None` when
+/// the cache/token/network is unavailable or the request fails — `None` is
+/// treated as "still locked" so a failed check never opens a sign-in form.
+fn duress_state_check_task(datadir: CoincubeDirectory, network: bitcoin::Network) -> Task<Message> {
+    use crate::app::view::duress::active_screen::Message as DuressMsg;
+    Task::perform(
+        async move {
+            let network_dir = datadir.network_directory(network);
+            let cache =
+                crate::services::connect::client::cache::ConnectCache::from_file(&network_dir)
+                    .ok()?;
+            let account = cache.accounts.into_iter().next()?;
+            let mut client = crate::services::coincube::CoincubeClient::new();
+            client.set_token(&account.tokens.access_token);
+            client.get_duress_state().await.ok().map(|s| s.active)
+        },
+        |active: Option<bool>| Message::Duress(DuressMsg::StateChecked(active)),
+    )
 }
 
 /// Performs the on-device duress wipe and returns the cryptic screen to lock
@@ -60,12 +131,14 @@ impl State {
 /// (`duress-state.json`, `duress-queue.json`, `duress.key`, the journal) are
 /// outside the wiped tree and survive by construction.
 fn activate_local_duress(
-    root: &std::path::Path,
+    datadir: CoincubeDirectory,
     network: bitcoin::Network,
 ) -> crate::app::view::duress::active_screen::DuressActiveScreen {
     use crate::app::view::duress::active_screen::DuressActiveScreen;
     use crate::services::duress::{journal::WipeJournal, wipe::CubeWiper, DuressLocalState};
 
+    let root = datadir.path().to_path_buf();
+    let root = root.as_path();
     let journal = WipeJournal::new(root);
     // Mark pending BEFORE enumeration so a crash mid-wipe is completed on the
     // next launch. The account id is recorded by the orchestrator engine; the
@@ -89,11 +162,12 @@ fn activate_local_duress(
         error!("duress: failed to persist active state: {e}");
     }
 
-    let mut screen = DuressActiveScreen::new();
-    screen.queue_pending = crate::services::duress::queue::DuressQueue::new(root)
+    let queue_pending = crate::services::duress::queue::DuressQueue::new(root)
         .is_empty()
         .map(|empty| !empty)
         .unwrap_or(false);
+    let mut screen = DuressActiveScreen::with_context(datadir.clone(), Some(network));
+    screen.queue_pending = queue_pending;
     screen
 }
 
@@ -1065,7 +1139,7 @@ impl Tab {
                             datadir.clone()
                         }
                     };
-                    let screen = activate_local_duress(datadir.path(), network);
+                    let screen = activate_local_duress(datadir, network);
                     self.state = State::DuressActive(screen);
                     Task::none()
                 }
@@ -1073,12 +1147,56 @@ impl Tab {
             },
             (State::DuressActive(screen), Message::Duress(msg)) => match msg {
                 crate::app::view::duress::active_screen::Message::SignInPressed => {
-                    // Phase 5 turns this into a `get_duress_state` check that
-                    // either stays (active) or exits (cleared). Until then,
-                    // staying on the cryptic screen is the safe default: never
-                    // show a credential prompt while duress may still be active.
-                    screen.error = Some("Duress mode is active. Try again later.".to_string());
-                    Task::none()
+                    // Gated entirely on server-side duress state. Read cached
+                    // Connect auth (preserved through the wipe) and check
+                    // get_duress_state BEFORE rendering any sign-in surface. No
+                    // credential prompt ever appears here.
+                    match (screen.datadir().cloned(), screen.network()) {
+                        (Some(datadir), Some(network)) => {
+                            screen.checking = true;
+                            screen.error = None;
+                            duress_state_check_task(datadir, network)
+                        }
+                        _ => {
+                            // No way to reach the server (no network resolved) —
+                            // safe default is to stay locked.
+                            screen.error =
+                                Some("Duress mode is active. Try again later.".to_string());
+                            Task::none()
+                        }
+                    }
+                }
+                crate::app::view::duress::active_screen::Message::StateChecked(active) => {
+                    match active {
+                        Some(false) => {
+                            // Server reports duress cleared from another device.
+                            // Update local state and exit into the normal flow.
+                            if let Some(datadir) = screen.datadir().cloned() {
+                                let root = datadir.path();
+                                let mut st = crate::services::duress::DuressLocalState::load(root)
+                                    .unwrap_or_default();
+                                st.active = false;
+                                st.unlock_at = None;
+                                if let Err(e) = st.save(root) {
+                                    error!("duress: failed to clear local state: {e}");
+                                }
+                                let network = screen.network();
+                                let (home, command) = Home::new(datadir, network);
+                                self.state = State::Home(home);
+                                return command.map(Message::Launch);
+                            }
+                            screen.checking = false;
+                            Task::none()
+                        }
+                        // Still active, or the check failed/was unreachable —
+                        // never reveal more than the cryptic message already does.
+                        _ => {
+                            screen.checking = false;
+                            screen.error =
+                                Some("Duress mode is active. Try again later.".to_string());
+                            Task::none()
+                        }
+                    }
                 }
             },
             (

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -36,6 +36,10 @@ pub enum State {
     Login(login::CoincubeLiteLogin),
     PinEntry(crate::pin_entry::PinEntry),
     App(App),
+    /// Cryptic "Duress Mode Activated" dead-end. Entered when a duress PIN is
+    /// detected at Cube unlock (after the wipe runs); the device is effectively
+    /// retired until duress clears server-side.
+    DuressActive(crate::app::view::duress::active_screen::DuressActiveScreen),
 }
 
 impl State {
@@ -48,6 +52,51 @@ impl State {
     }
 }
 
+/// Performs the on-device duress wipe and returns the cryptic screen to lock
+/// into. The wipe is the trust anchor (the plan's invariant): every byte of
+/// Cube data under `<root>/<network>/data` is obliterated atomically with
+/// respect to the wipe journal, and `DuressLocalState.active` is persisted so a
+/// relaunch routes straight back here. The duress stores at the data-dir root
+/// (`duress-state.json`, `duress-queue.json`, `duress.key`, the journal) are
+/// outside the wiped tree and survive by construction.
+fn activate_local_duress(
+    root: &std::path::Path,
+    network: bitcoin::Network,
+) -> crate::app::view::duress::active_screen::DuressActiveScreen {
+    use crate::app::view::duress::active_screen::DuressActiveScreen;
+    use crate::services::duress::{journal::WipeJournal, wipe::CubeWiper, DuressLocalState};
+
+    let journal = WipeJournal::new(root);
+    // Mark pending BEFORE enumeration so a crash mid-wipe is completed on the
+    // next launch. The account id is recorded by the orchestrator engine; the
+    // marker's existence is what drives completion.
+    if let Err(e) = journal.mark_pending_activation("") {
+        error!("duress: failed to write wipe journal: {e}");
+    }
+
+    let targets = vec![root.join(network.to_string()).join("data")];
+    let wiper = CubeWiper::new(targets, journal);
+    if let Err(e) = wiper.execute_atomic() {
+        error!("duress: wipe error (continuing to cryptic screen): {e}");
+    }
+
+    // Persist active state so launch-time reconcile re-enters the cryptic
+    // screen. Load-or-default tolerates a never-enrolled sovereign device.
+    let mut st = DuressLocalState::load(root).unwrap_or_default();
+    st.active = true;
+    st.last_activation_attempt = Some(chrono::Utc::now());
+    if let Err(e) = st.save(root) {
+        error!("duress: failed to persist active state: {e}");
+    }
+
+    let mut screen = DuressActiveScreen::new();
+    screen.queue_pending = crate::services::duress::queue::DuressQueue::new(root)
+        .is_empty()
+        .map(|empty| !empty)
+        .unwrap_or(false);
+    screen
+}
+
 #[derive(Debug)]
 pub enum Message {
     Launch(home::Message),
@@ -56,6 +105,8 @@ pub enum Message {
     Run(app::Message),
     Login(login::Message),
     PinEntry(crate::pin_entry::Message),
+    /// Messages from the cryptic "Duress Mode Activated" screen.
+    Duress(crate::app::view::duress::active_screen::Message),
     RemoteBackendBreezLoaded {
         wallet_settings: WalletSettings,
         backend_client: BackendWalletClient,
@@ -169,6 +220,7 @@ impl Tab {
             State::Login(_) => "Login",
             State::PinEntry(_) => "Enter PIN",
             State::App(a) => a.title(),
+            State::DuressActive(_) => "COINCUBE",
         }
     }
 
@@ -1000,7 +1052,34 @@ impl Tab {
                     self.state = State::Home(home);
                     command.map(Message::Launch)
                 }
+                crate::pin_entry::Message::DuressDetected => {
+                    // Duress PIN entered at Cube unlock. The on-device trust
+                    // anchor is the atomic local wipe — run it now, BEFORE
+                    // rendering anything, then lock into the cryptic screen.
+                    // (The activation POST/queue is driven by the duress
+                    // orchestrator engine; threading the Connect account context
+                    // into this surface so it can fire here is a follow-up.)
+                    let network = pin_entry.cube().network;
+                    let datadir = match &pin_entry.on_success {
+                        crate::pin_entry::PinEntrySuccess::LoadApp { datadir, .. } => {
+                            datadir.clone()
+                        }
+                    };
+                    let screen = activate_local_duress(datadir.path(), network);
+                    self.state = State::DuressActive(screen);
+                    Task::none()
+                }
                 m => pin_entry.update(m).map(Message::PinEntry),
+            },
+            (State::DuressActive(screen), Message::Duress(msg)) => match msg {
+                crate::app::view::duress::active_screen::Message::SignInPressed => {
+                    // Phase 5 turns this into a `get_duress_state` check that
+                    // either stays (active) or exits (cleared). Until then,
+                    // staying on the cryptic screen is the safe default: never
+                    // show a credential prompt while duress may still be active.
+                    screen.error = Some("Duress mode is active. Try again later.".to_string());
+                    Task::none()
+                }
             },
             (
                 _,
@@ -1138,6 +1217,7 @@ impl Tab {
             State::Home(v) => v.subscription().map(Message::Launch),
             State::Login(_) => Subscription::none(),
             State::PinEntry(_) => Subscription::none(),
+            State::DuressActive(_) => Subscription::none(),
         }
     }
 
@@ -1149,6 +1229,7 @@ impl Tab {
             State::Loader(v) => v.view().map(Message::Load),
             State::Login(v) => v.view().map(Message::Login),
             State::PinEntry(v) => v.view().map(Message::PinEntry),
+            State::DuressActive(v) => v.view().map(Message::Duress),
         }
     }
 
@@ -1160,6 +1241,7 @@ impl Tab {
             State::App(s) => s.stop(),
             State::Login(_) => {}
             State::PinEntry(_) => {}
+            State::DuressActive(_) => {}
         }
     }
 }

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -253,14 +253,32 @@ fn activate_local_duress(
     //    the first attempt is offline and the user never leaves this screen.
     let queue = DuressQueue::new(root);
     if let (Some(acct), Some(enc)) = (account_id.as_ref(), encrypted_code.as_ref()) {
-        if let Err(e) = queue.enqueue(PendingActivation {
+        let pending = PendingActivation {
             account_id: acct.clone(),
             // Stored encrypted, as everywhere else; the POST decrypts in-flight.
             duress_code: enc.clone(),
             enqueued_at: chrono::Utc::now(),
             attempts: 0,
-        }) {
-            error!("duress: failed to enqueue activation: {e}");
+        };
+        // This queue entry is the ONLY thing that drives the server-side lock —
+        // the drainer fires trigger-with-code from it and the launch reconcile
+        // re-drains it. A dropped enqueue means the account is never locked
+        // server-side, so retry the durable commit on a transient IO error.
+        // enqueue is atomic and idempotent per account (it replaces any existing
+        // entry), so retrying can't duplicate. We never gate the wipe/lock on
+        // this: the device locks into the cryptic screen regardless.
+        let mut enqueued = false;
+        for attempt in 1..=3 {
+            match queue.enqueue(pending.clone()) {
+                Ok(()) => {
+                    enqueued = true;
+                    break;
+                }
+                Err(e) => error!("duress: enqueue activation attempt {attempt}/3 failed: {e}"),
+            }
+        }
+        if !enqueued {
+            error!("duress: activation not durably queued; server-side lock may not fire");
         }
         spawn_duress_drainer(root);
     }

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -53,13 +53,22 @@ impl State {
         // screen. The user clears from another trusted device; the Sign-in
         // button here only confirms whether that has happened.
         let root = directory.path().to_path_buf();
-        let st = crate::services::duress::DuressLocalState::load(&root).unwrap_or_default();
+        // Fail CLOSED: if duress-state.json can't be read (parse/IO error, not a
+        // missing file — load() maps that to Ok(default)), assume the device may
+        // be locked rather than skipping the lock and opening the normal flow.
+        let active = match crate::services::duress::DuressLocalState::load(&root) {
+            Ok(st) => st.active,
+            Err(e) => {
+                error!("duress: reading duress state failed at launch; locking to be safe: {e}");
+                true
+            }
+        };
         let journal = crate::services::duress::journal::WipeJournal::new(&root);
         // Phase 4: resume draining any pending activation POSTs left by a prior
         // session (the durable queue survives restarts). Started here so an
         // offline-at-activation device eventually signals Connect.
         let drain = duress_drain_task(&root);
-        if st.active || journal.is_pending() {
+        if active || journal.is_pending() {
             complete_pending_wipe(&root, &journal);
             let queue_pending = crate::services::duress::queue::DuressQueue::new(&root)
                 .is_empty()
@@ -234,8 +243,20 @@ fn activate_local_duress(
     let root = root.as_path();
 
     // Load enrollment state up front: the encrypted duress code + Connect
-    // account id drive the server activation POST.
-    let mut st = DuressLocalState::load(root).unwrap_or_default();
+    // account id drive the server activation POST. A real read error (vs a
+    // missing file) is surfaced, not silently defaulted: it means the server
+    // POST can't be addressed, but we still wipe + lock locally — the local
+    // lock takes priority over preserving an already-unreadable file.
+    let mut st = match DuressLocalState::load(root) {
+        Ok(st) => st,
+        Err(e) => {
+            error!(
+                "duress: reading duress state failed during activation; the server lock \
+                 may be skipped, but wiping and locking locally anyway: {e}"
+            );
+            DuressLocalState::default()
+        }
+    };
     let account_id = st.account_id.clone();
     let encrypted_code = st.duress_code.clone();
 
@@ -1087,28 +1108,36 @@ impl Tab {
                         let datadir = app.datadir().clone();
                         let network = app.cache().network;
                         let root = datadir.path();
-                        let mut st = crate::services::duress::DuressLocalState::load(root)
-                            .unwrap_or_default();
-                        if !st.active {
-                            st.active = true;
-                            let mut saved = false;
-                            for attempt in 1..=3 {
-                                match st.save(root) {
-                                    Ok(()) => {
-                                        saved = true;
-                                        break;
+                        // Skip the persist on a real read error (vs a missing
+                        // file) rather than clobbering valid state with a default.
+                        // The UI still locks below; the cryptic screen's own
+                        // server poll re-syncs durability.
+                        match crate::services::duress::DuressLocalState::load(root) {
+                            Ok(mut st) if !st.active => {
+                                st.active = true;
+                                let mut saved = false;
+                                for attempt in 1..=3 {
+                                    match st.save(root) {
+                                        Ok(()) => {
+                                            saved = true;
+                                            break;
+                                        }
+                                        Err(e) => error!(
+                                            "duress: persist remote active state on UI lock \
+                                             attempt {attempt}/3 failed: {e}"
+                                        ),
                                     }
-                                    Err(e) => error!(
-                                        "duress: persist remote active state on UI lock \
-                                         attempt {attempt}/3 failed: {e}"
-                                    ),
+                                }
+                                if !saved {
+                                    error!(
+                                        "duress: remote active state not persisted; a relaunch \
+                                         may not stay locked"
+                                    );
                                 }
                             }
-                            if !saved {
-                                error!(
-                                    "duress: remote active state not persisted; a relaunch \
-                                     may not stay locked"
-                                );
+                            Ok(_) => {}
+                            Err(e) => {
+                                error!("duress: reading duress state failed; not overwriting: {e}")
                             }
                         }
                         let screen =
@@ -1375,12 +1404,20 @@ impl Tab {
                             // Update local state and exit into the normal flow.
                             if let Some(datadir) = screen.datadir().cloned() {
                                 let root = datadir.path();
-                                let mut st = crate::services::duress::DuressLocalState::load(root)
-                                    .unwrap_or_default();
-                                st.active = false;
-                                st.unlock_at = None;
-                                if let Err(e) = st.save(root) {
-                                    error!("duress: failed to clear local state: {e}");
+                                // Skip the write on a real read error rather than
+                                // clobbering valid state with a default; the next
+                                // poll re-clears once the file is readable again.
+                                match crate::services::duress::DuressLocalState::load(root) {
+                                    Ok(mut st) => {
+                                        st.active = false;
+                                        st.unlock_at = None;
+                                        if let Err(e) = st.save(root) {
+                                            error!("duress: failed to clear local state: {e}");
+                                        }
+                                    }
+                                    Err(e) => error!(
+                                        "duress: reading duress state failed; not overwriting: {e}"
+                                    ),
                                 }
                                 let network = screen.network();
                                 let (home, command) = Home::new(datadir, network);

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -993,6 +993,23 @@ impl Tab {
                     app::Message::View(app::view::Message::ToggleTheme) => {
                         Task::done(Message::ToggleTheme)
                     }
+                    app::Message::View(app::view::Message::DuressLockRemote) => {
+                        // Phase 7b: remote duress activation. Lock the running
+                        // app into the cryptic screen immediately — WITHOUT
+                        // wiping (remote activation can be accidental; only a
+                        // local duress PIN wipes). DuressLocalState.active was
+                        // already persisted by the App's gRPC handler, so a
+                        // relaunch stays locked too.
+                        let datadir = app.datadir().clone();
+                        let network = app.cache().network;
+                        let screen =
+                            crate::app::view::duress::active_screen::DuressActiveScreen::with_context(
+                                datadir,
+                                Some(network),
+                            );
+                        self.state = State::DuressActive(screen);
+                        Task::none()
+                    }
                     app::Message::View(app::view::Message::OpenConnectSignIn) => {
                         // Re-check this tab's ConnectAccountPanel against
                         // the keyring before deciding whether to bubble

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -1059,11 +1059,40 @@ impl Tab {
                         // Phase 7b: remote duress activation. Lock the running
                         // app into the cryptic screen immediately — WITHOUT
                         // wiping (remote activation can be accidental; only a
-                        // local duress PIN wipes). DuressLocalState.active was
-                        // already persisted by the App's gRPC handler, so a
-                        // relaunch stays locked too.
+                        // local duress PIN wipes). The App's gRPC handler already
+                        // attempts to persist DuressLocalState.active, but a
+                        // failed write there would let the relaunch reconcile
+                        // (which keys off st.active) drop back to the normal Home
+                        // flow with Cube data intact. So re-persist here as a
+                        // durable backstop tied to the UI lock, before showing
+                        // the cryptic screen.
                         let datadir = app.datadir().clone();
                         let network = app.cache().network;
+                        let root = datadir.path();
+                        let mut st = crate::services::duress::DuressLocalState::load(root)
+                            .unwrap_or_default();
+                        if !st.active {
+                            st.active = true;
+                            let mut saved = false;
+                            for attempt in 1..=3 {
+                                match st.save(root) {
+                                    Ok(()) => {
+                                        saved = true;
+                                        break;
+                                    }
+                                    Err(e) => error!(
+                                        "duress: persist remote active state on UI lock \
+                                         attempt {attempt}/3 failed: {e}"
+                                    ),
+                                }
+                            }
+                            if !saved {
+                                error!(
+                                    "duress: remote active state not persisted; a relaunch \
+                                     may not stay locked"
+                                );
+                            }
+                        }
                         let screen =
                             crate::app::view::duress::active_screen::DuressActiveScreen::with_context(
                                 datadir,

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -74,18 +74,13 @@ impl State {
     }
 }
 
-/// Completes an interrupted duress wipe on launch. Targets the `data` subdir of
-/// every per-network directory under the data root, so a multi-network device
-/// is fully scrubbed regardless of which Cube's PIN triggered duress. No-op
-/// when the journal marker is absent (wipe already finished cleanly).
-fn complete_pending_wipe(
-    root: &std::path::Path,
-    journal: &crate::services::duress::journal::WipeJournal,
-) {
-    use crate::services::duress::wipe::CubeWiper;
-    if !journal.is_pending() {
-        return;
-    }
+/// The set of Cube-data directories a duress wipe must obliterate: the `data`
+/// subdir of EVERY per-network directory under the data root. A duress wipe
+/// takes every Cube on the device regardless of which network's Cube triggered
+/// it, so activation and the launch-time reconcile must agree on this set —
+/// otherwise a PIN unlock on one network would leave other networks' Cube data
+/// on disk.
+fn duress_wipe_targets(root: &std::path::Path) -> Vec<std::path::PathBuf> {
     let mut targets = Vec::new();
     if let Ok(entries) = std::fs::read_dir(root) {
         for entry in entries.flatten() {
@@ -95,7 +90,20 @@ fn complete_pending_wipe(
             }
         }
     }
-    let wiper = CubeWiper::new(targets, journal.clone());
+    targets
+}
+
+/// Completes an interrupted duress wipe on launch. No-op when the journal
+/// marker is absent (wipe already finished cleanly).
+fn complete_pending_wipe(
+    root: &std::path::Path,
+    journal: &crate::services::duress::journal::WipeJournal,
+) {
+    use crate::services::duress::wipe::CubeWiper;
+    if !journal.is_pending() {
+        return;
+    }
+    let wiper = CubeWiper::new(duress_wipe_targets(root), journal.clone());
     if let Err(e) = wiper.complete_if_pending() {
         error!("duress: failed to complete interrupted wipe on launch: {e}");
     }
@@ -218,9 +226,10 @@ fn activate_local_duress(
         }
     }
 
-    // 4. Wipe (anchor) — runs in parallel with the POST above.
-    let targets = vec![root.join(network.to_string()).join("data")];
-    if let Err(e) = CubeWiper::new(targets, journal).execute_atomic() {
+    // 4. Wipe (anchor) — runs in parallel with the POST above. Targets EVERY
+    //    network's Cube data, matching the launch-time reconcile, so a PIN
+    //    unlock on one network can't leave another network's Cubes on disk.
+    if let Err(e) = CubeWiper::new(duress_wipe_targets(root), journal).execute_atomic() {
         error!("duress: wipe error (continuing to cryptic screen): {e}");
     }
 

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -55,6 +55,10 @@ impl State {
         let root = directory.path().to_path_buf();
         let st = crate::services::duress::DuressLocalState::load(&root).unwrap_or_default();
         let journal = crate::services::duress::journal::WipeJournal::new(&root);
+        // Phase 4: resume draining any pending activation POSTs left by a prior
+        // session (the durable queue survives restarts). Started here so an
+        // offline-at-activation device eventually signals Connect.
+        let drain = duress_drain_task(&root);
         if st.active || journal.is_pending() {
             complete_pending_wipe(&root, &journal);
             let queue_pending = crate::services::duress::queue::DuressQueue::new(&root)
@@ -66,11 +70,14 @@ impl State {
                     directory, network,
                 );
             screen.queue_pending = queue_pending;
-            return (State::DuressActive(screen), Task::none());
+            return (State::DuressActive(screen), drain);
         }
 
         let (home, command) = Home::new(directory, network);
-        (State::Home(home), command.map(Message::Launch))
+        (
+            State::Home(home),
+            Task::batch([command.map(Message::Launch), drain]),
+        )
     }
 }
 
@@ -126,6 +133,54 @@ fn complete_pending_wipe(
     }
 }
 
+/// Builds the Phase 4 activation-queue drainer, or `None` when there's nothing
+/// to drain (empty queue) or the device key can't be loaded. The drainer fires
+/// queued `trigger-with-code` POSTs and retries them with backoff until they
+/// land.
+fn build_duress_drainer(
+    root: &std::path::Path,
+) -> Option<crate::services::duress::drain::DuressDrainer> {
+    use crate::services::duress::{
+        cipher::DeviceKey, drain::DuressDrainer, orchestrator::DuressTrigger, queue::DuressQueue,
+    };
+    let queue = DuressQueue::new(root);
+    if queue.is_empty().unwrap_or(true) {
+        return None;
+    }
+    let cipher = DeviceKey::load_or_create(root).ok()?;
+    let client: std::sync::Arc<dyn DuressTrigger> =
+        std::sync::Arc::new(crate::services::coincube::CoincubeClient::new());
+    Some(DuressDrainer::new(queue, cipher, client))
+}
+
+/// Spawns the activation drainer as a fire-and-forget background task (used from
+/// the update context, which has a Tokio runtime). No-op if the queue is empty
+/// or no runtime is available — the launch-time `duress_drain_task` then picks
+/// it up.
+fn spawn_duress_drainer(root: &std::path::Path) {
+    let Some(drainer) = build_duress_drainer(root) else {
+        return;
+    };
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => {
+            handle.spawn(async move { drainer.run_until_empty().await });
+        }
+        Err(_) => warn!("duress: no runtime to drain activation queue now; queued for next launch"),
+    }
+}
+
+/// Launch-time drainer as an Iced `Task` (runs in Iced's executor, where
+/// `Handle::try_current` may not be available yet). Resumes any pending
+/// activation POSTs left by a prior session.
+fn duress_drain_task(root: &std::path::Path) -> Task<Message> {
+    match build_duress_drainer(root) {
+        Some(drainer) => Task::perform(async move { drainer.run_until_empty().await }, |()| {
+            Message::DuressDrainComplete
+        }),
+        None => Task::none(),
+    }
+}
+
 /// Builds an authenticated `get_duress_state` check from the Connect auth
 /// cached at `<network>/connect.json` (preserved through the wipe). Returns a
 /// task whose message is `Some(active)` on a successful check, or `None` when
@@ -171,11 +226,9 @@ fn activate_local_duress(
 ) -> crate::app::view::duress::active_screen::DuressActiveScreen {
     use crate::app::view::duress::active_screen::DuressActiveScreen;
     use crate::services::duress::{
-        cipher::DeviceKey, journal::WipeJournal, queue::DuressQueue, wipe::CubeWiper,
-        DuressLocalState, PendingActivation,
+        journal::WipeJournal, queue::DuressQueue, wipe::CubeWiper, DuressLocalState,
+        PendingActivation,
     };
-    use std::time::Duration;
-    use tokio::runtime::Handle;
 
     let root = datadir.path().to_path_buf();
     let root = root.as_path();
@@ -193,8 +246,11 @@ fn activate_local_duress(
         error!("duress: failed to write wipe journal: {e}");
     }
 
-    // 2 + 3. Connect tiers: durably enqueue BEFORE the wipe, then fire the POST
-    //    in the background, in parallel with the wipe.
+    // 2 + 3. Connect tiers: durably enqueue BEFORE the wipe, then start the
+    //    activation drainer in the background, in parallel with the wipe. The
+    //    drainer fires the POST immediately and KEEPS retrying with backoff
+    //    until it lands (Phase 4), so a coerced account is still locked even if
+    //    the first attempt is offline and the user never leaves this screen.
     let queue = DuressQueue::new(root);
     if let (Some(acct), Some(enc)) = (account_id.as_ref(), encrypted_code.as_ref()) {
         if let Err(e) = queue.enqueue(PendingActivation {
@@ -206,41 +262,7 @@ fn activate_local_duress(
         }) {
             error!("duress: failed to enqueue activation: {e}");
         }
-
-        let root_buf = root.to_path_buf();
-        let acct = acct.clone();
-        let enc = enc.clone();
-        let post = async move {
-            let code = match DeviceKey::load_or_create(&root_buf).and_then(|k| {
-                k.decrypt(&enc)
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
-            }) {
-                Ok(c) => c,
-                Err(e) => {
-                    warn!("duress: cannot recover code for activation POST: {e}");
-                    return;
-                }
-            };
-            let client = crate::services::coincube::CoincubeClient::new();
-            let result = tokio::time::timeout(
-                Duration::from_secs(5),
-                client.trigger_duress_with_code(&acct, &code),
-            )
-            .await;
-            if let Ok(Ok(_)) = result {
-                let _ = DuressQueue::new(&root_buf).dequeue(&acct);
-            }
-            // else: leave in queue; the Phase 4 drain loop retries on next
-            // online launch.
-        };
-        match Handle::try_current() {
-            Ok(handle) => {
-                handle.spawn(post);
-            }
-            // No async runtime in this context — the durable queue entry
-            // remains and the drain loop fires it on next launch.
-            Err(_) => warn!("duress: no runtime for immediate activation POST; queued for drain"),
-        }
+        spawn_duress_drainer(root);
     }
 
     // 4. Wipe (anchor) — runs in parallel with the POST above. Targets EVERY
@@ -274,6 +296,9 @@ pub enum Message {
     PinEntry(crate::pin_entry::Message),
     /// Messages from the cryptic "Duress Mode Activated" screen.
     Duress(crate::app::view::duress::active_screen::Message),
+    /// The background activation-queue drainer finished (queue emptied). No-op
+    /// at the UI level — the drainer did its work as a side effect.
+    DuressDrainComplete,
     RemoteBackendBreezLoaded {
         wallet_settings: WalletSettings,
         backend_client: BackendWalletClient,

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1481,7 +1481,18 @@ impl Home {
                         duress_code,
                         account_id,
                     ),
-                    |_| Message::View(ViewMessage::Check),
+                    |res| match res {
+                        Ok(()) => Message::View(ViewMessage::Check),
+                        Err(e) => {
+                            log::error!("duress: failed to persist enrollment: {e}");
+                            // Surface via the Connect panel's error display.
+                            Message::View(ViewMessage::ConnectAccount(
+                                ConnectAccountMessage::Error(format!(
+                                    "Couldn't finish enabling duress mode: {e}. Please try again."
+                                )),
+                            ))
+                        }
+                    },
                 )
             }
             Message::View(ViewMessage::ConnectAccount(msg)) => {

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1470,6 +1470,7 @@ impl Home {
                 let app::message::DuressEnrollmentPayload {
                     duress_pin,
                     duress_code,
+                    account_id,
                     ..
                 } = payload;
                 Task::perform(
@@ -1478,6 +1479,7 @@ impl Home {
                         self.network,
                         duress_pin,
                         duress_code,
+                        account_id,
                     ),
                     |_| Message::View(ViewMessage::Check),
                 )

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1468,6 +1468,7 @@ impl Home {
 
             Message::PersistDuressEnrollment(payload) => {
                 let app::message::DuressEnrollmentPayload {
+                    regular_pin,
                     duress_pin,
                     duress_code,
                     account_id,
@@ -1477,6 +1478,7 @@ impl Home {
                     app::persist_duress_enrollment(
                         self.datadir_path.clone(),
                         self.network,
+                        regular_pin,
                         duress_pin,
                         duress_code,
                         account_id,

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -2112,9 +2112,10 @@ fn home_sidebar<'a>(home: &'a Home) -> Element<'a, Message> {
             ("Contacts", ConnectSubMenu::Contacts),
             ("Plan & Billing", ConnectSubMenu::PlanBilling),
             ("Security", ConnectSubMenu::Security),
-            // Duress is hidden until the backend endpoint (/connect/duress)
-            // is implemented — keep the ConnectSubMenu::Duress variant and
-            // duress_ux() so re-enabling is a one-line revert.
+            // Duress (Phase 9). The duress_ux() panel gates on the
+            // `duress_remote_lock` entitlement and shows an upgrade prompt for
+            // Free, so the entry is safe to show for any authenticated user.
+            ("Duress", ConnectSubMenu::Duress),
         ];
         for (label, sub) in items {
             let is_active = matches!(

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -27,7 +27,7 @@ use crate::{
         settings::{
             self,
             global::{AccountTier, GlobalSettings},
-            AuthConfig, CubeSettings, WalletSettings,
+            AuthConfig, CubeConnectState, CubeSettings, WalletSettings,
         },
         state::connect::ConnectAccountPanel,
         view::ConnectAccountMessage,
@@ -2382,29 +2382,33 @@ fn cubes_list_item<'a>(
     i: usize,
     signed_in: bool,
 ) -> Element<'a, ViewMessage> {
-    // Hover hint on the cloud icon explains the sync state. When the user
-    // is signed out, an unsynced Cube is local-only and the tooltip points
-    // them at sign-in; when signed in, an unsynced Cube is mid-sync (the
-    // catch-up sync registers it on reload) so the wording differs.
-    let (sync_icon, sync_hint): (Element<'a, ViewMessage>, &'static str) = if cube.remote_synced {
-        (
-            icon::cloud_check_icon().style(theme::text::success).into(),
-            "Synced to Connect and available on your other devices.",
-        )
-    } else if signed_in {
-        (
-            icon::cloud_slash_icon()
-                .style(theme::text::secondary)
-                .into(),
-            "Not yet synced to Connect. It will sync automatically in a moment.",
-        )
-    } else {
-        (
-            icon::cloud_slash_icon().style(theme::text::warning).into(),
-            "Saved on this device only. Sign in to Connect to sync this Cube to \
-             your other devices and the Keychain mobile app.",
-        )
-    };
+    // Single tri-state cube icon (Phase 1, duress mode): the Cube's
+    // relationship to Connect — Sovereign (outline) → Registered (filled,
+    // half-tone) → Backed up (filled, full colour) — so users can tell at a
+    // glance whether a Cube has a recovery kit before they're told what a
+    // duress wipe costs. The signed-in-but-not-yet-synced case keeps its
+    // distinct "mid-sync" wording (catch-up sync registers it on reload).
+    let (sync_icon, sync_hint): (Element<'a, ViewMessage>, &'static str) =
+        match cube.connect_state() {
+            CubeConnectState::BackedUp => (
+                icon::cube_icon().style(theme::text::success).into(),
+                "Backed up to Connect — recovery kit ready",
+            ),
+            CubeConnectState::Registered => (
+                icon::cube_icon().style(theme::text::secondary).into(),
+                "Registered to Connect — no recovery kit",
+            ),
+            CubeConnectState::Sovereign if signed_in => (
+                icon::cube_outline_icon()
+                    .style(theme::text::secondary)
+                    .into(),
+                "Not yet synced to Connect. It will sync automatically in a moment.",
+            ),
+            CubeConnectState::Sovereign => (
+                icon::cube_outline_icon().style(theme::text::warning).into(),
+                "Sovereign — local only",
+            ),
+        };
     let sync_indicator = iced_tooltip::Tooltip::new(
         sync_icon,
         Container::new(p2_regular(sync_hint))

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1466,6 +1466,22 @@ impl Home {
                 Task::none()
             }
 
+            Message::PersistDuressEnrollment(payload) => {
+                let app::message::DuressEnrollmentPayload {
+                    duress_pin,
+                    duress_code,
+                    ..
+                } = payload;
+                Task::perform(
+                    app::persist_duress_enrollment(
+                        self.datadir_path.clone(),
+                        self.network,
+                        duress_pin,
+                        duress_code,
+                    ),
+                    |_| Message::View(ViewMessage::Check),
+                )
+            }
             Message::View(ViewMessage::ConnectAccount(msg)) => {
                 let was_authenticated = self.connect_account.is_authenticated();
                 let task = map_connect_task(self.connect_account.update_message(msg));
@@ -2722,6 +2738,11 @@ fn map_connect_task(task: Task<app::message::Message>) -> Task<Message> {
         app::message::Message::View(app::view::Message::OpenUrl(url)) => {
             Message::View(ViewMessage::OpenUrl(url))
         }
+        // Duress enrollment persistence (Phases 2 & 8): relay to Home, which
+        // has the datadir + Cube settings to actually write it.
+        app::message::Message::CompleteDuressEnrollment(payload) => {
+            Message::PersistDuressEnrollment(payload)
+        }
         _ => {
             log::warn!("[LAUNCHER] Unexpected message from ConnectAccountPanel");
             Message::View(ViewMessage::Check)
@@ -2753,6 +2774,11 @@ pub enum Message {
     ),
     StartRecovery,
     CubeCreated(Result<CubeSettings, String>),
+    /// Relay of `app::Message::CompleteDuressEnrollment` from the Connect panel
+    /// hosted here. Home owns the datadir + Cube settings, so it persists the
+    /// duress PIN + device code (the panel itself can't). Without this the
+    /// enrollment would be silently dropped by `map_connect_task`.
+    PersistDuressEnrollment(app::message::DuressEnrollmentPayload),
     /// Window ID extracted for passkey webview.
     PasskeyWindowId(iced_wry::ExtractedWindowId),
     /// Passkey webview manager update.

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1477,7 +1477,6 @@ impl Home {
                 Task::perform(
                     app::persist_duress_enrollment(
                         self.datadir_path.clone(),
-                        self.network,
                         regular_pin,
                         duress_pin,
                         duress_code,

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1467,6 +1467,14 @@ impl Home {
             }
 
             Message::PersistDuressEnrollment(payload) => {
+                // Drop a completion that outlived its Connect session: a logout
+                // or session reset bumps `session_generation`, and persisting
+                // now would arm the duress PIN + DuressLocalState for an account
+                // the user is no longer signed into.
+                if payload.gen != self.connect_account.session_generation() {
+                    log::warn!("duress: ignoring enrollment completion from a stale session");
+                    return Task::none();
+                }
                 let app::message::DuressEnrollmentPayload {
                     regular_pin,
                     duress_pin,

--- a/coincube-gui/src/installer/step/recovery_kit_restore.rs
+++ b/coincube-gui/src/installer/step/recovery_kit_restore.rs
@@ -648,9 +648,26 @@ impl Step for RecoveryKitRestoreStep {
                             });
                             self.error = Some(e.to_string());
                         } else {
-                            self.set_phase(Phase::Error {
-                                message: e.to_string(),
-                            });
+                            // Approach C (Phase 7): a 423 from the download is a
+                            // terminal, plausibly-deniable cue — not a password
+                            // retry. DURESS_LOCKED acknowledges the activation
+                            // landed; TRUSTED_DEVICE_DELAY shows the wait time.
+                            let message = match &e {
+                                RestoreError::DuressLocked { .. } => e.to_string(),
+                                RestoreError::TrustedDeviceDelay { available_at } => {
+                                    match available_at {
+                                        Some(at) => format!(
+                                            "Recovery kit download is delayed on new devices. \
+                                             Available at {}.",
+                                            at.with_timezone(&chrono::Local)
+                                                .format("%b %d, %Y %H:%M %Z")
+                                        ),
+                                        None => e.to_string(),
+                                    }
+                                }
+                                _ => e.to_string(),
+                            };
+                            self.set_phase(Phase::Error { message });
                         }
                         Task::none()
                     }

--- a/coincube-gui/src/installer/step/recovery_kit_restore.rs
+++ b/coincube-gui/src/installer/step/recovery_kit_restore.rs
@@ -653,18 +653,16 @@ impl Step for RecoveryKitRestoreStep {
                             // retry. DURESS_LOCKED acknowledges the activation
                             // landed; TRUSTED_DEVICE_DELAY shows the wait time.
                             let message = match &e {
-                                RestoreError::DuressLocked { .. } => e.to_string(),
-                                RestoreError::TrustedDeviceDelay { available_at } => {
-                                    match available_at {
-                                        Some(at) => format!(
-                                            "Recovery kit download is delayed on new devices. \
-                                             Available at {}.",
-                                            at.with_timezone(&chrono::Local)
-                                                .format("%b %d, %Y %H:%M %Z")
-                                        ),
-                                        None => e.to_string(),
-                                    }
-                                }
+                                RestoreError::TrustedDeviceDelay {
+                                    available_at: Some(at),
+                                } => format!(
+                                    "Recovery kit download is delayed on new devices. \
+                                     Available at {}.",
+                                    at.with_timezone(&chrono::Local)
+                                        .format("%b %d, %Y %H:%M %Z")
+                                ),
+                                // DURESS_LOCKED and a timeless delay use the
+                                // typed Display message.
                                 _ => e.to_string(),
                             };
                             self.set_phase(Phase::Error { message });

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -1461,6 +1461,7 @@ impl Launcher {
                 let app::message::DuressEnrollmentPayload {
                     duress_pin,
                     duress_code,
+                    account_id,
                     ..
                 } = payload;
                 return Task::perform(
@@ -1469,6 +1470,7 @@ impl Launcher {
                         self.network,
                         duress_pin,
                         duress_code,
+                        account_id,
                     ),
                     |_| Message::View(ViewMessage::Check),
                 );

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -1472,7 +1472,18 @@ impl Launcher {
                         duress_code,
                         account_id,
                     ),
-                    |_| Message::View(ViewMessage::Check),
+                    |res| match res {
+                        Ok(()) => Message::View(ViewMessage::Check),
+                        Err(e) => {
+                            log::error!("duress: failed to persist enrollment: {e}");
+                            // Surface via the Connect panel's error display.
+                            Message::View(ViewMessage::ConnectAccount(
+                                ConnectAccountMessage::Error(format!(
+                                    "Couldn't finish enabling duress mode: {e}. Please try again."
+                                )),
+                            ))
+                        }
+                    },
                 );
             }
             Message::View(ViewMessage::ConnectAccount(msg)) => {

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -1457,6 +1457,22 @@ impl Launcher {
                 Task::none()
             }
 
+            Message::PersistDuressEnrollment(payload) => {
+                let app::message::DuressEnrollmentPayload {
+                    duress_pin,
+                    duress_code,
+                    ..
+                } = payload;
+                return Task::perform(
+                    app::persist_duress_enrollment(
+                        self.datadir_path.clone(),
+                        self.network,
+                        duress_pin,
+                        duress_code,
+                    ),
+                    |_| Message::View(ViewMessage::Check),
+                );
+            }
             Message::View(ViewMessage::ConnectAccount(msg)) => {
                 let was_authenticated = self.connect_account.is_authenticated();
                 let task = map_connect_task(self.connect_account.update_message(msg));
@@ -2621,6 +2637,11 @@ fn map_connect_task(task: Task<app::message::Message>) -> Task<Message> {
         app::message::Message::View(app::view::Message::OpenUrl(url)) => {
             Message::View(ViewMessage::OpenUrl(url))
         }
+        // Duress enrollment persistence (Phases 2 & 8): relay to the launcher,
+        // which has the datadir + Cube settings to actually write it.
+        app::message::Message::CompleteDuressEnrollment(payload) => {
+            Message::PersistDuressEnrollment(payload)
+        }
         _ => {
             log::warn!("[LAUNCHER] Unexpected message from ConnectAccountPanel");
             Message::View(ViewMessage::Check)
@@ -2648,6 +2669,11 @@ pub enum Message {
     ),
     StartRecovery,
     CubeCreated(Result<CubeSettings, String>),
+    /// Relay of `app::Message::CompleteDuressEnrollment` from the Connect panel
+    /// hosted here. The launcher owns the datadir + Cube settings, so it
+    /// persists the duress PIN + device code (the panel itself can't). Without
+    /// this the enrollment would be silently dropped by `map_connect_task`.
+    PersistDuressEnrollment(app::message::DuressEnrollmentPayload),
     /// Window ID extracted for passkey webview.
     PasskeyWindowId(iced_wry::ExtractedWindowId),
     /// Passkey webview manager update.

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -1458,6 +1458,14 @@ impl Launcher {
             }
 
             Message::PersistDuressEnrollment(payload) => {
+                // Drop a completion that outlived its Connect session: a logout
+                // or session reset bumps `session_generation`, and persisting
+                // now would arm the duress PIN + DuressLocalState for an account
+                // the user is no longer signed into.
+                if payload.gen != self.connect_account.session_generation() {
+                    log::warn!("duress: ignoring enrollment completion from a stale session");
+                    return Task::none();
+                }
                 let app::message::DuressEnrollmentPayload {
                     regular_pin,
                     duress_pin,

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -1459,6 +1459,7 @@ impl Launcher {
 
             Message::PersistDuressEnrollment(payload) => {
                 let app::message::DuressEnrollmentPayload {
+                    regular_pin,
                     duress_pin,
                     duress_code,
                     account_id,
@@ -1468,6 +1469,7 @@ impl Launcher {
                     app::persist_duress_enrollment(
                         self.datadir_path.clone(),
                         self.network,
+                        regular_pin,
                         duress_pin,
                         duress_code,
                         account_id,

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -1468,7 +1468,6 @@ impl Launcher {
                 return Task::perform(
                     app::persist_duress_enrollment(
                         self.datadir_path.clone(),
-                        self.network,
                         regular_pin,
                         duress_pin,
                         duress_code,

--- a/coincube-gui/src/pin_entry.rs
+++ b/coincube-gui/src/pin_entry.rs
@@ -43,6 +43,11 @@ pub enum Message {
     Submit,
     Back,
     PinVerified,
+    /// The submitted PIN matched this Cube's **duress** PIN. Bubbles up to the
+    /// tab state machine, which wipes Cube data and locks into the cryptic
+    /// "Duress Mode Activated" screen. The parent intercepts this; it is never
+    /// handled inside `PinEntry::update`.
+    DuressDetected,
 }
 
 impl PinEntry {
@@ -93,13 +98,23 @@ impl PinEntry {
                 if self.cube.verify_pin(&pin) {
                     self.loading = true;
                     Task::perform(async {}, |_| Message::PinVerified)
+                } else if self.cube.verify_duress_pin(&pin) {
+                    // Duress PIN match. Check regular FIRST (above) so the happy
+                    // path is never shadowed and the two argon2 verifies take
+                    // comparable time. Clear the buffer and bubble up — the
+                    // cryptic screen reveals the duress signal regardless, so a
+                    // fake-success delay buys nothing.
+                    self.pin_input.clear();
+                    Task::perform(async {}, |_| Message::DuressDetected)
                 } else {
                     self.error = Some("Incorrect PIN. Please try again.".to_string());
                     self.pin_input.clear();
                     Task::none()
                 }
             }
-            Message::Back | Message::PinVerified => Task::none(),
+            // `DuressDetected` is intercepted by the parent (tab state machine);
+            // if it ever reaches here it's a no-op.
+            Message::Back | Message::PinVerified | Message::DuressDetected => Task::none(),
         }
     }
 

--- a/coincube-gui/src/pin_entry.rs
+++ b/coincube-gui/src/pin_entry.rs
@@ -50,6 +50,13 @@ pub enum Message {
     DuressDetected,
 }
 
+/// Classification of a submitted PIN at Cube unlock.
+enum PinOutcome {
+    Unlock,
+    Duress,
+    Wrong,
+}
+
 impl PinEntry {
     pub fn new(cube: CubeSettings, on_success: PinEntrySuccess) -> Self {
         let loading_quote = quote_display::random_quote("loading");
@@ -95,21 +102,44 @@ impl PinEntry {
 
                 let pin = self.pin_input.value();
 
-                if self.cube.verify_pin(&pin) {
-                    self.loading = true;
-                    Task::perform(async {}, |_| Message::PinVerified)
+                // A Cube without a regular PIN has a permissive `verify_pin`
+                // (returns true for ANY input), which would swallow the duress
+                // PIN before `verify_duress_pin` ran. So when there's no regular
+                // PIN, check duress FIRST. When there IS a regular PIN, check it
+                // first (the happy path is never shadowed, and duress vs. wrong
+                // both take two argon2 verifies so they're timing-indistinct).
+                let outcome = if self.cube.has_pin() {
+                    if self.cube.verify_pin(&pin) {
+                        PinOutcome::Unlock
+                    } else if self.cube.verify_duress_pin(&pin) {
+                        PinOutcome::Duress
+                    } else {
+                        PinOutcome::Wrong
+                    }
                 } else if self.cube.verify_duress_pin(&pin) {
-                    // Duress PIN match. Check regular FIRST (above) so the happy
-                    // path is never shadowed and the two argon2 verifies take
-                    // comparable time. Clear the buffer and bubble up — the
-                    // cryptic screen reveals the duress signal regardless, so a
-                    // fake-success delay buys nothing.
-                    self.pin_input.clear();
-                    Task::perform(async {}, |_| Message::DuressDetected)
+                    PinOutcome::Duress
                 } else {
-                    self.error = Some("Incorrect PIN. Please try again.".to_string());
-                    self.pin_input.clear();
-                    Task::none()
+                    // No regular PIN → any non-duress input unlocks.
+                    PinOutcome::Unlock
+                };
+
+                match outcome {
+                    PinOutcome::Unlock => {
+                        self.loading = true;
+                        Task::perform(async {}, |_| Message::PinVerified)
+                    }
+                    PinOutcome::Duress => {
+                        // Clear the buffer and bubble up — the cryptic screen
+                        // reveals the duress signal regardless, so a fake-success
+                        // delay buys nothing.
+                        self.pin_input.clear();
+                        Task::perform(async {}, |_| Message::DuressDetected)
+                    }
+                    PinOutcome::Wrong => {
+                        self.error = Some("Incorrect PIN. Please try again.".to_string());
+                        self.pin_input.clear();
+                        Task::none()
+                    }
                 }
             }
             // `DuressDetected` is intercepted by the parent (tab state machine);

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -1132,6 +1132,152 @@ impl CoincubeClient {
     }
 }
 
+// =============================================================================
+// Duress (desktop) — Phase 0 client plumbing
+// =============================================================================
+//
+// See the DTO block in `mod.rs` for the trust-posture rationale behind these
+// shapes (per-device codes, hash-only on the wire, unauth `trigger-with-code`).
+
+impl CoincubeClient {
+    /// `POST /api/v1/connect/duress/enroll` (authenticated). The desktop has
+    /// already generated and hashed its own duress code; only the hash is in
+    /// `req`. Enables duress for the whole account.
+    pub async fn enroll_duress(
+        &self,
+        req: super::EnrollDuressRequest,
+    ) -> Result<(), CoincubeError> {
+        let url = format!("{}/api/v1/connect/duress/enroll", self.base_url);
+        let res = self.client.post(&url).json(&req).send().await?;
+        res.check_success().await?;
+        Ok(())
+    }
+
+    /// `POST /api/v1/connect/duress/register-device-code` (authenticated).
+    /// Called by a non-enrolling desktop on its first sign-in after the account
+    /// already has duress enrolled — it generates its own code, hashes it, and
+    /// registers the hash under its device fingerprint.
+    pub async fn register_device_duress_code(
+        &self,
+        device_fingerprint: &str,
+        duress_code_hash: &str,
+    ) -> Result<(), CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/duress/register-device-code",
+            self.base_url
+        );
+        let req = super::RegisterDeviceDuressCodeRequest {
+            device_fingerprint: device_fingerprint.to_string(),
+            duress_code_hash: duress_code_hash.to_string(),
+        };
+        let res = self.client.post(&url).json(&req).send().await?;
+        res.check_success().await?;
+        Ok(())
+    }
+
+    /// `POST /api/v1/connect/duress/trigger-with-code` (UNAUTHENTICATED).
+    ///
+    /// The desktop's primary activation path: the Cube-unlock surface may be
+    /// reached without a live Connect session, and we don't want activation to
+    /// depend on session validity at the moment of coercion. The server matches
+    /// the submitted code against all of the account's active per-device hashes.
+    pub async fn trigger_duress_with_code(
+        &self,
+        account_id: &str,
+        duress_code: &str,
+    ) -> Result<super::DuressUnlockAt, CoincubeError> {
+        let url = format!("{}/api/v1/connect/duress/trigger-with-code", self.base_url);
+        let req = super::TriggerWithCodeRequest {
+            account_id: account_id.to_string(),
+            duress_code: duress_code.to_string(),
+        };
+        let res = self.client.post(&url).json(&req).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<super::DuressUnlockAt> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// `POST /api/v1/connect/duress/trigger` (authenticated). Used by
+    /// activation paths where the user is already signed in (e.g. an in-app
+    /// "Activate Duress Mode" button), parallel to the Keychain fallback.
+    pub async fn trigger_duress_authed(&self) -> Result<super::DuressUnlockAt, CoincubeError> {
+        let url = format!("{}/api/v1/connect/duress/trigger", self.base_url);
+        let res = self.client.post(&url).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<super::DuressUnlockAt> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// `POST /api/v1/connect/duress/clear` (authenticated). Submits the
+    /// all-clear passphrase hash after the lockout window expires.
+    pub async fn clear_duress(&self, all_clear_passphrase_hash: &str) -> Result<(), CoincubeError> {
+        let url = format!("{}/api/v1/connect/duress/clear", self.base_url);
+        let req = super::ClearDuressRequest {
+            all_clear_passphrase_hash: all_clear_passphrase_hash.to_string(),
+        };
+        let res = self.client.post(&url).json(&req).send().await?;
+        res.check_success().await?;
+        Ok(())
+    }
+
+    /// `GET /api/v1/connect/duress` (authenticated). Returns the account's
+    /// duress state plus whether THIS device is already registered.
+    pub async fn get_duress_state(&self) -> Result<super::DuressState, CoincubeError> {
+        let url = format!("{}/api/v1/connect/duress", self.base_url);
+        let res = self.client.get(&url).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<super::DuressState> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// `GET /api/v1/cubes/{cube_id}/recovery-kit` (Approach C, dual-password).
+    ///
+    /// Distinct from [`get_recovery_kit`](Self::get_recovery_kit): the password
+    /// hash gates which envelope (regular vs. duress) the server returns, and a
+    /// duress password yields `423 DURESS_LOCKED` rather than a kit. The hash is
+    /// sent in the `X-CRK-Password-Hash` header rather than the query string so
+    /// it never lands in access logs.
+    ///
+    /// NOTE: the exact transport is pinned by Connect API Phase 4; the header
+    /// name here is provisional and revisited in Phase 7.
+    pub async fn download_recovery_kit(
+        &self,
+        cube_id: u64,
+        crk_password_hash: &str,
+    ) -> Result<RecoveryKit, super::DownloadError> {
+        use super::DownloadError;
+        let url = format!("{}/api/v1/cubes/{}/recovery-kit", self.base_url, cube_id);
+        let res = self
+            .client
+            .get(&url)
+            .header("X-CRK-Password-Hash", crk_password_hash)
+            .send()
+            .await
+            .map_err(|e| DownloadError::Other(e.into()))?;
+        let status = res.status();
+        if status.is_success() {
+            let resp: ApiResponse<RecoveryKit> = res
+                .json()
+                .await
+                .map_err(|e| DownloadError::Other(e.into()))?;
+            return Ok(resp.data);
+        }
+        match status.as_u16() {
+            423 => {
+                let body = res.text().await.unwrap_or_default();
+                Err(DownloadError::from_locked_body(&body))
+            }
+            400 | 401 | 403 | 404 | 422 => Err(DownloadError::Invalid),
+            other => Err(DownloadError::Other(CoincubeError::Unsuccessful(
+                crate::services::http::NotSuccessResponseInfo {
+                    status_code: other,
+                    text: res.text().await.unwrap_or_default(),
+                },
+            ))),
+        }
+    }
+}
+
 /// Parses a response's `Retry-After` header per RFC 7231 §7.1.3.
 ///
 /// Accepts both documented forms:
@@ -2455,5 +2601,292 @@ mod cube_member_tests {
             "expected 400 Unsuccessful; got {:?}",
             err
         );
+    }
+}
+
+#[cfg(test)]
+mod duress_tests {
+    use super::*;
+    use crate::services::coincube::{DownloadError, EnrollDuressRequest};
+    use httpmock::{Method as MockMethod, MockServer};
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn enroll_duress_200_ok() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::POST)
+                .path("/api/v1/connect/duress/enroll");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "success": true, "data": {} }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        client
+            .enroll_duress(EnrollDuressRequest {
+                all_clear_hash: "ac-hash".into(),
+                duress_crk_password_hash: Some("crk-hash".into()),
+                unlock_delay_minutes: 1440,
+                device_fingerprint: "fp-1".into(),
+                duress_code_hash: "code-hash".into(),
+            })
+            .await
+            .expect("enroll should succeed");
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn register_device_code_200_ok() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::POST)
+                .path("/api/v1/connect/duress/register-device-code");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "success": true, "data": {} }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        client
+            .register_device_duress_code("fp-2", "code-hash-2")
+            .await
+            .expect("register should succeed");
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn trigger_with_code_200_decodes_unlock_at() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::POST)
+                .path("/api/v1/connect/duress/trigger-with-code");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": { "unlockAt": "2026-06-09T12:00:00Z" }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let out = client
+            .trigger_duress_with_code("acct_1", "raw-code")
+            .await
+            .expect("trigger should succeed");
+        mock.assert();
+        assert_eq!(out.unlock_at.to_rfc3339(), "2026-06-09T12:00:00+00:00");
+    }
+
+    #[tokio::test]
+    async fn trigger_authed_200_decodes_unlock_at() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::POST)
+                .path("/api/v1/connect/duress/trigger");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": { "unlockAt": "2026-07-01T00:00:00Z" }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let out = client
+            .trigger_duress_authed()
+            .await
+            .expect("trigger should succeed");
+        mock.assert();
+        assert_eq!(out.unlock_at.to_rfc3339(), "2026-07-01T00:00:00+00:00");
+    }
+
+    #[tokio::test]
+    async fn clear_duress_200_ok() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::POST)
+                .path("/api/v1/connect/duress/clear");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "success": true, "data": {} }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        client
+            .clear_duress("ac-hash")
+            .await
+            .expect("clear should succeed");
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn get_duress_state_200_decodes() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET).path("/api/v1/connect/duress");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "active": true,
+                        "unlockAt": "2026-06-09T12:00:00Z",
+                        "enrolled": true,
+                        "thisDeviceRegistered": false
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let state = client
+            .get_duress_state()
+            .await
+            .expect("state should decode");
+        mock.assert();
+        assert!(state.active);
+        assert!(state.enrolled);
+        assert!(!state.this_device_registered);
+        assert!(state.unlock_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn get_duress_state_tolerates_missing_optionals() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(MockMethod::GET).path("/api/v1/connect/duress");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": { "active": false, "enrolled": false }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let state = client
+            .get_duress_state()
+            .await
+            .expect("state should decode");
+        assert!(!state.active);
+        assert!(!state.enrolled);
+        assert!(!state.this_device_registered);
+        assert!(state.unlock_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn download_kit_200_returns_kit() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/cubes/42/recovery-kit")
+                .header("X-CRK-Password-Hash", "regular-hash");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 1,
+                        "cubeId": 42,
+                        "encryptedCubeSeed": "seed-envelope",
+                        "encryptedWalletDescriptor": "",
+                        "encryptionScheme": "aes-256-gcm",
+                        "createdAt": "2026-04-23T00:00:00Z",
+                        "updatedAt": "2026-04-23T00:00:00Z"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let kit = client
+            .download_recovery_kit(42, "regular-hash")
+            .await
+            .expect("kit should download");
+        mock.assert();
+        assert_eq!(kit.cube_id, 42);
+        assert_eq!(kit.encrypted_cube_seed, "seed-envelope");
+    }
+
+    #[tokio::test]
+    async fn download_kit_423_duress_locked() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/cubes/42/recovery-kit");
+            then.status(423)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "error": {
+                        "code": "DURESS_LOCKED",
+                        "unlockAt": "2026-06-10T00:00:00Z"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .download_recovery_kit(42, "duress-hash")
+            .await
+            .expect_err("expected duress lock");
+        match err {
+            DownloadError::DuressLocked { unlock_at } => {
+                assert_eq!(
+                    unlock_at.expect("unlock_at present").to_rfc3339(),
+                    "2026-06-10T00:00:00+00:00"
+                );
+            }
+            other => panic!("expected DuressLocked, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn download_kit_423_trusted_device_delay() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/cubes/42/recovery-kit");
+            then.status(423)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "error": {
+                        "code": "TRUSTED_DEVICE_DELAY",
+                        "availableAt": "2026-06-11T00:00:00Z"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .download_recovery_kit(42, "regular-hash")
+            .await
+            .expect_err("expected trusted-device delay");
+        match err {
+            DownloadError::TrustedDeviceDelay { available_at } => {
+                assert_eq!(
+                    available_at.expect("available_at present").to_rfc3339(),
+                    "2026-06-11T00:00:00+00:00"
+                );
+            }
+            other => panic!("expected TrustedDeviceDelay, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn download_kit_403_is_invalid() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/cubes/42/recovery-kit");
+            then.status(403)
+                .header("content-type", "application/json")
+                .json_body(json!({ "error": { "code": "WRONG_PASSWORD" } }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .download_recovery_kit(42, "bad-hash")
+            .await
+            .expect_err("expected invalid");
+        assert!(matches!(err, DownloadError::Invalid), "got {:?}", err);
     }
 }

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -1347,6 +1347,167 @@ pub struct UpsertRecoveryKitRequest<'a> {
     pub encryption_scheme: &'a str,
 }
 
+// =============================================================================
+// Duress (desktop) — Phase 0 client plumbing
+// =============================================================================
+//
+// The desktop is the surface where duress *happens*. These DTOs back the
+// Connect REST client methods in `client.rs`. Trust-posture notes that bind
+// the shapes below:
+//
+//   * Every desktop generates its OWN ~128-bit duress code locally with a
+//     CSPRNG, argon2id-hashes it, and sends only the hash. The server stores
+//     N per-device hashes per account and never sees plaintext, so a DB breach
+//     reveals only argon2id hashes of 128-bit inputs (infeasible to brute
+//     force → no grief-triggering duress).
+//   * `trigger-with-code` is UNAUTHENTICATED on purpose: the Cube-unlock
+//     surface may be reached without a live Connect session, and even with one
+//     we don't want activation to depend on session validity at the moment of
+//     coercion.
+
+/// Body for `POST /api/v1/connect/duress/enroll` (authenticated).
+///
+/// The enrolling desktop has already generated its own duress code and
+/// argon2id-hashed it; only `duress_code_hash` crosses the wire. The raw code
+/// lives solely in this desktop's `DuressLocalState`. `duress_crk_password_hash`
+/// is `None` for Tier 2/3 (no CRK), `Some(..)` for Tier 1 (Approach C).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnrollDuressRequest {
+    pub all_clear_hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duress_crk_password_hash: Option<String>,
+    pub unlock_delay_minutes: u32,
+    pub device_fingerprint: String,
+    pub duress_code_hash: String,
+}
+
+/// Body for `POST /api/v1/connect/duress/register-device-code` (authenticated).
+/// Called by every desktop OTHER than the enrolling one, on its first sign-in
+/// after the account has duress enrolled.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegisterDeviceDuressCodeRequest {
+    pub device_fingerprint: String,
+    pub duress_code_hash: String,
+}
+
+/// Body for `POST /api/v1/connect/duress/trigger-with-code` (UNAUTHENTICATED).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TriggerWithCodeRequest {
+    pub account_id: String,
+    pub duress_code: String,
+}
+
+/// Body for `POST /api/v1/connect/duress/clear` (authenticated).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClearDuressRequest {
+    pub all_clear_passphrase_hash: String,
+}
+
+/// Returned by the trigger routes — the timestamp after which the account can
+/// be cleared with the all-clear passphrase (the lockout-window expiry).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DuressUnlockAt {
+    pub unlock_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// `GET /api/v1/connect/duress` (authenticated).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DuressState {
+    pub active: bool,
+    #[serde(default)]
+    pub unlock_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub enrolled: bool,
+    /// Whether THIS desktop (by device fingerprint) already has a code hash
+    /// registered server-side. `enrolled && !this_device_registered` means
+    /// "new device on an enrolled account" → generate + register a code.
+    #[serde(default)]
+    pub this_device_registered: bool,
+}
+
+/// Typed failure modes for the password-gated recovery-kit download
+/// (Approach C, Phase 7). The server returns `423 Locked` with a
+/// discriminating `error.code` for both the duress-lock and
+/// trusted-device-delay cases; everything else collapses to `Invalid`
+/// (wrong password / malformed) or `Other`.
+#[derive(Debug)]
+pub enum DownloadError {
+    /// `423 DURESS_LOCKED` — the account is in duress; the kit is withheld
+    /// until `unlock_at`.
+    DuressLocked {
+        unlock_at: Option<chrono::DateTime<chrono::Utc>>,
+    },
+    /// `423 TRUSTED_DEVICE_DELAY` — a fresh device must wait until
+    /// `available_at` even with the correct password.
+    TrustedDeviceDelay {
+        available_at: Option<chrono::DateTime<chrono::Utc>>,
+    },
+    /// Wrong password / malformed request (4xx other than 423).
+    Invalid,
+    /// Network, 5xx, or parse failure.
+    Other(CoincubeError),
+}
+
+impl std::fmt::Display for DownloadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DownloadError::DuressLocked { .. } => {
+                write!(f, "Recovery kit cannot be downloaded at this time.")
+            }
+            DownloadError::TrustedDeviceDelay { .. } => {
+                write!(f, "Recovery kit download is delayed on new devices.")
+            }
+            DownloadError::Invalid => write!(f, "Incorrect recovery kit password."),
+            DownloadError::Other(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for DownloadError {}
+
+/// `423 Locked` body shape, used to discriminate `DURESS_LOCKED` from
+/// `TRUSTED_DEVICE_DELAY`. Both timestamp fields are optional — the
+/// duress case carries `unlock_at`, the trusted-device case `available_at`.
+#[derive(Debug, Deserialize)]
+struct DuressLockEnvelope {
+    error: DuressLockBody,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DuressLockBody {
+    code: String,
+    #[serde(default)]
+    unlock_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(default)]
+    available_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl DownloadError {
+    /// Parses a `423 Locked` body into the discriminated variant. Falls back
+    /// to `DuressLocked { unlock_at: None }` when the body can't be parsed —
+    /// the safe default is to treat an opaque 423 as a duress lock rather than
+    /// leak the kit.
+    pub(crate) fn from_locked_body(body: &str) -> Self {
+        match serde_json::from_str::<DuressLockEnvelope>(body) {
+            Ok(env) if env.error.code == "TRUSTED_DEVICE_DELAY" => {
+                DownloadError::TrustedDeviceDelay {
+                    available_at: env.error.available_at,
+                }
+            }
+            Ok(env) => DownloadError::DuressLocked {
+                unlock_at: env.error.unlock_at,
+            },
+            Err(_) => DownloadError::DuressLocked { unlock_at: None },
+        }
+    }
+}
+
 #[cfg(test)]
 mod recovery_kit_response_tests {
     //! Regression tests for `RecoveryKit` deserialisation tolerance.

--- a/coincube-gui/src/services/connect/grpc/mod.rs
+++ b/coincube-gui/src/services/connect/grpc/mod.rs
@@ -20,6 +20,16 @@ pub enum ConnectStreamMessage {
     SessionEvent(connect_v1::SessionEvent),
     Disconnected(String),
     Error(String),
+    /// Duress was activated elsewhere (Keychain Settings, email-link, Approach
+    /// C, another desktop's PIN). Phase 7b: the receiving desktop locks into the
+    /// cryptic screen but does **NOT** wipe — remote activation can be
+    /// accidental, and wiping then would be too destructive.
+    DuressActivated {
+        unlock_at: Option<chrono::DateTime<chrono::Utc>>,
+        source: String,
+    },
+    /// Duress was cleared server-side — exit the cryptic screen.
+    DuressCleared,
 }
 
 #[derive(Debug)]

--- a/coincube-gui/src/services/connect/grpc/stream.rs
+++ b/coincube-gui/src/services/connect/grpc/stream.rs
@@ -145,6 +145,41 @@ pub fn connect_stream(
                                                     );
                                                 }
                                             }
+                                            Some(Body::DuressActivated(event)) => {
+                                                // Phase 7b: remote duress activation. Convert the
+                                                // protobuf timestamp and forward; the app locks the
+                                                // cryptic screen WITHOUT wiping.
+                                                let unlock_at =
+                                                    event.duress_unlock_at.and_then(|ts| {
+                                                        chrono::DateTime::from_timestamp(
+                                                            ts.seconds,
+                                                            ts.nanos as u32,
+                                                        )
+                                                    });
+                                                if let Err(e) = channel
+                                                    .send(ConnectStreamMessage::DuressActivated {
+                                                        unlock_at,
+                                                        source: event.source,
+                                                    })
+                                                    .await
+                                                {
+                                                    log::warn!(
+                                                        "[CONNECT GRPC] Failed to forward DuressActivated: {}",
+                                                        e
+                                                    );
+                                                }
+                                            }
+                                            Some(Body::DuressCleared(_)) => {
+                                                if let Err(e) = channel
+                                                    .send(ConnectStreamMessage::DuressCleared)
+                                                    .await
+                                                {
+                                                    log::warn!(
+                                                        "[CONNECT GRPC] Failed to forward DuressCleared: {}",
+                                                        e
+                                                    );
+                                                }
+                                            }
                                             _ => {}
                                         },
                                         Ok(None) => {

--- a/coincube-gui/src/services/duress/cipher.rs
+++ b/coincube-gui/src/services/duress/cipher.rs
@@ -1,0 +1,153 @@
+//! At-rest encryption for duress secrets (Phase 3).
+//!
+//! The duress code and any queued copy of it are encrypted at rest with a
+//! **device key that is separate from the Cube key** (trust-posture invariant:
+//! the wipe destroys Cube material, but the duress queue + code must survive it,
+//! so they cannot be protected by the Cube key). The device key lives in
+//! `duress.key` at the data-directory root — outside the `cubes/` tree, so it is
+//! never touched by [`wipe::CubeWiper`](super::wipe::CubeWiper).
+//!
+//! This is not a substitute for OS keychain storage; it raises the bar so a
+//! casual disk read doesn't reveal the raw duress code, while keeping the code
+//! recoverable across reboots without any Cube being unlocked.
+
+use base64::Engine;
+use chacha20poly1305::{aead::Aead, ChaCha20Poly1305, KeyInit, Nonce};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+/// Filename of the device key, relative to the data-directory root.
+pub const DEVICE_KEY_FILE: &str = "duress.key";
+
+const KEY_LEN: usize = 32;
+const NONCE_LEN: usize = 12;
+
+/// A persisted 32-byte device key used to encrypt duress secrets at rest.
+#[derive(Clone)]
+pub struct DeviceKey {
+    key: [u8; KEY_LEN],
+}
+
+impl DeviceKey {
+    /// Loads the device key from `coincube_dir/duress.key`, generating and
+    /// persisting a fresh CSPRNG key on first use. The key file is created with
+    /// `0o600` permissions on Unix.
+    pub fn load_or_create(coincube_dir: &Path) -> io::Result<Self> {
+        let path = Self::path(coincube_dir);
+        match std::fs::read(&path) {
+            Ok(bytes) if bytes.len() == KEY_LEN => {
+                let mut key = [0u8; KEY_LEN];
+                key.copy_from_slice(&bytes);
+                Ok(Self { key })
+            }
+            Ok(_) => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "duress.key has unexpected length",
+            )),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                let key: [u8; KEY_LEN] = rand::random();
+                write_key(&path, &key)?;
+                Ok(Self { key })
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Constructs a key from raw bytes (test helper / explicit injection).
+    pub fn from_bytes(key: [u8; KEY_LEN]) -> Self {
+        Self { key }
+    }
+
+    fn path(coincube_dir: &Path) -> PathBuf {
+        coincube_dir.join(DEVICE_KEY_FILE)
+    }
+
+    /// Encrypts a plaintext secret, returning `base64(nonce || ciphertext+tag)`.
+    pub fn encrypt(&self, plaintext: &str) -> Result<String, String> {
+        let cipher = ChaCha20Poly1305::new((&self.key).into());
+        let nonce_bytes: [u8; NONCE_LEN] = rand::random();
+        let nonce = Nonce::from(nonce_bytes);
+        let ciphertext = cipher
+            .encrypt(&nonce, plaintext.as_bytes())
+            .map_err(|e| format!("duress encrypt: {e}"))?;
+        let mut blob = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+        blob.extend_from_slice(&nonce_bytes);
+        blob.extend_from_slice(&ciphertext);
+        Ok(base64::engine::general_purpose::STANDARD.encode(blob))
+    }
+
+    /// Reverses [`encrypt`](Self::encrypt).
+    pub fn decrypt(&self, envelope_b64: &str) -> Result<String, String> {
+        let blob = base64::engine::general_purpose::STANDARD
+            .decode(envelope_b64)
+            .map_err(|e| format!("duress decrypt b64: {e}"))?;
+        if blob.len() < NONCE_LEN + 16 {
+            return Err("duress envelope too short".to_string());
+        }
+        let cipher = ChaCha20Poly1305::new((&self.key).into());
+        let nonce = Nonce::from_slice(&blob[..NONCE_LEN]);
+        let plaintext = cipher
+            .decrypt(nonce, &blob[NONCE_LEN..])
+            .map_err(|e| format!("duress decrypt: {e}"))?;
+        String::from_utf8(plaintext).map_err(|e| format!("duress decrypt utf8: {e}"))
+    }
+}
+
+fn write_key(path: &Path, key: &[u8; KEY_LEN]) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut f = std::fs::File::create(path)?;
+    f.write_all(key)?;
+    f.sync_all()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() {
+        let k = DeviceKey::from_bytes([7u8; KEY_LEN]);
+        let ct = k.encrypt("deadbeefcafebabe").unwrap();
+        assert_ne!(ct, "deadbeefcafebabe", "ciphertext must not be plaintext");
+        assert_eq!(k.decrypt(&ct).unwrap(), "deadbeefcafebabe");
+    }
+
+    #[test]
+    fn nonce_makes_ciphertext_unique() {
+        let k = DeviceKey::from_bytes([9u8; KEY_LEN]);
+        assert_ne!(k.encrypt("same").unwrap(), k.encrypt("same").unwrap());
+    }
+
+    #[test]
+    fn wrong_key_fails() {
+        let a = DeviceKey::from_bytes([1u8; KEY_LEN]);
+        let b = DeviceKey::from_bytes([2u8; KEY_LEN]);
+        let ct = a.encrypt("secret").unwrap();
+        assert!(b.decrypt(&ct).is_err());
+    }
+
+    #[test]
+    fn load_or_create_persists_and_reloads() {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-duress-key-{}-{:p}",
+            std::process::id(),
+            &0u8
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let k1 = DeviceKey::load_or_create(&dir).unwrap();
+        let ct = k1.encrypt("x").unwrap();
+        // Reload must read the same key and decrypt prior ciphertext.
+        let k2 = DeviceKey::load_or_create(&dir).unwrap();
+        assert_eq!(k2.decrypt(&ct).unwrap(), "x");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/coincube-gui/src/services/duress/drain.rs
+++ b/coincube-gui/src/services/duress/drain.rs
@@ -1,0 +1,242 @@
+//! Background retry-queue drain loop (Phase 4).
+//!
+//! On app launch and on a network-state-change-to-online, the drainer walks the
+//! durable [`DuressQueue`](super::queue::DuressQueue) and tries to land each
+//! pending activation `POST`. The queue was committed before the wipe, so this
+//! is what guarantees an offline-at-activation device eventually signals
+//! Connect — possibly days later, on the next online launch.
+//!
+//! Backoff between whole-queue passes: 5s → 30s → 5m → 30m → 1h, then 1h
+//! forever. Per-entry outcomes:
+//!   * success → dequeue,
+//!   * terminal (4xx≠429) → log + dequeue (the wipe already happened; we did
+//!     our best),
+//!   * retriable (429 / 5xx / network) → leave, bump `attempts`, retry next
+//!     pass.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::cipher::DeviceKey;
+use super::orchestrator::{DuressTrigger, TriggerError};
+use super::queue::DuressQueue;
+
+/// Backoff delay before the next whole-queue pass, given how many passes have
+/// already happened. Saturates at 1 hour.
+pub fn backoff_for_attempt(attempt: u32) -> Duration {
+    match attempt {
+        0 => Duration::from_secs(5),
+        1 => Duration::from_secs(30),
+        2 => Duration::from_secs(5 * 60),
+        3 => Duration::from_secs(30 * 60),
+        _ => Duration::from_secs(60 * 60),
+    }
+}
+
+/// Drives the retry queue toward empty. Cheap to clone (all fields are shared
+/// handles).
+#[derive(Clone)]
+pub struct DuressDrainer {
+    queue: DuressQueue,
+    cipher: DeviceKey,
+    client: Arc<dyn DuressTrigger>,
+}
+
+impl DuressDrainer {
+    pub fn new(queue: DuressQueue, cipher: DeviceKey, client: Arc<dyn DuressTrigger>) -> Self {
+        Self {
+            queue,
+            cipher,
+            client,
+        }
+    }
+
+    /// One pass over every queued entry. Returns the number of entries still
+    /// pending after the pass (0 means the queue drained).
+    ///
+    /// Each entry's stored code is the encrypted envelope; it's decrypted to a
+    /// short-lived plaintext only for the POST. A code that won't decrypt is
+    /// treated as terminal and dropped — we can never make that POST succeed.
+    pub async fn drain_once(&self) -> std::io::Result<usize> {
+        let entries = self.queue.entries()?;
+        for entry in entries {
+            let plaintext = match self.cipher.decrypt(&entry.duress_code) {
+                Ok(p) => p,
+                Err(_) => {
+                    // Undecryptable — abandon it.
+                    self.queue.dequeue(&entry.account_id)?;
+                    continue;
+                }
+            };
+            match self.client.trigger(&entry.account_id, &plaintext).await {
+                Ok(()) => {
+                    self.queue.dequeue(&entry.account_id)?;
+                }
+                Err(TriggerError::Terminal) => {
+                    // The wipe already happened; stop retrying a request the
+                    // server will never accept.
+                    self.queue.dequeue(&entry.account_id)?;
+                }
+                Err(TriggerError::Retriable) => {
+                    // Leave it; bump attempts so diagnostics can see progress.
+                    let mut all = self.queue.entries()?;
+                    if let Some(e) = all.iter_mut().find(|e| e.account_id == entry.account_id) {
+                        e.attempts = e.attempts.saturating_add(1);
+                    }
+                    self.queue.replace_all(&all)?;
+                }
+            }
+        }
+        Ok(self.queue.entries()?.len())
+    }
+
+    /// Runs passes with exponential backoff until the queue drains. The caller
+    /// spawns this on launch / online-transition; it exits once empty.
+    pub async fn run_until_empty(&self) {
+        let mut pass = 0u32;
+        loop {
+            match self.drain_once().await {
+                Ok(0) => return,
+                Ok(_) => {}
+                Err(e) => {
+                    log::warn!("duress drain pass failed: {e}");
+                }
+            }
+            tokio::time::sleep(backoff_for_attempt(pass)).await;
+            pass = pass.saturating_add(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::duress::{queue::DuressQueue, PendingActivation};
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    fn temp_dir() -> PathBuf {
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-duress-drain-{}-{}",
+            std::process::id(),
+            seq
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    struct ScriptedTrigger {
+        // account_id -> sequence of outcomes (popped front each call)
+        plan: Mutex<Vec<Result<(), TriggerError>>>,
+        calls: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl DuressTrigger for ScriptedTrigger {
+        async fn trigger(&self, account_id: &str, _code: &str) -> Result<(), TriggerError> {
+            self.calls.lock().unwrap().push(account_id.to_string());
+            let mut plan = self.plan.lock().unwrap();
+            if plan.is_empty() {
+                Ok(())
+            } else {
+                plan.remove(0)
+            }
+        }
+    }
+
+    fn enqueue(q: &DuressQueue, cipher: &DeviceKey, account: &str) {
+        q.enqueue(PendingActivation {
+            account_id: account.to_string(),
+            duress_code: cipher.encrypt("raw-code").unwrap(),
+            enqueued_at: Utc::now(),
+            attempts: 0,
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn backoff_schedule_matches_spec() {
+        assert_eq!(backoff_for_attempt(0), Duration::from_secs(5));
+        assert_eq!(backoff_for_attempt(1), Duration::from_secs(30));
+        assert_eq!(backoff_for_attempt(2), Duration::from_secs(300));
+        assert_eq!(backoff_for_attempt(3), Duration::from_secs(1800));
+        assert_eq!(backoff_for_attempt(4), Duration::from_secs(3600));
+        assert_eq!(backoff_for_attempt(99), Duration::from_secs(3600));
+    }
+
+    #[tokio::test]
+    async fn drain_once_success_empties_queue() {
+        let dir = temp_dir();
+        let cipher = DeviceKey::from_bytes([5u8; 32]);
+        let q = DuressQueue::new(&dir);
+        enqueue(&q, &cipher, "acct_1");
+        let client = Arc::new(ScriptedTrigger {
+            plan: Mutex::new(vec![Ok(())]),
+            calls: Mutex::new(vec![]),
+        });
+        let drainer = DuressDrainer::new(q.clone(), cipher, client);
+        assert_eq!(drainer.drain_once().await.unwrap(), 0);
+        assert!(q.is_empty().unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn retriable_keeps_entry_and_bumps_attempts() {
+        let dir = temp_dir();
+        let cipher = DeviceKey::from_bytes([6u8; 32]);
+        let q = DuressQueue::new(&dir);
+        enqueue(&q, &cipher, "acct_2");
+        let client = Arc::new(ScriptedTrigger {
+            plan: Mutex::new(vec![Err(TriggerError::Retriable)]),
+            calls: Mutex::new(vec![]),
+        });
+        let drainer = DuressDrainer::new(q.clone(), cipher, client);
+        assert_eq!(drainer.drain_once().await.unwrap(), 1);
+        let entries = q.entries().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].attempts, 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn terminal_drops_entry() {
+        let dir = temp_dir();
+        let cipher = DeviceKey::from_bytes([7u8; 32]);
+        let q = DuressQueue::new(&dir);
+        enqueue(&q, &cipher, "acct_3");
+        let client = Arc::new(ScriptedTrigger {
+            plan: Mutex::new(vec![Err(TriggerError::Terminal)]),
+            calls: Mutex::new(vec![]),
+        });
+        let drainer = DuressDrainer::new(q.clone(), cipher, client);
+        assert_eq!(drainer.drain_once().await.unwrap(), 0);
+        assert!(q.is_empty().unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn undecryptable_code_is_abandoned() {
+        let dir = temp_dir();
+        let real = DeviceKey::from_bytes([8u8; 32]);
+        let q = DuressQueue::new(&dir);
+        enqueue(&q, &real, "acct_4");
+        // Drainer holds a DIFFERENT key, so the stored code can't be decrypted.
+        let wrong = DeviceKey::from_bytes([99u8; 32]);
+        let client = Arc::new(ScriptedTrigger {
+            plan: Mutex::new(vec![]),
+            calls: Mutex::new(vec![]),
+        });
+        let drainer = DuressDrainer::new(q.clone(), wrong, client.clone());
+        assert_eq!(drainer.drain_once().await.unwrap(), 0);
+        assert!(q.is_empty().unwrap());
+        // The POST was never attempted.
+        assert!(client.calls.lock().unwrap().is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/coincube-gui/src/services/duress/enroll.rs
+++ b/coincube-gui/src/services/duress/enroll.rs
@@ -1,0 +1,362 @@
+//! Duress enrollment — credential validation and secret generation (Phase 2).
+//!
+//! These are the pure, testable rules behind the enrollment wizard:
+//!
+//!   * the duress PIN must be meaningfully distinct from the regular PIN so it
+//!     can't be entered by accident under stress,
+//!   * the all-clear passphrase must be long enough to survive months of
+//!     disuse and distinct from both PINs,
+//!   * each desktop generates its **own** ~128-bit duress code with a CSPRNG and
+//!     only ever sends the argon2id hash to the server.
+//!
+//! The UI layer renders entropy meters and step navigation on top of this; the
+//! security-relevant decisions all live here where they can be unit-tested.
+
+use argon2::{
+    password_hash::{rand_core::OsRng as ArgonOsRng, PasswordHasher, SaltString},
+    Argon2, Params,
+};
+use rand::RngCore;
+
+/// Minimum Levenshtein distance the duress PIN must be from the regular PIN.
+pub const MIN_PIN_DISTANCE: usize = 2;
+
+/// Minimum all-clear passphrase length (characters).
+pub const MIN_ALL_CLEAR_LEN: usize = 12;
+
+/// Recommended all-clear passphrase length (characters), surfaced in the UI
+/// entropy meter as the "strong" threshold.
+pub const RECOMMENDED_ALL_CLEAR_LEN: usize = 24;
+
+/// Argon2id parameters, matching the regular-PIN and recovery-kit KDFs
+/// (19 MiB, 2 iterations, 1 lane) so duress secrets are no weaker than the
+/// rest of the app.
+const ARGON_M_COST: u32 = 19456;
+const ARGON_T_COST: u32 = 2;
+const ARGON_P_COST: u32 = 1;
+
+/// Bits of entropy in this desktop's generated duress code.
+const DURESS_CODE_BITS: usize = 128;
+
+/// The error string shown when the duress PIN is too close to the regular PIN.
+/// Kept as a constant so the wizard and its tests agree on the exact copy.
+pub const DURESS_PIN_TOO_CLOSE: &str =
+    "Your duress PIN must be at least 2 character changes from your regular PIN. \
+     This prevents accidental activation.";
+
+/// The five unlock-delay choices offered as chips in the wizard. `H24` is the
+/// default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DuressDelay {
+    #[default]
+    H24,
+    H48,
+    D7,
+    D30,
+    D90,
+}
+
+impl DuressDelay {
+    /// All choices in display order; the first is the default (24h).
+    pub const ALL: [DuressDelay; 5] = [
+        DuressDelay::H24,
+        DuressDelay::H48,
+        DuressDelay::D7,
+        DuressDelay::D30,
+        DuressDelay::D90,
+    ];
+
+    /// Lockout window length in minutes, sent to Connect as
+    /// `unlock_delay_minutes`.
+    pub fn minutes(self) -> u32 {
+        match self {
+            DuressDelay::H24 => 24 * 60,
+            DuressDelay::H48 => 48 * 60,
+            DuressDelay::D7 => 7 * 24 * 60,
+            DuressDelay::D30 => 30 * 24 * 60,
+            DuressDelay::D90 => 90 * 24 * 60,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            DuressDelay::H24 => "24h",
+            DuressDelay::H48 => "48h",
+            DuressDelay::D7 => "7d",
+            DuressDelay::D30 => "30d",
+            DuressDelay::D90 => "90d",
+        }
+    }
+}
+
+/// Validates a candidate duress PIN against the user's regular PIN.
+///
+/// Rejects PINs that are within [`MIN_PIN_DISTANCE`] edits of the regular PIN
+/// and obvious near-miss patterns (the reversed regular PIN, or an off-by-one
+/// in every digit) that a stressed user could enter by accident.
+pub fn validate_duress_pin(regular_pin: &str, duress_pin: &str) -> Result<(), String> {
+    if duress_pin.is_empty() {
+        return Err("Enter a duress PIN.".to_string());
+    }
+    if duress_pin == regular_pin
+        || levenshtein(regular_pin, duress_pin) < MIN_PIN_DISTANCE
+        || is_near_miss(regular_pin, duress_pin)
+    {
+        return Err(DURESS_PIN_TOO_CLOSE.to_string());
+    }
+    Ok(())
+}
+
+/// Validates the all-clear passphrase: minimum length and distinctness from
+/// both the regular and duress PINs.
+pub fn validate_all_clear(
+    passphrase: &str,
+    regular_pin: &str,
+    duress_pin: &str,
+) -> Result<(), String> {
+    if passphrase.chars().count() < MIN_ALL_CLEAR_LEN {
+        return Err(format!(
+            "Your all-clear passphrase must be at least {} characters.",
+            MIN_ALL_CLEAR_LEN
+        ));
+    }
+    if passphrase == regular_pin || passphrase == duress_pin {
+        return Err("Your all-clear passphrase must be different from your PINs.".to_string());
+    }
+    Ok(())
+}
+
+/// Validates the account-level duress CRK decryption password (Approach C,
+/// Tier 1 only): minimum length and distinctness from the PINs and all-clear.
+pub fn validate_duress_crk_password(
+    password: &str,
+    regular_pin: &str,
+    duress_pin: &str,
+    all_clear: &str,
+) -> Result<(), String> {
+    if password.chars().count() < MIN_ALL_CLEAR_LEN {
+        return Err(format!(
+            "Your duress recovery password must be at least {} characters.",
+            MIN_ALL_CLEAR_LEN
+        ));
+    }
+    if password == regular_pin || password == duress_pin || password == all_clear {
+        return Err(
+            "Your duress recovery password must be different from your other credentials."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// A coarse entropy estimate (bits) for the entropy meter. Deliberately
+/// simple — `len * log2(charset)` over the character classes present. Not a
+/// substitute for a real strength estimator, but enough to drive a 0..1 meter.
+pub fn estimate_entropy_bits(s: &str) -> f64 {
+    let mut classes = 0u32;
+    if s.chars().any(|c| c.is_ascii_lowercase()) {
+        classes += 26;
+    }
+    if s.chars().any(|c| c.is_ascii_uppercase()) {
+        classes += 26;
+    }
+    if s.chars().any(|c| c.is_ascii_digit()) {
+        classes += 10;
+    }
+    if s.chars().any(|c| !c.is_ascii_alphanumeric()) {
+        classes += 32;
+    }
+    if classes == 0 {
+        return 0.0;
+    }
+    (s.chars().count() as f64) * (classes as f64).log2()
+}
+
+/// Generates this desktop's own ~128-bit duress code as a lowercase hex string,
+/// using a cryptographically-secure RNG. The plaintext is held only on this
+/// desktop; only its argon2id hash is sent to the server.
+pub fn generate_duress_code() -> String {
+    let mut bytes = [0u8; DURESS_CODE_BITS / 8];
+    rand::rngs::OsRng.fill_bytes(&mut bytes);
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+/// Argon2id-hashes a duress secret (code, all-clear, CRK password) into a PHC
+/// string suitable for sending to the server. A fresh random salt is generated
+/// per call.
+pub fn hash_duress_secret(secret: &str) -> Result<String, String> {
+    let salt = SaltString::generate(&mut ArgonOsRng);
+    let params = Params::new(ARGON_M_COST, ARGON_T_COST, ARGON_P_COST, None)
+        .map_err(|e| format!("argon2 params: {e}"))?;
+    let argon2 = Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
+    let hash = argon2
+        .hash_password(secret.as_bytes(), &salt)
+        .map_err(|e| format!("argon2 hash: {e}"))?;
+    Ok(hash.to_string())
+}
+
+/// Classic Wagner–Fischer Levenshtein edit distance over Unicode scalar values.
+pub fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr = vec![0usize; b.len() + 1];
+    for (i, &ca) in a.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, &cb) in b.iter().enumerate() {
+            let cost = if ca == cb { 0 } else { 1 };
+            curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
+}
+
+/// Detects "near-miss" patterns that aren't caught by raw edit distance but a
+/// stressed user could still fat-finger: the regular PIN reversed, or every
+/// digit shifted by ±1 (mod 10) from the regular PIN.
+fn is_near_miss(regular: &str, duress: &str) -> bool {
+    if regular.is_empty() || regular.chars().count() != duress.chars().count() {
+        return false;
+    }
+    // Reversed regular PIN.
+    let reversed: String = regular.chars().rev().collect();
+    if duress == reversed {
+        return true;
+    }
+    // Uniform ±1 shift in every digit position (only meaningful for all-digit
+    // PINs).
+    if regular.chars().all(|c| c.is_ascii_digit()) && duress.chars().all(|c| c.is_ascii_digit()) {
+        let off_by_one_everywhere = regular.chars().zip(duress.chars()).all(|(r, d)| {
+            let r = r.to_digit(10).unwrap() as i32;
+            let d = d.to_digit(10).unwrap() as i32;
+            let diff = (r - d).rem_euclid(10);
+            diff == 1 || diff == 9
+        });
+        if off_by_one_everywhere {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn levenshtein_basic() {
+        assert_eq!(levenshtein("1234", "1234"), 0);
+        assert_eq!(levenshtein("1234", "1235"), 1);
+        assert_eq!(levenshtein("1234", "1245"), 2);
+        assert_eq!(levenshtein("", "abc"), 3);
+    }
+
+    #[test]
+    fn duress_pin_rejects_identical() {
+        let err = validate_duress_pin("1234", "1234").unwrap_err();
+        assert_eq!(err, DURESS_PIN_TOO_CLOSE);
+    }
+
+    #[test]
+    fn duress_pin_rejects_levenshtein_one() {
+        // Spec negative test: one edit away → rejected with the exact string.
+        let err = validate_duress_pin("1234", "1235").unwrap_err();
+        assert_eq!(err, DURESS_PIN_TOO_CLOSE);
+    }
+
+    #[test]
+    fn duress_pin_rejects_reversed() {
+        let err = validate_duress_pin("1234", "4321").unwrap_err();
+        assert_eq!(err, DURESS_PIN_TOO_CLOSE);
+    }
+
+    #[test]
+    fn duress_pin_rejects_off_by_one_everywhere() {
+        // 1234 -> 2345 (every digit +1)
+        let err = validate_duress_pin("1234", "2345").unwrap_err();
+        assert_eq!(err, DURESS_PIN_TOO_CLOSE);
+        // wrap-around: 9 -> 0
+        assert!(validate_duress_pin("1239", "2340").is_err());
+    }
+
+    #[test]
+    fn duress_pin_accepts_distinct() {
+        // Two independent edits, not a uniform shift, not reversed.
+        assert!(validate_duress_pin("1234", "1278").is_ok());
+        assert!(validate_duress_pin("0000", "9182").is_ok());
+    }
+
+    #[test]
+    fn all_clear_length_and_distinctness() {
+        assert!(validate_all_clear("short", "1234", "5678").is_err());
+        assert!(validate_all_clear("correct horse battery", "1234", "5678").is_ok());
+        // Must differ from PINs (edge: a 12+ char string equal to a PIN can't
+        // happen with 4-digit PINs, but the rule still holds for parity).
+        assert!(validate_all_clear("1234", "1234", "5678").is_err());
+    }
+
+    #[test]
+    fn crk_password_distinct_from_everything() {
+        assert!(validate_duress_crk_password(
+            "a-very-long-password",
+            "1234",
+            "5678",
+            "all clear phrase"
+        )
+        .is_ok());
+        assert!(validate_duress_crk_password(
+            "all clear phrase here",
+            "1234",
+            "5678",
+            "all clear phrase here"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn generated_code_is_128_bit_hex() {
+        let code = generate_duress_code();
+        assert_eq!(code.len(), 32, "128 bits == 32 hex chars");
+        assert!(code.chars().all(|c| c.is_ascii_hexdigit()));
+        // Two generations must differ (probability of collision is ~2^-128).
+        assert_ne!(generate_duress_code(), generate_duress_code());
+    }
+
+    #[test]
+    fn hash_round_trips_with_argon2() {
+        use argon2::password_hash::{PasswordHash, PasswordVerifier};
+        let code = generate_duress_code();
+        let phc = hash_duress_secret(&code).unwrap();
+        let parsed = PasswordHash::new(&phc).unwrap();
+        assert!(Argon2::default()
+            .verify_password(code.as_bytes(), &parsed)
+            .is_ok());
+        // Wrong secret fails.
+        assert!(Argon2::default()
+            .verify_password(b"not-the-code", &parsed)
+            .is_err());
+    }
+
+    #[test]
+    fn delays_are_in_minutes() {
+        assert_eq!(DuressDelay::H24.minutes(), 1440);
+        assert_eq!(DuressDelay::D90.minutes(), 129_600);
+        assert_eq!(DuressDelay::default(), DuressDelay::H24);
+        assert_eq!(DuressDelay::ALL.len(), 5);
+    }
+
+    #[test]
+    fn entropy_grows_with_length_and_classes() {
+        let weak = estimate_entropy_bits("aaaa");
+        let strong = estimate_entropy_bits("Aa1!Aa1!Aa1!");
+        assert!(strong > weak);
+        assert_eq!(estimate_entropy_bits(""), 0.0);
+    }
+}

--- a/coincube-gui/src/services/duress/journal.rs
+++ b/coincube-gui/src/services/duress/journal.rs
@@ -1,0 +1,102 @@
+//! Wipe-pending journal (Phase 3).
+//!
+//! The atomicity invariant: either every Cube file is gone or none is. The
+//! journal is the durability anchor — a marker is written *before* the wipe
+//! enumeration begins and removed only *after* the last file is deleted. On the
+//! next launch, if the marker still exists, the wipe was interrupted (power
+//! pulled, crash) and must be completed before anything else runs.
+//!
+//! The marker lives at the data-directory root, outside `cubes/`, so it
+//! survives a partial wipe.
+
+use chrono::Utc;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+/// Filename of the wipe-pending marker, relative to the data-directory root.
+pub const WIPE_JOURNAL_FILE: &str = "duress-wipe.journal";
+
+/// Durable marker that a duress wipe is in progress / pending completion.
+#[derive(Clone)]
+pub struct WipeJournal {
+    path: PathBuf,
+}
+
+impl WipeJournal {
+    pub fn new(coincube_dir: &Path) -> Self {
+        Self {
+            path: coincube_dir.join(WIPE_JOURNAL_FILE),
+        }
+    }
+
+    /// Writes the wipe-pending marker. Fast, synchronous, durable (`fsync`).
+    /// Records the activating account id and a timestamp for diagnostics; the
+    /// mere existence of the file is what drives wipe-completion on relaunch.
+    pub fn mark_pending_activation(&self, account_id: &str) -> io::Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut f = std::fs::File::create(&self.path)?;
+        writeln!(f, "{}\t{}", account_id, Utc::now().to_rfc3339())?;
+        f.sync_all()?;
+        Ok(())
+    }
+
+    /// True when a wipe is pending (marker present).
+    pub fn is_pending(&self) -> bool {
+        self.path.exists()
+    }
+
+    /// The account id recorded in the marker, if any (best-effort, for
+    /// reconciling the retry queue on relaunch).
+    pub fn pending_account_id(&self) -> Option<String> {
+        let contents = std::fs::read_to_string(&self.path).ok()?;
+        contents
+            .lines()
+            .next()
+            .and_then(|line| line.split('\t').next())
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty())
+    }
+
+    /// Removes the marker — called only after the wipe has fully completed.
+    pub fn clear(&self) -> io::Result<()> {
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-duress-journal-{}-{}-{:p}",
+            tag,
+            std::process::id(),
+            &0u8
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn mark_is_pending_then_clear() {
+        let dir = temp_dir("basic");
+        let j = WipeJournal::new(&dir);
+        assert!(!j.is_pending());
+        j.mark_pending_activation("acct_1").unwrap();
+        assert!(j.is_pending());
+        assert_eq!(j.pending_account_id().as_deref(), Some("acct_1"));
+        j.clear().unwrap();
+        assert!(!j.is_pending());
+        // Clearing an absent marker is a no-op.
+        j.clear().unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/coincube-gui/src/services/duress/mod.rs
+++ b/coincube-gui/src/services/duress/mod.rs
@@ -57,6 +57,40 @@ pub const DURESS_STATE_FILE: &str = "duress-state.json";
 /// data-directory root.
 pub const DURESS_QUEUE_FILE: &str = "duress-queue.json";
 
+/// Filename for this device's stable enrollment fingerprint, relative to the
+/// Coincube data-directory root.
+pub const DEVICE_FINGERPRINT_FILE: &str = "duress-device-fingerprint";
+
+/// Loads this device's **stable** duress enrollment fingerprint, generating and
+/// persisting one (a random UUID) on first use.
+///
+/// The server keys its per-device duress rows and `this_device_registered`
+/// semantics on this value, so it MUST be the same across launches, repeat
+/// enrollments, and re-registrations on the same install — a fresh value each
+/// time would make the server unable to recognise the same desktop. Persisted
+/// at the data-directory root, outside the wiped `cubes/` tree.
+pub fn device_fingerprint(coincube_dir: &Path) -> io::Result<String> {
+    let path = coincube_dir.join(DEVICE_FINGERPRINT_FILE);
+    match std::fs::read_to_string(&path) {
+        Ok(s) if !s.trim().is_empty() => Ok(s.trim().to_string()),
+        // Missing or empty/corrupt → mint and persist a fresh one.
+        Ok(_) => create_fingerprint(&path),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => create_fingerprint(&path),
+        Err(e) => Err(e),
+    }
+}
+
+fn create_fingerprint(path: &Path) -> io::Result<String> {
+    let fp = uuid::Uuid::new_v4().to_string();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut f = std::fs::File::create(path)?;
+    f.write_all(fp.as_bytes())?;
+    f.sync_all()?;
+    Ok(fp)
+}
+
 /// This desktop's persisted duress configuration and live status.
 ///
 /// `duress_code` is **this desktop's own** ~128-bit code, generated locally
@@ -201,6 +235,26 @@ mod tests {
         assert!(json.contains("\"pendingActivation\""));
         assert!(json.contains("\"duressCode\""));
         assert!(json.contains("\"enqueuedAt\""));
+    }
+
+    #[test]
+    fn device_fingerprint_is_stable_across_calls() {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-duress-fp-{}-{:p}",
+            std::process::id(),
+            &0u8
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let a = device_fingerprint(&dir).unwrap();
+        let b = device_fingerprint(&dir).unwrap();
+        assert_eq!(a, b, "fingerprint must be stable across calls");
+        assert!(!a.trim().is_empty());
+        // A fresh data dir yields a different fingerprint.
+        let dir2 = dir.join("other");
+        std::fs::create_dir_all(&dir2).unwrap();
+        assert_ne!(device_fingerprint(&dir2).unwrap(), a);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/coincube-gui/src/services/duress/mod.rs
+++ b/coincube-gui/src/services/duress/mod.rs
@@ -87,6 +87,12 @@ pub struct DuressLocalState {
     /// This desktop's own duress code (encrypted at rest in Phase 3).
     #[serde(default)]
     pub duress_code: Option<String>,
+    /// The Connect account id this device enrolled under, persisted so the
+    /// unauthenticated `trigger-with-code` POST can address the right account
+    /// at activation time even without a live session. `None` for sovereign
+    /// (no-Connect) enrollment — that path wipes locally with no server POST.
+    #[serde(default)]
+    pub account_id: Option<String>,
 }
 
 /// A durably-enqueued activation `POST` that must eventually reach Connect.
@@ -174,6 +180,7 @@ mod tests {
                 attempts: 2,
             }),
             duress_code: Some("enc:cafebabe".to_string()),
+            account_id: Some("acct_123".to_string()),
         }
     }
 

--- a/coincube-gui/src/services/duress/mod.rs
+++ b/coincube-gui/src/services/duress/mod.rs
@@ -72,22 +72,31 @@ pub const DEVICE_FINGERPRINT_FILE: &str = "duress-device-fingerprint";
 pub fn device_fingerprint(coincube_dir: &Path) -> io::Result<String> {
     let path = coincube_dir.join(DEVICE_FINGERPRINT_FILE);
     match std::fs::read_to_string(&path) {
-        Ok(s) if !s.trim().is_empty() => Ok(s.trim().to_string()),
-        // Missing or empty/corrupt → mint and persist a fresh one.
+        // Accept only a well-formed UUID. A non-empty-but-corrupt file (e.g. a
+        // truncated write from a crash) must NOT be handed to the server as a
+        // fingerprint — treat it like "missing" and re-mint.
+        Ok(s) if uuid::Uuid::parse_str(s.trim()).is_ok() => Ok(s.trim().to_string()),
         Ok(_) => create_fingerprint(&path),
         Err(e) if e.kind() == io::ErrorKind::NotFound => create_fingerprint(&path),
         Err(e) => Err(e),
     }
 }
 
+/// Mints a fresh fingerprint and persists it atomically (temp file + `fsync` +
+/// `rename`), so a crash mid-write can never leave a truncated id at the final
+/// path — a reader sees either the old file or the complete new one.
 fn create_fingerprint(path: &Path) -> io::Result<String> {
     let fp = uuid::Uuid::new_v4().to_string();
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let mut f = std::fs::File::create(path)?;
-    f.write_all(fp.as_bytes())?;
-    f.sync_all()?;
+    let tmp = path.with_extension("tmp");
+    {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(fp.as_bytes())?;
+        f.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
     Ok(fp)
 }
 
@@ -254,6 +263,29 @@ mod tests {
         let dir2 = dir.join("other");
         std::fs::create_dir_all(&dir2).unwrap();
         assert_ne!(device_fingerprint(&dir2).unwrap(), a);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn device_fingerprint_rejects_corrupt_file_and_remints() {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-duress-fp-corrupt-{}-{:p}",
+            std::process::id(),
+            &0u8
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // A truncated / non-UUID value (e.g. left by a crash mid-write) must
+        // not be accepted; it gets re-minted into a valid UUID.
+        let path = dir.join(DEVICE_FINGERPRINT_FILE);
+        std::fs::write(&path, b"not-a-uuid-truncat").unwrap();
+        let fp = device_fingerprint(&dir).unwrap();
+        assert!(
+            uuid::Uuid::parse_str(&fp).is_ok(),
+            "re-minted value must be a UUID"
+        );
+        // The corrupt content is gone, and the value is now stable.
+        assert_eq!(device_fingerprint(&dir).unwrap(), fp);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/coincube-gui/src/services/duress/mod.rs
+++ b/coincube-gui/src/services/duress/mod.rs
@@ -19,6 +19,7 @@
 //! crash never leaves a half-written JSON document on disk.
 
 pub mod cipher;
+pub mod drain;
 pub mod enroll;
 pub mod journal;
 pub mod orchestrator;

--- a/coincube-gui/src/services/duress/mod.rs
+++ b/coincube-gui/src/services/duress/mod.rs
@@ -18,6 +18,8 @@
 //! Both stores are written atomically (temp file + `fsync` + `rename`) so a
 //! crash never leaves a half-written JSON document on disk.
 
+pub mod enroll;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::io::{self, Write};

--- a/coincube-gui/src/services/duress/mod.rs
+++ b/coincube-gui/src/services/duress/mod.rs
@@ -1,0 +1,201 @@
+//! Duress mode — on-device state model and persistence.
+//!
+//! The desktop is where duress *happens*. The on-device trust anchor is an
+//! atomic local wipe of all Cube data (implemented in later phases); this
+//! module holds the durable state that survives that wipe and drives the
+//! orchestration.
+//!
+//! Two files live at the **root** of the Coincube data directory, *outside*
+//! the per-network `cubes/` tree, so they survive `wipe::execute_atomic()`:
+//!
+//!   * [`DURESS_STATE_FILE`] — [`DuressLocalState`], the per-device duress
+//!     configuration and live status.
+//!   * [`DURESS_QUEUE_FILE`] — the persistent retry queue of
+//!     [`PendingActivation`]s (drained by the Phase 4 background loop). This is
+//!     the source of truth that guarantees the activation `POST` eventually
+//!     fires even if power is pulled mid-activation.
+//!
+//! Both stores are written atomically (temp file + `fsync` + `rename`) so a
+//! crash never leaves a half-written JSON document on disk.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+/// Filename for the persisted [`DuressLocalState`], relative to the Coincube
+/// data-directory root.
+pub const DURESS_STATE_FILE: &str = "duress-state.json";
+
+/// Filename for the persisted activation retry queue, relative to the Coincube
+/// data-directory root.
+pub const DURESS_QUEUE_FILE: &str = "duress-queue.json";
+
+/// This desktop's persisted duress configuration and live status.
+///
+/// `duress_code` is **this desktop's own** ~128-bit code, generated locally
+/// with a CSPRNG and stored encrypted at rest with a key separate from the Cube
+/// key (the encryption layer is added in Phase 3). The server holds only the
+/// argon2id hash, on a per-device row; the plaintext never leaves this desktop
+/// and the user never sees it. Other desktops on the same account each generate
+/// their own independent code.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DuressLocalState {
+    /// Whether duress is enrolled for this account from this desktop's view.
+    pub enrolled: bool,
+    /// Whether duress is currently active (locks the app into the cryptic
+    /// screen).
+    pub active: bool,
+    /// When the account can be cleared with the all-clear passphrase. Only the
+    /// recovery flow on a *trusted device* ever renders this to the user.
+    #[serde(default)]
+    pub unlock_at: Option<DateTime<Utc>>,
+    /// Timestamp of the last local activation attempt (diagnostic only).
+    #[serde(default)]
+    pub last_activation_attempt: Option<DateTime<Utc>>,
+    /// The in-flight activation, mirrored from the retry queue for quick
+    /// inspection. The queue file is the durable source of truth.
+    #[serde(default)]
+    pub pending_activation: Option<PendingActivation>,
+    /// This desktop's own duress code (encrypted at rest in Phase 3).
+    #[serde(default)]
+    pub duress_code: Option<String>,
+}
+
+/// A durably-enqueued activation `POST` that must eventually reach Connect.
+///
+/// Enqueued *before* the wipe begins so that even if power is pulled in the
+/// next millisecond, the queue + journal together guarantee both the `POST` and
+/// the wipe complete on next launch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PendingActivation {
+    pub account_id: String,
+    /// Copied from [`DuressLocalState::duress_code`] at enqueue time; carries
+    /// the same encrypted-at-rest treatment.
+    pub duress_code: String,
+    pub enqueued_at: DateTime<Utc>,
+    #[serde(default)]
+    pub attempts: u32,
+}
+
+impl DuressLocalState {
+    /// Absolute path to the state file given the Coincube data-directory root.
+    pub fn path(coincube_dir: &Path) -> PathBuf {
+        coincube_dir.join(DURESS_STATE_FILE)
+    }
+
+    /// Loads the persisted state, returning [`DuressLocalState::default`] when
+    /// the file does not exist yet (first launch / never enrolled).
+    pub fn load(coincube_dir: &Path) -> io::Result<Self> {
+        load_json(&Self::path(coincube_dir))
+    }
+
+    /// Atomically persists the state to the state file.
+    pub fn save(&self, coincube_dir: &Path) -> io::Result<()> {
+        write_json_atomic(&Self::path(coincube_dir), self)
+    }
+}
+
+/// Reads and deserializes a JSON document, treating "file not found" as
+/// `T::default()`. Any other I/O or parse error is surfaced.
+fn load_json<T: Default + for<'de> Deserialize<'de>>(path: &Path) -> io::Result<T> {
+    match std::fs::read(path) {
+        Ok(bytes) => serde_json::from_slice(&bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e)),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(T::default()),
+        Err(e) => Err(e),
+    }
+}
+
+/// Serializes `value` to pretty JSON and writes it to `path` atomically:
+/// write to a sibling `*.tmp`, `fsync`, then `rename` over the target. The
+/// rename is atomic on every supported platform, so a reader never observes a
+/// torn write and a crash leaves either the old file or the new one — never a
+/// truncated document.
+fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
+    let bytes = serde_json::to_vec_pretty(value)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("tmp");
+    {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(&bytes)?;
+        f.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn sample_state() -> DuressLocalState {
+        DuressLocalState {
+            enrolled: true,
+            active: false,
+            unlock_at: Some(Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap()),
+            last_activation_attempt: None,
+            pending_activation: Some(PendingActivation {
+                account_id: "acct_123".to_string(),
+                duress_code: "enc:deadbeef".to_string(),
+                enqueued_at: Utc.with_ymd_and_hms(2026, 6, 8, 9, 30, 0).unwrap(),
+                attempts: 2,
+            }),
+            duress_code: Some("enc:cafebabe".to_string()),
+        }
+    }
+
+    #[test]
+    fn state_serde_round_trip() {
+        let state = sample_state();
+        let json = serde_json::to_string(&state).unwrap();
+        let back: DuressLocalState = serde_json::from_str(&json).unwrap();
+        assert_eq!(state, back);
+    }
+
+    #[test]
+    fn camel_case_wire_shape() {
+        let state = sample_state();
+        let json = serde_json::to_string(&state).unwrap();
+        // Field names must be camelCase on the wire.
+        assert!(json.contains("\"lastActivationAttempt\""));
+        assert!(json.contains("\"pendingActivation\""));
+        assert!(json.contains("\"duressCode\""));
+        assert!(json.contains("\"enqueuedAt\""));
+    }
+
+    #[test]
+    fn load_missing_file_is_default() {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-duress-test-missing-{}",
+            std::process::id()
+        ));
+        // Ensure it does not exist.
+        let _ = std::fs::remove_dir_all(&dir);
+        let loaded = DuressLocalState::load(&dir).unwrap();
+        assert_eq!(loaded, DuressLocalState::default());
+    }
+
+    #[test]
+    fn save_then_load_round_trips_on_disk() {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-duress-test-rt-{}-{:p}",
+            std::process::id(),
+            &0u8
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let state = sample_state();
+        state.save(&dir).unwrap();
+        let loaded = DuressLocalState::load(&dir).unwrap();
+        assert_eq!(state, loaded);
+        // No stray temp file left behind.
+        assert!(!dir.join("duress-state.tmp").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/coincube-gui/src/services/duress/mod.rs
+++ b/coincube-gui/src/services/duress/mod.rs
@@ -18,12 +18,35 @@
 //! Both stores are written atomically (temp file + `fsync` + `rename`) so a
 //! crash never leaves a half-written JSON document on disk.
 
+pub mod cipher;
 pub mod enroll;
+pub mod journal;
+pub mod orchestrator;
+pub mod queue;
+pub mod wipe;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+
+/// UI-facing duress lifecycle events. Emitted by the orchestrator and the gRPC
+/// stream dispatcher; the app shell routes them to the cryptic screen (Phase 5)
+/// and back.
+///
+/// `Activated` (local duress-PIN path) implies the local Cube wipe ran;
+/// `ActivatedRemote` (Phase 7b, triggered elsewhere) locks the screen but does
+/// **not** wipe — the only behavioural difference between the two.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DuressEvent {
+    /// Local duress-PIN activation — Cube data was wiped on this device.
+    Activated,
+    /// Remote activation received over the Connect gRPC stream — screen locks,
+    /// no wipe.
+    ActivatedRemote,
+    /// Duress cleared (server-side all-clear) — exit the cryptic screen.
+    Cleared,
+}
 
 /// Filename for the persisted [`DuressLocalState`], relative to the Coincube
 /// data-directory root.

--- a/coincube-gui/src/services/duress/orchestrator.rs
+++ b/coincube-gui/src/services/duress/orchestrator.rs
@@ -1,0 +1,427 @@
+//! Duress activation orchestrator (Phase 3, Task 3.2).
+//!
+//! This is the heart of the feature. The ordering invariant is sacred:
+//!
+//!   1. Validate the duress PIN (done by the caller, fast + local).
+//!   2. Write the wipe journal marker (fast, local, durable).
+//!   3. Enqueue the `PendingActivation` (fast, local, durable) — the source of
+//!      truth that the POST will eventually fire.
+//!   4. **In parallel:** kick off the activation `POST` as a fire-and-forget
+//!      background task **AND** begin the atomic wipe. The wipe is *never*
+//!      gated on any network condition.
+//!   5. After the wipe completes, transition to the cryptic screen.
+//!
+//! An attacker who controls the network must not be able to keep Cube data on
+//! disk by stalling the POST. With this ordering the wipe starts the instant
+//! the queue commit returns, and the queue's durability guarantees the POST
+//! eventually lands (immediately if it succeeds, else via the Phase 4 drain
+//! loop). Both the POST and the wipe may finish in either order; every code
+//! path handles both orderings.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::cipher::DeviceKey;
+use super::journal::WipeJournal;
+use super::queue::DuressQueue;
+use super::wipe::CubeWiper;
+use super::{DuressEvent, DuressLocalState, PendingActivation};
+
+/// The network side of activation, abstracted so the orchestrator can be tested
+/// without a live HTTP stack and so the wipe ordering can be exercised against
+/// a slow/failing/hanging server.
+#[async_trait]
+pub trait DuressTrigger: Send + Sync + 'static {
+    /// Fire the unauthenticated `trigger-with-code` POST. `Ok(())` on success.
+    async fn trigger(&self, account_id: &str, duress_code: &str) -> Result<(), String>;
+}
+
+#[async_trait]
+impl DuressTrigger for crate::services::coincube::CoincubeClient {
+    async fn trigger(&self, account_id: &str, duress_code: &str) -> Result<(), String> {
+        self.trigger_duress_with_code(account_id, duress_code)
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+}
+
+/// The wall-clock budget the *background* POST task is given before it gives up
+/// and leaves the entry for the drain loop. The wipe never waits on this.
+const POST_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug)]
+pub enum DuressError {
+    /// No duress code is present in local state — this desktop never enrolled
+    /// or registered a code, so it cannot activate.
+    NotEnrolledLocally,
+    /// The stored code envelope could not be decrypted with the device key.
+    Decrypt(String),
+    /// A durable write (journal / queue / state) failed.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for DuressError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DuressError::NotEnrolledLocally => write!(f, "duress not enrolled on this device"),
+            DuressError::Decrypt(e) => write!(f, "duress code decrypt failed: {e}"),
+            DuressError::Io(e) => write!(f, "duress durable write failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for DuressError {}
+
+/// Owns the durable stores and drives activation. Constructed by the app with
+/// the real Cube data roots; constructed by tests with temp dirs and a mock
+/// [`DuressTrigger`].
+pub struct DuressOrchestrator {
+    pub local_state: DuressLocalState,
+    data_dir: PathBuf,
+    journal: WipeJournal,
+    queue: DuressQueue,
+    wipe: CubeWiper,
+    cipher: DeviceKey,
+    client: Arc<dyn DuressTrigger>,
+    event_tx: Option<UnboundedSender<DuressEvent>>,
+}
+
+impl DuressOrchestrator {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        local_state: DuressLocalState,
+        data_dir: PathBuf,
+        journal: WipeJournal,
+        queue: DuressQueue,
+        wipe: CubeWiper,
+        cipher: DeviceKey,
+        client: Arc<dyn DuressTrigger>,
+        event_tx: Option<UnboundedSender<DuressEvent>>,
+    ) -> Self {
+        Self {
+            local_state,
+            data_dir,
+            journal,
+            queue,
+            wipe,
+            cipher,
+            client,
+            event_tx,
+        }
+    }
+
+    /// Activates duress: durably records intent, kicks off the POST in the
+    /// background, wipes in parallel, persists `active = true`, and emits
+    /// [`DuressEvent::Activated`].
+    pub async fn activate(&mut self, account_id: String) -> Result<(), DuressError> {
+        // The code is read from local state, NOT passed in by the caller — the
+        // user never sees or types it. It's stored encrypted at rest; decrypt
+        // to a short-lived plaintext for the POST only.
+        let encrypted = self
+            .local_state
+            .duress_code
+            .clone()
+            .ok_or(DuressError::NotEnrolledLocally)?;
+        let plaintext = self
+            .cipher
+            .decrypt(&encrypted)
+            .map_err(DuressError::Decrypt)?;
+
+        // 1. Journal marker FIRST. Synchronous, fast, durable.
+        self.journal
+            .mark_pending_activation(&account_id)
+            .map_err(DuressError::Io)?;
+
+        // 2. Enqueue (store the *encrypted* code, never plaintext). Durable
+        //    source of truth — survives a power-pull in the next millisecond.
+        self.queue
+            .enqueue(PendingActivation {
+                account_id: account_id.clone(),
+                duress_code: encrypted,
+                enqueued_at: Utc::now(),
+                attempts: 0,
+            })
+            .map_err(DuressError::Io)?;
+
+        // 3. Kick off the POST in the BACKGROUND. Fire-and-forget. The wipe
+        //    (step 4) does NOT wait for this. An attacker who controls the
+        //    network MUST NOT be able to delay the wipe.
+        let client = self.client.clone();
+        let queue = self.queue.clone();
+        let acct = account_id.clone();
+        tokio::spawn(async move {
+            Self::run_post(client, queue, acct, plaintext).await;
+        });
+
+        // 4. Wipe runs IN PARALLEL with the POST above. Starts immediately;
+        //    never gated on any network condition.
+        self.wipe.execute_atomic().map_err(DuressError::Io)?;
+
+        // 5. Persist active state (the file survives the wipe, so on relaunch
+        //    we route straight to the cryptic screen).
+        self.local_state.active = true;
+        self.local_state.last_activation_attempt = Some(Utc::now());
+        self.local_state
+            .save(&self.data_dir)
+            .map_err(DuressError::Io)?;
+
+        // 6. Transition UI to the cryptic activation screen.
+        if let Some(tx) = &self.event_tx {
+            let _ = tx.send(DuressEvent::Activated);
+        }
+        Ok(())
+    }
+
+    /// The fire-and-forget POST attempt: time-boxed, dequeues on success, leaves
+    /// the entry for the drain loop on failure/timeout. Also used directly by
+    /// tests to assert the success/failure → queue behaviour deterministically.
+    pub async fn run_post(
+        client: Arc<dyn DuressTrigger>,
+        queue: DuressQueue,
+        account_id: String,
+        plaintext_code: String,
+    ) {
+        let result =
+            tokio::time::timeout(POST_TIMEOUT, client.trigger(&account_id, &plaintext_code)).await;
+        if let Ok(Ok(())) = result {
+            let _ = queue.dequeue(&account_id);
+        }
+        // else: leave in queue; the Phase 4 drain loop retries.
+    }
+
+    /// Remote activation received over the gRPC stream (Phase 7b). Locks the
+    /// screen but does **NOT** wipe — remote activation can be accidental
+    /// (Keychain Settings tap, mis-entered CRK password) and wiping then would
+    /// be too destructive.
+    pub fn handle_remote_activation(
+        &mut self,
+        unlock_at: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<(), DuressError> {
+        self.local_state.active = true;
+        self.local_state.unlock_at = unlock_at;
+        self.local_state
+            .save(&self.data_dir)
+            .map_err(DuressError::Io)?;
+        if let Some(tx) = &self.event_tx {
+            let _ = tx.send(DuressEvent::ActivatedRemote);
+        }
+        Ok(())
+    }
+
+    /// Duress cleared server-side (gRPC `DuressCleared` or a launch/sign-in
+    /// reconcile). Exits the cryptic screen.
+    pub fn handle_remote_clear(&mut self) -> Result<(), DuressError> {
+        self.local_state.active = false;
+        self.local_state.unlock_at = None;
+        self.local_state
+            .save(&self.data_dir)
+            .map_err(DuressError::Io)?;
+        if let Some(tx) = &self.event_tx {
+            let _ = tx.send(DuressEvent::Cleared);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use tokio::sync::Notify;
+
+    /// Mock trigger that records calls and can be configured to succeed, fail,
+    /// or hang past the POST timeout.
+    struct MockTrigger {
+        calls: Arc<Mutex<Vec<String>>>,
+        notify: Arc<Notify>,
+        behavior: Behavior,
+    }
+
+    #[derive(Clone, Copy)]
+    enum Behavior {
+        Ok,
+        Err,
+        Hang,
+    }
+
+    #[async_trait]
+    impl DuressTrigger for MockTrigger {
+        async fn trigger(&self, account_id: &str, _code: &str) -> Result<(), String> {
+            self.calls.lock().unwrap().push(account_id.to_string());
+            self.notify.notify_one();
+            match self.behavior {
+                Behavior::Ok => Ok(()),
+                Behavior::Err => Err("boom".to_string()),
+                Behavior::Hang => {
+                    // Sleep well past POST_TIMEOUT so the timeout fires.
+                    tokio::time::sleep(Duration::from_secs(3600)).await;
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    struct Harness {
+        dir: PathBuf,
+        orch: DuressOrchestrator,
+        calls: Arc<Mutex<Vec<String>>>,
+        notify: Arc<Notify>,
+        rx: tokio::sync::mpsc::UnboundedReceiver<DuressEvent>,
+    }
+
+    static TEST_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    fn build(behavior: Behavior) -> Harness {
+        let seq = TEST_SEQ.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-duress-orch-{}-{}",
+            std::process::id(),
+            seq
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Seed Cube data to be wiped.
+        let cube_root = dir.join("bitcoin").join("data");
+        std::fs::create_dir_all(cube_root.join("cube_a")).unwrap();
+        std::fs::write(cube_root.join("cube_a").join("wallet.db"), b"SECRET").unwrap();
+
+        let cipher = DeviceKey::from_bytes([3u8; 32]);
+        let encrypted = cipher.encrypt("raw-duress-code").unwrap();
+        let state = DuressLocalState {
+            enrolled: true,
+            duress_code: Some(encrypted),
+            ..Default::default()
+        };
+        state.save(&dir).unwrap();
+
+        let journal = WipeJournal::new(&dir);
+        let queue = DuressQueue::new(&dir);
+        let wipe = CubeWiper::new(vec![cube_root], journal.clone());
+
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let notify = Arc::new(Notify::new());
+        let client = Arc::new(MockTrigger {
+            calls: calls.clone(),
+            notify: notify.clone(),
+            behavior,
+        });
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let orch = DuressOrchestrator::new(
+            state,
+            dir.clone(),
+            journal,
+            queue,
+            wipe,
+            cipher,
+            client,
+            Some(tx),
+        );
+        Harness {
+            dir,
+            orch,
+            calls,
+            notify,
+            rx,
+        }
+    }
+
+    #[tokio::test]
+    async fn activate_wipes_and_emits_event() {
+        let mut h = build(Behavior::Ok);
+        h.orch.activate("acct_1".to_string()).await.unwrap();
+
+        // Cube data gone.
+        assert!(!h.dir.join("bitcoin").join("data").exists());
+        // Active state persisted.
+        let reloaded = DuressLocalState::load(&h.dir).unwrap();
+        assert!(reloaded.active);
+        // Activated event emitted.
+        assert_eq!(h.rx.recv().await, Some(DuressEvent::Activated));
+        // POST eventually fired and drained the queue.
+        h.notify.notified().await;
+        // Give the spawned dequeue a moment to land.
+        for _ in 0..50 {
+            if h.orch_queue_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(h.calls.lock().unwrap().as_slice(), &["acct_1".to_string()]);
+        let _ = std::fs::remove_dir_all(&h.dir);
+    }
+
+    #[tokio::test]
+    async fn activate_with_post_error_retains_queue_entry() {
+        let mut h = build(Behavior::Err);
+        h.orch.activate("acct_2".to_string()).await.unwrap();
+        assert!(
+            !h.dir.join("bitcoin").join("data").exists(),
+            "wipe still ran"
+        );
+        // Wait for the POST to be attempted and fail.
+        h.notify.notified().await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Entry retained for the drain loop.
+        assert!(!h.orch_queue_empty());
+        let _ = std::fs::remove_dir_all(&h.dir);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn activate_does_not_wait_on_hung_post() {
+        let mut h = build(Behavior::Hang);
+        // activate() must return promptly even though the POST hangs forever —
+        // the wipe is not gated on the network.
+        h.orch.activate("acct_3".to_string()).await.unwrap();
+        assert!(!h.dir.join("bitcoin").join("data").exists());
+        assert!(DuressLocalState::load(&h.dir).unwrap().active);
+        let _ = std::fs::remove_dir_all(&h.dir);
+    }
+
+    #[tokio::test]
+    async fn activate_without_code_errors() {
+        let mut h = build(Behavior::Ok);
+        h.orch.local_state.duress_code = None;
+        let err = h.orch.activate("acct_x".to_string()).await.unwrap_err();
+        assert!(matches!(err, DuressError::NotEnrolledLocally));
+        // Nothing wiped, no journal left dangling.
+        assert!(h.dir.join("bitcoin").join("data").exists());
+        assert!(!h.orch.journal.is_pending());
+        let _ = std::fs::remove_dir_all(&h.dir);
+    }
+
+    #[tokio::test]
+    async fn remote_activation_does_not_wipe() {
+        let mut h = build(Behavior::Ok);
+        h.orch.handle_remote_activation(None).unwrap();
+        // Cube data still present — remote activation never wipes.
+        assert!(h.dir.join("bitcoin").join("data").join("cube_a").exists());
+        assert!(DuressLocalState::load(&h.dir).unwrap().active);
+        assert_eq!(h.rx.recv().await, Some(DuressEvent::ActivatedRemote));
+        let _ = std::fs::remove_dir_all(&h.dir);
+    }
+
+    #[tokio::test]
+    async fn remote_clear_exits() {
+        let mut h = build(Behavior::Ok);
+        h.orch.handle_remote_activation(None).unwrap();
+        let _ = h.rx.recv().await;
+        h.orch.handle_remote_clear().unwrap();
+        assert!(!DuressLocalState::load(&h.dir).unwrap().active);
+        assert_eq!(h.rx.recv().await, Some(DuressEvent::Cleared));
+        let _ = std::fs::remove_dir_all(&h.dir);
+    }
+
+    impl Harness {
+        fn orch_queue_empty(&self) -> bool {
+            DuressQueue::new(&self.dir).is_empty().unwrap()
+        }
+    }
+}

--- a/coincube-gui/src/services/duress/orchestrator.rs
+++ b/coincube-gui/src/services/duress/orchestrator.rs
@@ -32,22 +32,43 @@ use super::queue::DuressQueue;
 use super::wipe::CubeWiper;
 use super::{DuressEvent, DuressLocalState, PendingActivation};
 
+/// Whether a failed activation POST should be retried by the drain loop or
+/// abandoned. The wipe has already happened, so a terminal error just means
+/// "we did our best" — drop the entry rather than retry forever.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TriggerError {
+    /// Transient (network down, 429, 5xx) — keep the entry, retry later.
+    Retriable,
+    /// Permanent (4xx other than 429: bad request, already cleared, etc.) —
+    /// log and drop the entry.
+    Terminal,
+}
+
 /// The network side of activation, abstracted so the orchestrator can be tested
 /// without a live HTTP stack and so the wipe ordering can be exercised against
 /// a slow/failing/hanging server.
 #[async_trait]
 pub trait DuressTrigger: Send + Sync + 'static {
     /// Fire the unauthenticated `trigger-with-code` POST. `Ok(())` on success.
-    async fn trigger(&self, account_id: &str, duress_code: &str) -> Result<(), String>;
+    async fn trigger(&self, account_id: &str, duress_code: &str) -> Result<(), TriggerError>;
 }
 
 #[async_trait]
 impl DuressTrigger for crate::services::coincube::CoincubeClient {
-    async fn trigger(&self, account_id: &str, duress_code: &str) -> Result<(), String> {
-        self.trigger_duress_with_code(account_id, duress_code)
-            .await
-            .map(|_| ())
-            .map_err(|e| e.to_string())
+    async fn trigger(&self, account_id: &str, duress_code: &str) -> Result<(), TriggerError> {
+        use crate::services::coincube::CoincubeError;
+        match self.trigger_duress_with_code(account_id, duress_code).await {
+            Ok(_) => Ok(()),
+            Err(CoincubeError::Network(_)) | Err(CoincubeError::RateLimited { .. }) => {
+                Err(TriggerError::Retriable)
+            }
+            Err(CoincubeError::Unsuccessful(info)) if info.status_code >= 500 => {
+                Err(TriggerError::Retriable)
+            }
+            // 4xx (other than 429, handled above), parse errors, etc. — the
+            // server will never accept this request; stop retrying.
+            Err(_) => Err(TriggerError::Terminal),
+        }
     }
 }
 
@@ -252,12 +273,12 @@ mod tests {
 
     #[async_trait]
     impl DuressTrigger for MockTrigger {
-        async fn trigger(&self, account_id: &str, _code: &str) -> Result<(), String> {
+        async fn trigger(&self, account_id: &str, _code: &str) -> Result<(), TriggerError> {
             self.calls.lock().unwrap().push(account_id.to_string());
             self.notify.notify_one();
             match self.behavior {
                 Behavior::Ok => Ok(()),
-                Behavior::Err => Err("boom".to_string()),
+                Behavior::Err => Err(TriggerError::Retriable),
                 Behavior::Hang => {
                     // Sleep well past POST_TIMEOUT so the timeout fires.
                     tokio::time::sleep(Duration::from_secs(3600)).await;

--- a/coincube-gui/src/services/duress/queue.rs
+++ b/coincube-gui/src/services/duress/queue.rs
@@ -1,0 +1,171 @@
+//! Durable activation retry queue (Phase 3 persistence; Phase 4 drain loop).
+//!
+//! This file is the **source of truth** that guarantees the activation `POST`
+//! eventually fires. It is committed *before* the wipe starts and *before* the
+//! POST is kicked off, so even if power is pulled in the next millisecond the
+//! queue + journal together drive both the POST and the wipe to completion on
+//! next launch.
+//!
+//! It lives at `duress-queue.json` in the data-directory root and is **never**
+//! touched by [`CubeWiper`](super::wipe::CubeWiper).
+//!
+//! Phase 4 adds the background drain loop (exponential backoff, online-state
+//! triggers) on top of the primitives here.
+
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use super::{PendingActivation, DURESS_QUEUE_FILE};
+
+/// A cheaply-clonable handle to the persistent queue file. Cloning shares the
+/// same path and serialization lock, so the orchestrator's main thread and the
+/// spawned POST task can both touch the queue without racing.
+#[derive(Clone)]
+pub struct DuressQueue {
+    path: Arc<PathBuf>,
+    lock: Arc<Mutex<()>>,
+}
+
+impl DuressQueue {
+    pub fn new(coincube_dir: &Path) -> Self {
+        Self {
+            path: Arc::new(coincube_dir.join(DURESS_QUEUE_FILE)),
+            lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    /// All pending activations currently queued (empty when the file is
+    /// absent).
+    pub fn entries(&self) -> io::Result<Vec<PendingActivation>> {
+        let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
+        self.read_locked()
+    }
+
+    pub fn is_empty(&self) -> io::Result<bool> {
+        Ok(self.entries()?.is_empty())
+    }
+
+    /// Appends an activation, de-duplicating by `account_id` so a repeated
+    /// activation doesn't pile up multiple rows for the same account.
+    pub fn enqueue(&self, item: PendingActivation) -> io::Result<()> {
+        let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
+        let mut items = self.read_locked()?;
+        items.retain(|e| e.account_id != item.account_id);
+        items.push(item);
+        self.write_locked(&items)
+    }
+
+    /// Removes the queued activation for `account_id` (called when its POST
+    /// succeeds). A no-op if it isn't present.
+    pub fn dequeue(&self, account_id: &str) -> io::Result<()> {
+        let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
+        let mut items = self.read_locked()?;
+        let before = items.len();
+        items.retain(|e| e.account_id != account_id);
+        if items.len() == before {
+            return Ok(());
+        }
+        self.write_locked(&items)
+    }
+
+    /// Replaces the persisted entries wholesale (used by the Phase 4 drain loop
+    /// to bump `attempts`).
+    pub fn replace_all(&self, items: &[PendingActivation]) -> io::Result<()> {
+        let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
+        self.write_locked(items)
+    }
+
+    fn read_locked(&self) -> io::Result<Vec<PendingActivation>> {
+        match std::fs::read(self.path.as_path()) {
+            Ok(bytes) => serde_json::from_slice(&bytes)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Vec::new()),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn write_locked(&self, items: &[PendingActivation]) -> io::Result<()> {
+        let bytes = serde_json::to_vec_pretty(items)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let tmp = self.path.with_extension("tmp");
+        {
+            let mut f = std::fs::File::create(&tmp)?;
+            f.write_all(&bytes)?;
+            f.sync_all()?;
+        }
+        std::fs::rename(&tmp, self.path.as_path())?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-duress-queue-{}-{}-{:p}",
+            tag,
+            std::process::id(),
+            &0u8
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn item(account: &str) -> PendingActivation {
+        PendingActivation {
+            account_id: account.to_string(),
+            duress_code: "enc:abc".to_string(),
+            enqueued_at: Utc::now(),
+            attempts: 0,
+        }
+    }
+
+    #[test]
+    fn enqueue_dequeue_roundtrip() {
+        let dir = temp_dir("rt");
+        let q = DuressQueue::new(&dir);
+        assert!(q.is_empty().unwrap());
+        q.enqueue(item("acct_1")).unwrap();
+        assert_eq!(q.entries().unwrap().len(), 1);
+        q.dequeue("acct_1").unwrap();
+        assert!(q.is_empty().unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn enqueue_dedupes_by_account() {
+        let dir = temp_dir("dedupe");
+        let q = DuressQueue::new(&dir);
+        q.enqueue(item("acct_1")).unwrap();
+        q.enqueue(item("acct_1")).unwrap();
+        assert_eq!(q.entries().unwrap().len(), 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dequeue_missing_is_noop() {
+        let dir = temp_dir("noop");
+        let q = DuressQueue::new(&dir);
+        q.dequeue("nope").unwrap();
+        assert!(q.is_empty().unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn survives_reload_via_new_handle() {
+        let dir = temp_dir("reload");
+        DuressQueue::new(&dir).enqueue(item("acct_9")).unwrap();
+        // A fresh handle (simulating relaunch) sees the persisted entry.
+        let q2 = DuressQueue::new(&dir);
+        assert_eq!(q2.entries().unwrap()[0].account_id, "acct_9");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/coincube-gui/src/services/duress/wipe.rs
+++ b/coincube-gui/src/services/duress/wipe.rs
@@ -1,0 +1,243 @@
+//! Atomic Cube wipe (Phase 3, Task 3.2/3.3).
+//!
+//! The wipe is the on-device trust anchor: at duress activation every byte of
+//! Cube data on disk is obliterated. The sequence per file is
+//! `rename → flush → fsync → overwrite-with-zeros → delete`, bracketed by the
+//! [`WipeJournal`](super::journal::WipeJournal) so a power-pull mid-wipe is
+//! completed on next launch.
+//!
+//! ## What is and isn't wiped
+//!
+//! Wiped: everything under the configured Cube data roots — wallet databases
+//! (BDK), seed/signer material, Spark working dirs, any decrypted-at-rest
+//! tempfiles, and the per-Cube PIN hashes.
+//!
+//! **Never** wiped (these live at the data-directory root, outside the Cube
+//! roots, and are what make recovery and the eventual `POST` possible):
+//! `duress-state.json`, `duress-queue.json`, `duress.key`,
+//! `duress-wipe.journal`, and the cached Connect auth under `connect/`.
+//!
+//! Secure-erase guarantees on SSDs are weak (wear-levelling relocates blocks),
+//! so the zero-overwrite is defence-in-depth layered on top of the
+//! filesystem-level delete — the real guarantee is "the file is gone", not
+//! "the physical sectors are scrubbed".
+
+use std::io::{self, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use super::journal::WipeJournal;
+
+/// One overwrite pass of zeros. SSD wear-levelling makes additional passes
+/// pointless; the delete is the real guarantee.
+const ZERO_CHUNK: [u8; 4096] = [0u8; 4096];
+
+/// Obliterates a fixed set of Cube data roots atomically with respect to the
+/// wipe journal.
+#[derive(Clone)]
+pub struct CubeWiper {
+    /// Absolute paths to wipe — typically the per-network `data/` directories
+    /// plus any auxiliary Cube working dirs. May include files or directories.
+    targets: Vec<PathBuf>,
+    journal: WipeJournal,
+}
+
+impl CubeWiper {
+    pub fn new(targets: Vec<PathBuf>, journal: WipeJournal) -> Self {
+        Self { targets, journal }
+    }
+
+    /// Runs the wipe. Requires the journal marker to already be set by the
+    /// caller (the orchestrator writes it *before* spawning the POST so the
+    /// ordering invariant holds); this method clears the marker only after the
+    /// last target is gone.
+    ///
+    /// Idempotent: targets that don't exist are skipped, so re-running after an
+    /// interrupted wipe completes cleanly.
+    pub fn execute_atomic(&self) -> io::Result<()> {
+        for target in &self.targets {
+            obliterate(target)?;
+        }
+        self.journal.clear()?;
+        Ok(())
+    }
+
+    /// Completes a wipe that the journal says was interrupted. Called on launch
+    /// when `journal.is_pending()`. Same operation as [`execute_atomic`] —
+    /// every target is re-enumerated and removed.
+    pub fn complete_if_pending(&self) -> io::Result<bool> {
+        if !self.journal.is_pending() {
+            return Ok(false);
+        }
+        self.execute_atomic()?;
+        Ok(true)
+    }
+}
+
+/// Recursively obliterates a path. Directories are emptied depth-first then
+/// removed; files are zero-overwritten then unlinked. Missing paths are a
+/// no-op so the operation is idempotent.
+fn obliterate(path: &Path) -> io::Result<()> {
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    };
+
+    if meta.file_type().is_dir() {
+        // Recurse into children first, then remove the now-empty directory.
+        for entry in std::fs::read_dir(path)? {
+            let entry = entry?;
+            obliterate(&entry.path())?;
+        }
+        match std::fs::remove_dir(path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    } else if meta.file_type().is_symlink() {
+        // Never follow a symlink out of the Cube tree; just unlink it.
+        remove_file_idempotent(path)
+    } else {
+        zero_and_remove_file(path, meta.len())
+    }
+}
+
+/// `rename → fsync → zero-overwrite → delete` for a single regular file.
+fn zero_and_remove_file(path: &Path, len: u64) -> io::Result<()> {
+    // Rename to a sibling `.wiping` name first so a crash leaves an obviously
+    // partial artifact rather than a file that still looks like live data.
+    let wiping = path.with_extension("wiping");
+    let working = match std::fs::rename(path, &wiping) {
+        Ok(()) => wiping,
+        // If the rename target collides or the FS refuses, fall back to
+        // operating on the original path.
+        Err(_) => path.to_path_buf(),
+    };
+
+    if len > 0 {
+        if let Ok(mut f) = std::fs::OpenOptions::new().write(true).open(&working) {
+            f.seek(SeekFrom::Start(0))?;
+            let mut remaining = len;
+            while remaining > 0 {
+                let n = remaining.min(ZERO_CHUNK.len() as u64) as usize;
+                f.write_all(&ZERO_CHUNK[..n])?;
+                remaining -= n as u64;
+            }
+            f.flush()?;
+            let _ = f.sync_all();
+        }
+    }
+
+    remove_file_idempotent(&working)
+}
+
+fn remove_file_idempotent(path: &Path) -> io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-duress-wipe-{}-{}-{:p}",
+            tag,
+            std::process::id(),
+            &0u8
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_file(path: &Path, contents: &[u8]) {
+        if let Some(p) = path.parent() {
+            std::fs::create_dir_all(p).unwrap();
+        }
+        std::fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn wipe_removes_all_cube_files_and_clears_journal() {
+        let root = temp_dir("removes");
+        let cube_root = root.join("bitcoin").join("data");
+        write_file(&cube_root.join("cube_a").join("wallet.db"), b"SECRET-A");
+        write_file(&cube_root.join("cube_a").join("seed"), b"SEED-A");
+        write_file(&cube_root.join("cube_b").join("wallet.db"), b"SECRET-B");
+
+        // Files that must survive: duress stores at the root.
+        write_file(&root.join("duress-queue.json"), b"[{...}]");
+        write_file(&root.join("duress-state.json"), b"{...}");
+
+        let journal = WipeJournal::new(&root);
+        journal.mark_pending_activation("acct_1").unwrap();
+        let wiper = CubeWiper::new(vec![cube_root.clone()], journal.clone());
+        wiper.execute_atomic().unwrap();
+
+        assert!(!cube_root.exists(), "cube data root must be gone");
+        assert!(!journal.is_pending(), "journal marker must be cleared");
+        // Survivors intact.
+        assert!(root.join("duress-queue.json").exists());
+        assert!(root.join("duress-state.json").exists());
+
+        // Penetration check: the known cube string must not appear anywhere
+        // under the data root.
+        let mut found = false;
+        fn scan(p: &Path, needle: &[u8], found: &mut bool) {
+            if let Ok(rd) = std::fs::read_dir(p) {
+                for e in rd.flatten() {
+                    let path = e.path();
+                    if path.is_dir() {
+                        scan(&path, needle, found);
+                    } else if let Ok(bytes) = std::fs::read(&path) {
+                        if bytes.windows(needle.len()).any(|w| w == needle) {
+                            *found = true;
+                        }
+                    }
+                }
+            }
+        }
+        scan(&root, b"SECRET-A", &mut found);
+        assert!(!found, "no cube material may remain on disk");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn wipe_is_idempotent() {
+        let root = temp_dir("idempotent");
+        let cube_root = root.join("data");
+        write_file(&cube_root.join("x.db"), b"x");
+        let journal = WipeJournal::new(&root);
+        journal.mark_pending_activation("a").unwrap();
+        let wiper = CubeWiper::new(vec![cube_root.clone()], journal);
+        wiper.execute_atomic().unwrap();
+        // Second run on already-wiped targets must succeed.
+        wiper.execute_atomic().unwrap();
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn complete_if_pending_runs_only_when_marked() {
+        let root = temp_dir("pending");
+        let cube_root = root.join("data");
+        write_file(&cube_root.join("x.db"), b"x");
+        let journal = WipeJournal::new(&root);
+        let wiper = CubeWiper::new(vec![cube_root.clone()], journal.clone());
+
+        // No marker → nothing happens, files remain.
+        assert!(!wiper.complete_if_pending().unwrap());
+        assert!(cube_root.join("x.db").exists());
+
+        // With marker (simulating an interrupted wipe) → completes.
+        journal.mark_pending_activation("a").unwrap();
+        assert!(wiper.complete_if_pending().unwrap());
+        assert!(!cube_root.exists());
+        assert!(!journal.is_pending());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/coincube-gui/src/services/mod.rs
+++ b/coincube-gui/src/services/mod.rs
@@ -6,6 +6,7 @@ pub mod http;
 pub mod keys;
 
 pub mod coincube;
+pub mod duress;
 pub mod mavapay;
 pub mod meld;
 pub mod passkey;

--- a/coincube-gui/src/services/recovery/restore.rs
+++ b/coincube-gui/src/services/recovery/restore.rs
@@ -50,6 +50,21 @@ pub enum RestoreError {
     /// caller needs (e.g. W14 wants a descriptor; the server-side
     /// kit is seed-only).
     HalfMissing,
+    /// Approach C (Phase 7): the server returned `423 DURESS_LOCKED` —
+    /// the account is in duress (typically because the user entered their
+    /// *duress* CRK password), so the kit is withheld until `unlock_at`.
+    /// From a legitimate user's perspective this reads like a normal
+    /// "can't download right now"; from an under-duress user's it's
+    /// plausibly deniable.
+    DuressLocked {
+        unlock_at: Option<chrono::DateTime<chrono::Utc>>,
+    },
+    /// Approach C (Phase 7): `423 TRUSTED_DEVICE_DELAY` — a fresh device
+    /// must wait until `available_at` before it can download the kit, even
+    /// with the correct password.
+    TrustedDeviceDelay {
+        available_at: Option<chrono::DateTime<chrono::Utc>>,
+    },
 }
 
 impl std::fmt::Display for RestoreError {
@@ -69,6 +84,14 @@ impl std::fmt::Display for RestoreError {
                 f,
                 "This Recovery Kit doesn't include the part you're trying to restore."
             ),
+            Self::DuressLocked { .. } => write!(
+                f,
+                "Recovery kit cannot be downloaded at this time. If this is \
+                 unexpected, contact support."
+            ),
+            Self::TrustedDeviceDelay { .. } => {
+                write!(f, "Recovery kit download is delayed on new devices.")
+            }
         }
     }
 }
@@ -80,6 +103,22 @@ impl From<CoincubeError> for RestoreError {
         match e {
             CoincubeError::NotFound => Self::NotFound,
             CoincubeError::RateLimited { retry_after } => Self::RateLimited { retry_after },
+            // Approach C (Phase 7): the recovery-kit endpoint may now answer a
+            // download with `423 Locked` carrying a discriminating body. Parse
+            // it into the typed duress variants so the UI can render the right
+            // cue; anything that doesn't parse stays a generic Api error.
+            CoincubeError::Unsuccessful(ref info) if info.status_code == 423 => {
+                match crate::services::coincube::DownloadError::from_locked_body(&info.text) {
+                    crate::services::coincube::DownloadError::TrustedDeviceDelay {
+                        available_at,
+                    } => Self::TrustedDeviceDelay { available_at },
+                    // DuressLocked is the safe default for an opaque 423.
+                    crate::services::coincube::DownloadError::DuressLocked { unlock_at } => {
+                        Self::DuressLocked { unlock_at }
+                    }
+                    _ => Self::Api(e.to_string()),
+                }
+            }
             other => Self::Api(other.to_string()),
         }
     }
@@ -228,6 +267,53 @@ mod tests {
 
     fn pw(s: &str) -> Zeroizing<String> {
         Zeroizing::new(s.to_string())
+    }
+
+    fn unsuccessful(status: u16, text: &str) -> CoincubeError {
+        CoincubeError::Unsuccessful(crate::services::http::NotSuccessResponseInfo {
+            status_code: status,
+            text: text.to_string(),
+        })
+    }
+
+    #[test]
+    fn http_423_duress_locked_maps_to_typed_variant() {
+        let err: RestoreError = unsuccessful(
+            423,
+            r#"{"error":{"code":"DURESS_LOCKED","unlockAt":"2026-06-10T00:00:00Z"}}"#,
+        )
+        .into();
+        match err {
+            RestoreError::DuressLocked { unlock_at } => {
+                assert_eq!(unlock_at.unwrap().to_rfc3339(), "2026-06-10T00:00:00+00:00")
+            }
+            other => panic!("expected DuressLocked, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn http_423_trusted_device_delay_maps_to_typed_variant() {
+        let err: RestoreError = unsuccessful(
+            423,
+            r#"{"error":{"code":"TRUSTED_DEVICE_DELAY","availableAt":"2026-06-11T00:00:00Z"}}"#,
+        )
+        .into();
+        assert!(matches!(err, RestoreError::TrustedDeviceDelay { .. }));
+    }
+
+    #[test]
+    fn opaque_423_defaults_to_duress_locked() {
+        let err: RestoreError = unsuccessful(423, "nope").into();
+        assert!(matches!(
+            err,
+            RestoreError::DuressLocked { unlock_at: None }
+        ));
+    }
+
+    #[test]
+    fn non_423_unsuccessful_stays_api_error() {
+        let err: RestoreError = unsuccessful(500, "server boom").into();
+        assert!(matches!(err, RestoreError::Api(_)));
     }
 
     fn sample_seed_blob() -> SeedBlob {

--- a/coincube-gui/tests/duress_e2e.rs
+++ b/coincube-gui/tests/duress_e2e.rs
@@ -1,0 +1,117 @@
+//! End-to-end duress acceptance test (Phase 9 Task 9.2).
+//!
+//! This drives the duress engine through a full activate → cryptic → clear
+//! cycle against a mocked Connect trigger and a temp data directory, asserting
+//! the trust-posture invariants hold end to end:
+//!
+//!   1. enroll (store this device's encrypted duress code),
+//!   2. activate via the orchestrator → Cube files gone, queue/journal/state
+//!      durable,
+//!   3. the activation POST drains the queue,
+//!   4. a server-side clear flips local state back so launch reconcile exits.
+//!
+//! The staging-environment variant (real Connect, synthetic clock past
+//! `unlock_at`, all-clear submit, CRK download with the regular password,
+//! restore + balance assertion) is gated behind `--ignored` because it needs a
+//! live staging account; this in-process test runs in CI on every build.
+
+use std::sync::Arc;
+
+use coincube_gui::services::duress::{
+    cipher::DeviceKey,
+    journal::WipeJournal,
+    orchestrator::{DuressOrchestrator, DuressTrigger, TriggerError},
+    queue::DuressQueue,
+    wipe::CubeWiper,
+    DuressLocalState,
+};
+
+struct OkTrigger;
+
+#[async_trait::async_trait]
+impl DuressTrigger for OkTrigger {
+    async fn trigger(&self, _account_id: &str, _code: &str) -> Result<(), TriggerError> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn full_local_duress_cycle() {
+    // --- temp data dir with seeded Cube data ---
+    let dir = std::env::temp_dir().join(format!("coincube-duress-e2e-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    let cube_root = dir.join("bitcoin").join("data").join("cube_a");
+    std::fs::create_dir_all(&cube_root).unwrap();
+    std::fs::write(cube_root.join("wallet.db"), b"PRE-DURESS-SECRET").unwrap();
+
+    // --- 1. enroll: store this device's encrypted duress code ---
+    let cipher = DeviceKey::from_bytes([42u8; 32]);
+    let code = coincube_gui::services::duress::enroll::generate_duress_code();
+    let state = DuressLocalState {
+        enrolled: true,
+        duress_code: Some(cipher.encrypt(&code).unwrap()),
+        ..Default::default()
+    };
+    state.save(&dir).unwrap();
+
+    // --- 2/3. activate ---
+    let journal = WipeJournal::new(&dir);
+    let queue = DuressQueue::new(&dir);
+    let wipe = CubeWiper::new(vec![dir.join("bitcoin").join("data")], journal.clone());
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut orch = DuressOrchestrator::new(
+        state,
+        dir.clone(),
+        journal.clone(),
+        queue.clone(),
+        wipe,
+        cipher,
+        Arc::new(OkTrigger),
+        Some(tx),
+    );
+    orch.activate("acct_e2e".to_string()).await.unwrap();
+
+    // Cube data is gone; the cryptic-screen event fired; state is durable.
+    assert!(!dir.join("bitcoin").join("data").exists());
+    assert_eq!(
+        rx.recv().await,
+        Some(coincube_gui::services::duress::DuressEvent::Activated)
+    );
+    assert!(DuressLocalState::load(&dir).unwrap().active);
+    assert!(!journal.is_pending(), "journal cleared after wipe");
+
+    // The OK trigger drains the queue (give the spawned task a moment).
+    for _ in 0..100 {
+        if queue.is_empty().unwrap() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    assert!(queue.is_empty().unwrap(), "queue drains on POST success");
+
+    // --- 4. server-side clear → local state flips so launch reconcile exits ---
+    let mut cleared = DuressLocalState::load(&dir).unwrap();
+    cleared.active = false;
+    cleared.unlock_at = None;
+    cleared.save(&dir).unwrap();
+    assert!(!DuressLocalState::load(&dir).unwrap().active);
+
+    // Survivors: duress stores at the root persisted across the whole cycle.
+    assert!(dir.join("duress-state.json").exists());
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+#[ignore = "requires a live staging Connect account + CRK; run manually"]
+fn full_cycle_against_staging() {
+    // Scripted steps (see plan Phase 9 Task 9.2):
+    //   1. Enroll (Tier 1).
+    //   2. Activate via duress PIN.
+    //   3. Assert Cube files gone + cryptic screen rendered.
+    //   4. Sign in to staging Connect.
+    //   5. Wait synthetic clock past unlock_at.
+    //   6. Submit all-clear.
+    //   7. Download CRK with the regular password.
+    //   8. Restore Cubes; assert balances match pre-duress.
+}

--- a/coincube-ui/src/icon.rs
+++ b/coincube-ui/src/icon.rs
@@ -284,6 +284,13 @@ pub fn cube_icon<'a>() -> Text<'a> {
     bootstrap_icon('\u{F1C8}')
 }
 
+/// Outline (non-filled) cube — paired with [`cube_icon`] to distinguish a
+/// Sovereign (local-only) Cube from a Connect-registered one in the tri-state
+/// Cube indicator.
+pub fn cube_outline_icon<'a>() -> Text<'a> {
+    bootstrap_icon('\u{F1C7}')
+}
+
 pub fn receipt_icon<'a>() -> Text<'a> {
     bootstrap_icon('\u{F50F}')
 }

--- a/grpc/connect.proto
+++ b/grpc/connect.proto
@@ -194,7 +194,25 @@ message StreamEnvelope {
     ErrorEvent error = 4;
     Ping ping = 5;
     Pong pong = 6;
+    DuressActivatedEvent duress_activated = 7;
+    DuressClearedEvent duress_cleared = 8;
   }
+}
+
+// DuressActivatedEvent is broadcast on the existing Connect stream when an
+// account enters duress, so every connected desktop / Keychain client can
+// react in realtime. Offline clients reconcile via GET /connect/duress.
+// (Synced from coincube-api/grpc/connect.proto for Phase 7b.)
+message DuressActivatedEvent {
+  string account_id = 1;
+  google.protobuf.Timestamp duress_unlock_at = 2;
+  // "desktop_pin" | "auth_trigger" | "email_link" | "duress_crk_password"
+  string source = 3;
+}
+
+message DuressClearedEvent {
+  string account_id = 1;
+  google.protobuf.Timestamp cleared_at = 2;
 }
 
 message ClientHello {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes PIN unlock, destructive multi-network wipes, and Connect auth/duress gates; mistakes could brick access or leak credentials in logs if redaction regresses.
> 
> **Overview**
> Adds **duress mode** end-to-end: users can enroll (Connect Pro/Estate or sovereign), arm a **duress PIN** on every Cube across all networks, and trigger a **local wipe** plus optional **server lock** when that PIN is entered at unlock.
> 
> **Enrollment & persistence:** Connect gets a multi-step wizard (duress PIN, all-clear, optional CRK password, delay) with server `enroll` first for Connect tiers, then `persist_duress_enrollment` writes `duress_pin_hash` on all Cubes and encrypted per-device codes in `DuressLocalState`, with rollback if any step fails. Secrets use `Zeroizing` and redacted `Debug`.
> 
> **Activation paths:** **Local PIN** runs journal → durable activation queue → background `trigger-with-code` → multi-network wipe (preserving `connect.json`) → cryptic **Duress Active** tab state; launch reconcile completes interrupted wipes and drains the queue. **Remote gRPC** activation/clear updates local state and locks the UI **without** wiping.
> 
> **Connect UX:** Post-sign-in **CheckingDuress** gate (fail-closed), **DuressRecovery** with all-clear clear flow, device code auto-registration, and Duress nav re-enabled. Cube list shows **Sovereign / Registered / Backed up** connect state.
> 
> **API & recovery:** New Coincube client methods and DTOs for duress REST; recovery-kit download maps **423** to duress lock vs trusted-device delay. `CoincubeDirectory::active()` records `--datadir` for stable device fingerprints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a81097fa1419ab6ff160c569f717f7adc5ff8d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-step duress enrollment & recovery wizard, duress‑PIN detection, Duress Active lock screen, and tri-state Connect status.
  * Local duress persistence with encrypted on‑device secrets, stable device fingerprinting, durable wipe/journal and background retry/drain for offline activations.
  * Remote duress activation/clear syncing, client endpoints for duress flows, and recovery‑kit download handling with trusted‑device delay.

* **Tests**
  * Added unit and end‑to‑end duress test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->