### PR TITLE
Estate notifications

### DIFF
--- a/coincube-gui/src/app/message.rs
+++ b/coincube-gui/src/app/message.rs
@@ -37,6 +37,11 @@ pub enum Message {
     Tick,
     UpdateDaemonCache(Result<DaemonCache, Error>),
     CacheUpdated,
+    /// Terminal no-op for the fire-and-forget vault recovery heartbeat
+    /// (Estate Notifications — PR 2). The heartbeat POST must never block
+    /// or affect sync, so its result is discarded here. Carries the result
+    /// only so transient failures can be logged.
+    RecoveryHeartbeatSent(Result<(), String>),
     Fiat(FiatMessage),
     UpdatePanelCache(/* is current panel */ bool),
     View(view::Message),

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1425,11 +1425,32 @@ impl App {
             // Not synced enough to compute a meaningful recovery height yet.
             return Task::none();
         }
-        // earliest_recovery_height = chain tip + the earliest recovery-path
-        // relative timelock (Liana CSV semantics). The server's monotonic-
-        // staleness rule means a slightly-stale value only ever errs early.
+        // earliest_recovery_height = the absolute height at which this vault's
+        // EARLIEST recovery branch opens. Under Liana CSV semantics a coin's
+        // recovery path opens `timelock` blocks after the coin confirmed
+        // (`remaining_sequence`), so the binding constraint is the OLDEST
+        // confirmed coin — `min(block_height) + timelock` — NOT `tip +
+        // timelock`. The latter (the open height of a coin confirming right
+        // now) recedes one block per block as the tip advances, so under the
+        // server's monotonic "newest report wins" rule the recovery height
+        // would forever outrun the chain and the keyholder alert would fire
+        // late or never. Mirror `coins_summary`'s coin filter: confirmed,
+        // owned, unspent. With no such coins there are no funds at recovery
+        // risk yet, so fall back to the tip-based estimate — harmless and
+        // still monotonic.
         let timelock = wallet.main_descriptor.first_timelock_value() as i64;
-        let earliest = (tip as i64 + timelock).max(0) as u32;
+        let oldest_confirmed = self
+            .cache
+            .coins()
+            .iter()
+            .filter(|c| c.spend_info.is_none() && crate::daemon::model::coin_is_owned(c))
+            .filter_map(|c| c.block_height)
+            .min();
+        let earliest = match oldest_confirmed {
+            Some(h) => h as i64 + timelock,
+            None => tip as i64 + timelock,
+        };
+        let earliest = earliest.max(0) as u32;
         let req = VaultHeartbeatRequest {
             earliest_recovery_height: earliest,
             computed_at: chrono::Utc::now(),

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1396,6 +1396,55 @@ impl App {
         self.panels.connect.account.authenticated_client()
     }
 
+    /// Fire-and-forget vault recovery heartbeat (Estate Notifications —
+    /// PR 2). Returns a detached task that POSTs
+    /// `{earliest_recovery_height, computed_at}` after a sync when this
+    /// account has a Heartbeat- or Full-tier monitored vault and a live
+    /// descriptor on hand. The heartbeat NEVER blocks or affects sync — its
+    /// result is discarded via `RecoveryHeartbeatSent`. Returns
+    /// `Task::none()` whenever no heartbeat applies (not authenticated,
+    /// monitoring off, vault id not yet resolved, or no live wallet).
+    fn recovery_heartbeat_task(&self) -> Task<Message> {
+        use crate::services::coincube::{VaultHeartbeatRequest, VaultMonitoringLevel};
+        if !self.panels.connect.account.is_authenticated() {
+            return Task::none();
+        }
+        let ra = &self.panels.global_settings.recovery_alerts;
+        if matches!(ra.level(), VaultMonitoringLevel::Off) {
+            return Task::none();
+        }
+        let (Some(vault_id), Some(wallet), Some(client)) = (
+            ra.vault_id,
+            self.wallet.as_ref(),
+            self.authenticated_coincube_client(),
+        ) else {
+            return Task::none();
+        };
+        let tip = self.cache.blockheight();
+        if tip <= 0 {
+            // Not synced enough to compute a meaningful recovery height yet.
+            return Task::none();
+        }
+        // earliest_recovery_height = chain tip + the earliest recovery-path
+        // relative timelock (Liana CSV semantics). The server's monotonic-
+        // staleness rule means a slightly-stale value only ever errs early.
+        let timelock = wallet.main_descriptor.first_timelock_value() as i64;
+        let earliest = (tip as i64 + timelock).max(0) as u32;
+        let req = VaultHeartbeatRequest {
+            earliest_recovery_height: earliest,
+            computed_at: chrono::Utc::now(),
+        };
+        Task::perform(
+            async move {
+                client
+                    .post_vault_heartbeat(vault_id, req)
+                    .await
+                    .map_err(|e| e.to_string())
+            },
+            Message::RecoveryHeartbeatSent,
+        )
+    }
+
     /// True when this tab's ConnectAccountPanel either already holds an
     /// authenticated session or can pull one out of the shared keyring
     /// entry. Lets the tab-level OpenConnectSignIn handler short-circuit
@@ -2576,7 +2625,12 @@ impl App {
                         wallet.apply_coin_overrides(&mut daemon_cache.coins);
                     }
                     self.cache.daemon_cache = daemon_cache;
-                    return Task::done(Message::CacheUpdated);
+                    // Fire-and-forget recovery heartbeat after the sync's
+                    // fresh tip lands (Estate Notifications — PR 2). Batched
+                    // alongside the normal cache cascade so it never delays
+                    // or blocks it.
+                    let heartbeat = self.recovery_heartbeat_task();
+                    return Task::batch([heartbeat, Task::done(Message::CacheUpdated)]);
                 }
                 Err(e) => {
                     tracing::error!("Failed to update daemon cache: {}", e);
@@ -2679,6 +2733,16 @@ impl App {
                         }
                     },
                 );
+            }
+            Message::RecoveryHeartbeatSent(res) => {
+                // Fire-and-forget: the heartbeat must never affect app state
+                // or sync. Log a transient failure at debug and move on (a
+                // newer report always wins server-side, so a dropped one is
+                // harmless).
+                if let Err(e) = res {
+                    log::debug!("[RECOVERY] heartbeat post failed (ignored): {e}");
+                }
+                return Task::none();
             }
             Message::CacheUpdated => {
                 // Cube (Home) Settings lives on every cube, vault or not,
@@ -3485,6 +3549,28 @@ impl App {
                     client,
                     server_cube_id,
                     wallet,
+                );
+            }
+
+            // Vault Recovery Alerts dispatch (Estate Notifications — PR 2).
+            // Like the Recovery Kit above, the handler needs the
+            // authenticated client, the Connect cube id, the live wallet
+            // descriptor, the keyholder list, and the `recovery_alerts`
+            // entitlement — none plumbed through `State::update`.
+            Message::View(view::Message::Settings(view::SettingsMessage::RecoveryAlerts(msg))) => {
+                let client = self.authenticated_coincube_client();
+                let server_cube_id = self.panels.connect.cube.server_cube_id;
+                let wallet = self.wallet.clone();
+                let entitled = self.panels.connect.account.is_recovery_alerts_entitled();
+                let members = self.panels.connect.cube.members.members.clone();
+                return crate::app::state::settings::recovery_alerts::update(
+                    &mut self.panels.global_settings.recovery_alerts,
+                    msg,
+                    client,
+                    server_cube_id,
+                    wallet,
+                    entitled,
+                    &members,
                 );
             }
 

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1410,7 +1410,34 @@ impl App {
             return Task::none();
         }
         let ra = &self.panels.global_settings.recovery_alerts;
-        if matches!(ra.level(), VaultMonitoringLevel::Off) {
+        // The heartbeat must fire after every vault sync while authenticated
+        // (Estate Notifications plan P2) — it can't depend on the user having
+        // opened Settings, which is otherwise the only thing that hydrates the
+        // monitoring config. If we're entitled and a Connect cube is resolved
+        // but the config hasn't been fetched from any path yet, kick a
+        // one-shot `LoadStatus` now (the same hydrator the settings card uses);
+        // the next sync's heartbeat then sees the resolved level/vault_id. The
+        // `loaded_once`/`loading` flags — shared with the settings card and
+        // reset on logout — keep this to a single fetch, and gating on
+        // cube + entitlement avoids prematurely marking an un-loadable config
+        // as loaded before those prerequisites arrive.
+        if !ra.loaded_once
+            && !ra.loading
+            && self.panels.connect.account.is_recovery_alerts_entitled()
+            && self.panels.connect.cube.server_cube_id.is_some()
+        {
+            return Task::done(Message::View(view::Message::Settings(
+                view::SettingsMessage::RecoveryAlerts(view::RecoveryAlertsMessage::LoadStatus),
+            )));
+        }
+        // Defense in depth: never POST heartbeats for an account that isn't
+        // Estate-entitled. The cached monitoring level/vault_id can outlive a
+        // plan downgrade or Connect account switch — `ra.status` only reloads
+        // on settings-open or logout — so re-check the *live* entitlement here,
+        // the same gate the mutating monitoring APIs apply.
+        if !self.panels.connect.account.is_recovery_alerts_entitled()
+            || matches!(ra.level(), VaultMonitoringLevel::Off)
+        {
             return Task::none();
         }
         let (Some(vault_id), Some(wallet), Some(client)) = (
@@ -3003,6 +3030,14 @@ impl App {
                     self.cache.connect_device_id = None;
                     self.cache.connect_email = None;
                     self.cache.connect_stream_status = ConnectionStatus::Inactive;
+                    // Drop the previous session's vault-monitoring config so
+                    // it can't leak into the next account and so the
+                    // heartbeat's lazy `loaded_once` re-hydration re-fetches
+                    // for whoever signs in next (the card itself lives here on
+                    // `global_settings`, not on the connect panel that handles
+                    // the rest of the logout scrub).
+                    self.panels.global_settings.recovery_alerts =
+                        crate::app::state::settings::recovery_alerts::RecoveryAlerts::new();
                     // Logout breaks the "Switch to Connect" trip the
                     // user started; firing the auto-return on a fresh
                     // unrelated login later would be surprising.

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -3619,6 +3619,7 @@ impl App {
                 let wallet = self.wallet.clone();
                 let entitled = self.panels.connect.account.is_recovery_alerts_entitled();
                 let members = self.panels.connect.cube.members.members.clone();
+                let session_generation = self.panels.connect.account.session_generation();
                 return crate::app::state::settings::recovery_alerts::update(
                     &mut self.panels.global_settings.recovery_alerts,
                     msg,
@@ -3627,6 +3628,7 @@ impl App {
                     wallet,
                     entitled,
                     &members,
+                    session_generation,
                 );
             }
 

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1594,6 +1594,14 @@ impl ConnectAccountPanel {
             DuressContactsMessage::ToggleWhatsapp(b) => self.duress_contacts.form_ch_whatsapp = b,
             DuressContactsMessage::ToggleEmailChannel(b) => self.duress_contacts.form_ch_email = b,
             DuressContactsMessage::Submit => {
+                // A submit is already in flight — drop the duplicate before it
+                // spawns a second request. The button is view-disabled while
+                // `submitting`, but iced can enqueue two presses in one frame
+                // before the re-render lands, and create isn't idempotent (a
+                // double would make two contacts).
+                if self.duress_contacts.submitting {
+                    return iced::Task::none();
+                }
                 if !self.is_duress_alerts_entitled() {
                     self.duress_contacts.error =
                         Some("Emergency contacts require an Estate plan.".to_string());
@@ -1722,6 +1730,11 @@ impl ConnectAccountPanel {
             }
             DuressContactsMessage::Delete(id) => {
                 if !self.is_duress_alerts_entitled() {
+                    return iced::Task::none();
+                }
+                // Same-row delete already in flight — drop the duplicate
+                // before issuing a second DELETE (see the Submit guard above).
+                if self.duress_contacts.deleting_ids.contains(&id) {
                     return iced::Task::none();
                 }
                 self.duress_contacts.deleting_ids.insert(id);

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -4,13 +4,16 @@ use crate::{
     app::{
         menu::ConnectSubMenu,
         message::Message,
-        view::{self, ConnectAccountMessage, ContactsMessage, DuressMessage},
+        view::{self, ConnectAccountMessage, ContactsMessage, DuressContactsMessage, DuressMessage},
     },
     services::coincube::{
         BillingCycle, BillingHistoryEntry, ChargeStatus, CheckoutRequest, CheckoutResponse,
-        CoincubeClient, ConnectPlan, Contact, ContactCube, ContactRole, CreateInviteRequest,
-        FeaturesResponse, Invite, LoginActivity, LoginResponse, OtpRequest, OtpVerifyRequest,
-        PlanStatus, PlanTier, ReceivedInvite, User, VerifiedDevice,
+        CoincubeClient, ConnectPlan, Contact, ContactCube, ContactRole,
+        CreateDuressAlertContactRequest, CreateInviteRequest, DuressAlertContact, FeaturesResponse,
+        Invite, LoginActivity, LoginResponse, OtpRequest, OtpVerifyRequest, PlanStatus, PlanTier,
+        ReceivedInvite, UpdateDuressAlertContactRequest, User, VerifiedDevice,
+        DURESS_CHANNEL_EMAIL, DURESS_CHANNEL_SMS, DURESS_CHANNEL_WHATSAPP,
+        MAX_DURESS_ALERT_CONTACTS,
     },
 };
 
@@ -361,6 +364,82 @@ impl DuressEnrollState {
     }
 }
 
+/// Which sub-view of the duress "Emergency contacts" section is shown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DuressContactsStep {
+    /// The list of configured alert contacts (and the add affordance).
+    #[default]
+    List,
+    /// The add/edit form. `editing_id` on [`DuressContactsState`]
+    /// distinguishes add (`None`) from edit (`Some`).
+    Form,
+}
+
+/// State for the duress "Emergency contacts" section within
+/// `ConnectAccountPanel` (Estate Notifications — PR 1). Holds the loaded
+/// contacts and the transient add/edit form. Estate-gated: the data is
+/// only fetched when the account carries the `duress_alerts` entitlement,
+/// and the section is only ever rendered in normal-mode settings — never
+/// on the duress activation/cryptic screen.
+#[derive(Debug, Default)]
+pub struct DuressContactsState {
+    pub step: DuressContactsStep,
+    /// `None` until the first load lands; `Some(vec)` afterwards (possibly
+    /// empty).
+    pub contacts: Option<Vec<DuressAlertContact>>,
+    pub loading: bool,
+    pub error: Option<String>,
+    /// `Some(id)` when the form is editing an existing contact, `None`
+    /// when adding a new one.
+    pub editing_id: Option<u64>,
+    pub form_name: String,
+    pub form_phone: String,
+    pub form_email: String,
+    pub form_ch_sms: bool,
+    pub form_ch_whatsapp: bool,
+    pub form_ch_email: bool,
+    pub submitting: bool,
+    /// Contact ids with an in-flight delete (disables the row's button).
+    pub deleting_ids: std::collections::HashSet<u64>,
+}
+
+impl DuressContactsState {
+    /// Reset the form fields to empty and switch to "add" mode.
+    fn reset_form_for_add(&mut self) {
+        self.editing_id = None;
+        self.form_name.clear();
+        self.form_phone.clear();
+        self.form_email.clear();
+        self.form_ch_sms = false;
+        self.form_ch_whatsapp = false;
+        self.form_ch_email = false;
+        self.error = None;
+    }
+
+    /// Populate the form from an existing contact for "edit" mode.
+    fn load_form_from(&mut self, c: &DuressAlertContact) {
+        self.editing_id = Some(c.id);
+        self.form_name = c.display_name.clone();
+        self.form_phone = c.phone.clone().unwrap_or_default();
+        self.form_email = c.email.clone().unwrap_or_default();
+        self.form_ch_sms = c.has_channel(DURESS_CHANNEL_SMS);
+        self.form_ch_whatsapp = c.has_channel(DURESS_CHANNEL_WHATSAPP);
+        self.form_ch_email = c.has_channel(DURESS_CHANNEL_EMAIL);
+        self.error = None;
+    }
+
+    /// Number of configured contacts (0 while unloaded).
+    pub fn count(&self) -> usize {
+        self.contacts.as_ref().map(|c| c.len()).unwrap_or(0)
+    }
+
+    /// True when the per-account cap is reached — the view hides the add
+    /// affordance and the update handler refuses a create.
+    pub fn at_cap(&self) -> bool {
+        self.count() >= MAX_DURESS_ALERT_CONTACTS
+    }
+}
+
 pub struct ConnectAccountPanel {
     pub step: ConnectFlowStep,
     pub active_sub: ConnectSubMenu,
@@ -386,6 +465,8 @@ pub struct ConnectAccountPanel {
     pub show_billing_history: bool,
     /// Active duress enrollment wizard (Phases 2 & 8); `None` when closed.
     pub duress_enroll: Option<DuressEnrollState>,
+    /// Duress "Emergency contacts" section (Estate Notifications — PR 1).
+    pub duress_contacts: DuressContactsState,
     /// Whether the user dismissed the pre-expiry renewal banner this
     /// session (D1). Not persisted — re-shows on next launch while the
     /// plan is still within its renewal window.
@@ -411,8 +492,42 @@ impl ConnectAccountPanel {
             billing_history: None,
             show_billing_history: false,
             duress_enroll: None,
+            duress_contacts: DuressContactsState::default(),
             renewal_banner_dismissed: false,
         }
+    }
+
+    /// True when the account carries the Estate-only `duress_alerts`
+    /// entitlement. Gates both the Emergency-contacts data load and the
+    /// management UI (non-entitled accounts get the locked affordance).
+    pub fn is_duress_alerts_entitled(&self) -> bool {
+        self.plan
+            .as_ref()
+            .map(|p| p.entitlements.duress_alerts)
+            .unwrap_or(false)
+    }
+
+    /// True when the account carries the Estate-only `recovery_alerts`
+    /// entitlement. Gates the Vault Recovery Alerts settings card (Estate
+    /// Notifications — PR 2).
+    pub fn is_recovery_alerts_entitled(&self) -> bool {
+        self.plan
+            .as_ref()
+            .map(|p| p.entitlements.recovery_alerts)
+            .unwrap_or(false)
+    }
+
+    /// Reset the Emergency-contacts section to its list view and reload
+    /// from the API. No-op (returns an empty task) when the account isn't
+    /// Estate-entitled, so we never fire a request that would just 403.
+    pub fn reload_duress_contacts(&mut self) -> iced::Task<Message> {
+        if !self.is_duress_alerts_entitled() {
+            return iced::Task::none();
+        }
+        self.duress_contacts.step = DuressContactsStep::List;
+        self.duress_contacts.error = None;
+        self.duress_contacts.loading = true;
+        load_duress_alert_contacts(&self.client, self.session_generation)
     }
 
     /// Returns a clone of the authenticated client (with JWT set).
@@ -1346,6 +1461,9 @@ impl ConnectAccountPanel {
                 // state — set on the post-sign-in mirror, reset on recovery).
             }
             ConnectAccountMessage::Duress(m) => return self.update_duress(m),
+            ConnectAccountMessage::DuressContacts(m) => {
+                return self.update_duress_contacts(m)
+            }
         }
 
         iced::Task::none()
@@ -1392,6 +1510,244 @@ impl ConnectAccountPanel {
         if let Some(mut wizard) = self.duress_enroll.take() {
             wizard.zeroize_secrets();
         }
+    }
+
+    /// Duress "Emergency contacts" dispatcher (Estate Notifications — PR 1).
+    ///
+    /// Every mutating path re-asserts the `duress_alerts` entitlement before
+    /// hitting the network, so a plan downgrade mid-session can't drive a
+    /// create/update/delete that would only 403. The list view is harmless
+    /// for a downgraded account (it just shows the locked affordance), so
+    /// reads aren't re-gated here beyond `reload_duress_contacts`.
+    fn update_duress_contacts(&mut self, msg: DuressContactsMessage) -> iced::Task<Message> {
+        use crate::services::coincube::is_valid_e164;
+        match msg {
+            DuressContactsMessage::Loaded(res, gen) => {
+                if gen != self.session_generation {
+                    return iced::Task::none();
+                }
+                self.duress_contacts.loading = false;
+                match res {
+                    Ok(list) => {
+                        self.duress_contacts.contacts = Some(list);
+                        self.duress_contacts.error = None;
+                    }
+                    Err(e) => self.duress_contacts.error = Some(e),
+                }
+            }
+            DuressContactsMessage::ShowAddForm => {
+                let dc = &mut self.duress_contacts;
+                if dc.at_cap() {
+                    dc.error = Some(format!(
+                        "You can configure up to {} emergency contacts.",
+                        MAX_DURESS_ALERT_CONTACTS
+                    ));
+                    return iced::Task::none();
+                }
+                dc.reset_form_for_add();
+                dc.step = DuressContactsStep::Form;
+            }
+            DuressContactsMessage::EditContact(id) => {
+                let dc = &mut self.duress_contacts;
+                let found = dc
+                    .contacts
+                    .as_ref()
+                    .and_then(|cs| cs.iter().find(|c| c.id == id))
+                    .cloned();
+                if let Some(c) = found {
+                    dc.load_form_from(&c);
+                    dc.step = DuressContactsStep::Form;
+                }
+            }
+            DuressContactsMessage::BackToList => {
+                let dc = &mut self.duress_contacts;
+                dc.step = DuressContactsStep::List;
+                dc.error = None;
+            }
+            DuressContactsMessage::NameChanged(v) => self.duress_contacts.form_name = v,
+            DuressContactsMessage::PhoneChanged(v) => {
+                let dc = &mut self.duress_contacts;
+                dc.form_phone = v;
+                // A phone-dependent channel can't outlive its phone.
+                if dc.form_phone.trim().is_empty() {
+                    dc.form_ch_sms = false;
+                    dc.form_ch_whatsapp = false;
+                }
+            }
+            DuressContactsMessage::EmailChanged(v) => {
+                let dc = &mut self.duress_contacts;
+                dc.form_email = v;
+                if dc.form_email.trim().is_empty() {
+                    dc.form_ch_email = false;
+                }
+            }
+            DuressContactsMessage::ToggleSms(b) => self.duress_contacts.form_ch_sms = b,
+            DuressContactsMessage::ToggleWhatsapp(b) => self.duress_contacts.form_ch_whatsapp = b,
+            DuressContactsMessage::ToggleEmailChannel(b) => self.duress_contacts.form_ch_email = b,
+            DuressContactsMessage::Submit => {
+                if !self.is_duress_alerts_entitled() {
+                    self.duress_contacts.error =
+                        Some("Emergency contacts require an Estate plan.".to_string());
+                    return iced::Task::none();
+                }
+                // Validate the form. `validate_duress_contact_form` returns
+                // the normalised (name, phone, email, channels) tuple or a
+                // user-facing error.
+                let dc = &mut self.duress_contacts;
+                let name = dc.form_name.trim().to_string();
+                let phone = dc.form_phone.trim().to_string();
+                let email = dc.form_email.trim().to_string();
+                if name.is_empty() {
+                    dc.error = Some("Add a name for this contact.".to_string());
+                    return iced::Task::none();
+                }
+                if phone.is_empty() && email.is_empty() {
+                    dc.error =
+                        Some("Add a phone number or an email so we can reach them.".to_string());
+                    return iced::Task::none();
+                }
+                if !phone.is_empty() && !is_valid_e164(&phone) {
+                    dc.error = Some(
+                        "Enter the phone in international format, e.g. +15551234567.".to_string(),
+                    );
+                    return iced::Task::none();
+                }
+                if !email.is_empty()
+                    && email_address::EmailAddress::parse_with_options(
+                        &email,
+                        email_address::Options::default().with_required_tld(),
+                    )
+                    .is_err()
+                {
+                    dc.error = Some("That email doesn't look right.".to_string());
+                    return iced::Task::none();
+                }
+                let mut channels: u8 = 0;
+                if dc.form_ch_sms && !phone.is_empty() {
+                    channels |= DURESS_CHANNEL_SMS;
+                }
+                if dc.form_ch_whatsapp && !phone.is_empty() {
+                    channels |= DURESS_CHANNEL_WHATSAPP;
+                }
+                if dc.form_ch_email && !email.is_empty() {
+                    channels |= DURESS_CHANNEL_EMAIL;
+                }
+                if channels == 0 {
+                    dc.error = Some(
+                        "Pick at least one way to reach them (SMS, WhatsApp, or email)."
+                            .to_string(),
+                    );
+                    return iced::Task::none();
+                }
+                let editing_id = dc.editing_id;
+                // Cap is only enforced on create — an edit of an existing
+                // contact is always allowed even at the cap.
+                if editing_id.is_none() && dc.at_cap() {
+                    dc.error = Some(format!(
+                        "You can configure up to {} emergency contacts.",
+                        MAX_DURESS_ALERT_CONTACTS
+                    ));
+                    return iced::Task::none();
+                }
+                dc.submitting = true;
+                dc.error = None;
+                let phone_opt = (!phone.is_empty()).then_some(phone);
+                let email_opt = (!email.is_empty()).then_some(email);
+                let client = self.client.clone();
+                let gen = self.session_generation;
+                return match editing_id {
+                    None => {
+                        let req = CreateDuressAlertContactRequest {
+                            display_name: name,
+                            phone: phone_opt,
+                            email: email_opt,
+                            channels,
+                        };
+                        iced::Task::perform(
+                            async move { client.create_duress_alert_contact(req).await },
+                            move |res| {
+                                duress_contacts_msg(DuressContactsMessage::SubmitResult(
+                                    res.map(|_| ()).map_err(|e| e.to_string()),
+                                    gen,
+                                ))
+                            },
+                        )
+                    }
+                    Some(id) => {
+                        let req = UpdateDuressAlertContactRequest {
+                            display_name: Some(name),
+                            // Send explicit phone/email so clearing one in the
+                            // edit form persists. A `None` here would mean
+                            // "untouched"; we always send the current field
+                            // values (empty string maps to null server-side).
+                            phone: Some(phone_opt.unwrap_or_default()),
+                            email: Some(email_opt.unwrap_or_default()),
+                            channels: Some(channels),
+                        };
+                        iced::Task::perform(
+                            async move { client.update_duress_alert_contact(id, req).await },
+                            move |res| {
+                                duress_contacts_msg(DuressContactsMessage::SubmitResult(
+                                    res.map(|_| ()).map_err(|e| e.to_string()),
+                                    gen,
+                                ))
+                            },
+                        )
+                    }
+                };
+            }
+            DuressContactsMessage::SubmitResult(res, gen) => {
+                if gen != self.session_generation {
+                    return iced::Task::none();
+                }
+                self.duress_contacts.submitting = false;
+                match res {
+                    Ok(()) => {
+                        // Back to the list and refetch the authoritative set
+                        // (the create response's `intro_sent_at` may lag the
+                        // async send, so a refetch is the source of truth).
+                        return self.reload_duress_contacts();
+                    }
+                    Err(e) => self.duress_contacts.error = Some(e),
+                }
+            }
+            DuressContactsMessage::Delete(id) => {
+                if !self.is_duress_alerts_entitled() {
+                    return iced::Task::none();
+                }
+                self.duress_contacts.deleting_ids.insert(id);
+                self.duress_contacts.error = None;
+                let client = self.client.clone();
+                let gen = self.session_generation;
+                return iced::Task::perform(
+                    async move { client.delete_duress_alert_contact(id).await },
+                    move |res| {
+                        duress_contacts_msg(DuressContactsMessage::DeleteResult(
+                            id,
+                            res.map_err(|e| e.to_string()),
+                            gen,
+                        ))
+                    },
+                );
+            }
+            DuressContactsMessage::DeleteResult(id, res, gen) => {
+                if gen != self.session_generation {
+                    return iced::Task::none();
+                }
+                self.duress_contacts.deleting_ids.remove(&id);
+                match res {
+                    Ok(()) => {
+                        // Optimistically drop the row, then refetch.
+                        if let Some(cs) = self.duress_contacts.contacts.as_mut() {
+                            cs.retain(|c| c.id != id);
+                        }
+                        return self.reload_duress_contacts();
+                    }
+                    Err(e) => self.duress_contacts.error = Some(e),
+                }
+            }
+        }
+        iced::Task::none()
     }
 
     /// Recovery flow (Phase 6) + enrollment wizard (Phases 2 & 8) dispatcher.
@@ -2416,6 +2772,32 @@ pub fn load_contacts_data(client: &CoincubeClient, generation: u64) -> iced::Tas
             },
         ),
     ])
+}
+
+/// Wraps a [`DuressContactsMessage`] in the full
+/// `Message::View(ConnectAccount(DuressContacts(..)))` envelope. Keeps the
+/// async task closures in `update_duress_contacts` terse.
+fn duress_contacts_msg(m: DuressContactsMessage) -> Message {
+    Message::View(view::Message::ConnectAccount(
+        ConnectAccountMessage::DuressContacts(m),
+    ))
+}
+
+/// Fire a `get_duress_alert_contacts` fetch and wire the result into
+/// `DuressContactsMessage::Loaded`. Estate-gating is the caller's
+/// responsibility (`reload_duress_contacts` and the nav trigger both
+/// check `is_duress_alerts_entitled` first) so this never spuriously 403s.
+pub fn load_duress_alert_contacts(client: &CoincubeClient, generation: u64) -> iced::Task<Message> {
+    let client = client.clone();
+    iced::Task::perform(
+        async move { client.get_duress_alert_contacts().await },
+        move |res| {
+            duress_contacts_msg(DuressContactsMessage::Loaded(
+                res.map_err(|e| e.to_string()),
+                generation,
+            ))
+        },
+    )
 }
 
 /// Load the user's cubes for the W12 invite-form multi-select, mapping
@@ -3539,6 +3921,8 @@ mod plan_lifecycle_tests {
                 linked_keychains: false,
                 duress_remote_lock: false,
                 business_orgs: false,
+                duress_alerts: false,
+                recovery_alerts: false,
             },
             billing_cycle: cycle,
         }
@@ -3732,5 +4116,248 @@ mod plan_lifecycle_tests {
         let mut panel = ConnectAccountPanel::new();
         panel.features = Some(features(Some(SUPPORTED_PRICING_SCHEMA_VERSION + 1)));
         assert!(panel.pricing_schema_outdated());
+    }
+}
+
+#[cfg(test)]
+mod duress_contacts_tests {
+    //! State-machine tests for the duress "Emergency contacts" section
+    //! (Estate Notifications — PR 1): gating, cap enforcement, form
+    //! validation, and the duress-active hiding invariant.
+    use super::*;
+    use crate::services::coincube::{
+        DuressAlertContact, PlanEntitlements, DURESS_CHANNEL_EMAIL, DURESS_CHANNEL_SMS,
+    };
+
+    fn entitlements(duress_alerts: bool) -> PlanEntitlements {
+        PlanEntitlements {
+            free_signing_key_count: 0,
+            policy_editing: false,
+            legacy_invites: false,
+            linked_keychains: false,
+            duress_remote_lock: true,
+            business_orgs: false,
+            duress_alerts,
+            recovery_alerts: false,
+        }
+    }
+
+    fn plan(duress_alerts: bool) -> ConnectPlan {
+        ConnectPlan {
+            plan: if duress_alerts {
+                PlanTier::Estate
+            } else {
+                PlanTier::Pro
+            },
+            status: PlanStatus::Active,
+            renewal_at: None,
+            entitlements: entitlements(duress_alerts),
+            billing_cycle: Some(BillingCycle::Monthly),
+        }
+    }
+
+    /// Estate-entitled, authenticated panel ready to drive the section.
+    fn estate_panel() -> ConnectAccountPanel {
+        let mut panel = ConnectAccountPanel::new();
+        panel.plan = Some(plan(true));
+        panel.step = ConnectFlowStep::Dashboard;
+        panel
+    }
+
+    fn contact(id: u64) -> DuressAlertContact {
+        DuressAlertContact {
+            id,
+            display_name: format!("Contact {id}"),
+            phone: Some("+15551234567".into()),
+            email: None,
+            channels: DURESS_CHANNEL_SMS,
+            intro_sent_at: None,
+            opted_out_at: None,
+            created_at: "2026-06-11T00:00:00Z".into(),
+            updated_at: "2026-06-11T00:00:00Z".into(),
+        }
+    }
+
+    fn dispatch(panel: &mut ConnectAccountPanel, m: DuressContactsMessage) {
+        let _ = panel.update_duress_contacts(m);
+    }
+
+    #[test]
+    fn reload_is_noop_when_not_estate_entitled() {
+        // Gating: a Pro account (duress_alerts=false) must never fire the
+        // contacts fetch — `reload` leaves `loading` false so the UI shows
+        // the locked affordance, not a spinner.
+        let mut panel = ConnectAccountPanel::new();
+        panel.plan = Some(plan(false));
+        panel.step = ConnectFlowStep::Dashboard;
+        assert!(!panel.is_duress_alerts_entitled());
+        let _ = panel.reload_duress_contacts();
+        assert!(!panel.duress_contacts.loading);
+    }
+
+    #[test]
+    fn reload_starts_loading_when_estate_entitled() {
+        let mut panel = estate_panel();
+        assert!(panel.is_duress_alerts_entitled());
+        let _ = panel.reload_duress_contacts();
+        assert!(panel.duress_contacts.loading);
+        assert_eq!(panel.duress_contacts.step, DuressContactsStep::List);
+    }
+
+    #[test]
+    fn cap_blocks_add_form_at_five_contacts() {
+        let mut panel = estate_panel();
+        let five = (1..=5).map(contact).collect::<Vec<_>>();
+        panel.duress_contacts.contacts = Some(five);
+        assert!(panel.duress_contacts.at_cap());
+        dispatch(&mut panel, DuressContactsMessage::ShowAddForm);
+        // Stayed on the list with a cap message rather than opening the form.
+        assert_eq!(panel.duress_contacts.step, DuressContactsStep::List);
+        assert!(panel.duress_contacts.error.is_some());
+    }
+
+    #[test]
+    fn add_form_opens_below_cap() {
+        let mut panel = estate_panel();
+        panel.duress_contacts.contacts = Some(vec![contact(1)]);
+        dispatch(&mut panel, DuressContactsMessage::ShowAddForm);
+        assert_eq!(panel.duress_contacts.step, DuressContactsStep::Form);
+        assert!(panel.duress_contacts.editing_id.is_none());
+    }
+
+    #[test]
+    fn submit_requires_a_name() {
+        let mut panel = estate_panel();
+        panel.duress_contacts.contacts = Some(vec![]);
+        dispatch(&mut panel, DuressContactsMessage::ShowAddForm);
+        dispatch(
+            &mut panel,
+            DuressContactsMessage::PhoneChanged("+15551234567".into()),
+        );
+        dispatch(&mut panel, DuressContactsMessage::ToggleSms(true));
+        dispatch(&mut panel, DuressContactsMessage::Submit);
+        assert!(!panel.duress_contacts.submitting);
+        assert!(panel.duress_contacts.error.as_deref().unwrap().contains("name"));
+    }
+
+    #[test]
+    fn submit_requires_a_reachable_method() {
+        let mut panel = estate_panel();
+        panel.duress_contacts.contacts = Some(vec![]);
+        dispatch(&mut panel, DuressContactsMessage::ShowAddForm);
+        dispatch(
+            &mut panel,
+            DuressContactsMessage::NameChanged("Jane".into()),
+        );
+        dispatch(&mut panel, DuressContactsMessage::Submit);
+        assert!(!panel.duress_contacts.submitting);
+        assert!(panel.duress_contacts.error.is_some());
+    }
+
+    #[test]
+    fn submit_rejects_bad_phone() {
+        let mut panel = estate_panel();
+        panel.duress_contacts.contacts = Some(vec![]);
+        dispatch(&mut panel, DuressContactsMessage::ShowAddForm);
+        dispatch(
+            &mut panel,
+            DuressContactsMessage::NameChanged("Jane".into()),
+        );
+        dispatch(
+            &mut panel,
+            DuressContactsMessage::PhoneChanged("5551234567".into()), // no +
+        );
+        dispatch(&mut panel, DuressContactsMessage::ToggleSms(true));
+        dispatch(&mut panel, DuressContactsMessage::Submit);
+        assert!(!panel.duress_contacts.submitting);
+        assert!(panel
+            .duress_contacts
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("international"));
+    }
+
+    #[test]
+    fn submit_requires_at_least_one_channel() {
+        let mut panel = estate_panel();
+        panel.duress_contacts.contacts = Some(vec![]);
+        dispatch(&mut panel, DuressContactsMessage::ShowAddForm);
+        dispatch(
+            &mut panel,
+            DuressContactsMessage::NameChanged("Jane".into()),
+        );
+        dispatch(
+            &mut panel,
+            DuressContactsMessage::EmailChanged("jane@example.com".into()),
+        );
+        // No channel toggled.
+        dispatch(&mut panel, DuressContactsMessage::Submit);
+        assert!(!panel.duress_contacts.submitting);
+        assert!(panel.duress_contacts.error.is_some());
+    }
+
+    #[test]
+    fn valid_submit_starts_submitting() {
+        let mut panel = estate_panel();
+        panel.duress_contacts.contacts = Some(vec![]);
+        dispatch(&mut panel, DuressContactsMessage::ShowAddForm);
+        dispatch(
+            &mut panel,
+            DuressContactsMessage::NameChanged("Jane".into()),
+        );
+        dispatch(
+            &mut panel,
+            DuressContactsMessage::EmailChanged("jane@example.com".into()),
+        );
+        dispatch(&mut panel, DuressContactsMessage::ToggleEmailChannel(true));
+        // A valid submit transitions to the in-flight state and clears the
+        // error (the returned Task is the network call, ignored here).
+        dispatch(&mut panel, DuressContactsMessage::Submit);
+        assert!(panel.duress_contacts.submitting);
+        assert!(panel.duress_contacts.error.is_none());
+        let _ = DURESS_CHANNEL_EMAIL; // silence unused in some cfgs
+    }
+
+    #[test]
+    fn submit_refused_when_entitlement_lost_midsession() {
+        // Estate user opened the form, then the plan downgraded (e.g. a
+        // /connect/plan refresh). Submit must refuse rather than 403.
+        let mut panel = estate_panel();
+        panel.duress_contacts.contacts = Some(vec![]);
+        dispatch(&mut panel, DuressContactsMessage::ShowAddForm);
+        dispatch(
+            &mut panel,
+            DuressContactsMessage::NameChanged("Jane".into()),
+        );
+        dispatch(
+            &mut panel,
+            DuressContactsMessage::EmailChanged("jane@example.com".into()),
+        );
+        dispatch(&mut panel, DuressContactsMessage::ToggleEmailChannel(true));
+        panel.plan = Some(plan(false)); // downgrade
+        dispatch(&mut panel, DuressContactsMessage::Submit);
+        assert!(!panel.duress_contacts.submitting);
+        assert!(panel.duress_contacts.error.is_some());
+    }
+
+    #[test]
+    fn contacts_surface_hidden_while_duress_active() {
+        // The Emergency-contacts surface (and its on-demand load) gate on
+        // `is_authenticated()` == Dashboard. While duress is active the
+        // panel sits in DuressRecovery / a non-Dashboard step, so the
+        // surface is never reachable and the load never fires — a coercer
+        // can't see who would be alerted.
+        let mut panel = estate_panel();
+        panel.step = ConnectFlowStep::DuressRecovery {
+            unlock_at: None,
+            passphrase: String::new(),
+            submitting: false,
+            cleared: false,
+        };
+        assert!(!panel.is_authenticated());
+        // Even though the account is Estate-entitled, the nav guard keys on
+        // `is_authenticated()`, so the section is not rendered/loaded.
+        assert!(panel.is_duress_alerts_entitled());
     }
 }

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -4,7 +4,9 @@ use crate::{
     app::{
         menu::ConnectSubMenu,
         message::Message,
-        view::{self, ConnectAccountMessage, ContactsMessage, DuressContactsMessage, DuressMessage},
+        view::{
+            self, ConnectAccountMessage, ContactsMessage, DuressContactsMessage, DuressMessage,
+        },
     },
     services::coincube::{
         BillingCycle, BillingHistoryEntry, ChargeStatus, CheckoutRequest, CheckoutResponse,
@@ -404,6 +406,14 @@ pub struct DuressContactsState {
 }
 
 impl DuressContactsState {
+    /// Drop all session state — the loaded contacts (names, phones, emails)
+    /// and any in-flight add/edit form. Called on logout so one Connect
+    /// session's duress contacts can't linger in memory or flash into the
+    /// next user's Duress section before its reload lands.
+    pub fn clear(&mut self) {
+        *self = Self::default();
+    }
+
     /// Reset the form fields to empty and switch to "add" mode.
     fn reset_form_for_add(&mut self) {
         self.editing_id = None;
@@ -793,6 +803,7 @@ impl ConnectAccountPanel {
                 self.renewal_banner_dismissed = false;
                 self.selected_billing_cycle = BillingCycle::Monthly;
                 self.contacts_state.clear();
+                self.duress_contacts.clear();
                 // Scrub any in-flight enrollment wizard secrets (PINs,
                 // passphrases, generated code) and the recovery all-clear
                 // passphrase before dropping them, so they don't survive the
@@ -1461,9 +1472,7 @@ impl ConnectAccountPanel {
                 // state — set on the post-sign-in mirror, reset on recovery).
             }
             ConnectAccountMessage::Duress(m) => return self.update_duress(m),
-            ConnectAccountMessage::DuressContacts(m) => {
-                return self.update_duress_contacts(m)
-            }
+            ConnectAccountMessage::DuressContacts(m) => return self.update_duress_contacts(m),
         }
 
         iced::Task::none()
@@ -4237,7 +4246,12 @@ mod duress_contacts_tests {
         dispatch(&mut panel, DuressContactsMessage::ToggleSms(true));
         dispatch(&mut panel, DuressContactsMessage::Submit);
         assert!(!panel.duress_contacts.submitting);
-        assert!(panel.duress_contacts.error.as_deref().unwrap().contains("name"));
+        assert!(panel
+            .duress_contacts
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("name"));
     }
 
     #[test]

--- a/coincube-gui/src/app/state/connect/mod.rs
+++ b/coincube-gui/src/app/state/connect/mod.rs
@@ -83,8 +83,8 @@ pub(crate) fn delete_connect_secret(user_key: &str) {
 
 pub use account::{
     AddToCubeDialog, CheckoutPhase, CheckoutState, ConnectAccountPanel, ConnectFlowStep,
-    ContactsState, ContactsStep, DuressEnrollState, DuressEnrollStep, EnrollTier, InviteCubeOption,
-    PlanLifecycle,
+    ContactsState, ContactsStep, DuressContactsState, DuressContactsStep, DuressEnrollState,
+    DuressEnrollStep, EnrollTier, InviteCubeOption, PlanLifecycle,
 };
 pub use cube::ConnectCubePanel;
 pub use cube_members::ConnectCubeMembersState;

--- a/coincube-gui/src/app/state/settings/general.rs
+++ b/coincube-gui/src/app/state/settings/general.rs
@@ -538,6 +538,7 @@ impl GeneralSettingsState {
         menu: &'a Menu,
         cache: &'a Cache,
         rk: &'a super::recovery_kit::RecoveryKit,
+        ra: &'a super::recovery_alerts::RecoveryAlerts,
     ) -> Element<'a, view::Message> {
         crate::app::view::settings::general::general_section(
             menu,
@@ -551,6 +552,7 @@ impl GeneralSettingsState {
             &self.backup_pin,
             self.backup_mnemonic.as_deref().map(|v| v.as_slice()),
             Some(rk),
+            Some(ra),
         )
     }
 }
@@ -572,6 +574,7 @@ impl State for GeneralSettingsState {
             &self.backup_state,
             &self.backup_pin,
             self.backup_mnemonic.as_deref().map(|v| v.as_slice()),
+            None,
             None,
         )
     }

--- a/coincube-gui/src/app/state/settings/mod.rs
+++ b/coincube-gui/src/app/state/settings/mod.rs
@@ -2,6 +2,7 @@ pub mod about;
 pub mod general;
 mod install_stats;
 pub mod local_signing;
+pub mod recovery_alerts;
 pub mod recovery_kit;
 
 use std::sync::Arc;
@@ -38,6 +39,10 @@ pub struct SettingsState {
     /// Recovery-Kit card is rendered inside the General section's
     /// view, which reads this field through a parameter.
     pub recovery_kit: recovery_kit::RecoveryKit,
+    /// Vault Recovery Alerts card (Estate Notifications — PR 2). Held here
+    /// for the same reason as `recovery_kit`: the App-level handler injects
+    /// the authenticated client, cube id, wallet, and keyholders.
+    pub recovery_alerts: recovery_alerts::RecoveryAlerts,
 }
 
 impl SettingsState {
@@ -52,6 +57,7 @@ impl SettingsState {
             current_price_setting: price_setting,
             current_unit_setting: unit_setting,
             recovery_kit: recovery_kit::RecoveryKit::new(),
+            recovery_alerts: recovery_alerts::RecoveryAlerts::new(),
         }
     }
 }
@@ -86,7 +92,12 @@ impl State for SettingsState {
                 let load_status = Task::done(Message::View(view::Message::Settings(
                     view::SettingsMessage::RecoveryKit(view::RecoveryKitMessage::LoadStatus),
                 )));
-                Task::batch([reload_task, load_status])
+                // Same pattern for the Recovery Alerts card — kick its status
+                // fetch so the three-tier selector reflects the server.
+                let load_alerts = Task::done(Message::View(view::Message::Settings(
+                    view::SettingsMessage::RecoveryAlerts(view::RecoveryAlertsMessage::LoadStatus),
+                )));
+                Task::batch([reload_task, load_status, load_alerts])
             }
             Message::View(view::Message::Settings(view::SettingsMessage::AboutSection)) => {
                 self.setting = Some(AboutSettingsState::default().into());
@@ -161,7 +172,12 @@ impl State for SettingsState {
                 .as_any()
                 .and_then(|a| a.downcast_ref::<GeneralSettingsState>())
             {
-                return general.view_with_recovery_kit(menu, cache, &self.recovery_kit);
+                return general.view_with_recovery_kit(
+                    menu,
+                    cache,
+                    &self.recovery_kit,
+                    &self.recovery_alerts,
+                );
             }
             setting.view(menu, cache)
         } else {

--- a/coincube-gui/src/app/state/settings/recovery_alerts.rs
+++ b/coincube-gui/src/app/state/settings/recovery_alerts.rs
@@ -132,8 +132,13 @@ pub fn update(
             };
             if !entitled {
                 // Non-Estate: don't hit the network; the card shows the
-                // locked affordance.
-                ra.loaded_once = true;
+                // locked affordance. Deliberately leave `loaded_once` false:
+                // nothing was resolved here, and the heartbeat's lazy
+                // hydration is gated on `!loaded_once && entitled`. If we
+                // marked it loaded, a later upgrade to Estate would never
+                // re-fire that hydration and background heartbeats would
+                // never start until Settings is reopened. The entitlement
+                // gate keeps this from dispatching spuriously while unentitled.
                 return Task::none();
             }
             ra.loading = true;

--- a/coincube-gui/src/app/state/settings/recovery_alerts.rs
+++ b/coincube-gui/src/app/state/settings/recovery_alerts.rs
@@ -1,0 +1,291 @@
+//! Vault Recovery Alerts settings card (Estate Notifications — PR 2).
+//!
+//! Estate-only, per-vault opt-in for recovery-path monitoring. Modeled on
+//! the Cube Recovery Kit card (`recovery_kit.rs`): the state container lives
+//! on the outer `SettingsState` so `App::update` can inject the
+//! authenticated `CoincubeClient`, the Connect cube id, the live wallet
+//! descriptor, the keyholder list, and the entitlement — none of which are
+//! plumbed through `State::update`.
+//!
+//! Three tiers (`VaultMonitoringLevel`): **Off** (true-delete any escrowed
+//! descriptor), **Alerts only / Heartbeat** (timelock heartbeat only — the
+//! server never sees addresses/balances), **Full** (a service-encrypted
+//! copy of the descriptor is escrowed so keyholders can recover without the
+//! owner's password). A separate keyholder download policy governs when
+//! keyholders may pull the encrypted recovery kit.
+
+use std::sync::Arc;
+
+use iced::Task;
+
+use crate::{
+    app::{message::Message, view, wallet::Wallet},
+    services::coincube::{
+        CoincubeClient, CubeMember, KeyholderDownloadPolicy, SetVaultMonitoringRequest,
+        VaultMonitoringLevel, VaultMonitoringStatus,
+    },
+};
+
+use view::{RecoveryAlertsMessage, SettingsMessage};
+
+/// Settings-card state for Vault Recovery Alerts. Held on `SettingsState`.
+#[derive(Debug)]
+pub struct RecoveryAlerts {
+    /// Connect vault id, resolved from the cube on first load and cached so
+    /// level/policy changes don't re-resolve it.
+    pub vault_id: Option<u64>,
+    /// Last-known monitoring status from Connect. `None` until first load.
+    pub status: Option<VaultMonitoringStatus>,
+    pub loading: bool,
+    pub submitting: bool,
+    pub error: Option<String>,
+    /// Keyholder emails (the cube members who'd be notified), snapshotted on
+    /// each load so the card can show exactly who would receive alerts.
+    pub keyholders: Vec<String>,
+    /// Whether the account carries the Estate `recovery_alerts` entitlement.
+    pub entitled: bool,
+    /// True once a load resolved that there's no Connect vault to monitor
+    /// (no cube registered / no vault created yet).
+    pub no_vault: bool,
+    /// True once at least one load has been attempted — lets the card pick
+    /// the right loading vs. empty copy.
+    pub loaded_once: bool,
+}
+
+impl Default for RecoveryAlerts {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RecoveryAlerts {
+    pub fn new() -> Self {
+        Self {
+            vault_id: None,
+            status: None,
+            loading: false,
+            submitting: false,
+            error: None,
+            keyholders: Vec::new(),
+            entitled: false,
+            no_vault: false,
+            loaded_once: false,
+        }
+    }
+
+    /// Current monitoring level (Off when unloaded).
+    pub fn level(&self) -> VaultMonitoringLevel {
+        self.status
+            .as_ref()
+            .map(|s| s.level)
+            .unwrap_or(VaultMonitoringLevel::Off)
+    }
+
+    /// Current keyholder download policy (privacy-preserving default when
+    /// unloaded).
+    pub fn download_policy(&self) -> KeyholderDownloadPolicy {
+        self.status
+            .as_ref()
+            .map(|s| s.crk_keyholder_download)
+            .unwrap_or_default()
+    }
+}
+
+/// Wrap a [`RecoveryAlertsMessage`] in the settings-message envelope.
+fn ra_msg(m: RecoveryAlertsMessage) -> Message {
+    Message::View(view::Message::Settings(SettingsMessage::RecoveryAlerts(m)))
+}
+
+/// App-level dispatcher. `client` / `server_cube_id` / `wallet` / `members`
+/// are injected by `App::update`; `entitled` is the account's
+/// `recovery_alerts` entitlement.
+#[allow(clippy::too_many_arguments)]
+pub fn update(
+    ra: &mut RecoveryAlerts,
+    msg: RecoveryAlertsMessage,
+    client: Option<CoincubeClient>,
+    server_cube_id: Option<u64>,
+    wallet: Option<Arc<Wallet>>,
+    entitled: bool,
+    members: &[CubeMember],
+) -> Task<Message> {
+    ra.entitled = entitled;
+    match msg {
+        RecoveryAlertsMessage::LoadStatus => {
+            // Refresh the keyholder snapshot every load so the card reflects
+            // the current cube membership.
+            ra.keyholders = members.iter().map(|m| m.user.email.clone()).collect();
+            ra.error = None;
+
+            let (Some(client), Some(cube_id)) = (client, server_cube_id) else {
+                // No Connect session or no registered cube → nothing to
+                // monitor. Mark `no_vault` so the card shows the right copy.
+                ra.no_vault = server_cube_id.is_none();
+                ra.loaded_once = true;
+                return Task::none();
+            };
+            if !entitled {
+                // Non-Estate: don't hit the network; the card shows the
+                // locked affordance.
+                ra.loaded_once = true;
+                return Task::none();
+            }
+            ra.loading = true;
+            Task::perform(
+                async move {
+                    let vault = client
+                        .get_connect_vault(cube_id)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    let status = client
+                        .get_vault_monitoring(vault.id)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    Ok((vault.id, status))
+                },
+                |res| ra_msg(RecoveryAlertsMessage::StatusLoaded(res)),
+            )
+        }
+        RecoveryAlertsMessage::StatusLoaded(res) => {
+            ra.loading = false;
+            ra.loaded_once = true;
+            match res {
+                Ok((vid, status)) => {
+                    ra.vault_id = Some(vid);
+                    ra.status = Some(status);
+                    ra.no_vault = false;
+                    ra.error = None;
+                }
+                Err(e) => {
+                    // A missing Connect vault (the cube has no vault yet)
+                    // surfaces as a not-found error; treat it as "nothing to
+                    // monitor" rather than a hard error so the card degrades
+                    // gracefully.
+                    if e.to_lowercase().contains("not found") {
+                        ra.no_vault = true;
+                    } else {
+                        ra.error = Some(e);
+                    }
+                }
+            }
+            Task::none()
+        }
+        RecoveryAlertsMessage::SelectLevel(level) => {
+            if !entitled {
+                ra.error = Some("Recovery alerts require an Estate plan.".to_string());
+                return Task::none();
+            }
+            if ra.level() == level {
+                return Task::none();
+            }
+            let (Some(client), Some(vault_id)) = (client, ra.vault_id) else {
+                ra.error = Some(
+                    "Couldn't find this Vault on Connect yet — try again in a moment.".to_string(),
+                );
+                return Task::none();
+            };
+            let current_policy = ra.status.as_ref().map(|s| s.crk_keyholder_download);
+            ra.submitting = true;
+            ra.error = None;
+            match level {
+                VaultMonitoringLevel::Off => Task::perform(
+                    async move {
+                        client
+                            .delete_vault_monitoring(vault_id)
+                            .await
+                            .map(|_| VaultMonitoringStatus {
+                                level: VaultMonitoringLevel::Off,
+                                crk_keyholder_download: current_policy.unwrap_or_default(),
+                                last_notified_state: None,
+                                updated_at: None,
+                            })
+                            .map_err(|e| e.to_string())
+                    },
+                    |res| ra_msg(RecoveryAlertsMessage::ChangeResult(res)),
+                ),
+                VaultMonitoringLevel::Heartbeat => {
+                    let req = SetVaultMonitoringRequest {
+                        level,
+                        descriptor: None,
+                        gap_limit: None,
+                        crk_keyholder_download: current_policy,
+                    };
+                    Task::perform(
+                        async move {
+                            client
+                                .set_vault_monitoring(vault_id, req)
+                                .await
+                                .map_err(|e| e.to_string())
+                        },
+                        |res| ra_msg(RecoveryAlertsMessage::ChangeResult(res)),
+                    )
+                }
+                VaultMonitoringLevel::Full => {
+                    // Full needs the descriptor to escrow. It only exists on
+                    // a device holding the live wallet.
+                    let Some(descriptor) = wallet.as_ref().map(|w| w.main_descriptor.to_string())
+                    else {
+                        ra.submitting = false;
+                        ra.error = Some(
+                            "This Vault's descriptor isn't available on this device, so full \
+                             monitoring can't be enabled here."
+                                .to_string(),
+                        );
+                        return Task::none();
+                    };
+                    let req = SetVaultMonitoringRequest {
+                        level,
+                        descriptor: Some(descriptor),
+                        gap_limit: None,
+                        crk_keyholder_download: current_policy,
+                    };
+                    Task::perform(
+                        async move {
+                            client
+                                .set_vault_monitoring(vault_id, req)
+                                .await
+                                .map_err(|e| e.to_string())
+                        },
+                        |res| ra_msg(RecoveryAlertsMessage::ChangeResult(res)),
+                    )
+                }
+            }
+        }
+        RecoveryAlertsMessage::SetDownloadPolicy(policy) => {
+            if !entitled {
+                return Task::none();
+            }
+            if ra.download_policy() == policy {
+                return Task::none();
+            }
+            let (Some(client), Some(vault_id)) = (client, ra.vault_id) else {
+                ra.error = Some(
+                    "Couldn't find this Vault on Connect yet — try again in a moment.".to_string(),
+                );
+                return Task::none();
+            };
+            ra.submitting = true;
+            ra.error = None;
+            Task::perform(
+                async move {
+                    client
+                        .set_keyholder_download_policy(vault_id, policy)
+                        .await
+                        .map_err(|e| e.to_string())
+                },
+                |res| ra_msg(RecoveryAlertsMessage::ChangeResult(res)),
+            )
+        }
+        RecoveryAlertsMessage::ChangeResult(res) => {
+            ra.submitting = false;
+            match res {
+                Ok(status) => {
+                    ra.status = Some(status);
+                    ra.error = None;
+                }
+                Err(e) => ra.error = Some(e),
+            }
+            Task::none()
+        }
+    }
+}

--- a/coincube-gui/src/app/state/settings/recovery_alerts.rs
+++ b/coincube-gui/src/app/state/settings/recovery_alerts.rs
@@ -138,13 +138,21 @@ pub fn update(
             };
             if !entitled {
                 // Non-Estate: don't hit the network; the card shows the
-                // locked affordance. Deliberately leave `loaded_once` false:
-                // nothing was resolved here, and the heartbeat's lazy
-                // hydration is gated on `!loaded_once && entitled`. If we
-                // marked it loaded, a later upgrade to Estate would never
-                // re-fire that hydration and background heartbeats would
-                // never start until Settings is reopened. The entitlement
-                // gate keeps this from dispatching spuriously while unentitled.
+                // locked affordance. Clear any in-flight `loading`: a prior
+                // entitled fetch can still be marked loading here — e.g. after
+                // an in-place account switch to a non-Estate account, where the
+                // session bump drops the old fetch's `StatusLoaded` without
+                // resetting this state — and a stuck `loading` would keep the
+                // card on "Loading…" and block the heartbeat's `!loading`
+                // hydration gate.
+                ra.loading = false;
+                // Deliberately leave `loaded_once` false: nothing was resolved
+                // here, and the heartbeat's lazy hydration is gated on
+                // `!loaded_once && entitled`. If we marked it loaded, a later
+                // upgrade to Estate would never re-fire that hydration and
+                // background heartbeats would never start until Settings is
+                // reopened. The entitlement gate keeps this from dispatching
+                // spuriously while unentitled.
                 return Task::none();
             }
             ra.loading = true;

--- a/coincube-gui/src/app/state/settings/recovery_alerts.rs
+++ b/coincube-gui/src/app/state/settings/recovery_alerts.rs
@@ -157,12 +157,19 @@ pub fn update(
                     ra.error = None;
                 }
                 Err(e) => {
-                    // A missing Connect vault (the cube has no vault yet)
-                    // surfaces as a not-found error; treat it as "nothing to
-                    // monitor" rather than a hard error so the card degrades
-                    // gracefully.
+                    // A missing Connect vault (the cube has no vault yet, or a
+                    // previously-resolved vault was removed) surfaces as a
+                    // not-found error; treat it as "nothing to monitor" rather
+                    // than a hard error so the card degrades gracefully. Clear
+                    // any cached vault id and status too: otherwise
+                    // `recovery_heartbeat_task` would keep POSTing heartbeats
+                    // (level != Off && vault_id set) to a vault Connect no
+                    // longer has, even though the card now shows nothing to
+                    // monitor. A later successful load re-resolves both.
                     if e.to_lowercase().contains("not found") {
                         ra.no_vault = true;
+                        ra.vault_id = None;
+                        ra.status = None;
                     } else {
                         ra.error = Some(e);
                     }

--- a/coincube-gui/src/app/state/settings/recovery_alerts.rs
+++ b/coincube-gui/src/app/state/settings/recovery_alerts.rs
@@ -120,7 +120,13 @@ pub fn update(
             let (Some(client), Some(cube_id)) = (client, server_cube_id) else {
                 // No Connect session or no registered cube → nothing to
                 // monitor. Mark `no_vault` so the card shows the right copy.
+                // Clear any cached vault id/status too: the cube-deregistered
+                // case lands here (not the not-found arm, which only runs
+                // after a fetch), and a stale id + non-Off level would keep
+                // `recovery_heartbeat_task` POSTing to a vault that's gone.
                 ra.no_vault = server_cube_id.is_none();
+                ra.vault_id = None;
+                ra.status = None;
                 ra.loaded_once = true;
                 return Task::none();
             };

--- a/coincube-gui/src/app/state/settings/recovery_alerts.rs
+++ b/coincube-gui/src/app/state/settings/recovery_alerts.rs
@@ -98,7 +98,12 @@ fn ra_msg(m: RecoveryAlertsMessage) -> Message {
 
 /// App-level dispatcher. `client` / `server_cube_id` / `wallet` / `members`
 /// are injected by `App::update`; `entitled` is the account's
-/// `recovery_alerts` entitlement.
+/// `recovery_alerts` entitlement. `session_generation` is the connect
+/// account's current session counter (bumped on login / logout / reset):
+/// it's stamped into spawned async results so a load / change that lands
+/// after the session changed is dropped instead of writing a prior account's
+/// vault id + status into the reset state — the same guard the duress-contacts
+/// handlers use.
 #[allow(clippy::too_many_arguments)]
 pub fn update(
     ra: &mut RecoveryAlerts,
@@ -108,6 +113,7 @@ pub fn update(
     wallet: Option<Arc<Wallet>>,
     entitled: bool,
     members: &[CubeMember],
+    session_generation: u64,
 ) -> Task<Message> {
     ra.entitled = entitled;
     match msg {
@@ -154,10 +160,16 @@ pub fn update(
                         .map_err(|e| e.to_string())?;
                     Ok((vault.id, status))
                 },
-                |res| ra_msg(RecoveryAlertsMessage::StatusLoaded(res)),
+                move |res| ra_msg(RecoveryAlertsMessage::StatusLoaded(res, session_generation)),
             )
         }
-        RecoveryAlertsMessage::StatusLoaded(res) => {
+        RecoveryAlertsMessage::StatusLoaded(res, gen) => {
+            // Drop a load that resolved after the session changed (logout /
+            // account switch) so we never write the prior account's vault id +
+            // status into the freshly-reset state.
+            if gen != session_generation {
+                return Task::none();
+            }
             ra.loading = false;
             ra.loaded_once = true;
             match res {
@@ -219,7 +231,7 @@ pub fn update(
                             })
                             .map_err(|e| e.to_string())
                     },
-                    |res| ra_msg(RecoveryAlertsMessage::ChangeResult(res)),
+                    move |res| ra_msg(RecoveryAlertsMessage::ChangeResult(res, session_generation)),
                 ),
                 VaultMonitoringLevel::Heartbeat => {
                     let req = SetVaultMonitoringRequest {
@@ -235,7 +247,9 @@ pub fn update(
                                 .await
                                 .map_err(|e| e.to_string())
                         },
-                        |res| ra_msg(RecoveryAlertsMessage::ChangeResult(res)),
+                        move |res| {
+                            ra_msg(RecoveryAlertsMessage::ChangeResult(res, session_generation))
+                        },
                     )
                 }
                 VaultMonitoringLevel::Full => {
@@ -264,7 +278,9 @@ pub fn update(
                                 .await
                                 .map_err(|e| e.to_string())
                         },
-                        |res| ra_msg(RecoveryAlertsMessage::ChangeResult(res)),
+                        move |res| {
+                            ra_msg(RecoveryAlertsMessage::ChangeResult(res, session_generation))
+                        },
                     )
                 }
             }
@@ -291,10 +307,15 @@ pub fn update(
                         .await
                         .map_err(|e| e.to_string())
                 },
-                |res| ra_msg(RecoveryAlertsMessage::ChangeResult(res)),
+                move |res| ra_msg(RecoveryAlertsMessage::ChangeResult(res, session_generation)),
             )
         }
-        RecoveryAlertsMessage::ChangeResult(res) => {
+        RecoveryAlertsMessage::ChangeResult(res, gen) => {
+            // Drop a change that resolved after the session changed so a stale
+            // result can't clobber a newer session's state.
+            if gen != session_generation {
+                return Task::none();
+            }
             ra.submitting = false;
             match res {
                 Ok(status) => {

--- a/coincube-gui/src/app/view/connect/duress_contacts.rs
+++ b/coincube-gui/src/app/view/connect/duress_contacts.rs
@@ -489,8 +489,7 @@ pub fn form_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccount
     // Submit button. Enabled only when the form is minimally valid.
     let name_ok = !dc.form_name.trim().is_empty();
     let reachable = phone_present || email_present;
-    let any_channel = (dc.form_ch_sms && phone_present)
-        || (dc.form_ch_whatsapp && phone_present)
+    let any_channel = ((dc.form_ch_sms || dc.form_ch_whatsapp) && phone_present)
         || (dc.form_ch_email && email_present);
     let can_submit = !dc.submitting && name_ok && reachable && phone_ok && email_ok && any_channel;
 

--- a/coincube-gui/src/app/view/connect/duress_contacts.rs
+++ b/coincube-gui/src/app/view/connect/duress_contacts.rs
@@ -1,0 +1,594 @@
+//! Duress "Emergency contacts" management (Estate Notifications — PR 1).
+//!
+//! Rendered as a section appended to the duress settings panel
+//! (`duress_ux`), and — while adding/editing — as a focused form takeover.
+//! The whole surface is reachable ONLY from normal-mode settings; it is
+//! never shown on the duress activation/cryptic screen (that flow lives in
+//! a different `ConnectFlowStep`, so `duress_ux` isn't even rendered), so a
+//! coercer can't learn who would be alerted.
+//!
+//! Gating: Estate-only via the `duress_alerts` entitlement. Non-Estate
+//! accounts see the standard locked-feature affordance instead of the list.
+
+use coincube_ui::{
+    color,
+    component::{button, text},
+    theme,
+    widget::*,
+};
+use iced::{widget::container, Alignment, Length};
+
+use crate::{
+    app::{
+        state::connect::ConnectAccountPanel,
+        view::{ConnectAccountMessage, DuressContactsMessage},
+    },
+    services::coincube::{
+        is_valid_e164, DuressAlertContact, DURESS_CHANNEL_EMAIL, DURESS_CHANNEL_SMS,
+        DURESS_CHANNEL_WHATSAPP, MAX_DURESS_ALERT_CONTACTS,
+    },
+};
+
+use super::{card_style, format_datetime};
+
+/// Wrap a [`DuressContactsMessage`] for `on_press`.
+fn msg(m: DuressContactsMessage) -> ConnectAccountMessage {
+    ConnectAccountMessage::DuressContacts(m)
+}
+
+/// Exact copy of the alert a contact receives if duress activates, rendered
+/// so the owner sees precisely what's sent — no balances, addresses, or
+/// mechanics (master plan §4). `{name}` is substituted with the account's
+/// own identity where known. The real template lives server-side; this is a
+/// faithful preview, kept in sync with the coincube-api template at review.
+pub fn alert_template_preview(owner: &str) -> String {
+    format!(
+        "COINCUBE alert: {owner} asked us to notify you in an emergency. They may need your \
+         help — please reach out to them directly, by phone or in person. This is an automated \
+         message; reply STOP to opt out."
+    )
+}
+
+/// Copy of the one-time intro message sent when a contact is added.
+pub fn intro_template_preview(owner: &str) -> String {
+    format!(
+        "{owner} added you as an emergency contact on COINCUBE. You won't hear from us again \
+         unless they trigger an emergency alert. Reply STOP to opt out."
+    )
+}
+
+/// The owner label used in template previews — the account email when known,
+/// else a neutral stand-in.
+fn owner_label(state: &ConnectAccountPanel) -> String {
+    state
+        .user
+        .as_ref()
+        .map(|u| u.email.clone())
+        .unwrap_or_else(|| "Your COINCUBE contact".to_string())
+}
+
+// =============================================================================
+// Section (appended to the duress settings panel)
+// =============================================================================
+
+/// The "Emergency contacts" section. Either the locked-feature affordance
+/// (non-Estate) or the contacts list + explainer cards (Estate).
+pub fn section<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMessage> {
+    let mut col = Column::new()
+        .push(text::h4_bold("Emergency contacts").style(theme::text::primary))
+        .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+        .push(
+            text::p2_regular(
+                "People we'll notify only if you activate duress mode. They get one intro \
+                 message now, and nothing else unless an alert fires.",
+            )
+            .color(color::GREY_3),
+        )
+        .push(iced::widget::Space::new().height(Length::Fixed(14.0)))
+        .width(Length::Fill);
+
+    if !state.is_duress_alerts_entitled() {
+        return col
+            .push(locked_card())
+            .width(Length::Fill)
+            .into();
+    }
+
+    col = col.push(explainer_cards(state));
+    col = col.push(iced::widget::Space::new().height(Length::Fixed(16.0)));
+    col = col.push(list_body(state));
+    col.width(Length::Fill).into()
+}
+
+/// Estate-gated locked affordance, mirroring the duress panel's own
+/// upgrade-prompt pattern.
+fn locked_card<'a>() -> Element<'a, ConnectAccountMessage> {
+    container(
+        Column::new()
+            .push(
+                text::p1_bold("Available on the Estate plan").style(theme::text::primary),
+            )
+            .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+            .push(
+                text::p2_regular(
+                    "Emergency contacts are part of the Estate plan. Upgrade your Connect plan \
+                     to let trusted people be alerted if you ever activate duress mode.",
+                )
+                .color(color::GREY_3),
+            )
+            .padding(20)
+            .spacing(0),
+    )
+    .style(card_style)
+    .width(Length::Fill)
+    .into()
+}
+
+/// The two explainer cards: what the alert says, and the STOP/opt-out note.
+fn explainer_cards<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMessage> {
+    let owner = owner_label(state);
+
+    let alert_card = container(
+        Column::new()
+            .push(text::p1_bold("What the alert says").style(theme::text::primary))
+            .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+            .push(
+                container(text::p2_regular(alert_template_preview(&owner)).color(color::GREY_2))
+                    .padding(12)
+                    .width(Length::Fill)
+                    .style(|t| container::Style {
+                        background: Some(iced::Background::Color(
+                            t.colors.cards.simple.background,
+                        )),
+                        border: iced::Border {
+                            color: color::GREY_5,
+                            width: 0.5,
+                            radius: 10.0.into(),
+                        },
+                        ..Default::default()
+                    }),
+            )
+            .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+            .push(
+                text::p2_regular(
+                    "It never includes your balances, addresses, or how COINCUBE works — only \
+                     that you may need help.",
+                )
+                .color(color::GREY_3),
+            )
+            .padding(20)
+            .spacing(0),
+    )
+    .style(card_style)
+    .width(Length::Fill);
+
+    let intro_card = container(
+        Column::new()
+            .push(text::p1_bold("The one-time intro message").style(theme::text::primary))
+            .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+            .push(
+                text::p2_regular(intro_template_preview(&owner)).color(color::GREY_2),
+            )
+            .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+            .push(
+                text::p2_regular(
+                    "Anyone can reply STOP at any time to opt out — we'll never message them \
+                     again.",
+                )
+                .color(color::GREY_3),
+            )
+            .padding(20)
+            .spacing(0),
+    )
+    .style(card_style)
+    .width(Length::Fill);
+
+    Column::new()
+        .push(alert_card)
+        .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
+        .push(intro_card)
+        .width(Length::Fill)
+        .into()
+}
+
+/// The list of configured contacts + add affordance, or an empty state.
+fn list_body<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMessage> {
+    let dc = &state.duress_contacts;
+
+    let mut col = Column::new().width(Length::Fill);
+
+    if let Some(err) = dc.error.as_deref() {
+        col = col
+            .push(text::p2_regular(err).color(color::RED))
+            .push(iced::widget::Space::new().height(Length::Fixed(10.0)));
+    }
+
+    // Header row with count + Add button (hidden at cap).
+    let count = dc.count();
+    let header = Row::new()
+        .push(
+            text::p1_bold(format!("Contacts ({}/{})", count, MAX_DURESS_ALERT_CONTACTS))
+                .style(theme::text::primary),
+        )
+        .push(iced::widget::Space::new().width(Length::Fill))
+        .push(if dc.at_cap() {
+            Element::from(text::p2_regular("Maximum reached").color(color::GREY_3))
+        } else {
+            button::primary(None, "+ Add contact")
+                .on_press(msg(DuressContactsMessage::ShowAddForm))
+                .width(Length::Shrink)
+                .into()
+        })
+        .align_y(Alignment::Center);
+    col = col
+        .push(header)
+        .push(iced::widget::Space::new().height(Length::Fixed(10.0)));
+
+    match &dc.contacts {
+        None => {
+            col = col.push(text::p2_regular("Loading\u{2026}").color(color::GREY_3));
+        }
+        Some(list) if list.is_empty() => {
+            col = col.push(
+                container(
+                    Column::new()
+                        .push(
+                            text::p1_bold("No emergency contacts yet")
+                                .style(theme::text::primary),
+                        )
+                        .push(iced::widget::Space::new().height(Length::Fixed(4.0)))
+                        .push(
+                            text::p2_regular(
+                                "Add up to 5 people who should be alerted if you activate \
+                                 duress mode.",
+                            )
+                            .color(color::GREY_3),
+                        )
+                        .push(iced::widget::Space::new().height(Length::Fixed(14.0)))
+                        .push(button::primary(None, "Add a contact").on_press(msg(
+                            DuressContactsMessage::ShowAddForm,
+                        )))
+                        .align_x(Alignment::Center)
+                        .padding(24)
+                        .spacing(0),
+                )
+                .style(card_style)
+                .width(Length::Fill),
+            );
+        }
+        Some(list) => {
+            for c in list {
+                col = col.push(contact_card(dc, c));
+                col = col.push(iced::widget::Space::new().height(Length::Fixed(8.0)));
+            }
+        }
+    }
+
+    col.into()
+}
+
+/// One contact row: identity, channels, delivery state, edit/remove.
+fn contact_card<'a>(
+    dc: &'a crate::app::state::connect::DuressContactsState,
+    c: &'a DuressAlertContact,
+) -> Element<'a, ConnectAccountMessage> {
+    let mut info = Column::new()
+        .push(text::p1_regular(c.display_name.as_str()).style(theme::text::primary))
+        .spacing(2);
+
+    // Contact methods line.
+    let mut methods: Vec<String> = Vec::new();
+    if let Some(p) = c.phone.as_deref() {
+        if !p.is_empty() {
+            methods.push(p.to_string());
+        }
+    }
+    if let Some(e) = c.email.as_deref() {
+        if !e.is_empty() {
+            methods.push(e.to_string());
+        }
+    }
+    if !methods.is_empty() {
+        info = info.push(text::p2_regular(methods.join("  ·  ")).color(color::GREY_3));
+    }
+
+    // Channel badges.
+    let channels_line = channel_badges(c);
+    info = info.push(channels_line);
+
+    // Delivery state: opted out > intro sent > pending.
+    let status: Element<ConnectAccountMessage> = if c.is_opted_out() {
+        text::p2_regular("Opted out (replied STOP)")
+            .color(color::ORANGE)
+            .into()
+    } else if let Some(at) = c.intro_sent_at.as_deref() {
+        text::p2_regular(format!("Intro sent {}", format_datetime(at)))
+            .color(color::GREY_3)
+            .into()
+    } else {
+        text::p2_regular("Intro message queued")
+            .color(color::GREY_3)
+            .into()
+    };
+    info = info.push(status);
+
+    let id = c.id;
+    let deleting = dc.deleting_ids.contains(&id);
+    let remove_btn: Element<ConnectAccountMessage> = if deleting {
+        button::secondary(None, "Removing\u{2026}")
+            .on_press_maybe(None)
+            .into()
+    } else {
+        button::secondary(None, "Remove")
+            .on_press(msg(DuressContactsMessage::Delete(id)))
+            .into()
+    };
+
+    let actions = Row::new()
+        .push(
+            button::secondary(None, "Edit")
+                .on_press(msg(DuressContactsMessage::EditContact(id))),
+        )
+        .push(iced::widget::Space::new().width(Length::Fixed(8.0)))
+        .push(remove_btn)
+        .align_y(Alignment::Center);
+
+    container(
+        Row::new()
+            .push(info)
+            .push(iced::widget::Space::new().width(Length::Fill))
+            .push(actions)
+            .align_y(Alignment::Center)
+            .padding(14),
+    )
+    .style(card_style)
+    .width(Length::Fill)
+    .into()
+}
+
+/// Small inline channel badges (SMS / WhatsApp / Email) reflecting which
+/// channels are enabled for the contact.
+fn channel_badges<'a>(c: &'a DuressAlertContact) -> Element<'a, ConnectAccountMessage> {
+    let mut row = Row::new().spacing(6).align_y(Alignment::Center);
+    let mut any = false;
+    for (bit, label) in [
+        (DURESS_CHANNEL_SMS, "SMS"),
+        (DURESS_CHANNEL_WHATSAPP, "WhatsApp"),
+        (DURESS_CHANNEL_EMAIL, "Email"),
+    ] {
+        if c.has_channel(bit) {
+            any = true;
+            row = row.push(
+                container(text::caption(label).color(color::ORANGE))
+                    .padding(iced::Padding {
+                        top: 2.0,
+                        bottom: 2.0,
+                        left: 6.0,
+                        right: 6.0,
+                    })
+                    .style(|_t| container::Style {
+                        border: iced::Border {
+                            color: color::ORANGE,
+                            width: 0.5,
+                            radius: 6.0.into(),
+                        },
+                        ..Default::default()
+                    }),
+            );
+        }
+    }
+    if !any {
+        return text::p2_regular("No channels selected")
+            .color(color::RED)
+            .into();
+    }
+    row.into()
+}
+
+// =============================================================================
+// Add / Edit form (panel takeover)
+// =============================================================================
+
+/// The add/edit form. Takes over the duress panel (returned early by
+/// `duress_ux`) so the user focuses on one contact at a time.
+pub fn form_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMessage> {
+    let dc = &state.duress_contacts;
+    let editing = dc.editing_id.is_some();
+
+    let back_button = iced::widget::button(
+        Row::new()
+            .push(text::p1_medium("‹ Back").style(theme::text::secondary))
+            .align_y(Alignment::Center),
+    )
+    .style(theme::button::transparent)
+    .on_press(msg(DuressContactsMessage::BackToList));
+
+    let phone = dc.form_phone.trim();
+    let email = dc.form_email.trim();
+    let phone_present = !phone.is_empty();
+    let email_present = !email.is_empty();
+    let phone_ok = is_valid_e164(phone);
+    let email_ok = email.is_empty()
+        || email_address::EmailAddress::parse_with_options(
+            email,
+            email_address::Options::default().with_required_tld(),
+        )
+        .is_ok();
+
+    // Name field.
+    let name_field = Column::new()
+        .push(text::p2_regular("Name").color(color::GREY_3))
+        .push(iced::widget::Space::new().height(Length::Fixed(4.0)))
+        .push(
+            TextInput::new("e.g. Jane Doe", &dc.form_name)
+                .on_input(|s| msg(DuressContactsMessage::NameChanged(s)))
+                .size(16)
+                .padding(15),
+        )
+        .spacing(0);
+
+    // Phone field + validity hint.
+    let mut phone_col = Column::new()
+        .push(text::p2_regular("Phone (international format)").color(color::GREY_3))
+        .push(iced::widget::Space::new().height(Length::Fixed(4.0)))
+        .push(
+            TextInput::new("+15551234567", &dc.form_phone)
+                .on_input(|s| msg(DuressContactsMessage::PhoneChanged(s)))
+                .size(16)
+                .padding(15),
+        )
+        .spacing(0);
+    if phone_present && !phone_ok {
+        phone_col = phone_col
+            .push(iced::widget::Space::new().height(Length::Fixed(4.0)))
+            .push(
+                text::caption("Use international format, starting with + and country code.")
+                    .color(color::RED),
+            );
+    }
+
+    // Email field + validity hint.
+    let mut email_col = Column::new()
+        .push(text::p2_regular("Email").color(color::GREY_3))
+        .push(iced::widget::Space::new().height(Length::Fixed(4.0)))
+        .push(
+            TextInput::new("jane@example.com", &dc.form_email)
+                .on_input(|s| msg(DuressContactsMessage::EmailChanged(s)))
+                .size(16)
+                .padding(15),
+        )
+        .spacing(0);
+    if email_present && !email_ok {
+        email_col = email_col
+            .push(iced::widget::Space::new().height(Length::Fixed(4.0)))
+            .push(text::caption("That email doesn't look right.").color(color::RED));
+    }
+
+    // Channel checkboxes. SMS/WhatsApp require a phone; Email requires an
+    // email — disabled (no `on_toggle`) until the matching field is filled.
+    let sms_box = channel_checkbox(
+        "SMS",
+        dc.form_ch_sms && phone_present,
+        phone_present,
+        DuressContactsMessage::ToggleSms,
+    );
+    let wa_box = channel_checkbox(
+        "WhatsApp",
+        dc.form_ch_whatsapp && phone_present,
+        phone_present,
+        DuressContactsMessage::ToggleWhatsapp,
+    );
+    let email_box = channel_checkbox(
+        "Email",
+        dc.form_ch_email && email_present,
+        email_present,
+        DuressContactsMessage::ToggleEmailChannel,
+    );
+
+    let channels_section = Column::new()
+        .push(text::p2_regular("How should we reach them?").color(color::GREY_3))
+        .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+        .push(sms_box)
+        .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+        .push(wa_box)
+        .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+        .push(email_box)
+        .spacing(0);
+
+    // Submit button. Enabled only when the form is minimally valid.
+    let name_ok = !dc.form_name.trim().is_empty();
+    let reachable = phone_present || email_present;
+    let any_channel = (dc.form_ch_sms && phone_present)
+        || (dc.form_ch_whatsapp && phone_present)
+        || (dc.form_ch_email && email_present);
+    let can_submit = !dc.submitting
+        && name_ok
+        && reachable
+        && phone_ok
+        && email_ok
+        && any_channel;
+
+    let submit_label = if dc.submitting {
+        "Saving\u{2026}"
+    } else if editing {
+        "Save contact"
+    } else {
+        "Add contact"
+    };
+    let submit = button::primary(None, submit_label)
+        .on_press_maybe(can_submit.then_some(msg(DuressContactsMessage::Submit)))
+        .width(Length::Fill);
+
+    let title = if editing {
+        "Edit emergency contact"
+    } else {
+        "Add emergency contact"
+    };
+
+    let mut form = Column::new()
+        .push(back_button)
+        .push(iced::widget::Space::new().height(Length::Fixed(10.0)))
+        .push(text::h4_bold(title).style(theme::text::primary))
+        .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
+        .push(
+            text::p2_regular(
+                "Add a phone number, an email, or both — then pick at least one way to reach \
+                 them.",
+            )
+            .color(color::GREY_3),
+        )
+        .push(iced::widget::Space::new().height(Length::Fixed(18.0)))
+        .push(name_field)
+        .push(iced::widget::Space::new().height(Length::Fixed(14.0)))
+        .push(phone_col)
+        .push(iced::widget::Space::new().height(Length::Fixed(14.0)))
+        .push(email_col)
+        .push(iced::widget::Space::new().height(Length::Fixed(18.0)))
+        .push(channels_section)
+        .push(iced::widget::Space::new().height(Length::Fixed(20.0)))
+        .push(submit)
+        .spacing(0)
+        .max_width(520)
+        .width(Length::Fill);
+
+    if let Some(err) = dc.error.as_deref() {
+        form = form
+            .push(iced::widget::Space::new().height(Length::Fixed(10.0)))
+            .push(text::p2_regular(err).color(color::RED));
+    }
+
+    form.into()
+}
+
+/// A single channel checkbox. Disabled (no `on_toggle`) when `enabled` is
+/// false, so a channel can't be selected without its contact method.
+fn channel_checkbox<'a>(
+    label: &'a str,
+    checked: bool,
+    enabled: bool,
+    on_toggle: fn(bool) -> DuressContactsMessage,
+) -> Element<'a, ConnectAccountMessage> {
+    let base = CheckBox::new(checked)
+        .label(label)
+        .style(theme::checkbox::primary)
+        .size(18);
+    if enabled {
+        base.on_toggle(move |b| msg(on_toggle(b))).into()
+    } else {
+        // No `on_toggle` → rendered inert. Pair with a muted hint so the
+        // user understands why.
+        Row::new()
+            .push(base)
+            .push(iced::widget::Space::new().width(Length::Fixed(8.0)))
+            .push(
+                text::caption(if label == "Email" {
+                    "add an email first"
+                } else {
+                    "add a phone first"
+                })
+                .color(color::GREY_3),
+            )
+            .align_y(Alignment::Center)
+            .into()
+    }
+}

--- a/coincube-gui/src/app/view/connect/duress_contacts.rs
+++ b/coincube-gui/src/app/view/connect/duress_contacts.rs
@@ -88,10 +88,7 @@ pub fn section<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccount
         .width(Length::Fill);
 
     if !state.is_duress_alerts_entitled() {
-        return col
-            .push(locked_card())
-            .width(Length::Fill)
-            .into();
+        return col.push(locked_card()).width(Length::Fill).into();
     }
 
     col = col.push(explainer_cards(state));
@@ -105,9 +102,7 @@ pub fn section<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccount
 fn locked_card<'a>() -> Element<'a, ConnectAccountMessage> {
     container(
         Column::new()
-            .push(
-                text::p1_bold("Available on the Estate plan").style(theme::text::primary),
-            )
+            .push(text::p1_bold("Available on the Estate plan").style(theme::text::primary))
             .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
             .push(
                 text::p2_regular(
@@ -137,9 +132,7 @@ fn explainer_cards<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAcc
                     .padding(12)
                     .width(Length::Fill)
                     .style(|t| container::Style {
-                        background: Some(iced::Background::Color(
-                            t.colors.cards.simple.background,
-                        )),
+                        background: Some(iced::Background::Color(t.colors.cards.simple.background)),
                         border: iced::Border {
                             color: color::GREY_5,
                             width: 0.5,
@@ -166,9 +159,7 @@ fn explainer_cards<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAcc
         Column::new()
             .push(text::p1_bold("The one-time intro message").style(theme::text::primary))
             .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
-            .push(
-                text::p2_regular(intro_template_preview(&owner)).color(color::GREY_2),
-            )
+            .push(text::p2_regular(intro_template_preview(&owner)).color(color::GREY_2))
             .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
             .push(
                 text::p2_regular(
@@ -207,8 +198,11 @@ fn list_body<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
     let count = dc.count();
     let header = Row::new()
         .push(
-            text::p1_bold(format!("Contacts ({}/{})", count, MAX_DURESS_ALERT_CONTACTS))
-                .style(theme::text::primary),
+            text::p1_bold(format!(
+                "Contacts ({}/{})",
+                count, MAX_DURESS_ALERT_CONTACTS
+            ))
+            .style(theme::text::primary),
         )
         .push(iced::widget::Space::new().width(Length::Fill))
         .push(if dc.at_cap() {
@@ -233,8 +227,7 @@ fn list_body<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
                 container(
                     Column::new()
                         .push(
-                            text::p1_bold("No emergency contacts yet")
-                                .style(theme::text::primary),
+                            text::p1_bold("No emergency contacts yet").style(theme::text::primary),
                         )
                         .push(iced::widget::Space::new().height(Length::Fixed(4.0)))
                         .push(
@@ -245,9 +238,10 @@ fn list_body<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
                             .color(color::GREY_3),
                         )
                         .push(iced::widget::Space::new().height(Length::Fixed(14.0)))
-                        .push(button::primary(None, "Add a contact").on_press(msg(
-                            DuressContactsMessage::ShowAddForm,
-                        )))
+                        .push(
+                            button::primary(None, "Add a contact")
+                                .on_press(msg(DuressContactsMessage::ShowAddForm)),
+                        )
                         .align_x(Alignment::Center)
                         .padding(24)
                         .spacing(0),
@@ -325,10 +319,7 @@ fn contact_card<'a>(
     };
 
     let actions = Row::new()
-        .push(
-            button::secondary(None, "Edit")
-                .on_press(msg(DuressContactsMessage::EditContact(id))),
-        )
+        .push(button::secondary(None, "Edit").on_press(msg(DuressContactsMessage::EditContact(id))))
         .push(iced::widget::Space::new().width(Length::Fixed(8.0)))
         .push(remove_btn)
         .align_y(Alignment::Center);
@@ -501,12 +492,7 @@ pub fn form_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccount
     let any_channel = (dc.form_ch_sms && phone_present)
         || (dc.form_ch_whatsapp && phone_present)
         || (dc.form_ch_email && email_present);
-    let can_submit = !dc.submitting
-        && name_ok
-        && reachable
-        && phone_ok
-        && email_ok
-        && any_channel;
+    let can_submit = !dc.submitting && name_ok && reachable && phone_ok && email_ok && any_channel;
 
     let submit_label = if dc.submitting {
         "Saving\u{2026}"

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -1,5 +1,6 @@
 mod contacts;
 pub mod cube_members;
+pub mod duress_contacts;
 pub mod duress_enroll;
 pub mod sign_in_prompt;
 
@@ -22,7 +23,7 @@ use crate::{
         settings::global::AccountTier,
         state::connect::{
             AvatarFlowStep, CheckoutPhase, ConnectAccountPanel, ConnectCubePanel, ConnectFlowStep,
-            ConnectPanel, PlanLifecycle,
+            ConnectPanel, DuressContactsStep, PlanLifecycle,
         },
         view::{AvatarMessage, ConnectAccountMessage, ConnectCubeMessage, DuressMessage},
     },
@@ -1310,6 +1311,15 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
         return duress_enroll::enroll_ux(enroll);
     }
 
+    // The Emergency-contacts add/edit form takes over the panel too (only
+    // reachable from the Estate-entitled list, so the guard is belt-and-
+    // suspenders against a mid-session downgrade).
+    if matches!(state.duress_contacts.step, DuressContactsStep::Form)
+        && state.is_duress_alerts_entitled()
+    {
+        return duress_contacts::form_ux(state);
+    }
+
     let entitled = state
         .plan
         .as_ref()
@@ -1446,7 +1456,25 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
         ),
     );
 
+    // Emergency contacts (Estate Notifications — PR 1). Rendered below the
+    // enrollment surface as its own section; Estate-gated inside `section`.
+    col = col.push(iced::widget::Space::new().height(Length::Fixed(28.0)));
+    col = col.push(divider_line());
+    col = col.push(iced::widget::Space::new().height(Length::Fixed(20.0)));
+    col = col.push(duress_contacts::section(state));
+
     col.width(Length::Fill).into()
+}
+
+/// A thin full-width horizontal rule used to separate panel sections.
+fn divider_line<'a>() -> Element<'a, ConnectAccountMessage> {
+    container(iced::widget::Space::new().height(Length::Fixed(1.0)))
+        .width(Length::Fill)
+        .style(|_t| container::Style {
+            background: Some(iced::Background::Color(color::GREY_5)),
+            ..Default::default()
+        })
+        .into()
 }
 
 pub fn avatar_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, ConnectCubeMessage> {
@@ -1976,6 +2004,8 @@ mod renewal_banner_tests {
                 linked_keychains: false,
                 duress_remote_lock: false,
                 business_orgs: false,
+                duress_alerts: false,
+                recovery_alerts: false,
             },
             billing_cycle: Some(BillingCycle::Monthly),
         }

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -341,11 +341,35 @@ pub enum SettingsMessage {
     /// Coexists with `BackupMasterSeed` above (the local paper-phrase
     /// backup), it does not replace it.
     RecoveryKit(RecoveryKitMessage),
+    /// Vault Recovery Alerts — Estate-only chain monitoring opt-in
+    /// (descriptor escrow / timelock heartbeat) + keyholder download
+    /// policy. See `PLAN-estate-notifications.md` PR 2.
+    RecoveryAlerts(RecoveryAlertsMessage),
     /// Local LAN signer ("Paired phones") section — pairs a Keychain
     /// phone over the local network so it shows up in the signer
     /// list. See `PLAN-local-signer-lan-desktop.md`.
     LocalSigningSection,
     LocalSigning(LocalSigningMessage),
+}
+
+/// Messages for the Vault Recovery Alerts settings card (Estate
+/// Notifications — PR 2). Carries no secrets; the descriptor is built
+/// inside the App-level handler from the live wallet, never on the wire of
+/// these messages. `Debug` is derived.
+#[derive(Debug, Clone)]
+pub enum RecoveryAlertsMessage {
+    /// Fetch the vault's monitoring status (resolves the Connect vault id,
+    /// then GETs `/vaults/{id}/monitoring`). Fired on entering General
+    /// settings and after a successful change.
+    LoadStatus,
+    /// Async result of `LoadStatus`: `(connectVaultId, status)`.
+    StatusLoaded(Result<(u64, crate::services::coincube::VaultMonitoringStatus), String>),
+    /// User picked a monitoring level (Off / Alerts-only / Full).
+    SelectLevel(crate::services::coincube::VaultMonitoringLevel),
+    /// User changed the keyholder recovery-kit download policy.
+    SetDownloadPolicy(crate::services::coincube::KeyholderDownloadPolicy),
+    /// Async result of a level / policy change — the updated status.
+    ChangeResult(Result<crate::services::coincube::VaultMonitoringStatus, String>),
 }
 
 #[derive(Debug, Clone)]
@@ -1113,6 +1137,43 @@ pub enum ConnectAccountMessage {
     /// Recovery flow + enrollment wizard messages (nested to keep this enum
     /// tidy).
     Duress(DuressMessage),
+    /// Duress "Emergency contacts" management (Estate Notifications — PR 1).
+    DuressContacts(DuressContactsMessage),
+}
+
+/// Messages for the duress "Emergency contacts" section (Estate
+/// Notifications — PR 1), nested under
+/// [`ConnectAccountMessage::DuressContacts`]. Carries account-scoped PII
+/// (names, phones, emails) but no secrets, so `Debug` is derived — the
+/// same posture as `ContactsMessage`, which already prints contact emails.
+#[derive(Debug, Clone)]
+pub enum DuressContactsMessage {
+    /// Async result of the contacts load. Carries `session_generation` for
+    /// stale-response guarding.
+    Loaded(
+        Result<Vec<crate::services::coincube::DuressAlertContact>, String>,
+        u64,
+    ),
+    /// Open the add form (empty fields).
+    ShowAddForm,
+    /// Open the edit form for an existing contact id.
+    EditContact(u64),
+    /// Leave the form, return to the list.
+    BackToList,
+    NameChanged(String),
+    PhoneChanged(String),
+    EmailChanged(String),
+    ToggleSms(bool),
+    ToggleWhatsapp(bool),
+    ToggleEmailChannel(bool),
+    /// Submit the add/edit form (POST or PATCH depending on `editing_id`).
+    Submit,
+    /// Async result of a create/update. Carries `session_generation`.
+    SubmitResult(Result<(), String>, u64),
+    /// Delete a contact by id.
+    Delete(u64),
+    /// Async result of a delete. `(contact_id, result, session_generation)`.
+    DeleteResult(u64, Result<(), String>, u64),
 }
 
 /// Messages for the duress recovery flow (Phase 6) and enrollment wizard

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -362,14 +362,27 @@ pub enum RecoveryAlertsMessage {
     /// then GETs `/vaults/{id}/monitoring`). Fired on entering General
     /// settings and after a successful change.
     LoadStatus,
-    /// Async result of `LoadStatus`: `(connectVaultId, status)`.
-    StatusLoaded(Result<(u64, crate::services::coincube::VaultMonitoringStatus), String>),
+    /// Async result of `LoadStatus`: `(connectVaultId, status)`. The trailing
+    /// `u64` is the `session_generation` captured when the load was spawned;
+    /// the handler drops the result if the session has since changed (logout /
+    /// account switch) so a prior account's vault id + status can't be written
+    /// into the reset state.
+    StatusLoaded(
+        Result<(u64, crate::services::coincube::VaultMonitoringStatus), String>,
+        u64,
+    ),
     /// User picked a monitoring level (Off / Alerts-only / Full).
     SelectLevel(crate::services::coincube::VaultMonitoringLevel),
     /// User changed the keyholder recovery-kit download policy.
     SetDownloadPolicy(crate::services::coincube::KeyholderDownloadPolicy),
-    /// Async result of a level / policy change — the updated status.
-    ChangeResult(Result<crate::services::coincube::VaultMonitoringStatus, String>),
+    /// Async result of a level / policy change — the updated status. The
+    /// trailing `u64` is the spawn-time `session_generation` (see
+    /// `StatusLoaded`); a stale result is dropped rather than clobbering a
+    /// newer session's state.
+    ChangeResult(
+        Result<crate::services::coincube::VaultMonitoringStatus, String>,
+        u64,
+    ),
 }
 
 #[derive(Debug, Clone)]

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -11,10 +11,13 @@ use crate::app::menu::Menu;
 use crate::app::settings::display::DisplayMode;
 use crate::app::settings::fiat::PriceSetting;
 use crate::app::settings::unit::{BitcoinDisplayUnit, UnitSetting};
+use crate::app::state::settings::recovery_alerts::RecoveryAlerts;
 use crate::app::state::settings::recovery_kit::RecoveryKit;
 use crate::app::view::dashboard;
 use crate::app::view::message::*;
-use crate::services::coincube::RecoveryKitStatus;
+use crate::services::coincube::{
+    KeyholderDownloadPolicy, RecoveryKitStatus, VaultMonitoringLevel,
+};
 use crate::services::fiat::{Currency, ALL_PRICE_SOURCES};
 
 #[allow(clippy::too_many_arguments)]
@@ -30,6 +33,7 @@ pub fn general_section<'a>(
     backup_pin: &'a crate::pin_input::PinInput,
     backup_mnemonic: Option<&'a [String]>,
     recovery_kit: Option<&'a RecoveryKit>,
+    recovery_alerts: Option<&'a RecoveryAlerts>,
 ) -> Element<'a, Message> {
     use crate::app::state::settings::general::BackupSeedState;
 
@@ -85,11 +89,221 @@ pub fn general_section<'a>(
         ));
     }
 
+    // Vault Recovery Alerts card (Estate Notifications — PR 2). Same
+    // threading discipline as the Recovery Kit card above.
+    if let Some(ra) = recovery_alerts {
+        col = col.push(recovery_alerts_card(ra));
+    }
+
     if developer_mode {
         col = col.push(toast_testing());
     }
 
     dashboard(menu, cache, col)
+}
+
+/// Vault Recovery Alerts card: three-tier monitoring selector + keyholder
+/// download policy + the keyholder list, with honest opt-in copy. Estate-
+/// gated; shows the locked affordance for non-Estate accounts.
+fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
+    let mut body = Column::new()
+        .spacing(10)
+        .push(text("Vault Recovery Alerts").bold())
+        .push(
+            text(
+                "Let COINCUBE watch the chain and alert your keyholders when a recovery path \
+                 for this Vault opens.",
+            )
+            .size(13),
+        );
+
+    // Locked affordance for non-Estate accounts.
+    if !ra.entitled {
+        body = body.push(
+            text(
+                "Recovery alerts are part of the Estate plan. Upgrade your Connect plan to \
+                 enable chain monitoring and keyholder alerts.",
+            )
+            .size(13),
+        );
+        return card::simple(body).width(Length::Fill).into();
+    }
+
+    // No Connect vault to monitor yet.
+    if ra.no_vault {
+        body = body.push(
+            text(
+                "Create a Vault and register it with Connect to enable recovery alerts.",
+            )
+            .size(13),
+        );
+        return card::simple(body).width(Length::Fill).into();
+    }
+
+    if ra.loading && ra.status.is_none() {
+        body = body.push(text("Loading\u{2026}").size(13));
+        return card::simple(body).width(Length::Fill).into();
+    }
+
+    let level = ra.level();
+    let busy = ra.submitting;
+
+    // Three-tier selector row.
+    let level_row = Row::new()
+        .spacing(8)
+        .push(level_button(
+            "Off",
+            VaultMonitoringLevel::Off,
+            level,
+            busy,
+        ))
+        .push(level_button(
+            "Alerts only",
+            VaultMonitoringLevel::Heartbeat,
+            level,
+            busy,
+        ))
+        .push(level_button(
+            "Full",
+            VaultMonitoringLevel::Full,
+            level,
+            busy,
+        ));
+    body = body.push(level_row);
+
+    // The honest trade-off copy for the selected tier.
+    body = body.push(text(level_copy(level)).size(13));
+
+    // Keyholder list + download policy only make sense when monitoring is on.
+    if !matches!(level, VaultMonitoringLevel::Off) {
+        // Who would be notified.
+        body = body.push(Space::new().height(Length::Fixed(4.0)));
+        body = body.push(text("Keyholders who'd be notified").bold().size(14));
+        if ra.keyholders.is_empty() {
+            body = body.push(
+                text(
+                    "No keyholders on this Cube yet — add keyholders so someone is alerted.",
+                )
+                .size(13),
+            );
+        } else {
+            let mut who = Column::new().spacing(2);
+            for email in &ra.keyholders {
+                who = who.push(text(email.as_str()).size(13));
+            }
+            body = body.push(who);
+        }
+
+        // Keyholder download policy.
+        body = body.push(Space::new().height(Length::Fixed(6.0)));
+        body = body.push(text("When can keyholders download your recovery kit?").bold().size(14));
+        let policy = ra.download_policy();
+        body = body.push(
+            Row::new()
+                .spacing(8)
+                .push(policy_button(
+                    "Only when recovery nears",
+                    KeyholderDownloadPolicy::AtApproaching,
+                    policy,
+                    busy,
+                ))
+                .push(policy_button(
+                    "Anytime",
+                    KeyholderDownloadPolicy::Anytime,
+                    policy,
+                    busy,
+                )),
+        );
+        body = body.push(text(policy_copy(policy)).size(12));
+    }
+
+    if let Some(err) = ra.error.as_deref() {
+        body = body.push(text(err).size(13).style(theme::text::error));
+    }
+
+    card::simple(body).width(Length::Fill).into()
+}
+
+/// A monitoring-level option button. Highlighted (primary) when it's the
+/// active level; disabled while a change is in flight.
+fn level_button<'a>(
+    label: &'static str,
+    this: VaultMonitoringLevel,
+    active: VaultMonitoringLevel,
+    busy: bool,
+) -> Element<'a, Message> {
+    let on_press = (!busy && this != active)
+        .then_some(SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::SelectLevel(this)).into());
+    if this == active {
+        button::primary(None, label)
+            .padding([8, 14])
+            .on_press_maybe(None)
+            .into()
+    } else {
+        button::secondary(None, label)
+            .padding([8, 14])
+            .on_press_maybe(on_press)
+            .into()
+    }
+}
+
+/// A download-policy option button.
+fn policy_button<'a>(
+    label: &'static str,
+    this: KeyholderDownloadPolicy,
+    active: KeyholderDownloadPolicy,
+    busy: bool,
+) -> Element<'a, Message> {
+    let on_press = (!busy && this != active).then_some(
+        SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::SetDownloadPolicy(this)).into(),
+    );
+    if this == active {
+        button::primary(None, label)
+            .padding([8, 14])
+            .on_press_maybe(None)
+            .into()
+    } else {
+        button::secondary(None, label)
+            .padding([8, 14])
+            .on_press_maybe(on_press)
+            .into()
+    }
+}
+
+/// Plain-language trade-off for each monitoring tier (no euphemisms — the
+/// self-custody trust model demands it; see `PLAN-estate-notifications.md`).
+fn level_copy(level: VaultMonitoringLevel) -> &'static str {
+    match level {
+        VaultMonitoringLevel::Off => {
+            "Off: COINCUBE doesn't watch this Vault. No keyholder alerts, and no copy of your \
+             descriptor is kept."
+        }
+        VaultMonitoringLevel::Heartbeat => {
+            "Alerts only: your device tells COINCUBE just the date this Vault's recovery window \
+             opens — never its addresses or balances. Keyholders get an email when that date \
+             nears, and will still need the recovery password you shared with them."
+        }
+        VaultMonitoringLevel::Full => {
+            "Full: COINCUBE keeps an encrypted copy of this Vault's descriptor to watch the chain \
+             for you — it can see this Vault's addresses and balances, never spend. Keyholders \
+             get an email when a recovery path opens and can recover this Vault WITHOUT your \
+             password. Your Cube master-seed backup still needs your recovery password — that's \
+             the one to share carefully."
+        }
+    }
+}
+
+fn policy_copy(policy: KeyholderDownloadPolicy) -> &'static str {
+    match policy {
+        KeyholderDownloadPolicy::AtApproaching => {
+            "Keeps your balances private until the recovery window nears. You're notified \
+             whenever a keyholder downloads."
+        }
+        KeyholderDownloadPolicy::Anytime => {
+            "Lets family prepare and verify early — but if they have your recovery password, \
+             they'll also be able to see balances. You're notified whenever a keyholder downloads."
+        }
+    }
 }
 
 /// The "Backup Master Seed Phrase" card shown on the normal General

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -15,9 +15,7 @@ use crate::app::state::settings::recovery_alerts::RecoveryAlerts;
 use crate::app::state::settings::recovery_kit::RecoveryKit;
 use crate::app::view::dashboard;
 use crate::app::view::message::*;
-use crate::services::coincube::{
-    KeyholderDownloadPolicy, RecoveryKitStatus, VaultMonitoringLevel,
-};
+use crate::services::coincube::{KeyholderDownloadPolicy, RecoveryKitStatus, VaultMonitoringLevel};
 use crate::services::fiat::{Currency, ALL_PRICE_SOURCES};
 
 #[allow(clippy::too_many_arguments)]
@@ -132,10 +130,7 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
     // No Connect vault to monitor yet.
     if ra.no_vault {
         body = body.push(
-            text(
-                "Create a Vault and register it with Connect to enable recovery alerts.",
-            )
-            .size(13),
+            text("Create a Vault and register it with Connect to enable recovery alerts.").size(13),
         );
         return card::simple(body).width(Length::Fill).into();
     }
@@ -151,12 +146,7 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
     // Three-tier selector row.
     let level_row = Row::new()
         .spacing(8)
-        .push(level_button(
-            "Off",
-            VaultMonitoringLevel::Off,
-            level,
-            busy,
-        ))
+        .push(level_button("Off", VaultMonitoringLevel::Off, level, busy))
         .push(level_button(
             "Alerts only",
             VaultMonitoringLevel::Heartbeat,
@@ -181,10 +171,8 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
         body = body.push(text("Keyholders who'd be notified").bold().size(14));
         if ra.keyholders.is_empty() {
             body = body.push(
-                text(
-                    "No keyholders on this Cube yet — add keyholders so someone is alerted.",
-                )
-                .size(13),
+                text("No keyholders on this Cube yet — add keyholders so someone is alerted.")
+                    .size(13),
             );
         } else {
             let mut who = Column::new().spacing(2);
@@ -196,7 +184,11 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
 
         // Keyholder download policy.
         body = body.push(Space::new().height(Length::Fixed(6.0)));
-        body = body.push(text("When can keyholders download your recovery kit?").bold().size(14));
+        body = body.push(
+            text("When can keyholders download your recovery kit?")
+                .bold()
+                .size(14),
+        );
         let policy = ra.download_policy();
         body = body.push(
             Row::new()
@@ -232,8 +224,9 @@ fn level_button<'a>(
     active: VaultMonitoringLevel,
     busy: bool,
 ) -> Element<'a, Message> {
-    let on_press = (!busy && this != active)
-        .then_some(SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::SelectLevel(this)).into());
+    let on_press = (!busy && this != active).then_some(
+        SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::SelectLevel(this)).into(),
+    );
     if this == active {
         button::primary(None, label)
             .padding([8, 14])

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1389,6 +1389,16 @@ impl Home {
                 {
                     return map_connect_task(self.connect_account.reload_contacts());
                 }
+                // Load duress Emergency-contacts on demand (Estate Notifications).
+                // `reload_duress_contacts` no-ops for non-Estate accounts, so this
+                // never fires a request that would just 403.
+                if matches!(
+                    self.active_section,
+                    HomeSection::Connect(app::menu::ConnectSubMenu::Duress)
+                ) && self.connect_account.is_authenticated()
+                {
+                    return map_connect_task(self.connect_account.reload_duress_contacts());
+                }
                 Task::none()
             }
 

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -1380,6 +1380,15 @@ impl Launcher {
                 {
                     return map_connect_task(self.connect_account.reload_contacts());
                 }
+                // Load duress Emergency-contacts on demand (Estate Notifications).
+                // `reload_duress_contacts` no-ops for non-Estate accounts.
+                if matches!(
+                    self.active_section,
+                    LauncherSection::Connect(app::menu::ConnectSubMenu::Duress)
+                ) && self.connect_account.is_authenticated()
+                {
+                    return map_connect_task(self.connect_account.reload_duress_contacts());
+                }
                 Task::none()
             }
 

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -1278,6 +1278,187 @@ impl CoincubeClient {
     }
 }
 
+// =============================================================================
+// Vault recovery monitoring (Estate Notifications — PR 2)
+// =============================================================================
+//
+// Per-vault, three-tier monitoring opt-in keyed by the Connect vault id.
+// Estate-gated server-side (`recovery_alerts` entitlement). See the DTO
+// block in `mod.rs`.
+
+impl CoincubeClient {
+    /// `GET /api/v1/connect/vaults/{id}/monitoring` (authenticated). A vault
+    /// with no monitoring record yet (404) resolves to a default
+    /// "off / at_approaching" status so the settings panel renders cleanly
+    /// for a brand-new vault rather than erroring.
+    pub async fn get_vault_monitoring(
+        &self,
+        vault_id: u64,
+    ) -> Result<super::VaultMonitoringStatus, CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/vaults/{}/monitoring",
+            self.base_url, vault_id
+        );
+        let res = self.client.get(&url).send().await?;
+        let status = res.status();
+        if status.as_u16() == 404 {
+            return Ok(super::VaultMonitoringStatus::default());
+        }
+        let res = res.check_success().await?;
+        let resp: ApiResponse<super::VaultMonitoringStatus> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// `POST /api/v1/connect/vaults/{id}/monitoring` (authenticated,
+    /// Estate-gated). Sets the monitoring tier (and optionally the keyholder
+    /// download policy). For `Full`, `req.descriptor` carries the descriptor
+    /// to escrow; for `Heartbeat` it's omitted and any previously-escrowed
+    /// descriptor is true-deleted server-side.
+    pub async fn set_vault_monitoring(
+        &self,
+        vault_id: u64,
+        req: super::SetVaultMonitoringRequest,
+    ) -> Result<super::VaultMonitoringStatus, CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/vaults/{}/monitoring",
+            self.base_url, vault_id
+        );
+        let res = self.client.post(&url).json(&req).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<super::VaultMonitoringStatus> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// `DELETE /api/v1/connect/vaults/{id}/monitoring` (authenticated).
+    /// Turns monitoring off with a true delete of any escrowed descriptor
+    /// record. Idempotent: a 404 (nothing to delete) is treated as success.
+    pub async fn delete_vault_monitoring(&self, vault_id: u64) -> Result<(), CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/vaults/{}/monitoring",
+            self.base_url, vault_id
+        );
+        let res = self.client.delete(&url).send().await?;
+        if res.status().as_u16() == 404 {
+            return Ok(());
+        }
+        res.check_success().await?;
+        Ok(())
+    }
+
+    /// `PUT /api/v1/connect/vaults/{id}/keyholder-download-policy`
+    /// (authenticated, Estate-gated). Sets the keyholder recovery-kit
+    /// download policy independently of the monitoring level.
+    pub async fn set_keyholder_download_policy(
+        &self,
+        vault_id: u64,
+        policy: super::KeyholderDownloadPolicy,
+    ) -> Result<super::VaultMonitoringStatus, CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/vaults/{}/keyholder-download-policy",
+            self.base_url, vault_id
+        );
+        let req = super::SetKeyholderDownloadPolicyRequest {
+            crk_keyholder_download: policy,
+        };
+        let res = self.client.put(&url).json(&req).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<super::VaultMonitoringStatus> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// `POST /api/v1/connect/vaults/{id}/heartbeat` (authenticated, PR 5).
+    /// Fire-and-forget timelock heartbeat sent after a vault sync for
+    /// Heartbeat-tier (and Full, as a cross-check) vaults. Callers MUST NOT
+    /// block sync on this — wrap it in a detached task and ignore the
+    /// result (a newer report always wins server-side, so a dropped one is
+    /// harmless).
+    pub async fn post_vault_heartbeat(
+        &self,
+        vault_id: u64,
+        req: super::VaultHeartbeatRequest,
+    ) -> Result<(), CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/vaults/{}/heartbeat",
+            self.base_url, vault_id
+        );
+        let res = self.client.post(&url).json(&req).send().await?;
+        res.check_success().await?;
+        Ok(())
+    }
+}
+
+// =============================================================================
+// Duress alert contacts (Estate Notifications — PR 1)
+// =============================================================================
+//
+// CRUD under the duress prefix. Estate-gated server-side (`duress_alerts`
+// entitlement); a non-Estate caller gets 403, which surfaces through the
+// usual `Unsuccessful` path and is mapped to a locked-feature affordance
+// in the UI rather than these methods. See the DTO block in `mod.rs`.
+
+impl CoincubeClient {
+    /// `GET /api/v1/connect/duress/contacts` (authenticated, Estate-gated).
+    pub async fn get_duress_alert_contacts(
+        &self,
+    ) -> Result<Vec<super::DuressAlertContact>, CoincubeError> {
+        let url = format!("{}/api/v1/connect/duress/contacts", self.base_url);
+        let res = self.client.get(&url).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<Vec<super::DuressAlertContact>> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// `POST /api/v1/connect/duress/contacts` (authenticated, Estate-gated).
+    /// Creating a contact enqueues the one-time intro message server-side;
+    /// the returned record's `intro_sent_at` may still be `None` until the
+    /// async send lands.
+    pub async fn create_duress_alert_contact(
+        &self,
+        req: super::CreateDuressAlertContactRequest,
+    ) -> Result<super::DuressAlertContact, CoincubeError> {
+        let url = format!("{}/api/v1/connect/duress/contacts", self.base_url);
+        let res = self.client.post(&url).json(&req).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<super::DuressAlertContact> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// `PATCH /api/v1/connect/duress/contacts/{id}` (authenticated,
+    /// Estate-gated). Partial update — only the `Some` fields in `req` are
+    /// sent and changed.
+    pub async fn update_duress_alert_contact(
+        &self,
+        contact_id: u64,
+        req: super::UpdateDuressAlertContactRequest,
+    ) -> Result<super::DuressAlertContact, CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/duress/contacts/{}",
+            self.base_url, contact_id
+        );
+        let res = self
+            .client
+            .request(Method::PATCH, &url)
+            .json(&req)
+            .send()
+            .await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<super::DuressAlertContact> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// `DELETE /api/v1/connect/duress/contacts/{id}` (authenticated,
+    /// Estate-gated). Removes the contact permanently.
+    pub async fn delete_duress_alert_contact(&self, contact_id: u64) -> Result<(), CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/duress/contacts/{}",
+            self.base_url, contact_id
+        );
+        let res = self.client.delete(&url).send().await?;
+        res.check_success().await?;
+        Ok(())
+    }
+}
+
 /// Parses a response's `Retry-After` header per RFC 7231 §7.1.3.
 ///
 /// Accepts both documented forms:

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -1656,7 +1656,7 @@ pub fn is_valid_e164(phone: &str) -> bool {
         return false;
     };
     let digits: Vec<char> = rest.chars().collect();
-    if digits.len() < 1 || digits.len() > 15 {
+    if digits.is_empty() || digits.len() > 15 {
         return false;
     }
     if !digits.iter().all(|c| c.is_ascii_digit()) {

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -288,6 +288,21 @@ pub struct PlanEntitlements {
     pub linked_keychains: bool,
     pub duress_remote_lock: bool,
     pub business_orgs: bool,
+    /// Estate-only: duress-activation alert contacts (SMS/WhatsApp/email
+    /// fan-out when duress fires). See `PLAN-estate-notifications.md` PR 1.
+    ///
+    /// `#[serde(default)]` so a pre-estate-notifications API that doesn't
+    /// emit this field deserialises to `false` rather than failing the
+    /// whole `ConnectPlan` parse — the desktop treats an absent
+    /// entitlement as "not entitled", which is the safe default.
+    #[serde(default)]
+    pub duress_alerts: bool,
+    /// Estate-only: vault recovery-path monitoring (descriptor escrow or
+    /// timelock heartbeat → keyholder emails). See
+    /// `PLAN-estate-notifications.md` PR 2. Same forward-compat tolerance
+    /// as [`Self::duress_alerts`].
+    #[serde(default)]
+    pub recovery_alerts: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1518,6 +1533,423 @@ impl DownloadError {
             },
             Err(_) => DownloadError::DuressLocked { unlock_at: None },
         }
+    }
+}
+
+// =============================================================================
+// Duress alert contacts (Estate Notifications — PR 1)
+// =============================================================================
+//
+// Account-scoped contacts who receive a one-time intro message on
+// enrollment and a single alert if duress activates. Estate-gated
+// (`duress_alerts` entitlement). Backs the "Emergency contacts" panel in
+// the duress settings surface. See `plans/PLAN-estate-notifications.md`
+// PR 1 (desktop) and the coincube-api counterpart PR 1.
+//
+// Trust-posture notes:
+//   * The contacts list is account-scoped PII (names, phones, emails) and
+//     is ONLY ever rendered in normal-mode settings — never on the duress
+//     activation/cryptic screen, where it would leak who gets alerted to a
+//     coercer. The view layer enforces this; the data simply isn't fetched
+//     while the panel is in a duress-active flow.
+//   * `intro_sent_at` / `opted_out_at` are server-managed; the desktop
+//     reads them to render delivery state but never sets them. A contact
+//     with `opted_out_at` set has replied STOP and is never messaged again.
+
+/// Channel bitmask bits for [`DuressAlertContact::channels`]. Matches the
+/// coincube-api "channels mask" wire field. SMS/WhatsApp require a phone;
+/// Email requires an email — the UI enforces that pairing before letting a
+/// bit be set.
+pub const DURESS_CHANNEL_SMS: u8 = 1 << 0;
+pub const DURESS_CHANNEL_WHATSAPP: u8 = 1 << 1;
+pub const DURESS_CHANNEL_EMAIL: u8 = 1 << 2;
+
+/// A duress alert contact as returned by
+/// `GET /api/v1/connect/duress/contacts`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DuressAlertContact {
+    pub id: u64,
+    pub display_name: String,
+    /// E.164 phone (e.g. `+15551234567`). `None` when the contact is
+    /// email-only. At least one of `phone`/`email` is always set
+    /// (enforced server-side and in the desktop add/edit form).
+    #[serde(default)]
+    pub phone: Option<String>,
+    #[serde(default)]
+    pub email: Option<String>,
+    /// Bitmask of [`DURESS_CHANNEL_SMS`] / `_WHATSAPP` / `_EMAIL`.
+    #[serde(default)]
+    pub channels: u8,
+    /// RFC 3339 timestamp of when the one-time intro message was sent,
+    /// or `None` if it hasn't gone out yet (just-created contact).
+    #[serde(default)]
+    pub intro_sent_at: Option<String>,
+    /// RFC 3339 timestamp of when the contact replied STOP. When set, the
+    /// contact is permanently opted out and never messaged again.
+    #[serde(default)]
+    pub opted_out_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl DuressAlertContact {
+    /// True when the contact has replied STOP and will not be messaged.
+    pub fn is_opted_out(&self) -> bool {
+        self.opted_out_at.is_some()
+    }
+
+    pub fn has_channel(&self, bit: u8) -> bool {
+        self.channels & bit != 0
+    }
+}
+
+/// Body for `POST /api/v1/connect/duress/contacts` (Estate-gated). At
+/// least one of `phone`/`email` must be `Some`; `channels` must reference
+/// only contact methods that are present. Both are validated client-side
+/// before the call and re-checked server-side.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateDuressAlertContactRequest {
+    pub display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phone: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    pub channels: u8,
+}
+
+/// Body for `PATCH /api/v1/connect/duress/contacts/{id}`. Every field is
+/// optional — only the ones the user changed are sent. The API plan scopes
+/// PATCH to "channel prefs", but the desktop edit form can also amend the
+/// name / phone / email, so all four are partial-update fields. Fields left
+/// `None` are omitted from the JSON body and untouched server-side.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateDuressAlertContactRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phone: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channels: Option<u8>,
+}
+
+/// Maximum duress alert contacts per account. Cost + abuse bound, mirrored
+/// from the coincube-api cap (`PLAN-estate-notifications.md` PR 1).
+pub const MAX_DURESS_ALERT_CONTACTS: usize = 5;
+
+/// Validates a phone number as loosely-E.164: a leading `+`, a non-zero
+/// first digit, and 1–15 digits total (ITU-T E.164 max). This is a
+/// format gate for the input field, not a line-reachability check — the
+/// server / sent.dm does the authoritative validation. Returns `true` for
+/// the empty string so an email-only contact (no phone) passes; callers
+/// separately enforce "at least one of phone/email".
+pub fn is_valid_e164(phone: &str) -> bool {
+    let p = phone.trim();
+    if p.is_empty() {
+        return true;
+    }
+    let Some(rest) = p.strip_prefix('+') else {
+        return false;
+    };
+    let digits: Vec<char> = rest.chars().collect();
+    if digits.len() < 1 || digits.len() > 15 {
+        return false;
+    }
+    if !digits.iter().all(|c| c.is_ascii_digit()) {
+        return false;
+    }
+    // E.164 country codes never start with 0.
+    digits[0] != '0'
+}
+
+#[cfg(test)]
+mod duress_alert_contact_tests {
+    use super::*;
+
+    #[test]
+    fn e164_accepts_well_formed_numbers() {
+        assert!(is_valid_e164("+15551234567"));
+        assert!(is_valid_e164("+447911123456"));
+        assert!(is_valid_e164("+5491123456789"));
+        // Empty = "no phone provided", which is allowed (email-only contact).
+        assert!(is_valid_e164(""));
+        assert!(is_valid_e164("  +15551234567 "));
+    }
+
+    #[test]
+    fn e164_rejects_malformed_numbers() {
+        assert!(!is_valid_e164("5551234567")); // no leading +
+        assert!(!is_valid_e164("+0123456789")); // leading 0 after +
+        assert!(!is_valid_e164("+1 555 123 4567")); // spaces
+        assert!(!is_valid_e164("+1555123456789012")); // 16 digits, too long
+        assert!(!is_valid_e164("+")); // no digits
+        assert!(!is_valid_e164("+1-555-1234")); // dashes
+    }
+
+    #[test]
+    fn channel_bits_are_distinct() {
+        assert_eq!(DURESS_CHANNEL_SMS, 1);
+        assert_eq!(DURESS_CHANNEL_WHATSAPP, 2);
+        assert_eq!(DURESS_CHANNEL_EMAIL, 4);
+        let c = DuressAlertContact {
+            id: 1,
+            display_name: "Jane".into(),
+            phone: Some("+15551234567".into()),
+            email: None,
+            channels: DURESS_CHANNEL_SMS | DURESS_CHANNEL_WHATSAPP,
+            intro_sent_at: None,
+            opted_out_at: None,
+            created_at: "2026-06-11T00:00:00Z".into(),
+            updated_at: "2026-06-11T00:00:00Z".into(),
+        };
+        assert!(c.has_channel(DURESS_CHANNEL_SMS));
+        assert!(c.has_channel(DURESS_CHANNEL_WHATSAPP));
+        assert!(!c.has_channel(DURESS_CHANNEL_EMAIL));
+        assert!(!c.is_opted_out());
+    }
+
+    #[test]
+    fn deserialises_minimal_and_tolerates_missing_optionals() {
+        // Server may omit nullable fields entirely.
+        let v = serde_json::json!({
+            "id": 7,
+            "displayName": "Sam",
+            "email": "sam@example.com",
+            "channels": 4,
+            "createdAt": "2026-06-11T00:00:00Z",
+            "updatedAt": "2026-06-11T00:00:00Z"
+        });
+        let c: DuressAlertContact = serde_json::from_value(v).unwrap();
+        assert_eq!(c.display_name, "Sam");
+        assert!(c.phone.is_none());
+        assert_eq!(c.email.as_deref(), Some("sam@example.com"));
+        assert!(c.has_channel(DURESS_CHANNEL_EMAIL));
+        assert!(c.intro_sent_at.is_none());
+    }
+}
+
+// =============================================================================
+// Vault recovery monitoring (Estate Notifications — PR 2)
+// =============================================================================
+//
+// Three-tier, per-vault opt-in for recovery-path monitoring. Keyed by the
+// Connect vault numeric id (`ConnectVaultResponse::id`). Estate-gated
+// (`recovery_alerts` entitlement). See `plans/PLAN-estate-notifications.md`
+// PR 2 (desktop) and the coincube-api counterpart PRs 3–5.
+//
+// Trust-posture: "Full" uploads a service-encrypted copy of the vault
+// descriptor so COINCUBE can watch the chain (it can see this vault's
+// addresses + balances, never spend). "Alerts only" sends only a periodic
+// timelock heartbeat (`earliest_recovery_height`), never the descriptor.
+// "Off" is a true delete of any stored descriptor record. The opt-in copy
+// in the UI states this trade plainly — no euphemisms.
+
+/// Per-vault monitoring tier. Wire values `off` / `heartbeat` / `full`
+/// match the coincube-api `monitoring_level` column (PR 5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum VaultMonitoringLevel {
+    /// No monitoring. Any stored descriptor record is true-deleted.
+    #[default]
+    Off,
+    /// "Alerts only" — periodic timelock heartbeat. The server learns only
+    /// the block height at which the recovery window opens, never the
+    /// vault's addresses or balances. Keyholders still need the recovery
+    /// password.
+    Heartbeat,
+    /// "Full" — a service-encrypted copy of the descriptor is escrowed so
+    /// COINCUBE watches the chain and keyholders can recover without the
+    /// owner's password.
+    Full,
+}
+
+impl VaultMonitoringLevel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Heartbeat => "heartbeat",
+            Self::Full => "full",
+        }
+    }
+}
+
+/// Per-vault owner policy for when keyholders may download the encrypted
+/// recovery kit. Wire values `anytime` / `at_approaching` match the
+/// coincube-api `crk_keyholder_download` column (PR 3). Default is the
+/// privacy-preserving `at_approaching`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum KeyholderDownloadPolicy {
+    /// Keyholders can download anytime — lets family prepare/verify early,
+    /// but with the pre-shared password that also means balance visibility.
+    Anytime,
+    /// Keyholders can only download once recovery is approaching/open —
+    /// keeps balances private until the recovery window nears.
+    #[default]
+    AtApproaching,
+}
+
+impl KeyholderDownloadPolicy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Anytime => "anytime",
+            Self::AtApproaching => "at_approaching",
+        }
+    }
+}
+
+/// Status returned by `GET /api/v1/connect/vaults/{id}/monitoring`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultMonitoringStatus {
+    #[serde(default)]
+    pub level: VaultMonitoringLevel,
+    #[serde(default)]
+    pub crk_keyholder_download: KeyholderDownloadPolicy,
+    /// Server's per-vault recovery state machine value, when the sweep has
+    /// run: `none` / `approaching` / `available` / `reminding`. `None` when
+    /// the API doesn't expose it (nice-to-have; the UI degrades silently).
+    #[serde(default)]
+    pub last_notified_state: Option<String>,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+}
+
+impl Default for VaultMonitoringStatus {
+    fn default() -> Self {
+        Self {
+            level: VaultMonitoringLevel::Off,
+            crk_keyholder_download: KeyholderDownloadPolicy::AtApproaching,
+            last_notified_state: None,
+            updated_at: None,
+        }
+    }
+}
+
+/// Body for `POST /api/v1/connect/vaults/{id}/monitoring` (Estate-gated).
+/// Sets the monitoring tier. `descriptor` is required for
+/// [`VaultMonitoringLevel::Full`] (the escrowed copy) and omitted for
+/// `Heartbeat`. `crk_keyholder_download` is included when the owner changes
+/// the download policy alongside the level.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetVaultMonitoringRequest {
+    pub level: VaultMonitoringLevel,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub descriptor: Option<String>,
+    /// Gap-limit hint so the server's sweep derives enough addresses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gap_limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub crk_keyholder_download: Option<KeyholderDownloadPolicy>,
+}
+
+/// Body for `PUT /api/v1/connect/vaults/{id}/keyholder-download-policy`
+/// (Estate-gated). Sets the keyholder recovery-kit download policy
+/// independently of the monitoring level — the policy governs the existing
+/// recovery-kit GET for keyholder callers, so it's meaningful even when
+/// chain monitoring is off.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetKeyholderDownloadPolicyRequest {
+    pub crk_keyholder_download: KeyholderDownloadPolicy,
+}
+
+/// Body for `POST /api/v1/connect/vaults/{id}/heartbeat` (Estate-gated,
+/// PR 5). Fire-and-forget after each vault sync for Heartbeat-tier (and
+/// Full, as a cross-check) vaults. `earliest_recovery_height` is the block
+/// height at which this vault's earliest recovery branch opens; a newer
+/// report always wins server-side (monotonic-staleness rule).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultHeartbeatRequest {
+    pub earliest_recovery_height: u32,
+    pub computed_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[cfg(test)]
+mod vault_monitoring_tests {
+    use super::*;
+
+    #[test]
+    fn level_wire_values() {
+        assert_eq!(
+            serde_json::to_string(&VaultMonitoringLevel::Full).unwrap(),
+            "\"full\""
+        );
+        assert_eq!(
+            serde_json::to_string(&VaultMonitoringLevel::Heartbeat).unwrap(),
+            "\"heartbeat\""
+        );
+        assert_eq!(
+            serde_json::to_string(&VaultMonitoringLevel::Off).unwrap(),
+            "\"off\""
+        );
+        assert_eq!(VaultMonitoringLevel::default(), VaultMonitoringLevel::Off);
+    }
+
+    #[test]
+    fn download_policy_wire_values() {
+        assert_eq!(
+            serde_json::to_string(&KeyholderDownloadPolicy::AtApproaching).unwrap(),
+            "\"at_approaching\""
+        );
+        assert_eq!(
+            serde_json::to_string(&KeyholderDownloadPolicy::Anytime).unwrap(),
+            "\"anytime\""
+        );
+        // Default is the privacy-preserving option.
+        assert_eq!(
+            KeyholderDownloadPolicy::default(),
+            KeyholderDownloadPolicy::AtApproaching
+        );
+    }
+
+    #[test]
+    fn monitoring_status_tolerates_minimal_body() {
+        // A vault with no monitoring record: server may send just the level.
+        let v = serde_json::json!({ "level": "off" });
+        let s: VaultMonitoringStatus = serde_json::from_value(v).unwrap();
+        assert_eq!(s.level, VaultMonitoringLevel::Off);
+        // Absent download policy defaults to at_approaching.
+        assert_eq!(
+            s.crk_keyholder_download,
+            KeyholderDownloadPolicy::AtApproaching
+        );
+        assert!(s.last_notified_state.is_none());
+    }
+
+    #[test]
+    fn set_request_omits_descriptor_for_heartbeat() {
+        let req = SetVaultMonitoringRequest {
+            level: VaultMonitoringLevel::Heartbeat,
+            descriptor: None,
+            gap_limit: Some(20),
+            crk_keyholder_download: None,
+        };
+        let body = serde_json::to_value(&req).unwrap();
+        assert_eq!(body["level"], "heartbeat");
+        assert!(body.get("descriptor").is_none());
+        assert_eq!(body["gapLimit"], 20);
+        assert!(body.get("crkKeyholderDownload").is_none());
+    }
+
+    #[test]
+    fn set_request_includes_descriptor_for_full() {
+        let req = SetVaultMonitoringRequest {
+            level: VaultMonitoringLevel::Full,
+            descriptor: Some("wsh(...)".into()),
+            gap_limit: None,
+            crk_keyholder_download: Some(KeyholderDownloadPolicy::Anytime),
+        };
+        let body = serde_json::to_value(&req).unwrap();
+        assert_eq!(body["level"], "full");
+        assert_eq!(body["descriptor"], "wsh(...)");
+        assert_eq!(body["crkKeyholderDownload"], "anytime");
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Opt-in Full monitoring escrows vault descriptors to Connect and background heartbeats drive keyholder alert timing; duress contacts store account PII, though both paths are Estate-gated with session-generation and logout scrubbing.
> 
> **Overview**
> Adds **Estate Notifications** in two areas: **Vault Recovery Alerts** on Cube General Settings and **Emergency contacts** under Connect → Duress.
> 
> **Vault Recovery Alerts** introduces a new settings card and `recovery_alerts` state: Estate-gated **Off / Alerts only (heartbeat) / Full** monitoring, keyholder download policy (**at approaching** vs **anytime**), and honest tier copy. App-level handlers call new Connect APIs (`get/set/delete` monitoring, keyholder policy). **Full** uploads the live wallet descriptor; **Off** deletes escrow server-side. After each successful daemon cache sync, a **non-blocking** `recovery_heartbeat_task` may POST `earliest_recovery_height` (from oldest confirmed unspent coin + timelock, not tip+timelock) when monitoring is on; failures are logged via `RecoveryHeartbeatSent` only. Lazy `LoadStatus` hydration runs when entitled but config was never loaded (so heartbeats work without opening Settings). Logout resets `recovery_alerts` state.
> 
> **Duress emergency contacts** adds list/add/edit/delete UI (SMS/WhatsApp/email channels, E.164/email validation, max 5 contacts), wired through `DuressContactsState` and new duress contact API methods. Estate `duress_alerts` entitlement gates loads and mutations; contacts clear on logout and load on demand when opening the Duress section (home/launcher too). The add/edit form takes over the duress panel; the section stays off the duress-recovery flow.
> 
> `PlanEntitlements` gains `duress_alerts` and `recovery_alerts` with `#[serde(default)]`. Unit tests cover duress contact validation/gating and monitoring DTOs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f9bc362fa0f23a52eb9c8ce49e3d840c976e48c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault Recovery Alerts card in Settings to monitor vault recovery, set monitoring level, and manage keyholder download policy.
  * Emergency Contacts (Duress) UI to add/edit contacts and delivery channels (SMS, WhatsApp, Email) with validation and lifecycle handling.
  * Background, non-blocking vault recovery heartbeat to keep vault monitoring state up to date after sync.

* **Tests**
  * Added unit tests for duress contacts, phone/email validation, and recovery-monitoring DTOs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->