### PR TITLE
Estate Promo

### DIFF
--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -51,6 +51,23 @@ pub struct CheckoutState {
     pub poll_errors: u8,
 }
 
+// ── Campaign code redemption (v2 campaign engine) ───────────────────────────
+
+/// State for the generic "promo or referral code" field in Settings → Plan.
+/// Campaign-agnostic — the desktop forwards the typed code and renders the
+/// server's success/error message verbatim.
+#[derive(Debug, Default)]
+pub struct CampaignRedeemState {
+    /// Current text in the code field.
+    pub code: String,
+    /// A redeem request is in flight.
+    pub submitting: bool,
+    /// Last outcome: `Ok(server message)` on success, `Err(server message)`
+    /// on a typed failure (invalid / expired / exhausted / already-redeemed).
+    /// `None` before any attempt.
+    pub result: Option<Result<String, String>>,
+}
+
 // ── Plan lifecycle (renewal banner / expired state) ─────────────────────────
 
 /// Number of days before `renewal_at` at which the pre-expiry renewal
@@ -61,13 +78,6 @@ pub const PLAN_RENEWAL_BANNER_DAYS: i64 = 7;
 /// `/connect/features` payload advertising a higher version triggers the
 /// soft "update available" note in the plan picker (D4).
 pub const SUPPORTED_PRICING_SCHEMA_VERSION: u32 = 1;
-
-/// At launch the July-4 Estate promo suppresses the pre-expiry renewal
-/// banner for promo accounts (PLAN-estate-promo PR1) — the API likewise
-/// suppresses reminder emails, and the year-one cliff (Jul 2027) is too far
-/// out to nag about now. Flip to `false` for year-two GA to re-enable the
-/// banner with year-two renewal copy.
-pub const PROMO_SUPPRESS_RENEWAL_BANNER: bool = true;
 
 /// Where the user's plan sits in its lifecycle, derived from the
 /// `/connect/plan` response plus the current time. Drives the renewal
@@ -397,6 +407,14 @@ pub struct ConnectAccountPanel {
     /// session (D1). Not persisted — re-shows on next launch while the
     /// plan is still within its renewal window.
     pub renewal_banner_dismissed: bool,
+    /// Settings → Plan promo/referral code field (v2 campaign engine).
+    pub campaign_redeem: CampaignRedeemState,
+    /// Optional promo/referral code typed on the account-creation screen.
+    pub register_campaign_code: String,
+    /// Code captured at registration, redeemed once the new session
+    /// authenticates (the redeem endpoint requires a token). Consumed in
+    /// `SessionLoaded`.
+    pub pending_campaign_code: Option<String>,
 }
 
 impl ConnectAccountPanel {
@@ -419,6 +437,9 @@ impl ConnectAccountPanel {
             show_billing_history: false,
             duress_enroll: None,
             renewal_banner_dismissed: false,
+            campaign_redeem: CampaignRedeemState::default(),
+            register_campaign_code: String::new(),
+            pending_campaign_code: None,
         }
     }
 
@@ -465,6 +486,30 @@ impl ConnectAccountPanel {
     /// Cube" one-click action.
     pub fn set_active_cube_server_id(&mut self, cube_id: Option<u64>) {
         self.contacts_state.active_cube_server_id = cube_id;
+    }
+
+    /// Fire `POST /connect/campaigns/redeem` for `code` and route the
+    /// outcome to `CampaignRedeemed`. Shared by the Settings → Plan field
+    /// and the deferred post-auth redeem of an account-creation code. The
+    /// success message is server-authored; a failure carries the server's
+    /// typed error message, rendered verbatim (no campaign knowledge).
+    fn redeem_campaign_task(&self, code: String) -> iced::Task<Message> {
+        let gen = self.session_generation;
+        let client = self.client.clone();
+        iced::Task::perform(
+            async move {
+                client
+                    .redeem_campaign(&code)
+                    .await
+                    .map(|resp| resp.message.unwrap_or_else(|| "Code applied.".to_string()))
+                    .map_err(|e| e.to_string())
+            },
+            move |result| {
+                Message::View(view::Message::ConnectAccount(
+                    ConnectAccountMessage::CampaignRedeemed(result, gen),
+                ))
+            },
+        )
     }
 
     /// Kick off a `get_cubes_by_contact(contact_id)` fetch and wire
@@ -637,7 +682,7 @@ impl ConnectAccountPanel {
                 let c1 = self.client.clone();
                 let c2 = self.client.clone();
                 let c3 = self.client.clone();
-                return iced::Task::batch([
+                let mut tasks = vec![
                     iced::Task::perform(
                         async move { (c1.get_connect_plan().await.ok(), gen) },
                         |(plan, g)| {
@@ -659,7 +704,16 @@ impl ConnectAccountPanel {
                     // failed check retries (see the handler) so a transient
                     // error doesn't leave a duress account on the dashboard.
                     duress_state_check_task(c3, gen, 0),
-                ]);
+                ];
+                // Redeem an account-creation promo/referral code now that the
+                // session is authenticated. Best-effort: a bad code never
+                // blocks sign-in — the outcome surfaces in Settings → Plan,
+                // and `CampaignRedeemed` refreshes the plan on success.
+                if let Some(code) = self.pending_campaign_code.take() {
+                    self.campaign_redeem.submitting = true;
+                    tasks.push(self.redeem_campaign_task(code));
+                }
+                return iced::Task::batch(tasks);
             }
 
             ConnectAccountMessage::PlanLoaded(plan, gen) => {
@@ -683,6 +737,9 @@ impl ConnectAccountPanel {
                 self.billing_history = None;
                 self.show_billing_history = false;
                 self.renewal_banner_dismissed = false;
+                self.campaign_redeem = CampaignRedeemState::default();
+                self.register_campaign_code = String::new();
+                self.pending_campaign_code = None;
                 self.selected_billing_cycle = BillingCycle::Monthly;
                 self.contacts_state.clear();
                 // Scrub any in-flight enrollment wizard secrets (PINs,
@@ -762,6 +819,13 @@ impl ConnectAccountPanel {
             }
 
             ConnectAccountMessage::SubmitRegistration => {
+                // Stash any account-creation promo/referral code now; it's
+                // redeemed once the new session authenticates (the redeem
+                // endpoint requires a token). Empty → nothing to redeem.
+                self.pending_campaign_code = {
+                    let trimmed = self.register_campaign_code.trim();
+                    (!trimmed.is_empty()).then(|| trimmed.to_string())
+                };
                 let ConnectFlowStep::Register { email, loading } = &mut self.step else {
                     return iced::Task::none();
                 };
@@ -1289,6 +1353,56 @@ impl ConnectAccountPanel {
             ConnectAccountMessage::UserProfileFailed(error) => {
                 // Non-auth error - just show error, don't redirect to login
                 self.error = Some(error);
+            }
+
+            // ── Campaign code redemption (v2 campaign engine) ─────────────
+            ConnectAccountMessage::CampaignCodeChanged(code) => {
+                self.campaign_redeem.code = code;
+                // Editing past a prior outcome clears it so the field reads as
+                // a fresh attempt.
+                self.campaign_redeem.result = None;
+            }
+
+            ConnectAccountMessage::RegisterCampaignCodeChanged(code) => {
+                self.register_campaign_code = code;
+            }
+
+            ConnectAccountMessage::RedeemCampaignCode => {
+                let code = self.campaign_redeem.code.trim().to_string();
+                if code.is_empty() || self.campaign_redeem.submitting {
+                    return iced::Task::none();
+                }
+                self.campaign_redeem.submitting = true;
+                self.campaign_redeem.result = None;
+                return self.redeem_campaign_task(code);
+            }
+
+            ConnectAccountMessage::CampaignRedeemed(result, gen) => {
+                if gen != self.session_generation {
+                    return iced::Task::none();
+                }
+                self.campaign_redeem.submitting = false;
+                match result {
+                    Ok(msg) => {
+                        self.campaign_redeem.result = Some(Ok(msg));
+                        // Clear the field and refresh the plan so the granted
+                        // tier / provenance appear.
+                        self.campaign_redeem.code = String::new();
+                        let g = self.session_generation;
+                        let c = self.client.clone();
+                        return iced::Task::perform(
+                            async move { (c.get_connect_plan().await.ok(), g) },
+                            |(plan, g)| {
+                                Message::View(view::Message::ConnectAccount(
+                                    ConnectAccountMessage::PlanLoaded(plan, g),
+                                ))
+                            },
+                        );
+                    }
+                    Err(e) => {
+                        self.campaign_redeem.result = Some(Err(e));
+                    }
+                }
             }
             ConnectAccountMessage::DuressStateChecked(state, gen, attempt) => {
                 // Phase 6: post-sign-in gate. We sit in `CheckingDuress` until
@@ -2365,23 +2479,12 @@ impl ConnectAccountPanel {
         self.plan_lifecycle_at(chrono::Utc::now())
     }
 
-    /// True when the authenticated account currently holds the July-4 promo
-    /// grant (Estate free for year one). Drives the promo manage-plan
-    /// variant, the collapsed picker, and renewal-banner suppression
-    /// (PLAN-estate-promo PR1).
-    pub fn is_promo_plan(&self) -> bool {
-        self.plan
-            .as_ref()
-            .map(|p| p.is_active_promo())
-            .unwrap_or(false)
-    }
-
     /// Whether self-service purchasing is currently available. Sourced from
     /// `GET /connect/features` (`purchasing_enabled`); absent → enabled, so
     /// the existing checkout flow stays intact for backends that don't send
-    /// the flag (and for fall GA once the promo ends). The July-4 promo sets
-    /// it `false`, which hides every purchase surface (PLAN-estate-promo
-    /// PR2).
+    /// the flag (and for fall GA once a campaign closes). A campaign that
+    /// disables purchasing sets it `false`, which hides every purchase
+    /// surface (PLAN-estate-promo PR2).
     pub fn purchasing_enabled(&self) -> bool {
         self.features
             .as_ref()
@@ -2394,12 +2497,13 @@ impl ConnectAccountPanel {
     /// session. The expired state has its own dedicated UX (D3), so the
     /// banner intentionally does not cover `Expired`.
     ///
-    /// Suppressed entirely for promo accounts at launch (config-flagged via
-    /// [`PROMO_SUPPRESS_RENEWAL_BANNER`]) and whenever purchasing is
-    /// disabled — in both cases there is no purchase path, so a "Renew now"
-    /// nag would be a dead end (PLAN-estate-promo PR1/PR2).
+    /// Suppressed whenever purchasing is disabled — there is no purchase
+    /// path then, so a "Renew now" nag would be a dead end. This is the
+    /// generic, campaign-agnostic gate (a campaign that grants a plan also
+    /// closes purchasing, so its grantees never see the banner during the
+    /// window).
     pub fn show_renewal_banner(&self) -> bool {
-        if (PROMO_SUPPRESS_RENEWAL_BANNER && self.is_promo_plan()) || !self.purchasing_enabled() {
+        if !self.purchasing_enabled() {
             return false;
         }
         !self.renewal_banner_dismissed
@@ -3561,7 +3665,7 @@ mod add_to_cube_tests {
 #[cfg(test)]
 mod plan_lifecycle_tests {
     use super::*;
-    use crate::services::coincube::{PlanEntitlements, PlanFeatureInfo, PlanSource};
+    use crate::services::coincube::{PlanEntitlements, PlanFeatureInfo};
 
     /// Parse a fixed RFC-3339 instant for deterministic `now`/renewal math.
     fn at(iso: &str) -> chrono::DateTime<chrono::Utc> {
@@ -3589,20 +3693,8 @@ mod plan_lifecycle_tests {
                 business_orgs: false,
             },
             billing_cycle: cycle,
-            plan_source: None,
+            plan_provenance: None,
         }
-    }
-
-    /// A `ConnectPlan` carrying explicit promo provenance, for the
-    /// estate-promo cases.
-    fn promo_plan(
-        status: PlanStatus,
-        renewal_at: Option<&str>,
-        source: PlanSource,
-    ) -> ConnectPlan {
-        let mut p = plan(PlanTier::Estate, status, renewal_at, Some(BillingCycle::Annual));
-        p.plan_source = Some(source);
-        p
     }
 
     fn panel_with_plan(plan: ConnectPlan) -> ConnectAccountPanel {
@@ -3803,93 +3895,166 @@ mod plan_lifecycle_tests {
         assert!(panel.pricing_schema_outdated());
     }
 
-    // ── Estate promo: provenance detection (PR1) ──────────────────────
+    // ── Plan provenance: server-driven display contract (v2) ──────────
     #[test]
-    fn active_promo_is_detected() {
-        let panel = panel_with_plan(promo_plan(
-            PlanStatus::Active,
-            Some("2027-07-04T00:00:00Z"),
-            PlanSource::PromoEstateY1,
-        ));
-        assert!(panel.plan.as_ref().unwrap().is_promo());
-        assert!(panel.plan.as_ref().unwrap().is_active_promo());
-        assert!(panel.is_promo_plan());
+    fn plan_provenance_deserializes_from_wire() {
+        // Pure display passthrough — the only thing to verify is that the
+        // `{label, expires_at, badge}` contract parses. `ConnectPlan` is
+        // camelCase; `expiresAt` exercises `PlanProvenance`'s camelCase too.
+        let json = r#"{
+            "plan": "estate",
+            "status": "active",
+            "renewalAt": "2027-07-04T00:00:00Z",
+            "entitlements": {
+                "freeSigningKeyCount": 0, "policyEditing": true, "legacyInvites": true,
+                "linkedKeychains": true, "duressRemoteLock": true, "businessOrgs": true
+            },
+            "planProvenance": {
+                "label": "Free for your first year",
+                "expiresAt": "2027-07-04T00:00:00Z",
+                "badge": "Founding member"
+            }
+        }"#;
+        let p: ConnectPlan = serde_json::from_str(json).unwrap();
+        let prov = p.plan_provenance.expect("provenance present");
+        assert_eq!(prov.label, "Free for your first year");
+        assert_eq!(prov.badge.as_deref(), Some("Founding member"));
+        assert_eq!(prov.expires_at.as_deref(), Some("2027-07-04T00:00:00Z"));
     }
 
     #[test]
-    fn paid_plan_is_not_promo() {
-        // Explicit `paid` provenance must never read as promo.
-        let panel = panel_with_plan(promo_plan(
-            PlanStatus::Active,
-            Some("2027-07-04T00:00:00Z"),
-            PlanSource::Paid,
-        ));
-        assert!(!panel.plan.as_ref().unwrap().is_promo());
-        assert!(!panel.is_promo_plan());
+    fn plan_without_provenance_is_backward_compatible() {
+        // Older API omits `plan_provenance` → `None` → existing paid/free UX.
+        let json = r#"{
+            "plan": "pro",
+            "status": "active",
+            "renewalAt": null,
+            "entitlements": {
+                "freeSigningKeyCount": 0, "policyEditing": false, "legacyInvites": false,
+                "linkedKeychains": false, "duressRemoteLock": false, "businessOrgs": false
+            }
+        }"#;
+        let p: ConnectPlan = serde_json::from_str(json).unwrap();
+        assert!(p.plan_provenance.is_none());
+    }
+
+    // ── Campaign code redemption (server-driven, v2) ──────────────────
+    #[test]
+    fn campaign_code_change_clears_prior_result() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.campaign_redeem.result = Some(Err("invalid".into()));
+        let _ = panel.update_message(ConnectAccountMessage::CampaignCodeChanged("ABC".into()));
+        assert_eq!(panel.campaign_redeem.code, "ABC");
+        assert!(panel.campaign_redeem.result.is_none());
     }
 
     #[test]
-    fn missing_plan_source_is_not_promo() {
-        // Backward compatibility: older API omits `plan_source` → `None` →
-        // ordinary (non-promo) UX.
-        let panel = panel_with_plan(plan(
-            PlanTier::Estate,
-            PlanStatus::Active,
-            Some("2027-07-04T00:00:00Z"),
-            Some(BillingCycle::Annual),
-        ));
-        assert!(panel.plan.as_ref().unwrap().plan_source.is_none());
-        assert!(!panel.plan.as_ref().unwrap().is_promo());
-        assert!(!panel.is_promo_plan());
+    fn redeem_empty_code_is_noop() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.campaign_redeem.code = "   ".into();
+        let _ = panel.update_message(ConnectAccountMessage::RedeemCampaignCode);
+        assert!(!panel.campaign_redeem.submitting);
     }
 
     #[test]
-    fn unknown_plan_source_is_not_promo() {
-        // A future/unrecognized provenance value must not hide purchasing.
-        let panel = panel_with_plan(promo_plan(
-            PlanStatus::Active,
-            Some("2027-07-04T00:00:00Z"),
-            PlanSource::Unknown,
-        ));
-        assert!(!panel.is_promo_plan());
+    fn redeem_nonempty_marks_submitting_and_clears_result() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.campaign_redeem.code = "FOUNDER".into();
+        panel.campaign_redeem.result = Some(Err("old".into()));
+        let _ = panel.update_message(ConnectAccountMessage::RedeemCampaignCode);
+        assert!(panel.campaign_redeem.submitting);
+        assert!(panel.campaign_redeem.result.is_none());
     }
 
     #[test]
-    fn lapsed_promo_is_not_active_promo_and_reads_expired() {
-        // At the year-one cliff the backend demotes the promo to `past_due`;
-        // it must fall through to the ordinary expired UX, not the promo card.
-        let panel = panel_with_plan(promo_plan(
-            PlanStatus::PastDue,
-            Some("2026-06-01T00:00:00Z"),
-            PlanSource::PromoEstateY1,
+    fn redeem_success_records_message_and_clears_code() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.campaign_redeem.code = "FOUNDER".into();
+        panel.campaign_redeem.submitting = true;
+        let gen = panel.session_generation();
+        let _ = panel.update_message(ConnectAccountMessage::CampaignRedeemed(
+            Ok("Estate unlocked".into()),
+            gen,
         ));
-        assert!(panel.plan.as_ref().unwrap().is_promo());
-        assert!(!panel.plan.as_ref().unwrap().is_active_promo());
-        assert!(!panel.is_promo_plan());
-        assert_eq!(panel.plan_lifecycle_at(at(NOW)), PlanLifecycle::Expired);
-    }
-
-    #[test]
-    fn promo_account_suppresses_renewal_banner() {
-        // Even inside the renewal window, a promo account suppresses the
-        // pre-expiry banner at launch (config-flagged).
-        assert!(
-            PROMO_SUPPRESS_RENEWAL_BANNER,
-            "test assumes launch config; update if flipped for GA"
-        );
-        let panel = panel_with_plan(promo_plan(
-            PlanStatus::Active,
-            Some("2026-06-13T00:00:00Z"), // 5 days out → RenewalDue
-            PlanSource::PromoEstateY1,
-        ));
+        assert!(!panel.campaign_redeem.submitting);
         assert_eq!(
-            panel.plan_lifecycle_at(at(NOW)),
-            PlanLifecycle::RenewalDue { days_remaining: 5 }
+            panel.campaign_redeem.result,
+            Some(Ok("Estate unlocked".to_string()))
         );
-        assert!(!panel.show_renewal_banner());
+        assert!(panel.campaign_redeem.code.is_empty());
     }
 
-    // ── Estate promo: purchasing gate (PR2) ───────────────────────────
+    #[test]
+    fn redeem_failure_records_error_and_keeps_code() {
+        // The error message is the server's typed taxonomy string, rendered
+        // verbatim; the code stays so the user can correct and retry.
+        let mut panel = ConnectAccountPanel::new();
+        panel.campaign_redeem.code = "BADCODE".into();
+        panel.campaign_redeem.submitting = true;
+        let gen = panel.session_generation();
+        let _ = panel.update_message(ConnectAccountMessage::CampaignRedeemed(
+            Err("This code has already been redeemed.".into()),
+            gen,
+        ));
+        assert!(!panel.campaign_redeem.submitting);
+        assert_eq!(
+            panel.campaign_redeem.result,
+            Some(Err("This code has already been redeemed.".to_string()))
+        );
+        assert_eq!(panel.campaign_redeem.code, "BADCODE");
+    }
+
+    #[test]
+    fn redeem_result_from_stale_generation_ignored() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.campaign_redeem.submitting = true;
+        let _ = panel.update_message(ConnectAccountMessage::CampaignRedeemed(
+            Ok("late".into()),
+            999, // not the current session generation
+        ));
+        assert!(panel.campaign_redeem.submitting);
+        assert!(panel.campaign_redeem.result.is_none());
+    }
+
+    #[test]
+    fn register_code_is_stashed_trimmed_on_submit() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.step = ConnectFlowStep::Register {
+            email: "founder@example.com".into(),
+            loading: false,
+        };
+        panel.register_campaign_code = "  FOUNDER  ".into();
+        let _ = panel.update_message(ConnectAccountMessage::SubmitRegistration);
+        assert_eq!(panel.pending_campaign_code.as_deref(), Some("FOUNDER"));
+    }
+
+    #[test]
+    fn empty_register_code_stashes_nothing() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.step = ConnectFlowStep::Register {
+            email: "founder@example.com".into(),
+            loading: false,
+        };
+        panel.register_campaign_code = "   ".into();
+        let _ = panel.update_message(ConnectAccountMessage::SubmitRegistration);
+        assert!(panel.pending_campaign_code.is_none());
+    }
+
+    #[test]
+    fn logout_clears_campaign_state() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.campaign_redeem.code = "X".into();
+        panel.campaign_redeem.result = Some(Ok("y".into()));
+        panel.register_campaign_code = "Z".into();
+        panel.pending_campaign_code = Some("W".into());
+        let _ = panel.update_message(ConnectAccountMessage::LogOut);
+        assert!(panel.campaign_redeem.code.is_empty());
+        assert!(panel.campaign_redeem.result.is_none());
+        assert!(panel.register_campaign_code.is_empty());
+        assert!(panel.pending_campaign_code.is_none());
+    }
+
+    // ── Purchasing gate (PR2 — unchanged in v2) ───────────────────────
     #[test]
     fn purchasing_enabled_defaults_true() {
         // Absent features, and a features payload without the field, both

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -2523,16 +2523,21 @@ impl ConnectAccountPanel {
     }
 
     /// Whether self-service purchasing is currently available. Sourced from
-    /// `GET /connect/features` (`purchasing_enabled`); absent → enabled, so
-    /// the existing checkout flow stays intact for backends that don't send
-    /// the flag (and for fall GA once a campaign closes). A campaign that
-    /// disables purchasing sets it `false`, which hides every purchase
-    /// surface (PLAN-estate-promo PR2).
+    /// `GET /connect/features` (`purchasing_enabled`).
+    ///
+    /// Fails closed until features are known: while the fetch is in flight
+    /// (right after sign-in) or failed, this is `false`, so a promo window
+    /// never momentarily offers checkout before the server's stance loads.
+    /// Once features *are* loaded, an absent flag means an older backend with
+    /// purchasing on — enabled, so the existing flow stays intact for
+    /// backends that don't send it (and for fall GA once a campaign closes).
+    /// A campaign that disables purchasing sets it `false`, hiding every
+    /// purchase surface (PLAN-estate-promo PR2).
     pub fn purchasing_enabled(&self) -> bool {
-        self.features
-            .as_ref()
-            .and_then(|f| f.purchasing_enabled)
-            .unwrap_or(true)
+        match &self.features {
+            None => false,
+            Some(f) => f.purchasing_enabled.unwrap_or(true),
+        }
     }
 
     /// Whether the pre-expiry renewal banner should render: the plan is
@@ -4194,13 +4199,16 @@ mod plan_lifecycle_tests {
 
     // ── Purchasing gate (PR2 — unchanged in v2) ───────────────────────
     #[test]
-    fn purchasing_enabled_defaults_true() {
-        // Absent features, and a features payload without the field, both
-        // read as enabled — the existing flow stays intact for fall GA.
+    fn purchasing_enabled_requires_loaded_features() {
         let mut panel = ConnectAccountPanel::new();
-        assert!(panel.purchasing_enabled());
+        // Features not loaded yet (fetch in flight / failed) → fail closed so
+        // we never offer checkout before the server's stance is known.
+        assert!(!panel.purchasing_enabled());
+        // Loaded but flag absent → older backend with purchasing on (the
+        // existing flow stays intact for fall GA).
         panel.features = Some(features_with_purchasing(None, None));
         assert!(panel.purchasing_enabled());
+        // Loaded with the flag on.
         panel.features = Some(features_with_purchasing(None, Some(true)));
         assert!(panel.purchasing_enabled());
     }
@@ -4242,10 +4250,21 @@ mod plan_lifecycle_tests {
     }
 
     #[test]
-    fn start_checkout_proceeds_when_purchasing_enabled() {
-        // Default (no features / flag absent) keeps the existing checkout
-        // path working — regression guard for fall GA.
+    fn start_checkout_blocked_before_features_load() {
+        // Right after sign-in, features are still loading — don't open a
+        // checkout until the server's purchasing stance is known.
         let mut panel = panel_with_plan(plan(PlanTier::Free, PlanStatus::Active, None, None));
+        assert!(panel.features.is_none());
+        let _ = panel.update_message(ConnectAccountMessage::StartCheckout(PlanTier::Pro));
+        assert!(panel.checkout.is_none());
+    }
+
+    #[test]
+    fn start_checkout_proceeds_when_purchasing_enabled() {
+        // Features loaded with purchasing on (flag absent = older backend)
+        // keeps the existing checkout path working — regression for fall GA.
+        let mut panel = panel_with_plan(plan(PlanTier::Free, PlanStatus::Active, None, None));
+        panel.features = Some(features_with_purchasing(None, None));
         let _ = panel.update_message(ConnectAccountMessage::StartCheckout(PlanTier::Pro));
         assert!(matches!(
             panel.checkout.as_ref().map(|c| &c.phase),

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -682,20 +682,11 @@ impl ConnectAccountPanel {
                 // dashboard until we've confirmed the account isn't in duress.
                 self.step = ConnectFlowStep::CheckingDuress { failed: false };
                 self.error = None;
-                // Fetch plan + features in background (non-blocking)
+                // Fetch features + gate on duress in background (non-blocking).
                 let gen = self.session_generation;
-                let c1 = self.client.clone();
                 let c2 = self.client.clone();
                 let c3 = self.client.clone();
                 let mut tasks = vec![
-                    iced::Task::perform(
-                        async move { (c1.get_connect_plan().await.ok(), gen) },
-                        |(plan, g)| {
-                            Message::View(view::Message::ConnectAccount(
-                                ConnectAccountMessage::PlanLoaded(plan, g),
-                            ))
-                        },
-                    ),
                     iced::Task::perform(
                         async move { (c2.get_connect_features().await.ok(), gen) },
                         |(features, g)| {
@@ -712,11 +703,25 @@ impl ConnectAccountPanel {
                 ];
                 // Redeem an account-creation promo/referral code now that the
                 // session is authenticated. Best-effort: a bad code never
-                // blocks sign-in — the outcome surfaces in Settings → Plan,
-                // and `CampaignRedeemed` refreshes the plan on success.
+                // blocks sign-in — the outcome surfaces in Settings → Plan.
                 if let Some(code) = self.pending_campaign_code.take() {
+                    // Defer the plan fetch to the redeem (which fetches on
+                    // either outcome). Firing get_connect_plan here *and* again
+                    // after redemption races two PlanLoaded responses at the
+                    // same generation, and a slow pre-redeem fetch could
+                    // overwrite the granted tier/provenance.
                     self.campaign_redeem.submitting = true;
                     tasks.push(self.redeem_campaign_task(code));
+                } else {
+                    let c1 = self.client.clone();
+                    tasks.push(iced::Task::perform(
+                        async move { (c1.get_connect_plan().await.ok(), gen) },
+                        |(plan, g)| {
+                            Message::View(view::Message::ConnectAccount(
+                                ConnectAccountMessage::PlanLoaded(plan, g),
+                            ))
+                        },
+                    ));
                 }
                 return iced::Task::batch(tasks);
             }
@@ -1406,24 +1411,29 @@ impl ConnectAccountPanel {
                 match result {
                     Ok(msg) => {
                         self.campaign_redeem.result = Some(Ok(msg));
-                        // Clear the field and refresh the plan so the granted
-                        // tier / provenance appear.
+                        // Clear the field on success.
                         self.campaign_redeem.code = String::new();
-                        let g = self.session_generation;
-                        let c = self.client.clone();
-                        return iced::Task::perform(
-                            async move { (c.get_connect_plan().await.ok(), g) },
-                            |(plan, g)| {
-                                Message::View(view::Message::ConnectAccount(
-                                    ConnectAccountMessage::PlanLoaded(plan, g),
-                                ))
-                            },
-                        );
                     }
                     Err(e) => {
                         self.campaign_redeem.result = Some(Err(e));
                     }
                 }
+                // Refresh the plan after every redeem — on success to pick up
+                // the granted tier/provenance, and on failure because the
+                // account-creation path (SessionLoaded) defers its post-signup
+                // plan fetch to here, so the real plan (including any
+                // server-side auto-applied grant) still loads. This is the only
+                // plan fetch on that path, so there's no racing PlanLoaded.
+                let g = self.session_generation;
+                let c = self.client.clone();
+                return iced::Task::perform(
+                    async move { (c.get_connect_plan().await.ok(), g) },
+                    |(plan, g)| {
+                        Message::View(view::Message::ConnectAccount(
+                            ConnectAccountMessage::PlanLoaded(plan, g),
+                        ))
+                    },
+                );
             }
             ConnectAccountMessage::DuressStateChecked(state, gen, attempt) => {
                 // Phase 6: post-sign-in gate. We sit in `CheckingDuress` until

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1387,6 +1387,12 @@ impl ConnectAccountPanel {
 
             ConnectAccountMessage::CampaignRedeemed(result, gen) => {
                 if gen != self.session_generation {
+                    // Stale: the session changed since this redeem was fired
+                    // (e.g. a second SessionLoaded bumped the generation while
+                    // a registration redeem was in flight). Drop the result,
+                    // but still clear the in-flight flag so the field can't get
+                    // stuck on "Redeeming…".
+                    self.campaign_redeem.submitting = false;
                     return iced::Task::none();
                 }
                 self.campaign_redeem.submitting = false;
@@ -4020,8 +4026,11 @@ mod plan_lifecycle_tests {
             Ok("late".into()),
             999, // not the current session generation
         ));
-        assert!(panel.campaign_redeem.submitting);
+        // The result is dropped (wrong session)...
         assert!(panel.campaign_redeem.result.is_none());
+        // ...but the in-flight flag is cleared so the field doesn't stick on
+        // "Redeeming…" after a session change.
+        assert!(!panel.campaign_redeem.submitting);
     }
 
     #[test]

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1365,6 +1365,13 @@ impl ConnectAccountPanel {
 
             // ── Campaign code redemption (v2 campaign engine) ─────────────
             ConnectAccountMessage::CampaignCodeChanged(code) => {
+                // Ignore edits while a redeem is in flight — otherwise the
+                // response for the submitted code could land against
+                // newly-typed text (and a success would clear it). The view
+                // also disables the input while submitting.
+                if self.campaign_redeem.submitting {
+                    return iced::Task::none();
+                }
                 self.campaign_redeem.code = code;
                 // Editing past a prior outcome clears it so the field reads as
                 // a fresh attempt.
@@ -3960,6 +3967,17 @@ mod plan_lifecycle_tests {
         let _ = panel.update_message(ConnectAccountMessage::CampaignCodeChanged("ABC".into()));
         assert_eq!(panel.campaign_redeem.code, "ABC");
         assert!(panel.campaign_redeem.result.is_none());
+    }
+
+    #[test]
+    fn code_edits_ignored_while_redeem_in_flight() {
+        // While a redeem is submitting, edits are dropped so the result that
+        // comes back can't land against newly-typed text.
+        let mut panel = ConnectAccountPanel::new();
+        panel.campaign_redeem.code = "ABC".into();
+        panel.campaign_redeem.submitting = true;
+        let _ = panel.update_message(ConnectAccountMessage::CampaignCodeChanged("XYZ".into()));
+        assert_eq!(panel.campaign_redeem.code, "ABC");
     }
 
     #[test]

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -711,6 +711,11 @@ impl ConnectAccountPanel {
                     // same generation, and a slow pre-redeem fetch could
                     // overwrite the granted tier/provenance.
                     self.campaign_redeem.submitting = true;
+                    // Surface the code in the Settings → Plan field so that, if
+                    // the redeem fails, the error reads against the code and
+                    // the user can edit/retry without retyping. Cleared on
+                    // success by `CampaignRedeemed`.
+                    self.campaign_redeem.code = code.clone();
                     tasks.push(self.redeem_campaign_task(code));
                 } else {
                     let c1 = self.client.clone();
@@ -4116,6 +4121,27 @@ mod plan_lifecycle_tests {
         panel.register_campaign_code = "   ".into();
         let _ = panel.update_message(ConnectAccountMessage::SubmitRegistration);
         assert!(panel.pending_campaign_code.is_none());
+    }
+
+    #[test]
+    fn signup_redeem_surfaces_code_for_retry() {
+        // The deferred (account-creation) redeem must populate the
+        // Settings → Plan field so a failure shows the error against the code
+        // and the user can retry/edit without retyping.
+        let mut panel = ConnectAccountPanel::new();
+        panel.pending_campaign_code = Some("FOUNDER".into());
+        let user = User {
+            id: 1,
+            email: "founder@example.com".into(),
+            email_verified: Some(true),
+        };
+        let _ = panel.update_message(ConnectAccountMessage::SessionLoaded { user, plan: None });
+        assert!(panel.pending_campaign_code.is_none(), "code consumed");
+        assert!(panel.campaign_redeem.submitting, "redeem in flight");
+        assert_eq!(
+            panel.campaign_redeem.code, "FOUNDER",
+            "code surfaced for retry/edit"
+        );
     }
 
     #[test]

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -62,6 +62,13 @@ pub const PLAN_RENEWAL_BANNER_DAYS: i64 = 7;
 /// soft "update available" note in the plan picker (D4).
 pub const SUPPORTED_PRICING_SCHEMA_VERSION: u32 = 1;
 
+/// At launch the July-4 Estate promo suppresses the pre-expiry renewal
+/// banner for promo accounts (PLAN-estate-promo PR1) — the API likewise
+/// suppresses reminder emails, and the year-one cliff (Jul 2027) is too far
+/// out to nag about now. Flip to `false` for year-two GA to re-enable the
+/// banner with year-two renewal copy.
+pub const PROMO_SUPPRESS_RENEWAL_BANNER: bool = true;
+
 /// Where the user's plan sits in its lifecycle, derived from the
 /// `/connect/plan` response plus the current time. Drives the renewal
 /// banner (D1) and the expired-state UX (D3); kept as a pure projection
@@ -971,6 +978,15 @@ impl ConnectAccountPanel {
             }
 
             ConnectAccountMessage::StartCheckout(tier) => {
+                // Defense-in-depth (PLAN-estate-promo PR2): the picker hides
+                // upgrade CTAs and the renewal banner is suppressed while
+                // purchasing is disabled, but this is the single chokepoint
+                // every checkout flows through — never open one the API would
+                // reject even if a stale message slips through.
+                if !self.purchasing_enabled() {
+                    log::warn!("[CONNECT] StartCheckout ignored — purchasing disabled");
+                    return iced::Task::none();
+                }
                 self.checkout = Some(CheckoutState {
                     phase: CheckoutPhase::Creating,
                     checkout: None,
@@ -2349,11 +2365,43 @@ impl ConnectAccountPanel {
         self.plan_lifecycle_at(chrono::Utc::now())
     }
 
+    /// True when the authenticated account currently holds the July-4 promo
+    /// grant (Estate free for year one). Drives the promo manage-plan
+    /// variant, the collapsed picker, and renewal-banner suppression
+    /// (PLAN-estate-promo PR1).
+    pub fn is_promo_plan(&self) -> bool {
+        self.plan
+            .as_ref()
+            .map(|p| p.is_active_promo())
+            .unwrap_or(false)
+    }
+
+    /// Whether self-service purchasing is currently available. Sourced from
+    /// `GET /connect/features` (`purchasing_enabled`); absent → enabled, so
+    /// the existing checkout flow stays intact for backends that don't send
+    /// the flag (and for fall GA once the promo ends). The July-4 promo sets
+    /// it `false`, which hides every purchase surface (PLAN-estate-promo
+    /// PR2).
+    pub fn purchasing_enabled(&self) -> bool {
+        self.features
+            .as_ref()
+            .and_then(|f| f.purchasing_enabled)
+            .unwrap_or(true)
+    }
+
     /// Whether the pre-expiry renewal banner should render: the plan is
     /// within its renewal window AND the user hasn't dismissed it this
     /// session. The expired state has its own dedicated UX (D3), so the
     /// banner intentionally does not cover `Expired`.
+    ///
+    /// Suppressed entirely for promo accounts at launch (config-flagged via
+    /// [`PROMO_SUPPRESS_RENEWAL_BANNER`]) and whenever purchasing is
+    /// disabled — in both cases there is no purchase path, so a "Renew now"
+    /// nag would be a dead end (PLAN-estate-promo PR1/PR2).
     pub fn show_renewal_banner(&self) -> bool {
+        if (PROMO_SUPPRESS_RENEWAL_BANNER && self.is_promo_plan()) || !self.purchasing_enabled() {
+            return false;
+        }
         !self.renewal_banner_dismissed
             && matches!(self.plan_lifecycle(), PlanLifecycle::RenewalDue { .. })
     }
@@ -3513,7 +3561,7 @@ mod add_to_cube_tests {
 #[cfg(test)]
 mod plan_lifecycle_tests {
     use super::*;
-    use crate::services::coincube::{PlanEntitlements, PlanFeatureInfo};
+    use crate::services::coincube::{PlanEntitlements, PlanFeatureInfo, PlanSource};
 
     /// Parse a fixed RFC-3339 instant for deterministic `now`/renewal math.
     fn at(iso: &str) -> chrono::DateTime<chrono::Utc> {
@@ -3541,7 +3589,20 @@ mod plan_lifecycle_tests {
                 business_orgs: false,
             },
             billing_cycle: cycle,
+            plan_source: None,
         }
+    }
+
+    /// A `ConnectPlan` carrying explicit promo provenance, for the
+    /// estate-promo cases.
+    fn promo_plan(
+        status: PlanStatus,
+        renewal_at: Option<&str>,
+        source: PlanSource,
+    ) -> ConnectPlan {
+        let mut p = plan(PlanTier::Estate, status, renewal_at, Some(BillingCycle::Annual));
+        p.plan_source = Some(source);
+        p
     }
 
     fn panel_with_plan(plan: ConnectPlan) -> ConnectAccountPanel {
@@ -3701,6 +3762,13 @@ mod plan_lifecycle_tests {
 
     // ── Pricing schema soft-update note (D4) ──────────────────────────
     fn features(version: Option<u32>) -> FeaturesResponse {
+        features_with_purchasing(version, None)
+    }
+
+    fn features_with_purchasing(
+        version: Option<u32>,
+        purchasing_enabled: Option<bool>,
+    ) -> FeaturesResponse {
         FeaturesResponse {
             plans: vec![PlanFeatureInfo {
                 name: "pro".to_string(),
@@ -3709,6 +3777,7 @@ mod plan_lifecycle_tests {
                 included_linked_participants: None,
             }],
             pricing_schema_version: version,
+            purchasing_enabled,
         }
     }
 
@@ -3732,5 +3801,152 @@ mod plan_lifecycle_tests {
         let mut panel = ConnectAccountPanel::new();
         panel.features = Some(features(Some(SUPPORTED_PRICING_SCHEMA_VERSION + 1)));
         assert!(panel.pricing_schema_outdated());
+    }
+
+    // ── Estate promo: provenance detection (PR1) ──────────────────────
+    #[test]
+    fn active_promo_is_detected() {
+        let panel = panel_with_plan(promo_plan(
+            PlanStatus::Active,
+            Some("2027-07-04T00:00:00Z"),
+            PlanSource::PromoEstateY1,
+        ));
+        assert!(panel.plan.as_ref().unwrap().is_promo());
+        assert!(panel.plan.as_ref().unwrap().is_active_promo());
+        assert!(panel.is_promo_plan());
+    }
+
+    #[test]
+    fn paid_plan_is_not_promo() {
+        // Explicit `paid` provenance must never read as promo.
+        let panel = panel_with_plan(promo_plan(
+            PlanStatus::Active,
+            Some("2027-07-04T00:00:00Z"),
+            PlanSource::Paid,
+        ));
+        assert!(!panel.plan.as_ref().unwrap().is_promo());
+        assert!(!panel.is_promo_plan());
+    }
+
+    #[test]
+    fn missing_plan_source_is_not_promo() {
+        // Backward compatibility: older API omits `plan_source` → `None` →
+        // ordinary (non-promo) UX.
+        let panel = panel_with_plan(plan(
+            PlanTier::Estate,
+            PlanStatus::Active,
+            Some("2027-07-04T00:00:00Z"),
+            Some(BillingCycle::Annual),
+        ));
+        assert!(panel.plan.as_ref().unwrap().plan_source.is_none());
+        assert!(!panel.plan.as_ref().unwrap().is_promo());
+        assert!(!panel.is_promo_plan());
+    }
+
+    #[test]
+    fn unknown_plan_source_is_not_promo() {
+        // A future/unrecognized provenance value must not hide purchasing.
+        let panel = panel_with_plan(promo_plan(
+            PlanStatus::Active,
+            Some("2027-07-04T00:00:00Z"),
+            PlanSource::Unknown,
+        ));
+        assert!(!panel.is_promo_plan());
+    }
+
+    #[test]
+    fn lapsed_promo_is_not_active_promo_and_reads_expired() {
+        // At the year-one cliff the backend demotes the promo to `past_due`;
+        // it must fall through to the ordinary expired UX, not the promo card.
+        let panel = panel_with_plan(promo_plan(
+            PlanStatus::PastDue,
+            Some("2026-06-01T00:00:00Z"),
+            PlanSource::PromoEstateY1,
+        ));
+        assert!(panel.plan.as_ref().unwrap().is_promo());
+        assert!(!panel.plan.as_ref().unwrap().is_active_promo());
+        assert!(!panel.is_promo_plan());
+        assert_eq!(panel.plan_lifecycle_at(at(NOW)), PlanLifecycle::Expired);
+    }
+
+    #[test]
+    fn promo_account_suppresses_renewal_banner() {
+        // Even inside the renewal window, a promo account suppresses the
+        // pre-expiry banner at launch (config-flagged).
+        assert!(
+            PROMO_SUPPRESS_RENEWAL_BANNER,
+            "test assumes launch config; update if flipped for GA"
+        );
+        let panel = panel_with_plan(promo_plan(
+            PlanStatus::Active,
+            Some("2026-06-13T00:00:00Z"), // 5 days out → RenewalDue
+            PlanSource::PromoEstateY1,
+        ));
+        assert_eq!(
+            panel.plan_lifecycle_at(at(NOW)),
+            PlanLifecycle::RenewalDue { days_remaining: 5 }
+        );
+        assert!(!panel.show_renewal_banner());
+    }
+
+    // ── Estate promo: purchasing gate (PR2) ───────────────────────────
+    #[test]
+    fn purchasing_enabled_defaults_true() {
+        // Absent features, and a features payload without the field, both
+        // read as enabled — the existing flow stays intact for fall GA.
+        let mut panel = ConnectAccountPanel::new();
+        assert!(panel.purchasing_enabled());
+        panel.features = Some(features_with_purchasing(None, None));
+        assert!(panel.purchasing_enabled());
+        panel.features = Some(features_with_purchasing(None, Some(true)));
+        assert!(panel.purchasing_enabled());
+    }
+
+    #[test]
+    fn purchasing_disabled_when_flag_false() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.features = Some(features_with_purchasing(None, Some(false)));
+        assert!(!panel.purchasing_enabled());
+    }
+
+    #[test]
+    fn purchasing_disabled_suppresses_renewal_banner() {
+        // A paid account in its renewal window, but purchasing is closed —
+        // suppress the "Renew" nag rather than dangle a dead-end CTA.
+        let mut panel = panel_with_plan(plan(
+            PlanTier::Pro,
+            PlanStatus::Active,
+            Some("2026-06-13T00:00:00Z"),
+            Some(BillingCycle::Monthly),
+        ));
+        panel.features = Some(features_with_purchasing(None, Some(false)));
+        assert_eq!(
+            panel.plan_lifecycle_at(at(NOW)),
+            PlanLifecycle::RenewalDue { days_remaining: 5 }
+        );
+        assert!(!panel.show_renewal_banner());
+    }
+
+    #[test]
+    fn start_checkout_ignored_when_purchasing_disabled() {
+        let mut panel = panel_with_plan(plan(PlanTier::Free, PlanStatus::Active, None, None));
+        panel.features = Some(features_with_purchasing(None, Some(false)));
+        let _ = panel.update_message(ConnectAccountMessage::StartCheckout(PlanTier::Pro));
+        assert!(
+            panel.checkout.is_none(),
+            "checkout must not open while purchasing is disabled"
+        );
+    }
+
+    #[test]
+    fn start_checkout_proceeds_when_purchasing_enabled() {
+        // Default (no features / flag absent) keeps the existing checkout
+        // path working — regression guard for fall GA.
+        let mut panel = panel_with_plan(plan(PlanTier::Free, PlanStatus::Active, None, None));
+        let _ = panel.update_message(ConnectAccountMessage::StartCheckout(PlanTier::Pro));
+        assert!(matches!(
+            panel.checkout.as_ref().map(|c| &c.phase),
+            Some(CheckoutPhase::Creating)
+        ));
     }
 }

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1384,6 +1384,13 @@ impl ConnectAccountPanel {
             }
 
             ConnectAccountMessage::RegisterCampaignCodeChanged(code) => {
+                // Once signup is in flight the code is already stashed in
+                // `pending_campaign_code`; ignore further edits so the visible
+                // field can't diverge from what gets redeemed. The view also
+                // locks the field while loading.
+                if matches!(self.step, ConnectFlowStep::Register { loading: true, .. }) {
+                    return iced::Task::none();
+                }
                 self.register_campaign_code = code;
             }
 
@@ -4071,6 +4078,32 @@ mod plan_lifecycle_tests {
         panel.register_campaign_code = "  FOUNDER  ".into();
         let _ = panel.update_message(ConnectAccountMessage::SubmitRegistration);
         assert_eq!(panel.pending_campaign_code.as_deref(), Some("FOUNDER"));
+    }
+
+    #[test]
+    fn register_code_edit_ignored_while_signup_in_flight() {
+        // After SubmitRegistration (loading=true), the code is already stashed
+        // in pending_campaign_code; editing the visible field must not change
+        // what gets redeemed.
+        let mut panel = ConnectAccountPanel::new();
+        panel.register_campaign_code = "OLD".into();
+        panel.step = ConnectFlowStep::Register {
+            email: "founder@example.com".into(),
+            loading: true,
+        };
+        let _ = panel.update_message(ConnectAccountMessage::RegisterCampaignCodeChanged(
+            "NEW".into(),
+        ));
+        assert_eq!(panel.register_campaign_code, "OLD");
+        // Still editable before submit (loading=false).
+        panel.step = ConnectFlowStep::Register {
+            email: "founder@example.com".into(),
+            loading: false,
+        };
+        let _ = panel.update_message(ConnectAccountMessage::RegisterCampaignCodeChanged(
+            "NEW".into(),
+        ));
+        assert_eq!(panel.register_campaign_code, "NEW");
     }
 
     #[test]

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -612,6 +612,11 @@ impl ConnectAccountPanel {
                 if matches!(self.step, ConnectFlowStep::Login { loading: true, .. }) {
                     return iced::Task::none();
                 }
+                // A code stashed during an abandoned signup must not ride into
+                // a restored or next session — it belongs to that signup only.
+                // Clearing here (and in SubmitLogin) confines redemption to the
+                // uninterrupted signup → verify → SessionLoaded path.
+                self.pending_campaign_code = None;
                 if let Some(session) = self.load_session_from_keyring() {
                     let refresh_token = session.login.refresh_token.clone();
                     // Transition out of CheckingSession so re-navigation
@@ -774,6 +779,9 @@ impl ConnectAccountPanel {
 
             ConnectAccountMessage::SubmitLogin => {
                 self.error = None;
+                // A login must never redeem a code stashed for a (different)
+                // new account during an abandoned signup. See `Init`.
+                self.pending_campaign_code = None;
 
                 let ConnectFlowStep::Login { email, loading } = &mut self.step else {
                     return iced::Task::none();
@@ -4051,6 +4059,40 @@ mod plan_lifecycle_tests {
         assert!(panel.campaign_redeem.code.is_empty());
         assert!(panel.campaign_redeem.result.is_none());
         assert!(panel.register_campaign_code.is_empty());
+        assert!(panel.pending_campaign_code.is_none());
+    }
+
+    #[test]
+    fn init_drops_pending_code_from_abandoned_signup() {
+        // Regression: a code stashed by SubmitRegistration must not survive a
+        // re-init (navigate away & back) — otherwise a restored or next
+        // session would redeem it against the wrong account. Both Init
+        // branches (keyring restore / show-login) clear it, so the assertion
+        // holds regardless of stored-session state.
+        let mut panel = ConnectAccountPanel::new();
+        panel.step = ConnectFlowStep::OtpVerification {
+            email: "founder@example.com".into(),
+            otp: String::new(),
+            sending: false,
+            is_signup: true,
+            cooldown: 0,
+        };
+        panel.pending_campaign_code = Some("FOUNDER".into());
+        let _ = panel.update_message(ConnectAccountMessage::Init);
+        assert!(panel.pending_campaign_code.is_none());
+    }
+
+    #[test]
+    fn submit_login_drops_pending_code_from_abandoned_signup() {
+        // Regression: starting a login must drop a signup-stashed code so it
+        // never redeems against the account being signed into.
+        let mut panel = ConnectAccountPanel::new();
+        panel.step = ConnectFlowStep::Login {
+            email: "someone@example.com".into(),
+            loading: false,
+        };
+        panel.pending_campaign_code = Some("FOUNDER".into());
+        let _ = panel.update_message(ConnectAccountMessage::SubmitLogin);
         assert!(panel.pending_campaign_code.is_none());
     }
 

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -756,7 +756,9 @@ fn campaign_redeem_field<'a>(state: &'a ConnectAccountPanel) -> Element<'a, Conn
     };
 
     let input = TextInput::new("Promo or referral code", &rs.code)
-        .on_input(ConnectAccountMessage::CampaignCodeChanged)
+        // Locked while a redeem is in flight so the in-flight code can't drift
+        // out of sync with the result that comes back.
+        .on_input_maybe((!rs.submitting).then_some(ConnectAccountMessage::CampaignCodeChanged))
         .on_submit_maybe(
             (valid && !rs.submitting).then_some(ConnectAccountMessage::RedeemCampaignCode),
         )

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     },
     services::coincube::{
         AvatarAccentMotif, AvatarAgeFeel, AvatarArchetype, AvatarArmorStyle, AvatarDemeanor,
-        AvatarGender, BillingCycle, PlanTier,
+        AvatarGender, BillingCycle, ConnectPlan, PlanTier,
     },
 };
 
@@ -53,7 +53,8 @@ pub fn connect_panel<'a>(state: &'a ConnectPanel) -> Element<'a, ViewMessage> {
         }
 
         ConnectFlowStep::Register { email, loading } => {
-            register_ux(email, *loading).map(ViewMessage::ConnectAccount)
+            register_ux(email, &acct.register_campaign_code, *loading)
+                .map(ViewMessage::ConnectAccount)
         }
 
         ConnectFlowStep::OtpVerification {
@@ -136,7 +137,9 @@ pub fn connect_account_panel<'a>(
             .align_x(Alignment::Center)
             .into(),
         ConnectFlowStep::Login { email, loading } => login_ux(email, *loading),
-        ConnectFlowStep::Register { email, loading } => register_ux(email, *loading),
+        ConnectFlowStep::Register { email, loading } => {
+            register_ux(email, &acct.register_campaign_code, *loading)
+        }
         ConnectFlowStep::OtpVerification {
             email,
             otp,
@@ -278,7 +281,11 @@ fn login_ux<'a>(email: &'a str, loading: bool) -> Element<'a, ConnectAccountMess
         .into()
 }
 
-fn register_ux<'a>(email: &'a str, loading: bool) -> Element<'a, ConnectAccountMessage> {
+fn register_ux<'a>(
+    email: &'a str,
+    code: &'a str,
+    loading: bool,
+) -> Element<'a, ConnectAccountMessage> {
     let valid = email.contains('.') && email.contains('@') && email.len() >= 5;
 
     let submit: Element<ConnectAccountMessage> = if loading {
@@ -314,6 +321,18 @@ fn register_ux<'a>(email: &'a str, loading: bool) -> Element<'a, ConnectAccountM
         .push(
             TextInput::new("Email", email)
                 .on_input(ConnectAccountMessage::EmailChanged)
+                .on_submit_maybe(
+                    (!loading && valid).then_some(ConnectAccountMessage::SubmitRegistration),
+                )
+                .size(16)
+                .padding(15),
+        )
+        .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
+        // Optional promo/referral code (server-driven campaign engine, v2).
+        // Redeemed automatically once the new account authenticates.
+        .push(
+            TextInput::new("Promo or referral code (optional)", code)
+                .on_input(ConnectAccountMessage::RegisterCampaignCodeChanged)
                 .on_submit_maybe(
                     (!loading && valid).then_some(ConnectAccountMessage::SubmitRegistration),
                 )
@@ -514,11 +533,11 @@ fn renewal_banner<'a>(
         bool,
     ) = match state.plan_lifecycle() {
         PlanLifecycle::RenewalDue { .. } => {
-            // Folds in per-session dismissal plus the promo / purchasing-
-            // disabled suppression (PLAN-estate-promo PR1/PR2) — when there's
-            // no purchase path, the pre-expiry "Renew" reminder is hidden so
-            // it never becomes a dead-end CTA. The Expired arm below is
-            // navigation-only ("View plans"), so it stays unsuppressed.
+            // Folds in per-session dismissal plus the purchasing-disabled
+            // suppression (PLAN-estate-promo PR2) — when there's no purchase
+            // path, the pre-expiry "Renew" reminder is hidden so it never
+            // becomes a dead-end CTA. The Expired arm below is navigation-only
+            // ("View plans"), so it stays unsuppressed.
             if !state.show_renewal_banner() {
                 return None;
             }
@@ -634,14 +653,15 @@ fn schema_update_note<'a>() -> Element<'a, ConnectAccountMessage> {
 }
 
 /// Informational note shown atop the plan picker when self-service
-/// purchasing is closed (the July-4 promo window — PLAN-estate-promo PR2).
-/// The plans/prices still render so the user can see what each tier offers;
-/// this just explains why there's no purchase button behind them.
+/// purchasing is closed (`purchasing_enabled = false` — PLAN-estate-promo
+/// PR2). The plans/prices still render so the user can see what each tier
+/// offers; this just explains why there's no purchase button behind them.
+/// Copy is campaign-agnostic.
 fn purchasing_unavailable_note<'a>() -> Element<'a, ConnectAccountMessage> {
     container(
         text::p2_regular(
-            "Purchasing is currently unavailable. New accounts include Estate \
-             free for their first year — there's nothing to buy right now.",
+            "Purchasing is currently unavailable, so plans can't be bought \
+             right now. You can still review what each tier includes below.",
         )
         .color(color::GREY_3),
     )
@@ -665,90 +685,107 @@ fn plan_billing_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAcc
     if let Some(checkout_state) = &state.checkout {
         return checkout_ux(checkout_state);
     }
-    // Promo accounts (Estate free for year one) get an informational
-    // manage-plan variant instead of the picker — they already have
-    // everything Estate unlocks and there's no purchase to make
-    // (PLAN-estate-promo PR1).
-    if state.is_promo_plan() {
-        return promo_plan_ux(state);
-    }
     if state.show_billing_history {
         return billing_history_ux(state);
     }
     plan_selection_ux(state)
 }
 
-/// Provenance label on the promo manage-plan card. Working name from
-/// PLAN-estate-promo PR1 ("Founding member"); final display name is pending
-/// sign-off — change here when confirmed.
-const PROMO_PROVENANCE_LABEL: &str = "Founding member";
+// ── Plan provenance card (server-driven, v2) ────────────────────────────────
 
-// ── Promo manage-plan variant (PLAN-estate-promo PR1) ───────────────────────
+/// Renders the current plan's `plan_provenance` (`{label, expires_at,
+/// badge}`) verbatim — the desktop knows nothing about which campaign
+/// granted it. Returns `None` for purchased/free plans (no provenance),
+/// which keeps the existing paid/free UX. Display strings are entirely
+/// server-authored so a campaign's copy never needs an app release.
+fn plan_provenance_card<'a>(plan: &'a ConnectPlan) -> Option<Element<'a, ConnectAccountMessage>> {
+    let prov = plan.plan_provenance.as_ref()?;
+    let badge_color = plan_tier_color(plan.tier());
 
-/// Informational manage-plan view for an account holding the July-4 launch
-/// grant of Estate free for its first year. The picker collapses to a single
-/// card — no Renew / Change / checkout actions, since the user already has
-/// everything Estate unlocks and purchasing is closed during the promo.
-fn promo_plan_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMessage> {
-    let headline = match state
-        .plan
-        .as_ref()
-        .and_then(|p| p.renewal_at.as_deref())
-        .map(format_date)
-    {
-        Some(date) => format!("Free for your first year — expires {}", date),
-        None => "Free for your first year".to_string(),
+    let mut header = Row::new()
+        .push(text::p1_bold(plan.tier().to_string()).color(badge_color))
+        .push(iced::widget::Space::new().width(Length::Fill));
+    if let Some(badge) = prov.badge.as_deref().filter(|b| !b.is_empty()) {
+        header = header.push(text::p2_bold(badge).color(color::ORANGE));
+    }
+
+    let mut card_col = Column::new()
+        .push(header.align_y(Alignment::Center))
+        .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+        .push(text::p1_medium(prov.label.clone()).style(theme::text::primary));
+    if let Some(exp) = prov.expires_at.as_deref().filter(|e| !e.is_empty()) {
+        card_col = card_col
+            .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+            .push(text::p2_regular(format!("Expires {}", format_date(exp))).color(color::GREY_3));
+    }
+
+    Some(
+        container(card_col.padding(16).spacing(2))
+            .style(move |t| container::Style {
+                background: Some(iced::Background::Color(t.colors.cards.simple.background)),
+                border: iced::Border {
+                    color: badge_color,
+                    width: 1.0,
+                    radius: 16.0.into(),
+                },
+                ..Default::default()
+            })
+            .width(Length::Fill)
+            .into(),
+    )
+}
+
+// ── Campaign code redemption field (server-driven, v2) ──────────────────────
+
+/// The generic "promo or referral code" field for Settings → Plan. Campaign-
+/// agnostic: forwards the typed code to `POST /connect/campaigns/redeem` and
+/// renders the server's success/error message verbatim.
+fn campaign_redeem_field<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMessage> {
+    let rs = &state.campaign_redeem;
+    let valid = !rs.code.trim().is_empty();
+
+    let submit: Element<ConnectAccountMessage> = if rs.submitting {
+        button::secondary(None, "Redeeming…")
+            .width(Length::Fixed(130.0))
+            .into()
+    } else {
+        button::primary(None, "Redeem")
+            .on_press_maybe(valid.then_some(ConnectAccountMessage::RedeemCampaignCode))
+            .width(Length::Fixed(130.0))
+            .into()
     };
 
-    let badge_color = plan_tier_color(&PlanTier::Estate);
+    let input = TextInput::new("Promo or referral code", &rs.code)
+        .on_input(ConnectAccountMessage::CampaignCodeChanged)
+        .on_submit_maybe(
+            (valid && !rs.submitting).then_some(ConnectAccountMessage::RedeemCampaignCode),
+        )
+        .size(15)
+        .padding(12);
 
-    let card = container(
-        Column::new()
-            .push(
-                Row::new()
-                    .push(text::p1_bold("Estate").color(badge_color))
-                    .push(iced::widget::Space::new().width(Length::Fill))
-                    .push(text::p2_regular(PROMO_PROVENANCE_LABEL).color(color::ORANGE))
-                    .align_y(Alignment::Center),
-            )
-            .push(iced::widget::Space::new().height(Length::Fixed(4.0)))
-            .push(
-                Row::new()
-                    .push(text::p2_regular("Status").color(color::GREY_3))
-                    .push(iced::widget::Space::new().width(Length::Fill))
-                    .push(text::p2_bold("Active").color(color::ORANGE))
-                    .align_y(Alignment::Center),
-            )
-            .push(iced::widget::Space::new().height(Length::Fixed(10.0)))
-            .push(text::p1_medium(headline).style(theme::text::primary))
-            .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
-            .push(
-                text::p2_regular(
-                    "You have full access to every Estate feature. No payment \
-                     is needed during your first year — we'll email you before \
-                     it ends.",
-                )
-                .color(color::GREY_3),
-            )
-            .padding(16)
-            .spacing(2),
-    )
-    .style(move |t| container::Style {
-        background: Some(iced::Background::Color(t.colors.cards.simple.background)),
-        border: iced::Border {
-            color: badge_color,
-            width: 1.0,
-            radius: 16.0.into(),
-        },
-        ..Default::default()
-    })
-    .width(Length::Fill);
+    let mut col = Column::new()
+        .push(text::p2_bold("Have a promo or referral code?").style(theme::text::primary))
+        .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+        .push(
+            Row::new()
+                .push(input)
+                .push(iced::widget::Space::new().width(Length::Fixed(8.0)))
+                .push(submit)
+                .align_y(Alignment::Center),
+        );
 
-    Column::new()
-        .push(text::h4_bold("Plan & Billing").style(theme::text::primary))
-        .push(iced::widget::Space::new().height(Length::Fixed(15.0)))
-        .push(card)
-        .spacing(0)
+    if let Some(result) = &rs.result {
+        let (msg, accent) = match result {
+            Ok(m) => (m.clone(), color::GREEN),
+            Err(e) => (e.clone(), color::RED),
+        };
+        col = col
+            .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+            .push(text::p2_regular(msg).color(accent));
+    }
+
+    container(col.padding(16).spacing(2))
+        .style(card_style)
         .width(Length::Fill)
         .into()
 }
@@ -859,6 +896,14 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
                 .push(banner)
                 .push(iced::widget::Space::new().height(Length::Fixed(15.0)));
         }
+        // Plan provenance is driven by `/connect/plan`, not features, so
+        // render the grant card here too (it shows even while pricing is
+        // unavailable, e.g. offline).
+        if let Some(prov) = state.plan.as_ref().and_then(plan_provenance_card) {
+            col = col
+                .push(prov)
+                .push(iced::widget::Space::new().height(Length::Fixed(15.0)));
+        }
         // A newer schema can rename tiers so every card is filtered out,
         // landing here — exactly when the "update available" note is most
         // relevant, so surface it on this path too (D4).
@@ -867,13 +912,17 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
                 .push(schema_update_note())
                 .push(iced::widget::Space::new().height(Length::Fixed(12.0)));
         }
-        col = col.push(
-            text::p1_regular(
-                "Pricing temporarily unavailable.\n\
-                 Reconnect to the internet to view current plans and features.",
+        col = col
+            .push(
+                text::p1_regular(
+                    "Pricing temporarily unavailable.\n\
+                     Reconnect to the internet to view current plans and features.",
+                )
+                .color(color::GREY_3),
             )
-            .color(color::GREY_3),
-        );
+            // The redeem field doesn't depend on the pricing fetch.
+            .push(iced::widget::Space::new().height(Length::Fixed(15.0)))
+            .push(campaign_redeem_field(state));
         return container(col).padding(16).into();
     }
 
@@ -886,6 +935,14 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
     if let Some(banner) = renewal_banner(state) {
         col = col
             .push(banner)
+            .push(iced::widget::Space::new().height(Length::Fixed(15.0)));
+    }
+
+    // Server-driven provenance card for a campaign-granted plan (v2) — sits
+    // above the picker so the grant reads as the headline state.
+    if let Some(prov) = state.plan.as_ref().and_then(plan_provenance_card) {
+        col = col
+            .push(prov)
             .push(iced::widget::Space::new().height(Length::Fixed(15.0)));
     }
 
@@ -995,6 +1052,12 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
         );
         col = col.push(iced::widget::Space::new().height(Length::Fixed(10.0)));
     }
+
+    // Promo / referral code field (server-driven redemption, v2).
+    col = col
+        .push(iced::widget::Space::new().height(Length::Fixed(5.0)))
+        .push(campaign_redeem_field(state))
+        .push(iced::widget::Space::new().height(Length::Fixed(10.0)));
 
     // Billing history link
     col = col
@@ -2095,7 +2158,7 @@ mod renewal_banner_tests {
     //! `Option<Element>` and its `style`/`on_press` closures are deferred,
     //! so we can construct it headless and assert only Some/None.
     use super::*;
-    use crate::services::coincube::{ConnectPlan, PlanEntitlements, PlanSource, PlanStatus};
+    use crate::services::coincube::{ConnectPlan, PlanEntitlements, PlanProvenance, PlanStatus};
 
     fn plan(tier: PlanTier, status: PlanStatus, renewal_at: Option<&str>) -> ConnectPlan {
         ConnectPlan {
@@ -2111,7 +2174,7 @@ mod renewal_banner_tests {
                 business_orgs: false,
             },
             billing_cycle: Some(BillingCycle::Monthly),
-            plan_source: None,
+            plan_provenance: None,
         }
     }
 
@@ -2142,10 +2205,14 @@ mod renewal_banner_tests {
         assert!(renewal_banner(&panel).is_none());
     }
 
-    // ── Estate promo (PLAN-estate-promo PR1/PR2) ──────────────────────
-    fn promo_estate(renewal_at: Option<&str>) -> ConnectPlan {
+    // ── Estate promo: server-driven provenance + purchasing (v2) ──────
+    fn granted_estate(renewal_at: Option<&str>, badge: Option<&str>) -> ConnectPlan {
         let mut p = plan(PlanTier::Estate, PlanStatus::Active, renewal_at);
-        p.plan_source = Some(PlanSource::PromoEstateY1);
+        p.plan_provenance = Some(PlanProvenance {
+            label: "Free for your first year".to_string(),
+            expires_at: renewal_at.map(|s| s.to_string()),
+            badge: badge.map(|s| s.to_string()),
+        });
         p
     }
 
@@ -2162,21 +2229,43 @@ mod renewal_banner_tests {
         }
     }
 
-    /// PR1: a promo account in its renewal window still shows no pre-expiry
-    /// banner (suppressed at launch).
+    /// The provenance card renders only when the API sends `plan_provenance`
+    /// — a purchased/free plan (no provenance) shows nothing extra.
     #[test]
-    fn no_renewal_banner_for_active_promo() {
+    fn provenance_card_present_only_with_provenance() {
+        let granted = granted_estate(Some("2027-07-04T00:00:00Z"), Some("Founding member"));
+        assert!(plan_provenance_card(&granted).is_some());
+
+        let paid = plan(
+            PlanTier::Pro,
+            PlanStatus::Active,
+            Some("2027-01-01T00:00:00Z"),
+        );
+        assert!(plan_provenance_card(&paid).is_none());
+    }
+
+    /// A granted account still gets a renewal banner gated only by the
+    /// generic purchasing signal — promo provenance no longer suppresses it
+    /// by itself (v2 removes campaign conditionals). With purchasing closed
+    /// (the campaign window), it's suppressed.
+    #[test]
+    fn granted_account_banner_follows_purchasing_signal() {
         let mut panel = ConnectAccountPanel::new();
-        // Renewal in the past so `plan_lifecycle()` (wall clock) is RenewalDue.
-        panel.plan = Some(promo_estate(Some("2020-01-01T00:00:00Z")));
+        // Renewal in the past so `plan_lifecycle()` is RenewalDue.
+        panel.plan = Some(granted_estate(
+            Some("2020-01-01T00:00:00Z"),
+            Some("Founding member"),
+        ));
         assert!(matches!(
             panel.plan_lifecycle(),
             PlanLifecycle::RenewalDue { .. }
         ));
-        assert!(
-            renewal_banner(&panel).is_none(),
-            "promo accounts suppress the pre-expiry banner"
-        );
+        // Purchasing closed → suppressed (no dead-end CTA).
+        panel.features = Some(features_purchasing(Some(false)));
+        assert!(renewal_banner(&panel).is_none());
+        // Purchasing open → the generic reminder shows.
+        panel.features = Some(features_purchasing(Some(true)));
+        assert!(renewal_banner(&panel).is_some());
     }
 
     /// PR2: with purchasing disabled, the pre-expiry "Renew" banner is hidden
@@ -2184,7 +2273,11 @@ mod renewal_banner_tests {
     #[test]
     fn no_renewal_banner_when_purchasing_disabled() {
         let mut panel = ConnectAccountPanel::new();
-        panel.plan = Some(plan(PlanTier::Pro, PlanStatus::Active, Some("2020-01-01T00:00:00Z")));
+        panel.plan = Some(plan(
+            PlanTier::Pro,
+            PlanStatus::Active,
+            Some("2020-01-01T00:00:00Z"),
+        ));
         panel.features = Some(features_purchasing(Some(false)));
         assert!(matches!(
             panel.plan_lifecycle(),
@@ -2193,18 +2286,25 @@ mod renewal_banner_tests {
         assert!(renewal_banner(&panel).is_none());
     }
 
-    /// Smoke: the promo manage-plan variant and the purchasing-disabled
-    /// picker both construct without panicking. Element internals are
-    /// opaque, so this just exercises the render paths.
+    /// Smoke: the manage-plan view (with a provenance card + redeem field),
+    /// the purchasing-disabled picker, and the account-creation screen all
+    /// construct without panicking. Element internals are opaque, so this
+    /// just exercises the render paths.
     #[test]
-    fn promo_and_disabled_picker_render() {
-        let mut promo = ConnectAccountPanel::new();
-        promo.plan = Some(promo_estate(Some("2027-07-04T00:00:00Z")));
-        let _ = plan_billing_ux(&promo);
+    fn provenance_picker_and_register_render() {
+        let mut granted = ConnectAccountPanel::new();
+        granted.plan = Some(granted_estate(
+            Some("2027-07-04T00:00:00Z"),
+            Some("Founding member"),
+        ));
+        granted.features = Some(features_purchasing(Some(false)));
+        let _ = plan_billing_ux(&granted);
 
-        let mut disabled = ConnectAccountPanel::new();
-        disabled.plan = Some(plan(PlanTier::Free, PlanStatus::Active, None));
-        disabled.features = Some(features_purchasing(Some(false)));
-        let _ = plan_billing_ux(&disabled);
+        let mut paid = ConnectAccountPanel::new();
+        paid.plan = Some(plan(PlanTier::Free, PlanStatus::Active, None));
+        paid.campaign_redeem.result = Some(Err("This code has expired.".into()));
+        let _ = plan_billing_ux(&paid);
+
+        let _ = register_ux("founder@example.com", "FOUNDER", false);
     }
 }

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -329,10 +329,14 @@ fn register_ux<'a>(
         )
         .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
         // Optional promo/referral code (server-driven campaign engine, v2).
-        // Redeemed automatically once the new account authenticates.
+        // Redeemed automatically once the new account authenticates. Locked
+        // while signup is in flight — the code is already stashed at submit,
+        // so editing the visible field would diverge from what's redeemed.
         .push(
             TextInput::new("Promo or referral code (optional)", code)
-                .on_input(ConnectAccountMessage::RegisterCampaignCodeChanged)
+                .on_input_maybe(
+                    (!loading).then_some(ConnectAccountMessage::RegisterCampaignCodeChanged),
+                )
                 .on_submit_maybe(
                     (!loading && valid).then_some(ConnectAccountMessage::SubmitRegistration),
                 )

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -514,7 +514,12 @@ fn renewal_banner<'a>(
         bool,
     ) = match state.plan_lifecycle() {
         PlanLifecycle::RenewalDue { .. } => {
-            if state.renewal_banner_dismissed {
+            // Folds in per-session dismissal plus the promo / purchasing-
+            // disabled suppression (PLAN-estate-promo PR1/PR2) — when there's
+            // no purchase path, the pre-expiry "Renew" reminder is hidden so
+            // it never becomes a dead-end CTA. The Expired arm below is
+            // navigation-only ("View plans"), so it stays unsuppressed.
+            if !state.show_renewal_banner() {
                 return None;
             }
             let plan = state.plan.as_ref()?;
@@ -628,16 +633,124 @@ fn schema_update_note<'a>() -> Element<'a, ConnectAccountMessage> {
     .into()
 }
 
+/// Informational note shown atop the plan picker when self-service
+/// purchasing is closed (the July-4 promo window — PLAN-estate-promo PR2).
+/// The plans/prices still render so the user can see what each tier offers;
+/// this just explains why there's no purchase button behind them.
+fn purchasing_unavailable_note<'a>() -> Element<'a, ConnectAccountMessage> {
+    container(
+        text::p2_regular(
+            "Purchasing is currently unavailable. New accounts include Estate \
+             free for their first year — there's nothing to buy right now.",
+        )
+        .color(color::GREY_3),
+    )
+    .padding(12)
+    .width(Length::Fill)
+    .style(|t| container::Style {
+        background: Some(iced::Background::Color(t.colors.cards.simple.background)),
+        border: iced::Border {
+            color: color::ORANGE,
+            width: 0.5,
+            radius: 10.0.into(),
+        },
+        ..Default::default()
+    })
+    .into()
+}
+
 // ── Plan & Billing — top-level router ───────────────────────────────────────
 
 fn plan_billing_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMessage> {
     if let Some(checkout_state) = &state.checkout {
         return checkout_ux(checkout_state);
     }
+    // Promo accounts (Estate free for year one) get an informational
+    // manage-plan variant instead of the picker — they already have
+    // everything Estate unlocks and there's no purchase to make
+    // (PLAN-estate-promo PR1).
+    if state.is_promo_plan() {
+        return promo_plan_ux(state);
+    }
     if state.show_billing_history {
         return billing_history_ux(state);
     }
     plan_selection_ux(state)
+}
+
+/// Provenance label on the promo manage-plan card. Working name from
+/// PLAN-estate-promo PR1 ("Founding member"); final display name is pending
+/// sign-off — change here when confirmed.
+const PROMO_PROVENANCE_LABEL: &str = "Founding member";
+
+// ── Promo manage-plan variant (PLAN-estate-promo PR1) ───────────────────────
+
+/// Informational manage-plan view for an account holding the July-4 launch
+/// grant of Estate free for its first year. The picker collapses to a single
+/// card — no Renew / Change / checkout actions, since the user already has
+/// everything Estate unlocks and purchasing is closed during the promo.
+fn promo_plan_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMessage> {
+    let headline = match state
+        .plan
+        .as_ref()
+        .and_then(|p| p.renewal_at.as_deref())
+        .map(format_date)
+    {
+        Some(date) => format!("Free for your first year — expires {}", date),
+        None => "Free for your first year".to_string(),
+    };
+
+    let badge_color = plan_tier_color(&PlanTier::Estate);
+
+    let card = container(
+        Column::new()
+            .push(
+                Row::new()
+                    .push(text::p1_bold("Estate").color(badge_color))
+                    .push(iced::widget::Space::new().width(Length::Fill))
+                    .push(text::p2_regular(PROMO_PROVENANCE_LABEL).color(color::ORANGE))
+                    .align_y(Alignment::Center),
+            )
+            .push(iced::widget::Space::new().height(Length::Fixed(4.0)))
+            .push(
+                Row::new()
+                    .push(text::p2_regular("Status").color(color::GREY_3))
+                    .push(iced::widget::Space::new().width(Length::Fill))
+                    .push(text::p2_bold("Active").color(color::ORANGE))
+                    .align_y(Alignment::Center),
+            )
+            .push(iced::widget::Space::new().height(Length::Fixed(10.0)))
+            .push(text::p1_medium(headline).style(theme::text::primary))
+            .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+            .push(
+                text::p2_regular(
+                    "You have full access to every Estate feature. No payment \
+                     is needed during your first year — we'll email you before \
+                     it ends.",
+                )
+                .color(color::GREY_3),
+            )
+            .padding(16)
+            .spacing(2),
+    )
+    .style(move |t| container::Style {
+        background: Some(iced::Background::Color(t.colors.cards.simple.background)),
+        border: iced::Border {
+            color: badge_color,
+            width: 1.0,
+            radius: 16.0.into(),
+        },
+        ..Default::default()
+    })
+    .width(Length::Fill);
+
+    Column::new()
+        .push(text::h4_bold("Plan & Billing").style(theme::text::primary))
+        .push(iced::widget::Space::new().height(Length::Fixed(15.0)))
+        .push(card)
+        .spacing(0)
+        .width(Length::Fill)
+        .into()
 }
 
 // ── Plan selection view ─────────────────────────────────────────────────────
@@ -651,6 +764,12 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
     let current_cycle = state.plan.as_ref().and_then(|p| p.billing_cycle);
 
     let cycle = state.selected_billing_cycle;
+
+    // Whether to render checkout CTAs at all. Disabled while the promo
+    // window has purchasing closed server-side (PLAN-estate-promo PR2); the
+    // picker still shows plans/prices, just with no purchase path behind
+    // them so we never route to a checkout the API would reject.
+    let purchasing_enabled = state.purchasing_enabled();
 
     // Billing cycle toggle
     let monthly_btn = if cycle == BillingCycle::Monthly {
@@ -778,6 +897,15 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
             .push(iced::widget::Space::new().height(Length::Fixed(12.0)));
     }
 
+    // "Purchasing closed" note while the promo window has checkout disabled
+    // (PLAN-estate-promo PR2). The upgrade CTAs below render non-pressable in
+    // that state; this explains why.
+    if !purchasing_enabled {
+        col = col
+            .push(purchasing_unavailable_note())
+            .push(iced::widget::Space::new().height(Length::Fixed(12.0)));
+    }
+
     col = col
         .push(cycle_toggle)
         .push(iced::widget::Space::new().height(Length::Fixed(15.0)));
@@ -827,7 +955,7 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
             .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
             .push(if is_current {
                 button::secondary(None, "Current Plan").width(Length::Fill)
-            } else if is_upgrade {
+            } else if is_upgrade && purchasing_enabled {
                 let label = match &card.tier {
                     PlanTier::Pro => "Upgrade to Pro",
                     PlanTier::Estate => "Upgrade to Estate",
@@ -836,6 +964,11 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
                 button::primary(None, label)
                     .on_press(ConnectAccountMessage::StartCheckout(card.tier))
                     .width(Length::Fill)
+            } else if is_upgrade {
+                // Purchasing closed (promo window) — show the tier without a
+                // checkout CTA (PLAN-estate-promo PR2). Non-pressable, like
+                // the other informational buttons here.
+                button::secondary(None, "Unavailable").width(Length::Fill)
             } else {
                 // Downgrade or Free — no action
                 button::secondary(None, "—").width(Length::Fill)
@@ -1962,7 +2095,7 @@ mod renewal_banner_tests {
     //! `Option<Element>` and its `style`/`on_press` closures are deferred,
     //! so we can construct it headless and assert only Some/None.
     use super::*;
-    use crate::services::coincube::{ConnectPlan, PlanEntitlements, PlanStatus};
+    use crate::services::coincube::{ConnectPlan, PlanEntitlements, PlanSource, PlanStatus};
 
     fn plan(tier: PlanTier, status: PlanStatus, renewal_at: Option<&str>) -> ConnectPlan {
         ConnectPlan {
@@ -1978,6 +2111,7 @@ mod renewal_banner_tests {
                 business_orgs: false,
             },
             billing_cycle: Some(BillingCycle::Monthly),
+            plan_source: None,
         }
     }
 
@@ -2006,5 +2140,71 @@ mod renewal_banner_tests {
         let mut panel = ConnectAccountPanel::new();
         panel.plan = Some(plan(PlanTier::Free, PlanStatus::Active, None));
         assert!(renewal_banner(&panel).is_none());
+    }
+
+    // ── Estate promo (PLAN-estate-promo PR1/PR2) ──────────────────────
+    fn promo_estate(renewal_at: Option<&str>) -> ConnectPlan {
+        let mut p = plan(PlanTier::Estate, PlanStatus::Active, renewal_at);
+        p.plan_source = Some(PlanSource::PromoEstateY1);
+        p
+    }
+
+    fn features_purchasing(enabled: Option<bool>) -> crate::services::coincube::FeaturesResponse {
+        crate::services::coincube::FeaturesResponse {
+            plans: vec![crate::services::coincube::PlanFeatureInfo {
+                name: "pro".to_string(),
+                price: None,
+                features: Vec::new(),
+                included_linked_participants: None,
+            }],
+            pricing_schema_version: None,
+            purchasing_enabled: enabled,
+        }
+    }
+
+    /// PR1: a promo account in its renewal window still shows no pre-expiry
+    /// banner (suppressed at launch).
+    #[test]
+    fn no_renewal_banner_for_active_promo() {
+        let mut panel = ConnectAccountPanel::new();
+        // Renewal in the past so `plan_lifecycle()` (wall clock) is RenewalDue.
+        panel.plan = Some(promo_estate(Some("2020-01-01T00:00:00Z")));
+        assert!(matches!(
+            panel.plan_lifecycle(),
+            PlanLifecycle::RenewalDue { .. }
+        ));
+        assert!(
+            renewal_banner(&panel).is_none(),
+            "promo accounts suppress the pre-expiry banner"
+        );
+    }
+
+    /// PR2: with purchasing disabled, the pre-expiry "Renew" banner is hidden
+    /// for an ordinary paid account too — no dead-end CTA.
+    #[test]
+    fn no_renewal_banner_when_purchasing_disabled() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.plan = Some(plan(PlanTier::Pro, PlanStatus::Active, Some("2020-01-01T00:00:00Z")));
+        panel.features = Some(features_purchasing(Some(false)));
+        assert!(matches!(
+            panel.plan_lifecycle(),
+            PlanLifecycle::RenewalDue { .. }
+        ));
+        assert!(renewal_banner(&panel).is_none());
+    }
+
+    /// Smoke: the promo manage-plan variant and the purchasing-disabled
+    /// picker both construct without panicking. Element internals are
+    /// opaque, so this just exercises the render paths.
+    #[test]
+    fn promo_and_disabled_picker_render() {
+        let mut promo = ConnectAccountPanel::new();
+        promo.plan = Some(promo_estate(Some("2027-07-04T00:00:00Z")));
+        let _ = plan_billing_ux(&promo);
+
+        let mut disabled = ConnectAccountPanel::new();
+        disabled.plan = Some(plan(PlanTier::Free, PlanStatus::Active, None));
+        disabled.features = Some(features_purchasing(Some(false)));
+        let _ = plan_billing_ux(&disabled);
     }
 }

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1097,6 +1097,17 @@ pub enum ConnectAccountMessage {
     UserProfileLoaded(crate::services::coincube::User),
     /// User profile refresh failed (non-auth error)
     UserProfileFailed(String),
+    // --- Campaign code redemption (v2 campaign engine) ---
+    /// Settings → Plan code field edited.
+    CampaignCodeChanged(String),
+    /// Submit the settings → Plan code to `POST /connect/campaigns/redeem`.
+    RedeemCampaignCode,
+    /// Redeem result: `Ok(server message)` / `Err(server message)`. The
+    /// `u64` is the session generation guarding stale completions.
+    CampaignRedeemed(Result<String, String>, u64),
+    /// Optional code field on the account-creation screen edited. Stashed at
+    /// registration and redeemed once the new session authenticates.
+    RegisterCampaignCodeChanged(String),
     // --- Duress (Phases 6 & 8) ---
     /// Result of the post-sign-in `get_duress_state` gate. `Some` switches to
     /// the recovery flow when `active`; `None` is a failed/unreachable check

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -5,11 +5,11 @@ use super::{
     ContactCube, Country, CreateConnectVaultRequest, CreateInviteRequest, CubeInviteOrAddResult,
     CubeKeyRaw, CubeLimitsResponse, CubeResponse, DownloadStats, FeaturesResponse, GetAvatarData,
     Invite, LightningAddress, LoginActivity, LoginResponse, OtpRequest, OtpVerifyRequest,
-    PublicAvatarData, ReceivedInvite, RecoveryKit, RecoveryKitStatus, RefreshTokenRequest,
-    RegenerationData, RegisterCubeRequest, ReserveLightningAddressRequest, SaveQuoteRequest,
-    SaveQuoteResponse, StatsPeriod, TimeseriesResponse, TodayStats, UpdateCubeRequest,
-    UpdateLightningAddressRequest, UpsertRecoveryKitRequest, User, VaultMemberResponse,
-    VerifiedDevice,
+    PublicAvatarData, ReceivedInvite, RecoveryKit, RecoveryKitStatus, RedeemCampaignRequest,
+    RedeemCampaignResponse, RefreshTokenRequest, RegenerationData, RegisterCubeRequest,
+    ReserveLightningAddressRequest, SaveQuoteRequest, SaveQuoteResponse, StatsPeriod,
+    TimeseriesResponse, TodayStats, UpdateCubeRequest, UpdateLightningAddressRequest,
+    UpsertRecoveryKitRequest, User, VaultMemberResponse, VerifiedDevice,
 };
 use reqwest::{Client, Method};
 use serde::Deserialize;
@@ -338,6 +338,25 @@ impl CoincubeClient {
         let res = self.client.get(&url).send().await?;
         let res = res.check_success().await?;
         let resp: ApiResponse<Vec<BillingHistoryEntry>> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// POST /api/v1/connect/campaigns/redeem (authenticated). Redeems a
+    /// promo/referral code; the server applies the benefit and records the
+    /// redemption. A bad code returns a typed 4xx whose message the caller
+    /// surfaces verbatim (generic error taxonomy — the desktop has no
+    /// campaign-specific handling).
+    pub async fn redeem_campaign(
+        &self,
+        code: &str,
+    ) -> Result<RedeemCampaignResponse, CoincubeError> {
+        let url = format!("{}/api/v1/connect/campaigns/redeem", self.base_url);
+        let req = RedeemCampaignRequest {
+            code: code.to_string(),
+        };
+        let res = self.client.post(&url).json(&req).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<RedeemCampaignResponse> = res.json().await?;
         Ok(resp.data)
     }
 

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -279,27 +279,26 @@ pub enum PlanStatus {
     Canceled,
 }
 
-/// Provenance of the current plan grant, from `GET /connect/plan`
-/// (`plan_source`: `paid | promo_estate_y1 | admin`). The July-4 launch
-/// promo grants Estate free for a year and tags those accounts
-/// `promo_estate_y1`; the desktop reads this to render the promo
-/// manage-plan variant and hide purchase paths. Additive field — older
-/// backends omit it (deserialized as `None`), and any source string this
-/// build doesn't recognize maps to `Unknown` and is treated as non-promo,
-/// so a future grant type never accidentally hides purchasing.
+/// Server-authored display metadata for how the current plan was granted,
+/// from `GET /connect/plan`'s `plan_provenance` (campaign engine, v2). The
+/// desktop renders these strings verbatim and knows nothing about specific
+/// campaigns — a campaign's label/badge/expiry are authored server-side, so
+/// display never requires an app release. Absent (`None`) for ordinary
+/// purchased/free plans and older backends → existing paid/free UX.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PlanSource {
-    /// Ordinary self-service purchase.
-    Paid,
-    /// July-4 launch promo: Estate free for year one.
-    PromoEstateY1,
-    /// Granted by an administrator or the retro-grant tool.
-    Admin,
-    /// Any source string this build doesn't recognize — treated as
-    /// non-promo so purchasing is never hidden by an unknown grant type.
-    #[serde(other)]
-    Unknown,
+#[serde(rename_all = "camelCase")]
+pub struct PlanProvenance {
+    /// Primary descriptive line, e.g. "Free for your first year". Required
+    /// when provenance is present.
+    pub label: String,
+    /// RFC-3339 instant the grant lapses, if it expires. Rendered as an
+    /// "Expires {date}" line; `None`/absent → no expiry line.
+    #[serde(default)]
+    pub expires_at: Option<String>,
+    /// Short tag shown beside the plan tier, e.g. "Founding member".
+    /// `None`/absent → no badge.
+    #[serde(default)]
+    pub badge: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -323,11 +322,13 @@ pub struct ConnectPlan {
     /// Billing cycle of the current plan. `None` for free tier (no charge).
     #[serde(default)]
     pub billing_cycle: Option<BillingCycle>,
-    /// Provenance of the grant (`paid | promo_estate_y1 | admin`). Absent on
-    /// older backends and deserialized as `None` — never promo, so the
-    /// existing paid UX stays the backward-compatible default.
-    #[serde(default)]
-    pub plan_source: Option<PlanSource>,
+    /// Server-authored display metadata for a campaign-granted plan (v2).
+    /// `None`/absent for purchased/free plans and older backends — the
+    /// desktop renders this verbatim and never special-cases campaigns.
+    /// (`ConnectPlan` is camelCase, so the wire key is `planProvenance`; the
+    /// alias also accepts a snake_case `plan_provenance`.)
+    #[serde(default, alias = "plan_provenance")]
+    pub plan_provenance: Option<PlanProvenance>,
 }
 
 impl ConnectPlan {
@@ -335,21 +336,6 @@ impl ConnectPlan {
     /// that used the old `tier` field can migrate with minimal churn.
     pub fn tier(&self) -> &PlanTier {
         &self.plan
-    }
-
-    /// True when this plan was granted by the July-4 launch promo (Estate
-    /// free for year one). Drives the promo manage-plan variant, the
-    /// collapsed picker, and renewal-banner suppression.
-    pub fn is_promo(&self) -> bool {
-        matches!(self.plan_source, Some(PlanSource::PromoEstateY1))
-    }
-
-    /// True for a *currently held* promo grant — promo provenance and an
-    /// active status. A lapsed promo (demoted to `past_due` at the year-one
-    /// cliff) is intentionally excluded so it falls through to the ordinary
-    /// expired UX instead of the promo card.
-    pub fn is_active_promo(&self) -> bool {
-        self.is_promo() && matches!(self.status, PlanStatus::Active)
     }
 }
 
@@ -467,6 +453,30 @@ pub struct BillingHistoryEntry {
     pub status: ChargeStatus,
     pub created_at: String,
     pub paid_at: Option<String>,
+}
+
+// ── Campaign code redemption (v2 campaign engine) ───────────────────────────
+
+/// Request body for `POST /api/v1/connect/campaigns/redeem`. The desktop
+/// surface is campaign-agnostic — it just forwards whatever code the user
+/// typed; the server validates window/limits/enabled and applies the
+/// benefit.
+#[derive(Debug, Clone, Serialize)]
+pub struct RedeemCampaignRequest {
+    pub code: String,
+}
+
+/// Success response for a redeemed campaign code. `message` is an optional
+/// server-authored confirmation line (rendered verbatim); the desktop
+/// refreshes `GET /connect/plan` afterwards to pick up the granted tier and
+/// provenance, so no other fields are needed here. Failures arrive as the
+/// usual typed error (`invalid | expired | exhausted | already-redeemed`)
+/// and surface through `CoincubeError`'s message, rendered generically.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RedeemCampaignResponse {
+    #[serde(default)]
+    pub message: Option<String>,
 }
 
 /// Request body for POST /api/v1/connect/cubes

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -279,6 +279,29 @@ pub enum PlanStatus {
     Canceled,
 }
 
+/// Provenance of the current plan grant, from `GET /connect/plan`
+/// (`plan_source`: `paid | promo_estate_y1 | admin`). The July-4 launch
+/// promo grants Estate free for a year and tags those accounts
+/// `promo_estate_y1`; the desktop reads this to render the promo
+/// manage-plan variant and hide purchase paths. Additive field — older
+/// backends omit it (deserialized as `None`), and any source string this
+/// build doesn't recognize maps to `Unknown` and is treated as non-promo,
+/// so a future grant type never accidentally hides purchasing.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanSource {
+    /// Ordinary self-service purchase.
+    Paid,
+    /// July-4 launch promo: Estate free for year one.
+    PromoEstateY1,
+    /// Granted by an administrator or the retro-grant tool.
+    Admin,
+    /// Any source string this build doesn't recognize — treated as
+    /// non-promo so purchasing is never hidden by an unknown grant type.
+    #[serde(other)]
+    Unknown,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PlanEntitlements {
@@ -300,6 +323,11 @@ pub struct ConnectPlan {
     /// Billing cycle of the current plan. `None` for free tier (no charge).
     #[serde(default)]
     pub billing_cycle: Option<BillingCycle>,
+    /// Provenance of the grant (`paid | promo_estate_y1 | admin`). Absent on
+    /// older backends and deserialized as `None` — never promo, so the
+    /// existing paid UX stays the backward-compatible default.
+    #[serde(default)]
+    pub plan_source: Option<PlanSource>,
 }
 
 impl ConnectPlan {
@@ -307,6 +335,21 @@ impl ConnectPlan {
     /// that used the old `tier` field can migrate with minimal churn.
     pub fn tier(&self) -> &PlanTier {
         &self.plan
+    }
+
+    /// True when this plan was granted by the July-4 launch promo (Estate
+    /// free for year one). Drives the promo manage-plan variant, the
+    /// collapsed picker, and renewal-banner suppression.
+    pub fn is_promo(&self) -> bool {
+        matches!(self.plan_source, Some(PlanSource::PromoEstateY1))
+    }
+
+    /// True for a *currently held* promo grant — promo provenance and an
+    /// active status. A lapsed promo (demoted to `past_due` at the year-one
+    /// cliff) is intentionally excluded so it falls through to the ordinary
+    /// expired UX instead of the promo card.
+    pub fn is_active_promo(&self) -> bool {
+        self.is_promo() && matches!(self.status, PlanStatus::Active)
     }
 }
 
@@ -344,6 +387,15 @@ pub struct FeaturesResponse {
         alias = "pricing_schema_version"
     )]
     pub pricing_schema_version: Option<u32>,
+    /// Whether self-service purchasing is currently available. The July-4
+    /// Estate promo disables checkout server-side; when this is
+    /// `Some(false)` the desktop hides every purchase path so it never
+    /// routes anyone to a `POST /connect/checkout` the API will reject.
+    /// Absent/`None` (older backends, or purchasing simply on) is treated
+    /// as enabled — keeps the existing flow intact for fall GA. See
+    /// `ConnectAccountPanel::purchasing_enabled`.
+    #[serde(default, alias = "purchasingEnabled", alias = "purchasing_enabled")]
+    pub purchasing_enabled: Option<bool>,
 }
 
 // ── Checkout / Billing ──────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches sign-in/session bootstrap, plan refresh timing after redeem, and billing/checkout entry points; mistakes could show wrong plan state or allow checkout when the API would reject it, though fail-closed purchasing and session-generation checks mitigate that.
> 
> **Overview**
> Adds **server-driven campaign promo/referral redemption** in Connect: optional code on registration (redeemed after auth via `POST /connect/campaigns/redeem`) and a **Plan & Billing** redeem field that shows server success/error text verbatim, then refreshes plan state.
> 
> Extends API models with **`plan_provenance`** (label/badge/expiry card on Plan & Billing) and **`purchasing_enabled`** on features. When purchasing is off or features aren’t loaded yet, the UI **fails closed**: no upgrade checkout, `StartCheckout` ignored, renewal banner suppressed, and an informational “purchasing unavailable” note with disabled upgrade CTAs.
> 
> Includes session-generation guards, clearing of abandoned signup codes on init/login, and broad unit/view tests for redemption, provenance, and purchasing gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cfbbd279c153538ef886be1b0bf3a2d80a7de05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add promo/referral code redemption flow (redeem during registration or from billing).
  * Show server-provided plan provenance (label/badge/expiry) above plan selector.
  * UI indicates when purchasing is unavailable and disables purchase actions.

* **Bug Fixes**
  * Renewal reminder banner now respects purchasing availability and is suppressed when purchases are disabled.

* **Tests**
  * Expanded tests for promo redemption, provenance rendering, and purchasing-gate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->