### PR TITLE
P2WSH only

### DIFF
--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -4713,6 +4713,7 @@ mod duress_contacts_tests {
             renewal_at: None,
             entitlements: entitlements(duress_alerts),
             billing_cycle: Some(BillingCycle::Monthly),
+            plan_provenance: None,
         }
     }
 

--- a/coincube-gui/src/installer/step/descriptor/editor/mod.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/mod.rs
@@ -245,10 +245,14 @@ impl Step for DefineDescriptor {
             Message::Close => {
                 self.modal = None;
             }
-            Message::CreateTaprootDescriptor(use_taproot) => {
-                self.use_taproot = use_taproot;
-                self.check_setup();
-            }
+            // VAULT is P2WSH-only at launch (BIP-110/RDTS rule 7 freezes
+            // Taproot tapleaves that execute OP_IF/OP_NOTIF, which our
+            // recovery policies do). The descriptor-type selector that
+            // emitted this has been removed from the UI; the handler is kept
+            // as a no-op so a stray message can never flip `use_taproot` and
+            // produce a `tr(...)` descriptor. `use_taproot` therefore stays
+            // `false` for the lifetime of the editor.
+            Message::CreateTaprootDescriptor(_) => {}
             Message::DefineDescriptor(message::DefineDescriptor::ChangeTemplate(template)) => {
                 self.descriptor_template = template;
             }
@@ -676,11 +680,13 @@ impl Step for DefineDescriptor {
             PathInfo::Multi(self.paths[0].threshold, spending_keys)
         };
 
-        let policy = match if self.use_taproot {
-            CoincubePolicy::new(spending_keys, recovery_paths)
-        } else {
-            CoincubePolicy::new_legacy(spending_keys, recovery_paths)
-        } {
+        // VAULT is P2WSH-only at launch: always compile to `wsh(...)` via
+        // `new_legacy`. BIP-110/RDTS rule 7 would temporarily freeze Taproot
+        // tapleaves that execute OP_IF/OP_NOTIF — which VAULT's Miniscript
+        // recovery policies do — so we never compile creation output to
+        // `tr(...)`. The Taproot constructor (`CoincubePolicy::new`) is kept
+        // in coincube-core for restoring/spending imported `tr(...)` wallets.
+        let policy = match CoincubePolicy::new_legacy(spending_keys, recovery_paths) {
             Ok(policy) => policy,
             Err(e) => {
                 self.error = Some(e.to_string());
@@ -1107,6 +1113,100 @@ mod tests {
         sandbox.check(|step| {
             assert!((step).apply(&mut ctx));
             assert!(ctx.hw_is_used);
+        });
+    }
+
+    /// VAULT is P2WSH-only at launch (BIP-110/RDTS rule 7 safety). Even if a
+    /// stray `CreateTaprootDescriptor(true)` arrives — the UI selector that
+    /// used to emit it has been removed — the created descriptor must still be
+    /// `wsh(...)` and never `tr(...)`.
+    #[tokio::test]
+    async fn test_define_descriptor_is_p2wsh_only() {
+        let mut ctx = Context::new(
+            Network::Signet,
+            CoincubeDirectory::new(PathBuf::from_str("/").unwrap()),
+            crate::installer::context::RemoteBackend::None,
+            None,
+            None,
+        );
+        let sandbox: Sandbox<DefineDescriptor> = Sandbox::new(DefineDescriptor::new(
+            Network::Signet,
+            Arc::new(Mutex::new(Signer::generate(Network::Signet).unwrap())),
+        ));
+        sandbox.load(&ctx).await;
+
+        // Attempt to force Taproot — must be ignored (no-op handler).
+        sandbox.update(Message::CreateTaprootDescriptor(true)).await;
+        sandbox.check(|step| assert!(!step.use_taproot));
+
+        // Primary key: generated master key.
+        sandbox
+            .update(Message::DefineDescriptor(message::DefineDescriptor::Path(
+                0,
+                message::DefinePath::Key(0, message::DefineKey::Edit),
+            )))
+            .await;
+        sandbox
+            .update(SelectKeySource::route(
+                key::SelectKeySourceMessage::SelectGenerateMasterKey,
+            ))
+            .await;
+        sandbox
+            .update(SelectKeySource::route(key::SelectKeySourceMessage::Alias(
+                "master_signer_key".to_string(),
+            )))
+            .await;
+        sandbox
+            .update(SelectKeySource::route(key::SelectKeySourceMessage::Next))
+            .await;
+
+        // Recovery path: timelock sequence + external xpub.
+        sandbox
+            .update(Message::DefineDescriptor(message::DefineDescriptor::Path(
+                1,
+                message::DefinePath::SequenceEdited(1000),
+            )))
+            .await;
+        sandbox
+            .update(Message::DefineDescriptor(message::DefineDescriptor::Path(
+                1,
+                message::DefinePath::Key(0, message::DefineKey::Edit),
+            )))
+            .await;
+        sandbox
+            .update(SelectKeySource::route(
+                key::SelectKeySourceMessage::SelectEnterXpub,
+            ))
+            .await;
+        sandbox
+            .update(SelectKeySource::route(
+                key::SelectKeySourceMessage::Xpub("[f5acc2fd/48'/1'/0'/2']tpubDFAqEGNyad35aBCKUAXbQGDjdVhNueno5ZZVEn3sQbW5ci457gLR7HyTmHBg93oourBssgUxuWz1jX5uhc1qaqFo9VsybY1J5FuedLfm4dK".to_string())
+            ))
+            .await;
+        sandbox
+            .update(SelectKeySource::route(key::SelectKeySourceMessage::Alias(
+                "External recovery key".to_string(),
+            )))
+            .await;
+        sandbox
+            .update(SelectKeySource::route(key::SelectKeySourceMessage::Next))
+            .await;
+
+        sandbox.check(|step| {
+            assert!(step.modal.is_none());
+            assert!(!step.use_taproot);
+            assert!((step).apply(&mut ctx));
+            let desc = ctx.descriptor.as_ref().unwrap().to_string();
+            assert!(
+                desc.starts_with("wsh("),
+                "VAULT creation must produce a P2WSH descriptor, got: {}",
+                desc
+            );
+            assert!(
+                !desc.starts_with("tr("),
+                "VAULT must never create a Taproot descriptor: {}",
+                desc
+            );
         });
     }
 }

--- a/coincube-gui/src/installer/view/editor/mod.rs
+++ b/coincube-gui/src/installer/view/editor/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod template;
 
-use iced::widget::{container, pick_list, slider, Button, Space};
+use iced::widget::{slider, Button, Space};
 use iced::{alignment, Alignment, Length};
 
 use coincube_ui::component::text::{p1_bold, p2_regular, H3_SIZE};
@@ -11,7 +11,7 @@ use std::str::FromStr;
 
 use coincube_ui::{
     component::{
-        button, card, form, separation,
+        button, card, form,
         text::{p1_regular, text, Text},
     },
     icon, theme,
@@ -26,59 +26,14 @@ use crate::installer::{
 
 use super::defined_threshold;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DescriptorKind {
-    P2WSH,
-    Taproot,
-}
-
-const DESCRIPTOR_KINDS: [DescriptorKind; 2] = [DescriptorKind::P2WSH, DescriptorKind::Taproot];
-
-impl std::fmt::Display for DescriptorKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Self::P2WSH => write!(f, "P2WSH"),
-            Self::Taproot => write!(f, "Taproot"),
-        }
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn define_descriptor_advanced_settings<'a>(use_taproot: bool) -> Element<'a, Message> {
-    let col_wallet = Column::new()
-        .spacing(10)
-        .push(text("Descriptor type").bold())
-        .push(container(
-            pick_list(
-                &DESCRIPTOR_KINDS[..],
-                Some(if use_taproot {
-                    DescriptorKind::Taproot
-                } else {
-                    DescriptorKind::P2WSH
-                }),
-                |kind| Message::CreateTaprootDescriptor(kind == DescriptorKind::Taproot),
-            )
-            .style(theme::pick_list::primary)
-            .padding(10),
-        ));
-
-    container(
-        Column::new()
-            .spacing(20)
-            .push(Space::new().height(0))
-            .push(separation().width(500))
-            .push(Row::new().push(col_wallet))
-            .push(if use_taproot {
-                Some(
-                    p1_regular("Taproot is only supported by Coincube version 5.0 and above")
-                        .style(theme::text::secondary),
-                )
-            } else {
-                None
-            }),
-    )
-    .into()
-}
+// VAULT is P2WSH-only at launch: BIP-110/RDTS rule 7 invalidates tapscript
+// leaves that execute OP_IF/OP_NOTIF during the ~1-year deployment, and
+// VAULT's Miniscript recovery policies compile to exactly those opcodes in a
+// Taproot taptree. Witness-v0 (`wsh`) scripts are out of scope of rule 7, so
+// the descriptor-type selector (P2WSH vs Taproot) and its accompanying notice
+// have been removed from the creation flow. The core library still parses and
+// spends `tr(...)` descriptors for restore/import — see
+// `coincube-core/src/descriptors/analysis.rs` `from_multipath_descriptor`.
 
 pub fn path(
     color: iced::Color,

--- a/coincube-gui/src/installer/view/editor/template/custom.rs
+++ b/coincube-gui/src/installer/view/editor/template/custom.rs
@@ -7,8 +7,8 @@ use iced::{
 use coincube_ui::{
     color,
     component::{
-        button, collapse,
-        text::{h3, p1_regular, text, Text},
+        button,
+        text::{h3, p1_regular, text},
     },
     icon, image, theme,
     widget::*,
@@ -18,7 +18,7 @@ use crate::installer::{
     descriptor::Path,
     message::{self, Message},
     view::{
-        editor::{define_descriptor_advanced_settings, defined_key, path, undefined_key},
+        editor::{defined_key, path, undefined_key},
         layout,
     },
 };
@@ -70,29 +70,6 @@ pub fn custom_template<'a>(
         Column::new()
             .align_x(Alignment::Start)
             .max_width(1000.0)
-            .push(collapse::Collapse::new(
-                || {
-                    Button::new(
-                        Row::new()
-                            .align_y(Alignment::Center)
-                            .spacing(10)
-                            .push(text("Advanced settings").small().bold())
-                            .push(icon::collapse_icon()),
-                    )
-                    .style(theme::button::transparent)
-                },
-                || {
-                    Button::new(
-                        Row::new()
-                            .align_y(Alignment::Center)
-                            .spacing(10)
-                            .push(text("Advanced settings").small().bold())
-                            .push(icon::collapsed_icon()),
-                    )
-                    .style(theme::button::transparent)
-                },
-                move || define_descriptor_advanced_settings(use_taproot),
-            ))
             .push(
                 path(
                     color::ORANGE,

--- a/coincube-gui/src/installer/view/editor/template/inheritance.rs
+++ b/coincube-gui/src/installer/view/editor/template/inheritance.rs
@@ -3,8 +3,8 @@ use iced::{alignment, widget::Space, Alignment, Length};
 use coincube_ui::{
     color,
     component::{
-        button, collapse,
-        text::{h3, p1_regular, text, Text, H3_SIZE},
+        button,
+        text::{h3, p1_regular, Text, H3_SIZE},
     },
     icon, image, theme,
     widget::*,
@@ -15,7 +15,7 @@ use crate::installer::{
     descriptor::{Path, PathSequence},
     message::{self, Message},
     view::{
-        editor::{define_descriptor_advanced_settings, defined_key, path, undefined_key},
+        editor::{defined_key, path, undefined_key},
         layout,
     },
 };
@@ -83,29 +83,6 @@ pub fn inheritance_template<'a>(
         Column::new()
             .align_x(Alignment::Start)
             .max_width(1000.0)
-            .push(collapse::Collapse::new(
-                || {
-                    Button::new(
-                        Row::new()
-                            .align_y(Alignment::Center)
-                            .spacing(10)
-                            .push(text("Advanced settings").small().bold())
-                            .push(icon::collapse_icon()),
-                    )
-                    .style(theme::button::transparent)
-                },
-                || {
-                    Button::new(
-                        Row::new()
-                            .align_y(Alignment::Center)
-                            .spacing(10)
-                            .push(text("Advanced settings").small().bold())
-                            .push(icon::collapsed_icon()),
-                    )
-                    .style(theme::button::transparent)
-                },
-                move || define_descriptor_advanced_settings(use_taproot),
-            ))
             .push(
                 path(
                     color::ORANGE,

--- a/coincube-gui/src/installer/view/editor/template/multisig_security_wallet.rs
+++ b/coincube-gui/src/installer/view/editor/template/multisig_security_wallet.rs
@@ -3,8 +3,8 @@ use iced::{alignment, widget::Space, Alignment, Length};
 use coincube_ui::{
     color,
     component::{
-        button, collapse,
-        text::{h3, p1_regular, text, Text, H3_SIZE},
+        button,
+        text::{h3, p1_regular, Text, H3_SIZE},
     },
     icon, image, theme,
     widget::*,
@@ -15,10 +15,7 @@ use crate::installer::{
     descriptor::{Path, PathKind, PathSequence},
     message::{self, Message},
     view::{
-        editor::{
-            define_descriptor_advanced_settings, defined_key, path, undefined_key,
-            uneditable_defined_key,
-        },
+        editor::{defined_key, path, undefined_key, uneditable_defined_key},
         layout,
     },
 };
@@ -88,29 +85,6 @@ pub fn multisig_security_template<'a>(
         Column::new()
             .align_x(Alignment::Start)
             .max_width(1000.0)
-            .push(collapse::Collapse::new(
-                || {
-                    Button::new(
-                        Row::new()
-                            .align_y(Alignment::Center)
-                            .spacing(10)
-                            .push(text("Advanced settings").small().bold())
-                            .push(icon::collapse_icon()),
-                    )
-                    .style(theme::button::transparent)
-                },
-                || {
-                    Button::new(
-                        Row::new()
-                            .align_y(Alignment::Center)
-                            .spacing(10)
-                            .push(text("Advanced settings").small().bold())
-                            .push(icon::collapsed_icon()),
-                    )
-                    .style(theme::button::transparent)
-                },
-                move || define_descriptor_advanced_settings(use_taproot),
-            ))
             .push(
                 path(
                     color::GREEN,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> This changes which on-chain descriptor type new VAULT wallets get, which is security- and funds-relevant, though scope is limited to the creation path with restore/spend for existing `tr(...)` wallets unchanged.
> 
> **Overview**
> **VAULT creation is P2WSH-only at launch** because BIP-110/RDTS rule 7 would freeze Taproot tapleaves that use `OP_IF`/`OP_NOTIF`, which VAULT recovery Miniscript relies on; witness-v0 `wsh` scripts are unaffected.
> 
> The installer **drops the Advanced settings descriptor-type picker** (P2WSH vs Taproot) from the custom, inheritance, and multisig template flows. **`CreateTaprootDescriptor` is a no-op** so nothing can set `use_taproot`, and **`apply` always builds the policy with `CoincubePolicy::new_legacy`** so output is `wsh(...)` never `tr(...)`. Comments note **`tr(...)` restore/spend in coincube-core stays** for imported Taproot wallets.
> 
> A new **`test_define_descriptor_is_p2wsh_only`** sandbox test asserts that forcing Taproot via message is ignored and the created descriptor starts with `wsh(`.
> 
> Unrelated: **`plan_provenance: None`** is added to a `ConnectPlan` test fixture in `account.rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef12431f2341bd05c1e8ac0c8e3b4abfb3a7e304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed descriptor type selector and advanced settings UI from wallet creation flows across custom, inheritance, and multisig templates
  * New wallet creation standardized to P2WSH-only format
  * Import and restore workflows maintain support for additional descriptor types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->