### PR TITLE
Fixes/plans

### DIFF
--- a/coincube-gui/src/app/breez_spark/client.rs
+++ b/coincube-gui/src/app/breez_spark/client.rs
@@ -913,21 +913,27 @@ fn relay_bridge_log(raw: &str) {
 }
 
 /// Detects the tracing level token the bridge embedded in its formatted line
-/// (e.g. `... INFO spark::…: …`). Padded with spaces so substrings don't
-/// false-match.
+/// (e.g. `<timestamp>  INFO spark::…: …`). The level is a whitespace-delimited
+/// field that always precedes the `target: message` separator, so we only scan
+/// the prefix before the first `": "` and require an *exact* token match. This
+/// avoids false positives when the message payload itself contains a word like
+/// `INFO` or ` ERROR ` (which a plain `contains()` over the whole line would
+/// mis-detect, especially as ERROR is checked first).
 fn embedded_level(line: &str) -> Option<Level> {
-    for (token, level) in [
-        (" ERROR ", Level::ERROR),
-        (" WARN ", Level::WARN),
-        (" INFO ", Level::INFO),
-        (" DEBUG ", Level::DEBUG),
-        (" TRACE ", Level::TRACE),
-    ] {
-        if line.contains(token) {
-            return Some(level);
-        }
-    }
-    None
+    // Everything up to the `target: message` delimiter. The message (which may
+    // contain incidental level words) lives after it and is excluded.
+    let prefix = match line.find(": ") {
+        Some(i) => &line[..i],
+        None => line,
+    };
+    prefix.split_whitespace().find_map(|tok| match tok {
+        "ERROR" => Some(Level::ERROR),
+        "WARN" => Some(Level::WARN),
+        "INFO" => Some(Level::INFO),
+        "DEBUG" => Some(Level::DEBUG),
+        "TRACE" => Some(Level::TRACE),
+        _ => None,
+    })
 }
 
 /// Strips ANSI SGR escape sequences (the bridge colourises its tracing output,
@@ -1071,6 +1077,21 @@ mod stderr_relay_tests {
         assert_eq!(embedded_level("ts ERROR foo: boom"), Some(Level::ERROR));
         // Unstructured line (e.g. a panic) has no level token.
         assert_eq!(embedded_level("thread 'main' panicked at ..."), None);
+    }
+
+    #[test]
+    fn ignores_level_words_in_message_payload() {
+        // A real INFO line whose message mentions ERROR/WARN must stay INFO —
+        // the payload (after `target: `) is not scanned.
+        assert_eq!(
+            embedded_level("ts  INFO spark::x: retrying after ERROR response"),
+            Some(Level::INFO)
+        );
+        // No structured level field, only an incidental word in the message.
+        assert_eq!(
+            embedded_level("ts spark::x: user tapped the INFO button"),
+            None
+        );
     }
 
     #[test]

--- a/coincube-gui/src/app/breez_spark/client.rs
+++ b/coincube-gui/src/app/breez_spark/client.rs
@@ -17,7 +17,9 @@
 //!   [`Frame`]s, and routes [`Response`]s through a shared pending map
 //!   (`id -> oneshot::Sender`). [`Event`] frames go to a future event
 //!   channel (not wired in Phase 3 — just logged for now).
-//! - **stderr pump**: logs each stderr line from the bridge at warn level.
+//! - **stderr pump**: relays each stderr line from the bridge into tracing
+//!   at the severity the bridge itself emitted (see `relay_bridge_log`),
+//!   stripping ANSI and demoting the SDK's empty-event keepalive.
 //!
 //! A request goes like: allocate id, insert `oneshot::Sender` into pending
 //! map, send `Request` over the writer channel, await the oneshot. The
@@ -54,7 +56,7 @@ use coincube_spark_protocol::{
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::{broadcast, mpsc, oneshot, Mutex};
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, trace, warn, Level};
 
 use super::config::SparkConfig;
 
@@ -876,9 +878,76 @@ fn spawn_stderr_task(stderr: tokio::process::ChildStderr) {
     tokio::spawn(async move {
         let mut lines = BufReader::new(stderr).lines();
         while let Ok(Some(line)) = lines.next_line().await {
-            warn!(target: "spark_bridge", "{}", line);
+            relay_bridge_log(&line);
         }
     });
+}
+
+/// Relays one stderr line from the Spark bridge subprocess into our tracing at
+/// the severity the bridge ITSELF emitted, instead of blanket-`warn!`. Blanket
+/// warn made the bridge's own `INFO`/`DEBUG` show up as warnings and — together
+/// with the Spark SDK's keepalive chatter — flooded `coincube.log` with a WARN
+/// every few seconds. ANSI colour codes the bridge writes are stripped, and the
+/// benign empty-event heartbeat (the Spark server stream's ~5s keepalive, which
+/// carries no signal) is demoted to TRACE so it can't drown the log.
+fn relay_bridge_log(raw: &str) {
+    let line = strip_ansi(raw);
+    let line = line.trim();
+    if line.is_empty() {
+        return;
+    }
+    // High-frequency, zero-signal keepalive from the SDK's event stream.
+    if line.contains("Received empty event") {
+        trace!(target: "spark_bridge", "{line}");
+        return;
+    }
+    match embedded_level(line) {
+        Some(Level::ERROR) => error!(target: "spark_bridge", "{line}"),
+        Some(Level::WARN) => warn!(target: "spark_bridge", "{line}"),
+        Some(Level::INFO) => info!(target: "spark_bridge", "{line}"),
+        Some(Level::DEBUG) => debug!(target: "spark_bridge", "{line}"),
+        Some(Level::TRACE) => trace!(target: "spark_bridge", "{line}"),
+        // Unstructured output (e.g. a panic or raw stderr) — keep it visible.
+        None => warn!(target: "spark_bridge", "{line}"),
+    }
+}
+
+/// Detects the tracing level token the bridge embedded in its formatted line
+/// (e.g. `... INFO spark::…: …`). Padded with spaces so substrings don't
+/// false-match.
+fn embedded_level(line: &str) -> Option<Level> {
+    for (token, level) in [
+        (" ERROR ", Level::ERROR),
+        (" WARN ", Level::WARN),
+        (" INFO ", Level::INFO),
+        (" DEBUG ", Level::DEBUG),
+        (" TRACE ", Level::TRACE),
+    ] {
+        if line.contains(token) {
+            return Some(level);
+        }
+    }
+    None
+}
+
+/// Strips ANSI SGR escape sequences (the bridge colourises its tracing output,
+/// which would otherwise land as raw escape codes in our log file).
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            // Consume up to and including the sequence's terminating letter.
+            for c2 in chars.by_ref() {
+                if c2.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -982,4 +1051,37 @@ fn make_spark_event_stream(
             std::future::pending::<()>().await;
         },
     )
+}
+
+#[cfg(test)]
+mod stderr_relay_tests {
+    use super::{embedded_level, strip_ansi};
+    use tracing::Level;
+
+    #[test]
+    fn parses_embedded_level() {
+        assert_eq!(
+            embedded_level("2026-06-13T07:08:38Z  INFO spark::services::tokens: ok"),
+            Some(Level::INFO)
+        );
+        assert_eq!(
+            embedded_level("ts  WARN spark::events::server_stream: x"),
+            Some(Level::WARN)
+        );
+        assert_eq!(embedded_level("ts ERROR foo: boom"), Some(Level::ERROR));
+        // Unstructured line (e.g. a panic) has no level token.
+        assert_eq!(embedded_level("thread 'main' panicked at ..."), None);
+    }
+
+    #[test]
+    fn strips_ansi_colour_codes() {
+        let raw =
+            "\x1b[2m2026-06-13T07:08:38Z\x1b[0m \x1b[32m INFO\x1b[0m \x1b[2mspark::x\x1b[0m: ok";
+        let clean = strip_ansi(raw);
+        assert!(!clean.contains('\x1b'));
+        assert!(clean.contains(" INFO "));
+        assert!(clean.contains("spark::x"));
+        // Level is still detectable post-strip.
+        assert_eq!(embedded_level(&clean), Some(Level::INFO));
+    }
 }

--- a/coincube-gui/src/app/message.rs
+++ b/coincube-gui/src/app/message.rs
@@ -47,6 +47,10 @@ pub enum Message {
     View(view::Message),
     LoadDaemonConfig(Box<DaemonConfig>),
     DaemonConfigLoaded(Result<(), Error>),
+    /// Result of an off-UI-thread daemon restart (a backend switch). Carries the
+    /// new daemon — or a recovered previous one on failure — so the App can swap
+    /// it in without freezing the UI on `daemon.stop()` / `EmbeddedDaemon::start`.
+    DaemonRestarted(super::DaemonRestart),
     LoadWallet(Wallet),
     Info(Result<GetInfoResult, Error>),
     ReceiveAddress(Result<(Address, ChildNumber), Error>),

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1910,6 +1910,13 @@ impl App {
             tracing::debug!("Skipping tick - no vault configured");
             return Task::none();
         }
+        // Skip while a backend switch is in flight: `self.daemon` still points at
+        // the daemon the off-thread switch is stopping, so polling it here would
+        // hit a stopped poller/RPC. The next tick after `DaemonRestarted` swaps in
+        // the new daemon resumes normally.
+        if self.daemon_switch_in_progress {
+            return Task::none();
+        }
 
         let tick = std::time::Instant::now();
         let mut tasks = if let Some(daemon) = &self.daemon {
@@ -2864,14 +2871,36 @@ impl App {
             }
             Message::DaemonRestarted(outcome) => {
                 self.daemon_switch_in_progress = false;
+                // Non-blocking toast emitted on top of the normal result (e.g. a
+                // switch that succeeded but couldn't be persisted to disk).
+                let mut extra = Task::none();
                 let result = match outcome {
                     DaemonRestart::Started(daemon) => {
                         self.daemon = Some(daemon);
                         Ok(())
                     }
+                    DaemonRestart::StartedNotPersisted(daemon) => {
+                        // The switch succeeded (wallet is on the new backend); the
+                        // only problem is the config wasn't saved. Report success
+                        // but warn that it may not survive a restart.
+                        self.daemon = Some(daemon);
+                        extra = Task::done(Message::View(view::Message::ShowToast(
+                            log::Level::Warn,
+                            "Switched Bitcoin backend, but couldn't save the change to disk — \
+                             it may revert if you restart Coincube."
+                                .to_string(),
+                        )));
+                        Ok(())
+                    }
                     DaemonRestart::Failed { error, recovered } => {
                         if let Some(daemon) = recovered {
                             self.daemon = Some(daemon);
+                        } else {
+                            // The old daemon was already stopped during the switch
+                            // and recovery couldn't bring one back. Drop it rather
+                            // than keep referencing a dead daemon that ticks and
+                            // config loads would keep poking.
+                            self.daemon = None;
                         }
                         error!("Daemon backend switch failed: {}", error);
                         Err(error)
@@ -2884,7 +2913,7 @@ impl App {
                     self.cache.node_bitcoind_last_log = None;
                 }
                 let cfg_task = self.update_dispatch(Message::DaemonConfigLoaded(result));
-                return Task::batch([cfg_task, Task::done(Message::CacheUpdated)]);
+                return Task::batch([cfg_task, extra, Task::done(Message::CacheUpdated)]);
             }
             Message::WalletUpdated(Ok(wallet)) => {
                 // Check if we're transitioning from no-vault to has-vault state
@@ -3731,11 +3760,27 @@ impl App {
         daemon_config_path.push("daemon.toml");
         Task::perform(
             async move {
-                tokio::task::spawn_blocking(move || {
+                match tokio::task::spawn_blocking(move || {
                     restart_daemon_blocking(old_daemon, cfg, daemon_config_path)
                 })
                 .await
-                .expect("daemon restart task panicked")
+                {
+                    Ok(outcome) => outcome,
+                    // The blocking switch panicked. Still deliver a DaemonRestarted
+                    // message so its handler clears `daemon_switch_in_progress` —
+                    // otherwise the guard sticks `true` and blocks every later
+                    // LoadDaemonConfig / auto-switch indefinitely. `old_daemon` was
+                    // moved into the (now-dead) task, so there's nothing to recover.
+                    Err(join_err) => {
+                        error!("daemon restart task panicked: {join_err}");
+                        DaemonRestart::Failed {
+                            error: Error::Config(format!(
+                                "daemon restart task panicked: {join_err}"
+                            )),
+                            recovered: None,
+                        }
+                    }
+                }
             },
             Message::DaemonRestarted,
         )
@@ -3883,9 +3928,13 @@ fn new_recovery_panel(
 pub enum DaemonRestart {
     /// The new daemon started; swap it in.
     Started(Arc<dyn Daemon + Sync + Send>),
-    /// The switch failed. `recovered` is a daemon to install so the app stays
-    /// usable — either the previous daemon brought back up, or (on a
-    /// persist-only failure) the freshly started one.
+    /// The new daemon started and should be installed (the switch SUCCEEDED),
+    /// but persisting `daemon.toml` failed. Not a switch failure — the wallet is
+    /// on the new backend — but the change may not survive a restart, so the app
+    /// installs the daemon AND shows a non-blocking warning.
+    StartedNotPersisted(Arc<dyn Daemon + Sync + Send>),
+    /// The switch failed. `recovered` is the previous daemon brought back up (if
+    /// any) so the app stays usable.
     Failed {
         error: Error,
         recovered: Option<Arc<dyn Daemon + Sync + Send>>,
@@ -3945,8 +3994,12 @@ fn restart_daemon_blocking(
         }
     };
 
-    // Persist the new backend. A write failure doesn't invalidate the running
-    // daemon, so keep it and surface the error.
+    // Persist the new backend. The switch ALREADY succeeded — the new daemon is
+    // running and about to be installed — so a failed `daemon.toml` write is NOT
+    // a switch failure: reporting one would show an error in Settings while the
+    // wallet is actually on the new backend. Treat it as success and just log
+    // the persistence problem loudly; its only consequence is that the change
+    // may not survive a restart (the stale on-disk config would reload).
     let persisted = (|| -> Result<(), Error> {
         let content =
             toml::to_string(&daemon.config()).map_err(|e| Error::Config(e.to_string()))?;
@@ -3959,14 +4012,13 @@ fn restart_daemon_blocking(
             .map_err(|e| Error::Config(e.to_string()))
     })();
 
-    match persisted {
-        Ok(()) => DaemonRestart::Started(daemon),
-        Err(e) => {
-            warn!("failed to persist daemon.toml after switch: {:?}", e);
-            DaemonRestart::Failed {
-                error: e,
-                recovered: Some(daemon),
-            }
-        }
+    if let Err(e) = persisted {
+        error!(
+            "Backend switch succeeded but persisting daemon.toml failed; the wallet is on the \
+             new backend now, but the change may not survive a restart: {:?}",
+            e
+        );
+        return DaemonRestart::StartedNotPersisted(daemon);
     }
+    DaemonRestart::Started(daemon)
 }

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -679,6 +679,12 @@ pub struct App {
     /// True while a check_bitcoind_sync_progress probe is in flight; prevents
     /// multiple concurrent RPC calls from piling up across subscription ticks.
     bitcoind_sync_probe_in_progress: bool,
+    /// True while an off-thread daemon backend switch ([`Self::spawn_daemon_switch`])
+    /// is in flight. The config isn't updated until the switch completes, so
+    /// without this guard the next sync probe would keep re-firing the switch
+    /// every tick — spawning concurrent daemon starts that race to load the same
+    /// watchonly wallet and corrupt it. Cleared by `Message::DaemonRestarted`.
+    daemon_switch_in_progress: bool,
     /// Global "payment received" celebration overlay — shown for incoming
     /// Liquid payments (e.g. LNURL) regardless of which panel is active.
     show_received_celebration: bool,
@@ -1241,6 +1247,7 @@ impl App {
                 errors: Vec::with_capacity(8),
                 current_error_id: 256,
                 bitcoind_sync_probe_in_progress: false,
+                daemon_switch_in_progress: false,
                 show_received_celebration: false,
                 received_celebration_amount: String::new(),
                 received_celebration_context: "transaction-received".to_string(),
@@ -1342,6 +1349,7 @@ impl App {
                 errors: Vec::with_capacity(8),
                 current_error_id: 256,
                 bitcoind_sync_probe_in_progress: false,
+                daemon_switch_in_progress: false,
                 show_received_celebration: false,
                 received_celebration_amount: String::new(),
                 received_celebration_context: "transaction-received".to_string(),
@@ -2510,18 +2518,23 @@ impl App {
                 match res {
                     Err(e) => tracing::warn!("Bitcoind sync check failed: {}", e),
                     Ok((progress, ibd)) => {
-                        let was_in_ibd = self.cache.node_bitcoind_ibd == Some(true);
                         self.cache.node_bitcoind_sync_progress = Some(progress);
                         self.cache.node_bitcoind_ibd = Some(ibd);
-                        // Only auto-switch when we have observed the node transition
-                        // OUT of IBD (was_in_ibd=true → ibd=false).  This prevents
-                        // the immediate reversal that occurs when the
-                        // SwitchToConnect flow saves an already-synced Bitcoind
-                        // into pending_bitcoind: the first poll would otherwise
-                        // see ibd=false and switch back.
-                        if !ibd && was_in_ibd {
+                        // Auto-switch to the pending node once it's synced, but
+                        // only if the user *adopted* it (`auto_switch_to_pending`).
+                        // This fires even for a node that reused an existing
+                        // chainstate and was therefore never observed in IBD —
+                        // while never reverting a node merely parked by a
+                        // switch-to-Connect or a Bitcoind-failure fallback (those
+                        // clear the flag). Skip while a switch is already in
+                        // flight, so we don't spawn overlapping switches every
+                        // tick (which raced to load — and corrupted — the wallet).
+                        if !ibd && !self.daemon_switch_in_progress {
                             let switch =
                                 self.daemon.as_ref().and_then(|d| d.config()).and_then(|c| {
+                                    if !c.auto_switch_to_pending {
+                                        return None;
+                                    }
                                     let pending = c.pending_bitcoind.clone()?;
                                     // Preserve the current Connect config as the new fallback.
                                     let old_esplora = match &c.bitcoin_backend {
@@ -2534,26 +2547,13 @@ impl App {
                                     new_cfg.bitcoin_backend =
                                         Some(coincubed::config::BitcoinBackend::Bitcoind(pending));
                                     new_cfg.pending_bitcoind = None;
+                                    new_cfg.auto_switch_to_pending = false;
                                     new_cfg.fallback_esplora = old_esplora;
                                     Some(new_cfg)
                                 });
                             if let Some(new_cfg) = switch {
-                                let datadir = self.cache.datadir_path.clone();
-                                match self.load_daemon_config(datadir, new_cfg) {
-                                    Ok(()) => {
-                                        info!("Switched to local Bitcoind — IBD complete");
-                                        self.cache.node_bitcoind_sync_progress = None;
-                                        self.cache.node_bitcoind_ibd = None;
-                                        self.cache.node_bitcoind_last_log = None;
-                                        let cfg_task = self
-                                            .update_dispatch(Message::DaemonConfigLoaded(Ok(())));
-                                        return Task::batch([
-                                            cfg_task,
-                                            Task::done(Message::CacheUpdated),
-                                        ]);
-                                    }
-                                    Err(e) => error!("Failed to switch to Bitcoind: {}", e),
-                                }
+                                info!("Switching to local Bitcoind — node synced");
+                                return self.spawn_daemon_switch(new_cfg);
                             }
                         }
                     }
@@ -2659,87 +2659,84 @@ impl App {
                     return Task::done(Message::CacheUpdated);
                 }
             }
-            Message::UpdateDaemonCache(res) => match res {
-                Ok(mut daemon_cache) => {
-                    // Apply optimistic-broadcast overrides before the
-                    // cache is published: reconcile drops entries the
-                    // daemon now reflects on its own, then any still-
-                    // pending broadcasts get synthetic `spend_info` so
-                    // `coins_summary` (Vault balance) and every other
-                    // `cache.coins()` consumer treats the inputs as
-                    // already spent.
-                    if let Some(wallet) = &self.wallet {
-                        wallet.reconcile_with_coins(&daemon_cache.coins);
-                        wallet.apply_coin_overrides(&mut daemon_cache.coins);
+            Message::UpdateDaemonCache(res) => {
+                match res {
+                    Ok(mut daemon_cache) => {
+                        // Apply optimistic-broadcast overrides before the
+                        // cache is published: reconcile drops entries the
+                        // daemon now reflects on its own, then any still-
+                        // pending broadcasts get synthetic `spend_info` so
+                        // `coins_summary` (Vault balance) and every other
+                        // `cache.coins()` consumer treats the inputs as
+                        // already spent.
+                        if let Some(wallet) = &self.wallet {
+                            wallet.reconcile_with_coins(&daemon_cache.coins);
+                            wallet.apply_coin_overrides(&mut daemon_cache.coins);
+                        }
+                        self.cache.daemon_cache = daemon_cache;
+                        // Fire-and-forget recovery heartbeat after the sync's
+                        // fresh tip lands (Estate Notifications — PR 2). Batched
+                        // alongside the normal cache cascade so it never delays
+                        // or blocks it.
+                        let heartbeat = self.recovery_heartbeat_task();
+                        return Task::batch([heartbeat, Task::done(Message::CacheUpdated)]);
                     }
-                    self.cache.daemon_cache = daemon_cache;
-                    // Fire-and-forget recovery heartbeat after the sync's
-                    // fresh tip lands (Estate Notifications — PR 2). Batched
-                    // alongside the normal cache cascade so it never delays
-                    // or blocks it.
-                    let heartbeat = self.recovery_heartbeat_task();
-                    return Task::batch([heartbeat, Task::done(Message::CacheUpdated)]);
-                }
-                Err(e) => {
-                    tracing::error!("Failed to update daemon cache: {}", e);
-                    // If the active Bitcoind daemon has failed and a Connect
-                    // Esplora fallback is configured (set when IBD completed),
-                    // restart using Connect — but only on transport/stopped
-                    // errors, not transient RPC application-level responses.
-                    if is_daemon_unreachable(&e) {
-                        let fallback = self
-                            .daemon
-                            .as_ref()
-                            .filter(|d| {
-                                matches!(
-                                    d.backend(),
-                                    DaemonBackend::EmbeddedCoincubed(Some(NodeType::Bitcoind))
-                                )
-                            })
-                            .and_then(|d| d.config())
-                            .and_then(|c| {
-                                c.fallback_esplora.as_ref().map(|fb| {
-                                    let mut new_cfg = c.clone();
-                                    // Demote the current Bitcoind to
-                                    // `pending_bitcoind` so the syncing card
-                                    // reappears and the user can retry once
-                                    // the node is healthy. Without this the
-                                    // fallback strands the user on Connect
-                                    // with an empty pending slot, which
-                                    // surfaces the "Set up local node" prompt
-                                    // and forces a full re-install.
-                                    let preserved_bitcoind = match &c.bitcoin_backend {
-                                        Some(coincubed::config::BitcoinBackend::Bitcoind(bc)) => {
-                                            Some(bc.clone())
-                                        }
-                                        _ => None,
-                                    };
-                                    new_cfg.bitcoin_backend = Some(
-                                        coincubed::config::BitcoinBackend::Esplora(fb.clone()),
-                                    );
-                                    new_cfg.pending_bitcoind = preserved_bitcoind;
-                                    new_cfg.fallback_esplora = None;
-                                    new_cfg
+                    Err(e) => {
+                        tracing::error!("Failed to update daemon cache: {}", e);
+                        // If the active Bitcoind daemon has failed and a Connect
+                        // Esplora fallback is configured (set when IBD completed),
+                        // restart using Connect — but only on transport/stopped
+                        // errors, not transient RPC application-level responses.
+                        if is_daemon_unreachable(&e) {
+                            let fallback = self
+                                .daemon
+                                .as_ref()
+                                .filter(|d| {
+                                    matches!(
+                                        d.backend(),
+                                        DaemonBackend::EmbeddedCoincubed(Some(NodeType::Bitcoind))
+                                    )
                                 })
-                            });
-                        if let Some(new_cfg) = fallback {
-                            let datadir = self.cache.datadir_path.clone();
-                            match self.load_daemon_config(datadir, new_cfg) {
-                                Ok(()) => {
-                                    info!("Switched to COINCUBE | Connect fallback after Bitcoind failure");
-                                    let cfg_task =
-                                        self.update_dispatch(Message::DaemonConfigLoaded(Ok(())));
-                                    return Task::batch([
-                                        cfg_task,
-                                        Task::done(Message::CacheUpdated),
-                                    ]);
+                                .and_then(|d| d.config())
+                                .and_then(|c| {
+                                    c.fallback_esplora.as_ref().map(|fb| {
+                                        let mut new_cfg = c.clone();
+                                        // Demote the current Bitcoind to
+                                        // `pending_bitcoind` so the syncing card
+                                        // reappears and the user can retry once
+                                        // the node is healthy. Without this the
+                                        // fallback strands the user on Connect
+                                        // with an empty pending slot, which
+                                        // surfaces the "Set up local node" prompt
+                                        // and forces a full re-install.
+                                        let preserved_bitcoind = match &c.bitcoin_backend {
+                                            Some(coincubed::config::BitcoinBackend::Bitcoind(
+                                                bc,
+                                            )) => Some(bc.clone()),
+                                            _ => None,
+                                        };
+                                        new_cfg.bitcoin_backend = Some(
+                                            coincubed::config::BitcoinBackend::Esplora(fb.clone()),
+                                        );
+                                        new_cfg.pending_bitcoind = preserved_bitcoind;
+                                        // Fell back to Connect after a Bitcoind
+                                        // failure — park the node but don't
+                                        // auto-revert to it on the next probe.
+                                        new_cfg.auto_switch_to_pending = false;
+                                        new_cfg.fallback_esplora = None;
+                                        new_cfg
+                                    })
+                                });
+                            if let Some(new_cfg) = fallback {
+                                if !self.daemon_switch_in_progress {
+                                    info!("Switching to COINCUBE | Connect fallback after Bitcoind failure");
+                                    return self.spawn_daemon_switch(new_cfg);
                                 }
-                                Err(e) => error!("Failed to activate Connect fallback: {}", e),
                             }
                         }
                     }
                 }
-            },
+            }
             Message::CompleteDuressEnrollment(payload) => {
                 // Drop a completion that outlived its Connect session: a logout
                 // or session reset bumps `session_generation`, and persisting
@@ -2853,28 +2850,41 @@ impl App {
                 return Task::batch(commands);
             }
             Message::LoadDaemonConfig(cfg) => {
-                // Only load daemon config if we have a vault (daemon and wallet exist)
-                if self.daemon.is_some() && self.wallet.is_some() {
-                    // If pending_bitcoind is being cleared (e.g. manual SwitchToBitcoind),
-                    // clear the associated sync progress fields so the vault overview
-                    // stops showing a stale "syncing" card.
-                    let pending_cleared = self
-                        .daemon
-                        .as_ref()
-                        .and_then(|d| d.config())
-                        .map(|c| c.pending_bitcoind.is_some())
-                        .unwrap_or(false)
-                        && cfg.pending_bitcoind.is_none();
-                    if pending_cleared {
-                        self.cache.node_bitcoind_sync_progress = None;
-                        self.cache.node_bitcoind_ibd = None;
-                        self.cache.node_bitcoind_last_log = None;
-                    }
-                    let res = self.load_daemon_config(self.cache.datadir_path.clone(), *cfg);
-                    return self.update_dispatch(Message::DaemonConfigLoaded(res));
+                // Only switch if we have a vault (daemon and wallet exist). The
+                // stop-old/start-new runs off the UI thread; the pending "syncing"
+                // card is cleared in the `DaemonRestarted` success path.
+                if self.daemon.is_some() && self.wallet.is_some() && !self.daemon_switch_in_progress
+                {
+                    return self.spawn_daemon_switch(*cfg);
+                } else if self.daemon_switch_in_progress {
+                    tracing::warn!("Ignoring backend switch — one is already in progress");
                 } else {
                     tracing::warn!("Attempted to load daemon config without vault");
                 }
+            }
+            Message::DaemonRestarted(outcome) => {
+                self.daemon_switch_in_progress = false;
+                let result = match outcome {
+                    DaemonRestart::Started(daemon) => {
+                        self.daemon = Some(daemon);
+                        Ok(())
+                    }
+                    DaemonRestart::Failed { error, recovered } => {
+                        if let Some(daemon) = recovered {
+                            self.daemon = Some(daemon);
+                        }
+                        error!("Daemon backend switch failed: {}", error);
+                        Err(error)
+                    }
+                };
+                // A successful switch clears the pending local-node sync card.
+                if result.is_ok() {
+                    self.cache.node_bitcoind_sync_progress = None;
+                    self.cache.node_bitcoind_ibd = None;
+                    self.cache.node_bitcoind_last_log = None;
+                }
+                let cfg_task = self.update_dispatch(Message::DaemonConfigLoaded(result));
+                return Task::batch([cfg_task, Task::done(Message::CacheUpdated)]);
             }
             Message::WalletUpdated(Ok(wallet)) => {
                 // Check if we're transitioning from no-vault to has-vault state
@@ -3696,68 +3706,39 @@ impl App {
         Task::none()
     }
 
-    pub fn load_daemon_config(
-        &mut self,
-        datadir_path: CoincubeDirectory,
-        cfg: DaemonConfig,
-    ) -> Result<(), Error> {
-        // Keep a copy of the running config so we can recover if the new
-        // daemon fails to start and the user would otherwise be stuck with
-        // no daemon at all.
-        let recovery_cfg = self.daemon.as_ref().and_then(|d| d.config().cloned());
-
-        if let Some(daemon) = &self.daemon {
-            Handle::current().block_on(async { daemon.stop().await })?;
-        }
+    /// Switch the daemon to `cfg` OFF the UI thread.
+    ///
+    /// Stopping the old daemon blocks until its poller finishes the work in
+    /// flight — which over Esplora can be a slow wallet scan — and starting the
+    /// new one is synchronous, so doing this inline (the previous
+    /// `load_daemon_config`) froze the whole app on every backend switch. The
+    /// blocking work now runs on a `spawn_blocking` task; the new daemon arrives
+    /// via [`Message::DaemonRestarted`], which swaps it in on the UI thread.
+    pub fn spawn_daemon_switch(&mut self, cfg: DaemonConfig) -> Task<Message> {
+        // Mark a switch in flight so subsequent sync probes / triggers don't
+        // re-fire it before it completes (the config only changes on success).
+        self.daemon_switch_in_progress = true;
+        let old_daemon = self.daemon.clone();
         let network = cfg.bitcoin_config.network;
-        let daemon = match EmbeddedDaemon::start(cfg) {
-            Ok(d) => d,
-            Err(start_err) => {
-                // New daemon failed to start.  Try to bring the old one back
-                // so the app is left in a usable state rather than dead.
-                if let Some(old_cfg) = recovery_cfg {
-                    match EmbeddedDaemon::start(old_cfg) {
-                        Ok(old_daemon) => {
-                            self.daemon = Some(Arc::new(old_daemon));
-                            warn!(
-                                "New daemon failed to start; recovered previous daemon. \
-                                 Start error: {}",
-                                start_err
-                            );
-                        }
-                        Err(recovery_err) => {
-                            error!(
-                                "New daemon failed to start and recovery also failed: \
-                                 start={} recovery={}",
-                                start_err, recovery_err
-                            );
-                        }
-                    }
-                }
-                return Err(start_err.into());
-            }
-        };
-        self.daemon = Some(Arc::new(daemon));
-        let mut daemon_config_path = datadir_path
+        let wallet_id = self.wallet.as_ref().expect("wallet should exist").id();
+        let mut daemon_config_path = self
+            .cache
+            .datadir_path
             .network_directory(network)
-            .coincubed_data_directory(&self.wallet.as_ref().expect("wallet should exist").id())
+            .coincubed_data_directory(&wallet_id)
             .path()
             .to_path_buf();
         daemon_config_path.push("daemon.toml");
-
-        let content = toml::to_string(&self.daemon.as_ref().expect("daemon should exist").config())
-            .map_err(|e| Error::Config(e.to_string()))?;
-
-        OpenOptions::new()
-            .write(true)
-            .truncate(true)
-            .open(daemon_config_path)
-            .map_err(|e| Error::Config(e.to_string()))?
-            .write_all(content.as_bytes())
-            .map_err(|e| {
-                warn!("failed to write to file: {:?}", e);
-                Error::Config(e.to_string())
-            })
+        Task::perform(
+            async move {
+                tokio::task::spawn_blocking(move || {
+                    restart_daemon_blocking(old_daemon, cfg, daemon_config_path)
+                })
+                .await
+                .expect("daemon restart task panicked")
+            },
+            Message::DaemonRestarted,
+        )
     }
 
     /// Render content for a settings sub-page that needs both its
@@ -3895,4 +3876,97 @@ fn new_recovery_panel(
         sync_status,
         cache.bitcoin_unit,
     )
+}
+
+/// Outcome of an off-UI-thread daemon restart (see [`restart_daemon_blocking`]).
+#[derive(Debug)]
+pub enum DaemonRestart {
+    /// The new daemon started; swap it in.
+    Started(Arc<dyn Daemon + Sync + Send>),
+    /// The switch failed. `recovered` is a daemon to install so the app stays
+    /// usable — either the previous daemon brought back up, or (on a
+    /// persist-only failure) the freshly started one.
+    Failed {
+        error: Error,
+        recovered: Option<Arc<dyn Daemon + Sync + Send>>,
+    },
+}
+
+/// Stop `old_daemon`, start a new one for `cfg`, then persist `daemon.toml`.
+///
+/// This is the blocking half of a backend switch, factored out of the App so it
+/// can run on a `spawn_blocking` task rather than the UI thread (see
+/// [`App::spawn_daemon_switch`]). `daemon.stop()` can block until a poller
+/// finishes a slow scan, and `EmbeddedDaemon::start` is synchronous, so running
+/// this inline froze the app. On a start failure the previous daemon is brought
+/// back so the app is never left without one.
+fn restart_daemon_blocking(
+    old_daemon: Option<Arc<dyn Daemon + Sync + Send>>,
+    cfg: DaemonConfig,
+    daemon_config_path: std::path::PathBuf,
+) -> DaemonRestart {
+    let recovery_cfg = old_daemon.as_ref().and_then(|d| d.config().cloned());
+
+    if let Some(daemon) = &old_daemon {
+        if let Err(e) = Handle::current().block_on(async { daemon.stop().await }) {
+            // Couldn't stop the old daemon — keep it rather than leave none.
+            return DaemonRestart::Failed {
+                error: e.into(),
+                recovered: old_daemon.clone(),
+            };
+        }
+    }
+
+    let daemon: Arc<dyn Daemon + Sync + Send> = match EmbeddedDaemon::start(cfg) {
+        Ok(d) => Arc::new(d),
+        Err(start_err) => {
+            // New daemon failed to start. Bring the old one back so the app is
+            // left usable rather than dead.
+            let recovered = recovery_cfg.and_then(|old_cfg| match EmbeddedDaemon::start(old_cfg) {
+                Ok(old_daemon) => {
+                    warn!(
+                        "New daemon failed to start; recovered previous daemon. Start error: {}",
+                        start_err
+                    );
+                    Some(Arc::new(old_daemon) as Arc<dyn Daemon + Sync + Send>)
+                }
+                Err(recovery_err) => {
+                    error!(
+                        "New daemon failed to start and recovery also failed: start={} recovery={}",
+                        start_err, recovery_err
+                    );
+                    None
+                }
+            });
+            return DaemonRestart::Failed {
+                error: start_err.into(),
+                recovered,
+            };
+        }
+    };
+
+    // Persist the new backend. A write failure doesn't invalidate the running
+    // daemon, so keep it and surface the error.
+    let persisted = (|| -> Result<(), Error> {
+        let content =
+            toml::to_string(&daemon.config()).map_err(|e| Error::Config(e.to_string()))?;
+        OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&daemon_config_path)
+            .map_err(|e| Error::Config(e.to_string()))?
+            .write_all(content.as_bytes())
+            .map_err(|e| Error::Config(e.to_string()))
+    })();
+
+    match persisted {
+        Ok(()) => DaemonRestart::Started(daemon),
+        Err(e) => {
+            warn!("failed to persist daemon.toml after switch: {:?}", e);
+            DaemonRestart::Failed {
+                error: e,
+                recovered: Some(daemon),
+            }
+        }
+    }
 }

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -685,6 +685,13 @@ pub struct App {
     /// every tick — spawning concurrent daemon starts that race to load the same
     /// watchonly wallet and corrupt it. Cleared by `Message::DaemonRestarted`.
     daemon_switch_in_progress: bool,
+    /// Set when an auto-promotion to the pending local node fails and the
+    /// previous daemon is recovered. The recovered daemon still carries
+    /// `auto_switch_to_pending = true` + `pending_bitcoind`, so without this the
+    /// periodic sync probe would re-fire the same failing switch every poll,
+    /// churning the daemon. Suppresses auto-switch until the next *successful*
+    /// switch (a fresh adopt / manual switch re-arms it by clearing this).
+    auto_switch_suppressed: bool,
     /// Global "payment received" celebration overlay — shown for incoming
     /// Liquid payments (e.g. LNURL) regardless of which panel is active.
     show_received_celebration: bool,
@@ -1248,6 +1255,7 @@ impl App {
                 current_error_id: 256,
                 bitcoind_sync_probe_in_progress: false,
                 daemon_switch_in_progress: false,
+                auto_switch_suppressed: false,
                 show_received_celebration: false,
                 received_celebration_amount: String::new(),
                 received_celebration_context: "transaction-received".to_string(),
@@ -1350,6 +1358,7 @@ impl App {
                 current_error_id: 256,
                 bitcoind_sync_probe_in_progress: false,
                 daemon_switch_in_progress: false,
+                auto_switch_suppressed: false,
                 show_received_celebration: false,
                 received_celebration_amount: String::new(),
                 received_celebration_context: "transaction-received".to_string(),
@@ -2536,7 +2545,7 @@ impl App {
                         // clear the flag). Skip while a switch is already in
                         // flight, so we don't spawn overlapping switches every
                         // tick (which raced to load — and corrupted — the wallet).
-                        if !ibd && !self.daemon_switch_in_progress {
+                        if !ibd && !self.daemon_switch_in_progress && !self.auto_switch_suppressed {
                             let switch =
                                 self.daemon.as_ref().and_then(|d| d.config()).and_then(|c| {
                                     if !c.auto_switch_to_pending {
@@ -2865,6 +2874,19 @@ impl App {
                     return self.spawn_daemon_switch(*cfg);
                 } else if self.daemon_switch_in_progress {
                     tracing::warn!("Ignoring backend switch — one is already in progress");
+                    // Every LoadDaemonConfig originates in the node-settings panel,
+                    // which has already flipped its local `processing` flags and is
+                    // awaiting a DaemonConfigLoaded reply. Dropping the request
+                    // silently would leave those flags to be cleared by an
+                    // *unrelated* switch's later success — masquerading as this
+                    // one and losing its config. Route an explicit error back so
+                    // the panel resets and the user can retry once the in-flight
+                    // switch finishes.
+                    return self.update_dispatch(Message::DaemonConfigLoaded(Err(Error::Config(
+                        "A Bitcoin backend switch is already in progress. \
+                         Please wait for it to finish, then try again."
+                            .to_string(),
+                    ))));
                 } else {
                     tracing::warn!("Attempted to load daemon config without vault");
                 }
@@ -2877,6 +2899,9 @@ impl App {
                 let result = match outcome {
                     DaemonRestart::Started(daemon) => {
                         self.daemon = Some(daemon);
+                        // A fresh successful switch (adopt / manual) re-arms
+                        // auto-promotion that a prior failure had suppressed.
+                        self.auto_switch_suppressed = false;
                         Ok(())
                     }
                     DaemonRestart::StartedNotPersisted(daemon) => {
@@ -2884,6 +2909,7 @@ impl App {
                         // only problem is the config wasn't saved. Report success
                         // but warn that it may not survive a restart.
                         self.daemon = Some(daemon);
+                        self.auto_switch_suppressed = false;
                         extra = Task::done(Message::View(view::Message::ShowToast(
                             log::Level::Warn,
                             "Switched Bitcoin backend, but couldn't save the change to disk — \
@@ -2895,6 +2921,12 @@ impl App {
                     DaemonRestart::Failed { error, recovered } => {
                         if let Some(daemon) = recovered {
                             self.daemon = Some(daemon);
+                            // The recovered daemon still carries the armed
+                            // `auto_switch_to_pending` + `pending_bitcoind`, so
+                            // suppress auto-promotion to stop the same failing
+                            // switch re-firing every poll. A later user-initiated
+                            // switch re-arms it (see the Started arms).
+                            self.auto_switch_suppressed = true;
                         } else {
                             // The old daemon was already stopped during the switch
                             // and recovery couldn't bring one back. Drop it rather

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -2548,7 +2548,11 @@ impl App {
                         if !ibd && !self.daemon_switch_in_progress && !self.auto_switch_suppressed {
                             let switch =
                                 self.daemon.as_ref().and_then(|d| d.config()).and_then(|c| {
-                                    if !c.auto_switch_to_pending {
+                                    // Promote unless the node was explicitly parked
+                                    // (`Some(false)`). An absent flag (`None`) is a
+                                    // legacy adopted node — the old build promoted it
+                                    // on sync with no flag — so it must promote too.
+                                    if c.auto_switch_to_pending == Some(false) {
                                         return None;
                                     }
                                     let pending = c.pending_bitcoind.clone()?;
@@ -2563,7 +2567,7 @@ impl App {
                                     new_cfg.bitcoin_backend =
                                         Some(coincubed::config::BitcoinBackend::Bitcoind(pending));
                                     new_cfg.pending_bitcoind = None;
-                                    new_cfg.auto_switch_to_pending = false;
+                                    new_cfg.auto_switch_to_pending = Some(false);
                                     new_cfg.fallback_esplora = old_esplora;
                                     Some(new_cfg)
                                 });
@@ -2738,7 +2742,7 @@ impl App {
                                         // Fell back to Connect after a Bitcoind
                                         // failure — park the node but don't
                                         // auto-revert to it on the next probe.
-                                        new_cfg.auto_switch_to_pending = false;
+                                        new_cfg.auto_switch_to_pending = Some(false);
                                         new_cfg.fallback_esplora = None;
                                         new_cfg
                                     })
@@ -2935,6 +2939,17 @@ impl App {
                             self.daemon = None;
                         }
                         error!("Daemon backend switch failed: {}", error);
+                        Err(error)
+                    }
+                    DaemonRestart::Panicked(error) => {
+                        // Unknown post-panic state. self.daemon still holds the
+                        // pre-switch daemon (cloned, not taken), so leave it in
+                        // place — a possibly-stopped backend the user can re-switch
+                        // beats no backend on an open vault. Suppress auto-promotion
+                        // so a still-armed config can't re-trigger the same panic
+                        // every poll; a manual switch re-arms it.
+                        self.auto_switch_suppressed = true;
+                        error!("Daemon backend switch panicked; keeping previous daemon: {error}");
                         Err(error)
                     }
                 };
@@ -3801,16 +3816,15 @@ impl App {
                     // The blocking switch panicked. Still deliver a DaemonRestarted
                     // message so its handler clears `daemon_switch_in_progress` —
                     // otherwise the guard sticks `true` and blocks every later
-                    // LoadDaemonConfig / auto-switch indefinitely. `old_daemon` was
-                    // moved into the (now-dead) task, so there's nothing to recover.
+                    // LoadDaemonConfig / auto-switch indefinitely. Report it as
+                    // `Panicked` (not `Failed`) so the handler KEEPS the App's
+                    // existing daemon (still held, since `old_daemon` was cloned)
+                    // rather than nulling it and leaving the vault backend-less.
                     Err(join_err) => {
                         error!("daemon restart task panicked: {join_err}");
-                        DaemonRestart::Failed {
-                            error: Error::Config(format!(
-                                "daemon restart task panicked: {join_err}"
-                            )),
-                            recovered: None,
-                        }
+                        DaemonRestart::Panicked(Error::Config(format!(
+                            "daemon restart task panicked: {join_err}"
+                        )))
                     }
                 }
             },
@@ -3971,6 +3985,12 @@ pub enum DaemonRestart {
         error: Error,
         recovered: Option<Arc<dyn Daemon + Sync + Send>>,
     },
+    /// The blocking restart task itself panicked, so its outcome (and whether the
+    /// old daemon was stopped) is unknown. Distinct from `Failed` because the App
+    /// still holds the pre-switch daemon (`spawn_daemon_switch` clones it rather
+    /// than taking it): the handler keeps that reference so an open vault isn't
+    /// left with no backend, instead of nulling it like the clean-failure path.
+    Panicked(Error),
 }
 
 /// Stop `old_daemon`, start a new one for `cfg`, then persist `daemon.toml`.

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -11,11 +11,10 @@ use crate::{
     services::coincube::{
         BillingCycle, BillingHistoryEntry, ChargeStatus, CheckoutRequest, CheckoutResponse,
         CoincubeClient, ConnectPlan, Contact, ContactCube, ContactRole,
-        CreateDuressAlertContactRequest, CreateInviteRequest, DuressAlertContact, DuressCheckOutcome,
-        FeaturesResponse,
-        Invite, LoginActivity, LoginResponse, OtpRequest, OtpVerifyRequest, PlanStatus, PlanTier,
-        ReceivedInvite, UpdateDuressAlertContactRequest, User, VerifiedDevice,
-        DURESS_CHANNEL_EMAIL, DURESS_CHANNEL_SMS, DURESS_CHANNEL_WHATSAPP,
+        CreateDuressAlertContactRequest, CreateInviteRequest, DuressAlertContact,
+        DuressCheckOutcome, FeaturesResponse, Invite, LoginActivity, LoginResponse, OtpRequest,
+        OtpVerifyRequest, PlanStatus, PlanTier, ReceivedInvite, UpdateDuressAlertContactRequest,
+        User, VerifiedDevice, DURESS_CHANNEL_EMAIL, DURESS_CHANNEL_SMS, DURESS_CHANNEL_WHATSAPP,
         MAX_DURESS_ALERT_CONTACTS,
     },
 };
@@ -1674,7 +1673,8 @@ impl ConnectAccountPanel {
                         log::warn!(
                             "[CONNECT] duress gate: session rejected (401); returning to login"
                         );
-                        self.error = Some("Your session expired. Please sign in again.".to_string());
+                        self.error =
+                            Some("Your session expired. Please sign in again.".to_string());
                         self.scrub_recovery_passphrase();
                         self.step = ConnectFlowStep::Login {
                             email: String::new(),

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1650,6 +1650,7 @@ impl ConnectAccountPanel {
                         log::warn!(
                             "[CONNECT] duress gate: session rejected (401); returning to login"
                         );
+                        let was_logged_in = self.user.is_some();
                         // The session is dead — tear it all down (bumps
                         // session_generation so stale async results are ignored,
                         // drops the JWT client, keyring session, and cached
@@ -1661,6 +1662,14 @@ impl ConnectAccountPanel {
                             email: String::new(),
                             loading: false,
                         };
+                        // Mirror the normal LogOut path: Buy/Sell shares this
+                        // session, so it must drop its stale in-memory token too
+                        // rather than keep showing a logged-in state.
+                        if was_logged_in {
+                            return iced::Task::done(Message::View(view::Message::BuySell(
+                                view::BuySellMessage::LogOut,
+                            )));
+                        }
                     }
                 }
             }

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -11,7 +11,8 @@ use crate::{
     services::coincube::{
         BillingCycle, BillingHistoryEntry, ChargeStatus, CheckoutRequest, CheckoutResponse,
         CoincubeClient, ConnectPlan, Contact, ContactCube, ContactRole,
-        CreateDuressAlertContactRequest, CreateInviteRequest, DuressAlertContact, FeaturesResponse,
+        CreateDuressAlertContactRequest, CreateInviteRequest, DuressAlertContact, DuressCheckOutcome,
+        FeaturesResponse,
         Invite, LoginActivity, LoginResponse, OtpRequest, OtpVerifyRequest, PlanStatus, PlanTier,
         ReceivedInvite, UpdateDuressAlertContactRequest, User, VerifiedDevice,
         DURESS_CHANNEL_EMAIL, DURESS_CHANNEL_SMS, DURESS_CHANNEL_WHATSAPP,
@@ -269,6 +270,21 @@ impl Default for ContactsState {
     }
 }
 
+/// Terminal/in-flight state of the post-login duress gate ([`ConnectFlowStep::CheckingDuress`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DuressGateStatus {
+    /// `get_duress_state` is in flight (or retrying).
+    Checking,
+    /// Transient failure after exhausting retries (network / 5xx / rate-limit).
+    /// The view offers Retry.
+    Unreachable,
+    /// The server returned a body this build can't decode. Auto-retry is
+    /// suppressed (futile in the common case), but the view still offers a
+    /// manual Retry — the mismatch may be a server bug that gets hotfixed while
+    /// the app is open — plus an update hint and a Sign Out escape hatch.
+    Incompatible,
+}
+
 #[derive(Debug)]
 pub enum ConnectFlowStep {
     CheckingSession,
@@ -288,13 +304,15 @@ pub enum ConnectFlowStep {
         cooldown: u8,
     },
     /// Post-auth, pre-dashboard gate (Phase 6): block on `get_duress_state` so
-    /// the dashboard is never shown to a possibly-in-duress account. `failed`
-    /// is set once retries are exhausted, switching the view to an error +
-    /// Retry affordance. We fail CLOSED here (no dashboard) rather than open —
-    /// the whole Connect dashboard is server-backed, so if this check is
-    /// unreachable the dashboard is non-functional anyway.
+    /// the dashboard is never shown to a possibly-in-duress account. `status`
+    /// distinguishes in-flight from the two terminal failure modes so the view
+    /// can show the right copy and the handler can stop retrying a futile
+    /// (contract-mismatch) check. We fail CLOSED here (no dashboard) on every
+    /// failure — the whole Connect dashboard is server-backed, so if this check
+    /// is unreachable the dashboard is non-functional anyway, and a body we
+    /// can't decode must never be read as "not in duress".
     CheckingDuress {
-        failed: bool,
+        status: DuressGateStatus,
     },
     Dashboard,
     /// Post-lockout recovery (Phase 6). Shown as the FIRST thing after sign-in
@@ -805,7 +823,9 @@ impl ConnectAccountPanel {
                 self.plan = plan;
                 // Phase 6: gate on the duress check FIRST — don't reveal the
                 // dashboard until we've confirmed the account isn't in duress.
-                self.step = ConnectFlowStep::CheckingDuress { failed: false };
+                self.step = ConnectFlowStep::CheckingDuress {
+                    status: DuressGateStatus::Checking,
+                };
                 self.error = None;
                 // Fetch features + gate on duress in background (non-blocking).
                 let gen = self.session_generation;
@@ -1573,15 +1593,15 @@ impl ConnectAccountPanel {
                     },
                 );
             }
-            ConnectAccountMessage::DuressStateChecked(state, gen, attempt) => {
+            ConnectAccountMessage::DuressStateChecked(outcome, gen, attempt) => {
                 // Phase 6: post-sign-in gate. We sit in `CheckingDuress` until
                 // this resolves, so the dashboard is never shown to a possibly-
                 // in-duress account.
                 if gen != self.session_generation {
                     return iced::Task::none();
                 }
-                match state {
-                    Some(s) if s.active => {
+                match outcome {
+                    DuressCheckOutcome::Ok(s) if s.active => {
                         // This signed-in device is the trusted recovery vehicle:
                         // show the all-clear entry. Do NOT persist
                         // DuressLocalState.active here — the launch reconcile
@@ -1598,7 +1618,7 @@ impl ConnectAccountPanel {
                         };
                     }
                     // Confirmed not in duress — NOW reveal the dashboard.
-                    Some(s) => {
+                    DuressCheckOutcome::Ok(s) => {
                         self.step = ConnectFlowStep::Dashboard;
                         // Phase 0: a signed-in device on an already-enrolled
                         // account that isn't yet registered server-side mints +
@@ -1615,27 +1635,59 @@ impl ConnectAccountPanel {
                             }
                         }
                     }
-                    // Failed / unreachable check — retry with backoff.
-                    None if attempt + 1 < DURESS_CHECK_MAX_ATTEMPTS => {
+                    // Transient (network / 5xx / rate-limit) — retry with
+                    // backoff while attempts remain.
+                    DuressCheckOutcome::Unreachable if attempt + 1 < DURESS_CHECK_MAX_ATTEMPTS => {
                         return duress_state_check_task(self.client.clone(), gen, attempt + 1);
                     }
                     // Retries exhausted. Fail CLOSED: do not reveal the
                     // dashboard. Show an error + Retry on the checking screen.
                     // (The dashboard is server-backed anyway, so it would be
                     // non-functional during this outage.)
-                    None => {
+                    DuressCheckOutcome::Unreachable => {
                         log::warn!(
-                            "[CONNECT] duress state check failed after {} attempts; \
+                            "[CONNECT] duress state check unreachable after {} attempts; \
                              holding at the verification gate",
                             attempt + 1
                         );
-                        self.step = ConnectFlowStep::CheckingDuress { failed: true };
+                        self.step = ConnectFlowStep::CheckingDuress {
+                            status: DuressGateStatus::Unreachable,
+                        };
+                    }
+                    // The server returned a body we can't decode. Auto-retrying
+                    // is futile (it'll mismatch every time), so DON'T loop —
+                    // hold closed with distinct copy + an update hint. The body
+                    // was already logged in `get_duress_state`. A manual Retry
+                    // is still offered in case it's a server bug being hotfixed.
+                    DuressCheckOutcome::Incompatible => {
+                        log::error!(
+                            "[CONNECT] duress state response is undecodable (contract \
+                             mismatch); holding the gate closed — app may need updating"
+                        );
+                        self.step = ConnectFlowStep::CheckingDuress {
+                            status: DuressGateStatus::Incompatible,
+                        };
+                    }
+                    // The session was rejected mid-gate. Sitting on the duress
+                    // gate would loop forever; drop to login instead.
+                    DuressCheckOutcome::Unauthorized => {
+                        log::warn!(
+                            "[CONNECT] duress gate: session rejected (401); returning to login"
+                        );
+                        self.error = Some("Your session expired. Please sign in again.".to_string());
+                        self.scrub_recovery_passphrase();
+                        self.step = ConnectFlowStep::Login {
+                            email: String::new(),
+                            loading: false,
+                        };
                     }
                 }
             }
             ConnectAccountMessage::RetryDuressCheck => {
-                // From the CheckingDuress error screen.
-                self.step = ConnectFlowStep::CheckingDuress { failed: false };
+                // From the CheckingDuress error screen (either failure mode).
+                self.step = ConnectFlowStep::CheckingDuress {
+                    status: DuressGateStatus::Checking,
+                };
                 let gen = self.session_generation;
                 return duress_state_check_task(self.client.clone(), gen, 0);
             }
@@ -3187,19 +3239,31 @@ const DURESS_CHECK_MAX_ATTEMPTS: u8 = 3;
 const DURESS_CHECK_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// Issues a post-sign-in `get_duress_state` check (Phase 6). `attempt > 0`
-/// sleeps first so a transient failure backs off before retrying. A failed
-/// request collapses to `None`, which the handler turns into a bounded retry.
+/// sleeps first so a transient failure backs off before retrying. The result is
+/// classified into a [`DuressCheckOutcome`] (rather than collapsed to `None`) so
+/// the handler can retry only what's retryable and surface the right copy.
 fn duress_state_check_task(client: CoincubeClient, gen: u64, attempt: u8) -> iced::Task<Message> {
     iced::Task::perform(
         async move {
             if attempt > 0 {
                 tokio::time::sleep(DURESS_CHECK_RETRY_DELAY).await;
             }
-            (client.get_duress_state().await.ok(), gen, attempt)
+            let outcome = match client.get_duress_state().await {
+                Ok(state) => DuressCheckOutcome::Ok(state),
+                Err(e) => {
+                    let outcome = DuressCheckOutcome::from_err(&e);
+                    log::warn!(
+                        "[CONNECT] duress state check failed (attempt {}): {e} → {outcome:?}",
+                        attempt + 1
+                    );
+                    outcome
+                }
+            };
+            (outcome, gen, attempt)
         },
-        |(state, g, a)| {
+        |(outcome, g, a)| {
             Message::View(view::Message::ConnectAccount(
-                ConnectAccountMessage::DuressStateChecked(state, g, a),
+                ConnectAccountMessage::DuressStateChecked(outcome, g, a),
             ))
         },
     )

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -2112,7 +2112,7 @@ impl ConnectAccountPanel {
                 let entitled = self
                     .plan
                     .as_ref()
-                    .map(|p| p.entitlements.duress_remote_lock)
+                    .map(|p| p.entitlements.duress)
                     .unwrap_or(false);
                 // Entitled (signed-in) users default to Tier 1, which collects
                 // the account-level duress recovery-kit password — that password
@@ -4200,16 +4200,7 @@ mod plan_lifecycle_tests {
             plan: tier,
             status,
             renewal_at: renewal_at.map(|s| s.to_string()),
-            entitlements: PlanEntitlements {
-                free_signing_key_count: 0,
-                policy_editing: false,
-                legacy_invites: false,
-                linked_keychains: false,
-                duress_remote_lock: false,
-                business_orgs: false,
-                duress_alerts: false,
-                recovery_alerts: false,
-            },
+            entitlements: PlanEntitlements::default(),
             billing_cycle: cycle,
             plan_provenance: None,
         }
@@ -4755,14 +4746,9 @@ mod duress_contacts_tests {
 
     fn entitlements(duress_alerts: bool) -> PlanEntitlements {
         PlanEntitlements {
-            free_signing_key_count: 0,
-            policy_editing: false,
-            legacy_invites: false,
-            linked_keychains: false,
-            duress_remote_lock: true,
-            business_orgs: false,
+            duress: true,
             duress_alerts,
-            recovery_alerts: false,
+            ..PlanEntitlements::default()
         }
     }
 

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -886,30 +886,7 @@ impl ConnectAccountPanel {
 
             ConnectAccountMessage::LogOut => {
                 let was_logged_in = self.user.is_some();
-                self.session_generation += 1;
-                self.user = None;
-                self.plan = None;
-                self.verified_devices = None;
-                self.login_activity = None;
-                self.features = None;
-                self.checkout = None;
-                self.billing_history = None;
-                self.show_billing_history = false;
-                self.renewal_banner_dismissed = false;
-                self.campaign_redeem = CampaignRedeemState::default();
-                self.register_campaign_code = String::new();
-                self.pending_campaign_code = None;
-                self.selected_billing_cycle = BillingCycle::Monthly;
-                self.contacts_state.clear();
-                self.duress_contacts.clear();
-                // Scrub any in-flight enrollment wizard secrets (PINs,
-                // passphrases, generated code) and the recovery all-clear
-                // passphrase before dropping them, so they don't survive the
-                // session reset.
-                self.clear_duress_enroll();
-                self.scrub_recovery_passphrase();
-                self.clear_keyring_session();
-                self.client = CoincubeClient::new();
+                self.clear_session();
                 self.step = ConnectFlowStep::Login {
                     email: String::new(),
                     loading: false,
@@ -1673,9 +1650,13 @@ impl ConnectAccountPanel {
                         log::warn!(
                             "[CONNECT] duress gate: session rejected (401); returning to login"
                         );
+                        // The session is dead — tear it all down (bumps
+                        // session_generation so stale async results are ignored,
+                        // drops the JWT client, keyring session, and cached
+                        // user/plan) so the next Init doesn't restore it.
+                        self.clear_session();
                         self.error =
                             Some("Your session expired. Please sign in again.".to_string());
-                        self.scrub_recovery_passphrase();
                         self.step = ConnectFlowStep::Login {
                             email: String::new(),
                             loading: false,
@@ -1723,6 +1704,39 @@ impl ConnectAccountPanel {
             error: None,
             pending_code: None,
         });
+    }
+
+    /// Tears down all session state: bumps `session_generation` (so any
+    /// in-flight async results keyed to the old generation are ignored),
+    /// clears cached user/plan/feature data, scrubs secrets, drops the keyring
+    /// session, and replaces the JWT-bearing client with a fresh anonymous one.
+    /// Does NOT set `self.step` — the caller picks the destination (Login, an
+    /// error screen, etc.). Shared by `LogOut` and the duress-gate 401 path so
+    /// a rejected session can't leave stale state behind for the next `Init`.
+    fn clear_session(&mut self) {
+        self.session_generation += 1;
+        self.user = None;
+        self.plan = None;
+        self.verified_devices = None;
+        self.login_activity = None;
+        self.features = None;
+        self.checkout = None;
+        self.billing_history = None;
+        self.show_billing_history = false;
+        self.renewal_banner_dismissed = false;
+        self.campaign_redeem = CampaignRedeemState::default();
+        self.register_campaign_code = String::new();
+        self.pending_campaign_code = None;
+        self.selected_billing_cycle = BillingCycle::Monthly;
+        self.contacts_state.clear();
+        self.duress_contacts.clear();
+        // Scrub any in-flight enrollment wizard secrets (PINs, passphrases,
+        // generated code) and the recovery all-clear passphrase before
+        // dropping them, so they don't survive the session reset.
+        self.clear_duress_enroll();
+        self.scrub_recovery_passphrase();
+        self.clear_keyring_session();
+        self.client = CoincubeClient::new();
     }
 
     /// Zeroizes the in-memory all-clear passphrase when the panel is in the

--- a/coincube-gui/src/app/state/connect/mod.rs
+++ b/coincube-gui/src/app/state/connect/mod.rs
@@ -84,7 +84,7 @@ pub(crate) fn delete_connect_secret(user_key: &str) {
 pub use account::{
     AddToCubeDialog, CheckoutPhase, CheckoutState, ConnectAccountPanel, ConnectFlowStep,
     ContactsState, ContactsStep, DuressContactsState, DuressContactsStep, DuressEnrollState,
-    DuressEnrollStep, EnrollTier, InviteCubeOption, PlanLifecycle,
+    DuressEnrollStep, DuressGateStatus, EnrollTier, InviteCubeOption, PlanLifecycle,
 };
 pub use cube::ConnectCubePanel;
 pub use cube_members::ConnectCubeMembersState;

--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -187,7 +187,7 @@ impl BitcoindSettingsState {
         }
         // The user deliberately switched to Connect — park the node, but don't
         // auto-revert to it on the next sync probe.
-        new_cfg.auto_switch_to_pending = false;
+        new_cfg.auto_switch_to_pending = Some(false);
         new_cfg.bitcoin_backend = Some(BitcoinBackend::Esplora(esplora));
         // Bump the poll cadence to the Esplora-safe interval so
         // we don't carry a snappy localhost cadence into a path
@@ -292,7 +292,7 @@ impl State for BitcoindSettingsState {
                             // Keep the invariant: no pending node ⇒ nothing to
                             // auto-switch to. Leaving the flag set would strand a
                             // stale "auto-switch enabled" state with no target.
-                            rollback_cfg.auto_switch_to_pending = false;
+                            rollback_cfg.auto_switch_to_pending = Some(false);
                             return Task::done(Message::LoadDaemonConfig(Box::new(rollback_cfg)));
                         }
                     }
@@ -498,7 +498,7 @@ impl State for BitcoindSettingsState {
                                         new_cfg.pending_bitcoind = Some(bitcoind_cfg);
                                         // Adopted a freshly set-up node — switch to
                                         // it once synced.
-                                        new_cfg.auto_switch_to_pending = true;
+                                        new_cfg.auto_switch_to_pending = Some(true);
                                         setup.internal_stage = InternalSetupStage::Done;
                                         setup.processing = true;
                                         return Task::batch([
@@ -591,7 +591,7 @@ impl State for BitcoindSettingsState {
                                         Some(BitcoindConfig { rpc_auth, addr });
                                     // Adopted an existing/external node — switch to
                                     // it once it's reachable and synced.
-                                    new_cfg.auto_switch_to_pending = true;
+                                    new_cfg.auto_switch_to_pending = Some(true);
                                     setup.processing = true;
                                     return Task::done(Message::LoadDaemonConfig(Box::new(
                                         new_cfg,
@@ -632,7 +632,7 @@ impl State for BitcoindSettingsState {
                                 // The pending node is now the active backend, so
                                 // clear the auto-switch flag too — keeping it set
                                 // with no pending target violates the invariant.
-                                new_cfg.auto_switch_to_pending = false;
+                                new_cfg.auto_switch_to_pending = Some(false);
                                 new_cfg.fallback_esplora = old_esplora;
                                 // Drop the poll cadence back to the
                                 // snappy local-node interval. The

--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -289,6 +289,10 @@ impl State for BitcoindSettingsState {
                         if let Some(cfg) = daemon.config() {
                             let mut rollback_cfg = cfg.clone();
                             rollback_cfg.pending_bitcoind = None;
+                            // Keep the invariant: no pending node ⇒ nothing to
+                            // auto-switch to. Leaving the flag set would strand a
+                            // stale "auto-switch enabled" state with no target.
+                            rollback_cfg.auto_switch_to_pending = false;
                             return Task::done(Message::LoadDaemonConfig(Box::new(rollback_cfg)));
                         }
                     }
@@ -625,6 +629,10 @@ impl State for BitcoindSettingsState {
                                 let mut new_cfg = cfg.clone();
                                 new_cfg.bitcoin_backend = Some(BitcoinBackend::Bitcoind(pending));
                                 new_cfg.pending_bitcoind = None;
+                                // The pending node is now the active backend, so
+                                // clear the auto-switch flag too — keeping it set
+                                // with no pending target violates the invariant.
+                                new_cfg.auto_switch_to_pending = false;
                                 new_cfg.fallback_esplora = old_esplora;
                                 // Drop the poll cadence back to the
                                 // snappy local-node interval. The

--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -185,6 +185,9 @@ impl BitcoindSettingsState {
         if let Some(BitcoinBackend::Bitcoind(current)) = cfg.bitcoin_backend.clone() {
             new_cfg.pending_bitcoind = Some(current);
         }
+        // The user deliberately switched to Connect — park the node, but don't
+        // auto-revert to it on the next sync probe.
+        new_cfg.auto_switch_to_pending = false;
         new_cfg.bitcoin_backend = Some(BitcoinBackend::Esplora(esplora));
         // Bump the poll cadence to the Esplora-safe interval so
         // we don't carry a snappy localhost cadence into a path
@@ -396,7 +399,18 @@ impl State for BitcoindSettingsState {
                             },
                             selected_auth_type: RpcAuthType::CookieFile,
                             processing: false,
-                            flavor: NodeFlavor::default(),
+                            // The managed node is shared by every Vault, so its
+                            // flavour is global: default the picker to whatever is
+                            // already configured, else Knots (matching the
+                            // installer). Switching it restarts the node for all
+                            // Vaults (handled by `maybe_start`).
+                            flavor: InternalBitcoindConfig::from_file(
+                                &internal_bitcoind_config_path(&internal_bitcoind_datadir(
+                                    &cache.datadir_path,
+                                )),
+                            )
+                            .map(|c| c.flavor)
+                            .unwrap_or(NodeFlavor::Knots),
                             internal_stage: InternalSetupStage::Idle,
                             internal_error: None,
                             download_progress: 0.0,
@@ -478,6 +492,9 @@ impl State for BitcoindSettingsState {
                                     if let Some(cfg) = daemon.config() {
                                         let mut new_cfg = cfg.clone();
                                         new_cfg.pending_bitcoind = Some(bitcoind_cfg);
+                                        // Adopted a freshly set-up node — switch to
+                                        // it once synced.
+                                        new_cfg.auto_switch_to_pending = true;
                                         setup.internal_stage = InternalSetupStage::Done;
                                         setup.processing = true;
                                         return Task::batch([
@@ -568,6 +585,9 @@ impl State for BitcoindSettingsState {
                                     let mut new_cfg = cfg.clone();
                                     new_cfg.pending_bitcoind =
                                         Some(BitcoindConfig { rpc_auth, addr });
+                                    // Adopted an existing/external node — switch to
+                                    // it once it's reachable and synced.
+                                    new_cfg.auto_switch_to_pending = true;
                                     setup.processing = true;
                                     return Task::done(Message::LoadDaemonConfig(Box::new(
                                         new_cfg,

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -1557,7 +1557,7 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
     let entitled = state
         .plan
         .as_ref()
-        .map(|p| p.entitlements.duress_remote_lock)
+        .map(|p| p.entitlements.duress)
         .unwrap_or(false);
 
     let mut col = Column::new()
@@ -2231,16 +2231,7 @@ mod renewal_banner_tests {
             plan: tier,
             status,
             renewal_at: renewal_at.map(|s| s.to_string()),
-            entitlements: PlanEntitlements {
-                free_signing_key_count: 0,
-                policy_editing: false,
-                legacy_invites: false,
-                linked_keychains: false,
-                duress_remote_lock: false,
-                business_orgs: false,
-                duress_alerts: false,
-                recovery_alerts: false,
-            },
+            entitlements: PlanEntitlements::default(),
             billing_cycle: Some(BillingCycle::Monthly),
             plan_provenance: None,
         }

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -1507,8 +1507,7 @@ fn checking_duress_ux<'a>(status: DuressGateStatus) -> Element<'a, ConnectAccoun
         DuressGateStatus::Incompatible => {
             col = col
                 .push(
-                    text::p1_regular("We couldn't read your account status.")
-                        .color(color::GREY_3),
+                    text::p1_regular("We couldn't read your account status.").color(color::GREY_3),
                 )
                 .push(
                     text::caption("Make sure COINCUBE is up to date, then try again.")

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -23,7 +23,7 @@ use crate::{
         settings::global::AccountTier,
         state::connect::{
             AvatarFlowStep, CheckoutPhase, ConnectAccountPanel, ConnectCubePanel, ConnectFlowStep,
-            ConnectPanel, DuressContactsStep, PlanLifecycle,
+            ConnectPanel, DuressContactsStep, DuressGateStatus, PlanLifecycle,
         },
         view::{AvatarMessage, ConnectAccountMessage, ConnectCubeMessage, DuressMessage},
     },
@@ -66,8 +66,8 @@ pub fn connect_panel<'a>(state: &'a ConnectPanel) -> Element<'a, ViewMessage> {
             ..
         } => otp_ux(email, otp, *sending, *cooldown).map(ViewMessage::ConnectAccount),
 
-        ConnectFlowStep::CheckingDuress { failed } => {
-            checking_duress_ux(*failed).map(ViewMessage::ConnectAccount)
+        ConnectFlowStep::CheckingDuress { status } => {
+            checking_duress_ux(*status).map(ViewMessage::ConnectAccount)
         }
 
         ConnectFlowStep::DuressRecovery {
@@ -148,7 +148,7 @@ pub fn connect_account_panel<'a>(
             cooldown,
             ..
         } => otp_ux(email, otp, *sending, *cooldown),
-        ConnectFlowStep::CheckingDuress { failed } => checking_duress_ux(*failed),
+        ConnectFlowStep::CheckingDuress { status } => checking_duress_ux(*status),
         ConnectFlowStep::DuressRecovery {
             unlock_at,
             passphrase,
@@ -1479,20 +1479,52 @@ fn security_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccount
 
 /// Post-login duress verification gate (Phase 6). Shown after auth while
 /// `get_duress_state` is in flight, so the dashboard isn't revealed to a
-/// possibly-in-duress account. On terminal failure (`failed`) it offers a Retry
-/// rather than falling through to the dashboard.
-fn checking_duress_ux<'a>(failed: bool) -> Element<'a, ConnectAccountMessage> {
+/// possibly-in-duress account. Both terminal failure modes fail CLOSED (no
+/// dashboard) but show distinct copy: `Unreachable` reads as a transient
+/// connectivity problem, `Incompatible` (a body we couldn't decode) hints at an
+/// out-of-date app. Both offer a Sign Out escape hatch so the user is never
+/// fully trapped.
+fn checking_duress_ux<'a>(status: DuressGateStatus) -> Element<'a, ConnectAccountMessage> {
     let mut col = Column::new().spacing(16).align_x(Alignment::Center);
-    if failed {
-        col = col
-            .push(text::p1_regular("Couldn't verify your account status.").color(color::GREY_3))
-            .push(
-                button::primary(None, "Retry")
-                    .width(Length::Fixed(160.0))
-                    .on_press(ConnectAccountMessage::RetryDuressCheck),
-            );
-    } else {
-        col = col.push(text::p1_regular("Checking your account…").color(color::GREY_3));
+    match status {
+        DuressGateStatus::Checking => {
+            col = col.push(text::p1_regular("Checking your account…").color(color::GREY_3));
+        }
+        DuressGateStatus::Unreachable => {
+            col = col
+                .push(text::p1_regular("Couldn't verify your account status.").color(color::GREY_3))
+                .push(
+                    button::primary(None, "Retry")
+                        .width(Length::Fixed(160.0))
+                        .on_press(ConnectAccountMessage::RetryDuressCheck),
+                )
+                .push(
+                    button::secondary(None, "Sign Out")
+                        .width(Length::Fixed(160.0))
+                        .on_press(ConnectAccountMessage::LogOut),
+                );
+        }
+        DuressGateStatus::Incompatible => {
+            col = col
+                .push(
+                    text::p1_regular("We couldn't read your account status.")
+                        .color(color::GREY_3),
+                )
+                .push(
+                    text::caption("Make sure COINCUBE is up to date, then try again.")
+                        .color(color::GREY_3),
+                )
+                .push(
+                    button::primary(None, "Retry")
+                        .width(Length::Fixed(160.0))
+                        .on_press(ConnectAccountMessage::RetryDuressCheck),
+                )
+                .push(
+                    button::secondary(None, "Sign Out")
+                        .width(Length::Fixed(160.0))
+                        .on_press(ConnectAccountMessage::LogOut),
+                );
+        }
     }
     col.width(Length::Fill).into()
 }

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1149,12 +1149,12 @@ pub enum ConnectAccountMessage {
     /// registration and redeemed once the new session authenticates.
     RegisterCampaignCodeChanged(String),
     // --- Duress (Phases 6 & 8) ---
-    /// Result of the post-sign-in `get_duress_state` gate. `Some` switches to
-    /// the recovery flow when `active`; `None` is a failed/unreachable check
-    /// and triggers a bounded retry (the `u8` is the attempt count) so a
-    /// transient error doesn't silently leave the user on the dashboard while
-    /// the account is in duress.
-    DuressStateChecked(Option<crate::services::coincube::DuressState>, u64, u8),
+    /// Result of the post-sign-in `get_duress_state` gate, classified so the
+    /// handler can tell a transient failure (retry) from a contract mismatch
+    /// (stop retrying — futile) from a rejected session (re-auth). `Ok(active)`
+    /// switches to the recovery flow; `Ok(!active)` reveals the dashboard. The
+    /// `u64` is the session generation and the `u8` the attempt count.
+    DuressStateChecked(crate::services::coincube::DuressCheckOutcome, u64, u8),
     /// User tapped Retry on the post-login duress verification gate after the
     /// check failed (retries exhausted).
     RetryDuressCheck,

--- a/coincube-gui/src/app/view/vault/settings/mod.rs
+++ b/coincube-gui/src/app/view/vault/settings/mod.rs
@@ -1601,17 +1601,17 @@ pub fn node_setup_mode_picker_panel<'a>() -> Element<'a, NodeSettingsMessage> {
                     Row::new()
                         .spacing(10)
                         .push(
-                            button::primary(None, "Bitcoin Core →")
-                                .padding([8, 14])
-                                .on_press(NodeSettingsMessage::SetupLocalNodeManagedFlavor(
-                                    NodeFlavor::Core,
-                                )),
-                        )
-                        .push(
-                            button::secondary(None, "Bitcoin Knots + RDTS →")
+                            button::primary(None, "Bitcoin Knots + RDTS →")
                                 .padding([8, 14])
                                 .on_press(NodeSettingsMessage::SetupLocalNodeManagedFlavor(
                                     NodeFlavor::Knots,
+                                )),
+                        )
+                        .push(
+                            button::secondary(None, "Bitcoin Core →")
+                                .padding([8, 14])
+                                .on_press(NodeSettingsMessage::SetupLocalNodeManagedFlavor(
+                                    NodeFlavor::Core,
                                 )),
                         ),
                 )
@@ -1619,6 +1619,14 @@ pub fn node_setup_mode_picker_panel<'a>() -> Element<'a, NodeSettingsMessage> {
                     text(
                         "Knots enforces BIP-110 (Reduced Data Temporary Softfork): it rejects \
                          oversized data-carrier transactions. Standard sends are unaffected.",
+                    )
+                    .size(12)
+                    .style(theme::text::secondary),
+                )
+                .push(
+                    text(
+                        "Your Vaults share one Bitcoin node, so this applies to every Vault — \
+                         switching restarts the node and moves them all to the chosen build.",
                     )
                     .size(12)
                     .style(theme::text::secondary),

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -2174,9 +2174,9 @@ fn home_sidebar<'a>(home: &'a Home) -> Element<'a, Message> {
             ("Contacts", ConnectSubMenu::Contacts),
             ("Plan & Billing", ConnectSubMenu::PlanBilling),
             ("Security", ConnectSubMenu::Security),
-            // Duress (Phase 9). The duress_ux() panel gates on the
-            // `duress_remote_lock` entitlement and shows an upgrade prompt for
-            // Free, so the entry is safe to show for any authenticated user.
+            // Duress (Phase 9). The duress_ux() panel gates on the `duress`
+            // entitlement and shows an upgrade prompt for Free, so the entry is
+            // safe to show for any authenticated user.
             ("Duress", ConnectSubMenu::Duress),
         ];
         for (label, sub) in items {

--- a/coincube-gui/src/installer/context.rs
+++ b/coincube-gui/src/installer/context.rs
@@ -7,7 +7,7 @@ use crate::{
     backup::Backup,
     dir::CoincubeDirectory,
     installer::descriptor::PathKind,
-    node::bitcoind::{Bitcoind, InternalBitcoindConfig},
+    node::bitcoind::{Bitcoind, InternalBitcoindConfig, NodeFlavor},
     services::{
         coincube::CoincubeClient,
         connect::client::backend::{BackendClient, BackendWalletClient},
@@ -104,6 +104,12 @@ pub struct Context {
     /// downstream step that copies it into `EsploraConfig.token`.
     pub connect_jwt: Option<zeroize::Zeroizing<String>>,
     pub install_node_alongside_connect: bool,
+    /// Managed-node flavour chosen on the node-management step, carried to the
+    /// `InternalBitcoindStep` that actually downloads/configures it. Defaults to
+    /// Knots (BIP-110 / RDTS); the user can switch to Core on that step. Only
+    /// consulted for a *fresh* install — an existing on-disk `bitcoin.conf`'s
+    /// flavour is always preserved so we never silently swap a running node.
+    pub node_flavor: NodeFlavor,
     pub internal_bitcoind_config: Option<InternalBitcoindConfig>,
     pub internal_bitcoind: Option<Bitcoind>,
     /// Set when `install_node_alongside_connect` is true; holds the Bitcoind
@@ -182,6 +188,7 @@ impl Context {
             use_coincube_connect: false,
             connect_jwt: None,
             install_node_alongside_connect: false,
+            node_flavor: NodeFlavor::Knots,
             internal_bitcoind_config: None,
             internal_bitcoind: None,
             pending_bitcoind_config: None,

--- a/coincube-gui/src/installer/message.rs
+++ b/coincube-gui/src/installer/message.rs
@@ -209,6 +209,9 @@ pub enum SelectBitcoindTypeMsg {
     ContinueWithConnect,
     ToggleInstallNode,
     ToggleAdvanced,
+    /// Pick which managed-node flavour to install (Bitcoin Knots / Core) when
+    /// installing a node alongside Connect. Defaults to Knots.
+    SelectNodeFlavor(crate::node::bitcoind::NodeFlavor),
     // Advanced options
     UseExternal(bool),
     UseConnect,

--- a/coincube-gui/src/installer/mod.rs
+++ b/coincube-gui/src/installer/mod.rs
@@ -1055,6 +1055,9 @@ pub fn extract_daemon_config(ctx: &Context, settings: &WalletSettings) -> Result
         coincubed::datadir::DataDirectory::new(data_directory),
     );
     cfg.pending_bitcoind = ctx.pending_bitcoind_config.clone();
+    // The user installed a node alongside Connect: adopt it (auto-switch) once
+    // it's synced, even if it reused a chainstate and never entered IBD.
+    cfg.auto_switch_to_pending = ctx.install_node_alongside_connect;
     Ok(cfg)
 }
 

--- a/coincube-gui/src/installer/mod.rs
+++ b/coincube-gui/src/installer/mod.rs
@@ -1057,7 +1057,7 @@ pub fn extract_daemon_config(ctx: &Context, settings: &WalletSettings) -> Result
     cfg.pending_bitcoind = ctx.pending_bitcoind_config.clone();
     // The user installed a node alongside Connect: adopt it (auto-switch) once
     // it's synced, even if it reused a chainstate and never entered IBD.
-    cfg.auto_switch_to_pending = ctx.install_node_alongside_connect;
+    cfg.auto_switch_to_pending = Some(ctx.install_node_alongside_connect);
     Ok(cfg)
 }
 

--- a/coincube-gui/src/installer/step/node/bitcoind.rs
+++ b/coincube-gui/src/installer/step/node/bitcoind.rs
@@ -459,6 +459,15 @@ pub struct SelectBitcoindTypeStep {
     show_advanced: bool,
     network: Network,
     connect_authenticated: bool,
+    /// Managed-node flavour to install when a node is installed. Defaults to
+    /// Knots (BIP-110 / RDTS); the user can switch to Core. Carried into
+    /// `Context::node_flavor` by `apply`.
+    node_flavor: NodeFlavor,
+    /// The flavour of the managed node already configured on disk, if any. The
+    /// node is shared by every Vault, so its flavour is global: when one exists
+    /// we reflect it as the current selection and warn that changing it switches
+    /// every Vault.
+    existing_flavor: Option<NodeFlavor>,
 }
 
 impl Default for SelectBitcoindTypeStep {
@@ -482,6 +491,8 @@ impl SelectBitcoindTypeStep {
             show_advanced: false,
             network: Network::Bitcoin,
             connect_authenticated: false,
+            node_flavor: NodeFlavor::Knots,
+            existing_flavor: None,
         }
     }
 }
@@ -493,6 +504,19 @@ impl Step for SelectBitcoindTypeStep {
         // Expand advanced section by default on non-mainnet networks.
         if ctx.network != Network::Bitcoin {
             self.show_advanced = true;
+        }
+        // The managed node is shared by every Vault, so its flavour is global.
+        // If one already exists, reflect its flavour as the current selection —
+        // so creating a Vault doesn't silently switch it — and remember it so the
+        // picker can warn that changing the choice switches every Vault.
+        let bitcoind_datadir = internal_bitcoind_datadir(&ctx.coincube_directory);
+        self.existing_flavor = InternalBitcoindConfig::from_file(
+            &bitcoind::internal_bitcoind_config_path(&bitcoind_datadir),
+        )
+        .ok()
+        .map(|conf| conf.flavor);
+        if let Some(flavor) = self.existing_flavor {
+            self.node_flavor = flavor;
         }
     }
 
@@ -514,6 +538,9 @@ impl Step for SelectBitcoindTypeStep {
                 message::SelectBitcoindTypeMsg::ToggleAdvanced => {
                     self.show_advanced = !self.show_advanced;
                 }
+                message::SelectBitcoindTypeMsg::SelectNodeFlavor(flavor) => {
+                    self.node_flavor = flavor;
+                }
                 message::SelectBitcoindTypeMsg::UseExternal(selected) => {
                     self.use_external = selected;
                     self.use_connect = false;
@@ -531,6 +558,9 @@ impl Step for SelectBitcoindTypeStep {
     }
 
     fn apply(&mut self, ctx: &mut Context) -> bool {
+        // Carry the chosen managed-node flavour to the InternalBitcoindStep.
+        // Harmless on the non-install paths (that step is skipped then).
+        ctx.node_flavor = self.node_flavor;
         if self.use_connect {
             let install_node = self.install_node && !self.use_external;
             ctx.use_coincube_connect = true;
@@ -621,6 +651,8 @@ impl Step for SelectBitcoindTypeStep {
             self.show_advanced,
             PRUNE_DEFAULT,
             self.connect_authenticated,
+            self.node_flavor,
+            self.existing_flavor,
         )
     }
 }
@@ -825,16 +857,15 @@ impl InternalBitcoindStep {
 
 impl Step for InternalBitcoindStep {
     fn load_context(&mut self, ctx: &Context) {
-        // The installer has no Knots picker, so `self.flavor` defaults to Core.
-        // Adopt the flavour already configured on disk (if any) so we don't
-        // silently downgrade an existing Knots+RDTS node to Core or fetch the
-        // wrong binary. A brand-new install (no conf yet) keeps the step's own
-        // default flavour.
-        if let Ok(conf) = InternalBitcoindConfig::from_file(
-            &bitcoind::internal_bitcoind_config_path(&self.bitcoind_datadir),
-        ) {
-            self.flavor = conf.flavor;
-        }
+        // The flavour the user picked on the node-management step
+        // (`Context::node_flavor`, default Knots) is authoritative. We must NOT
+        // adopt a leftover on-disk `InternalBitcoindConfig`'s flavour here: the
+        // managed-node directory is shared and survives a cube delete, so a
+        // config written by an earlier (pre-picker) Core install would silently
+        // override an explicit Knots pick — installing Core for a user who asked
+        // for Knots. `DefineConfig` reuses a matching on-disk config (ports /
+        // RDTS) and rebuilds it on a flavour change.
+        self.flavor = ctx.node_flavor;
         if self.exe_path.is_none() {
             // Check if current managed bitcoind version is already installed.
             // For new installations, we ignore any previous managed bitcoind versions that might be installed.
@@ -889,13 +920,20 @@ impl Step for InternalBitcoindStep {
                     let mut conf = match InternalBitcoindConfig::from_file(
                         &bitcoind::internal_bitcoind_config_path(&self.bitcoind_datadir),
                     ) {
-                        // Preserve an existing conf's flavour and RDTS setting:
-                        // the installer has no Knots picker, so it must not
-                        // rewrite an existing Knots `bitcoin.conf` and drop
-                        // `consensusrules=rdts`.
-                        Ok(conf) => conf,
-                        // Fresh install: use the step's selected flavour (Core by
-                        // default); `for_flavor` enables RDTS only for Knots.
+                        // An existing managed node is shared by every Vault, so
+                        // flavour is global. Keep its ports/datadir (so every
+                        // Vault keeps connecting to the same RPC endpoint) and
+                        // apply the chosen flavour in place — a Core→Knots switch
+                        // just flips the binary and toggles `consensusrules=rdts`,
+                        // and `maybe_start` stops the old-flavour node so the
+                        // configured binary takes over the same port.
+                        Ok(mut conf) => {
+                            conf.flavor = self.flavor;
+                            conf.enforce_rdts = matches!(self.flavor, NodeFlavor::Knots);
+                            conf
+                        }
+                        // Fresh install: build for the chosen flavour (ports are
+                        // allocated below); `for_flavor` enables RDTS only for Knots.
                         Err(InternalBitcoindConfigError::FileNotFound) => {
                             InternalBitcoindConfig::for_flavor(self.flavor)
                         }
@@ -1230,6 +1268,13 @@ mod tests {
 
     fn sha256_hex(bytes: &[u8]) -> String {
         sha256::Hash::hash(bytes).to_string()
+    }
+
+    /// The managed-node install must default to Knots (BIP-110 / RDTS); Core is
+    /// the opt-out. Guards against the default silently reverting to Core.
+    #[test]
+    fn installer_defaults_to_knots() {
+        assert_eq!(SelectBitcoindTypeStep::new().node_flavor, NodeFlavor::Knots);
     }
 
     // The real published release manifest and its detached signature. Used to

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -1167,6 +1167,64 @@ pub fn define_coincube_connect<'a>(
     )
 }
 
+/// Knots / Core picker shown on the node-management step when the user opts to
+/// install a managed node. Knots is the default (enforces BIP-110 / RDTS); the
+/// selected flavour is primary-styled. Because the headless node never shows
+/// Knots' own confirmation prompt, this one-line blurb is where the user
+/// consents to RDTS enforcement.
+fn node_flavor_selector<'a>(
+    selected: crate::node::bitcoind::NodeFlavor,
+    existing: Option<crate::node::bitcoind::NodeFlavor>,
+) -> Element<'a, Message> {
+    use crate::node::bitcoind::NodeFlavor;
+    let option = |flavor: NodeFlavor| {
+        let label = flavor.display_name();
+        let btn = if selected == flavor {
+            button::primary(None, label)
+        } else {
+            button::secondary(None, label)
+        };
+        btn.width(Length::Fixed(260.0))
+            .on_press(Message::SelectBitcoindType(
+                message::SelectBitcoindTypeMsg::SelectNodeFlavor(flavor),
+            ))
+    };
+    let blurb = match selected {
+        NodeFlavor::Knots => {
+            "Bitcoin Knots enforces BIP-110 (Reduced Data Temporary Softfork). Recommended."
+        }
+        NodeFlavor::Core => "Bitcoin Core — the reference implementation; no RDTS enforcement.",
+    };
+    let mut col = Column::new()
+        .spacing(10)
+        .push(text("Node software").bold())
+        .push(
+            Row::new()
+                .spacing(15)
+                .push(option(NodeFlavor::Knots))
+                .push(option(NodeFlavor::Core)),
+        )
+        .push(text(blurb))
+        // The managed node is shared across every Vault, so the choice is global.
+        .push(text(
+            "All your Vaults share one Bitcoin node, so this choice applies to every Vault.",
+        ));
+    // When a node already exists and this would change its flavour, make the
+    // global impact explicit: switching restarts the node for ALL Vaults.
+    if let Some(existing) = existing {
+        if existing != selected {
+            col = col.push(
+                text(format!(
+                    "Changing this will restart your node and switch all existing Vaults to {}.",
+                    selected.display_name()
+                ))
+                .bold(),
+            );
+        }
+    }
+    col.into()
+}
+
 pub fn select_bitcoind_type<'a>(
     progress: (usize, usize),
     network: bitcoin::Network,
@@ -1174,6 +1232,8 @@ pub fn select_bitcoind_type<'a>(
     show_advanced: bool,
     prune_default_mb: u32,
     connect_authenticated: bool,
+    node_flavor: crate::node::bitcoind::NodeFlavor,
+    existing_flavor: Option<crate::node::bitcoind::NodeFlavor>,
 ) -> Element<'a, Message> {
     let content: Column<'a, Message> =
         if network == bitcoin::Network::Regtest {
@@ -1348,40 +1408,45 @@ pub fn select_bitcoind_type<'a>(
             let node_description = if install_node {
                 let disk_gb = (prune_default_mb as f64 / 1024.0).round() as u32;
                 format!(
-                    "Coincube will download and configure a pruned Bitcoin node \
+                    "Coincube will download and configure a pruned {} node \
                 (~{} GB of disk space required). \
                 Once synced, your Vault will automatically switch to your local node.",
+                    node_flavor.display_name(),
                     disk_gb
                 )
             } else {
                 "Your Vault will use COINCUBE | Connect as its only Bitcoin backend.".to_string()
             };
 
-            let default_card = Container::new(
-                Column::new()
-                    .spacing(20)
-                    .max_width(620)
-                    .push(text("Start with COINCUBE | Connect").bold())
-                    .push(text(
-                        "Your Vault will use our hosted Esplora server immediately. \
+            let mut default_col = Column::new()
+                .spacing(20)
+                .max_width(620)
+                .push(text("Start with COINCUBE | Connect").bold())
+                .push(text(
+                    "Your Vault will use our hosted Esplora server immediately. \
                     No setup required.",
-                    ))
-                    .push(
-                        checkbox(install_node)
-                            .label("Also install a Bitcoin node on my device")
-                            .on_toggle(|_| {
-                                Message::SelectBitcoindType(
-                                    message::SelectBitcoindTypeMsg::ToggleInstallNode,
-                                )
-                            }),
-                    )
-                    .push(text(node_description))
-                    .push(
-                        button::primary(None, "Continue").on_press(Message::SelectBitcoindType(
-                            message::SelectBitcoindTypeMsg::ContinueWithConnect,
-                        )),
-                    ),
-            )
+                ))
+                .push(
+                    checkbox(install_node)
+                        .label("Also install a Bitcoin node on my device")
+                        .on_toggle(|_| {
+                            Message::SelectBitcoindType(
+                                message::SelectBitcoindTypeMsg::ToggleInstallNode,
+                            )
+                        }),
+                );
+
+            // When installing a managed node, let the user pick the flavour.
+            // Defaults to Knots (enforces BIP-110 / RDTS); Core is the opt-out.
+            if install_node {
+                default_col = default_col.push(node_flavor_selector(node_flavor, existing_flavor));
+            }
+
+            let default_card = Container::new(default_col.push(text(node_description)).push(
+                button::primary(None, "Continue").on_press(Message::SelectBitcoindType(
+                    message::SelectBitcoindTypeMsg::ContinueWithConnect,
+                )),
+            ))
             .padding(30);
 
             let toggle_label = if show_advanced {

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -1225,6 +1225,7 @@ fn node_flavor_selector<'a>(
     col.into()
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn select_bitcoind_type<'a>(
     progress: (usize, usize),
     network: bitcoin::Network,

--- a/coincube-gui/src/node/bitcoind.rs
+++ b/coincube-gui/src/node/bitcoind.rs
@@ -150,6 +150,18 @@ impl NodeFlavor {
         }
     }
 
+    /// Infer the flavour from a running node's `getnetworkinfo.subversion`
+    /// (e.g. `/Satoshi:29.3.0(knots20260508)/`). Knots embeds `knots`; Core
+    /// never does. Used to decide whether a reachable managed node already
+    /// matches the configured flavour or must be replaced.
+    pub fn from_subversion(subversion: &str) -> Self {
+        if subversion.to_lowercase().contains("knots") {
+            NodeFlavor::Knots
+        } else {
+            NodeFlavor::Core
+        }
+    }
+
     /// Human-readable name for UI copy and logs.
     pub fn display_name(self) -> &'static str {
         match self {
@@ -643,6 +655,27 @@ fn select_managed_bitcoind_exe(
         .find(|path| path.exists())
 }
 
+/// Block until a managed bitcoind we just asked to `stop` is no longer reachable
+/// (it has shut down and released the datadir lock), so a replacement can start
+/// on the same datadir without a lock conflict. Bounded, so a node that refuses
+/// to exit can't hang startup forever; the brief grace after the RPC closes
+/// covers the gap before the `.lock` file is actually released.
+fn wait_for_internal_bitcoind_shutdown(config: &BitcoindConfig) {
+    let deadline = time::Instant::now() + time::Duration::from_secs(90);
+    while time::Instant::now() < deadline {
+        if coincubed::BitcoinD::new(config, "internal_bitcoind_stop_wait".to_string()).is_err() {
+            // RPC is down; give the OS a moment to release the datadir `.lock`.
+            thread::sleep(time::Duration::from_millis(750));
+            return;
+        }
+        thread::sleep(time::Duration::from_millis(500));
+    }
+    log::warn!(
+        "Timed out waiting for the previous managed node to stop; \
+         the replacement may fail to acquire the datadir lock"
+    );
+}
+
 impl Bitcoind {
     /// Start internal bitcoind for the given network.
     pub fn maybe_start(
@@ -650,14 +683,6 @@ impl Bitcoind {
         config: BitcoindConfig,
         coincube_datadir: &CoincubeDirectory,
     ) -> Result<Self, StartInternalBitcoindError> {
-        if coincubed::BitcoinD::new(&config, "internal_bitcoind_start".to_string()).is_ok() {
-            info!("Internal bitcoind is already running");
-            return Ok(Bitcoind {
-                config,
-                lock: LockFile::create(coincube_datadir.bitcoind_directory(), network)
-                    .map_err(|e| StartInternalBitcoindError::Lock(format!("{:?}", e)))?,
-            });
-        }
         let bitcoind_datadir = internal_bitcoind_datadir(coincube_datadir);
         // Launch a binary consistent with the on-disk `bitcoin.conf`. A conf
         // carrying `consensusrules=rdts` *requires* a Knots binary — starting
@@ -669,6 +694,36 @@ impl Bitcoind {
             InternalBitcoindConfig::from_file(&internal_bitcoind_config_path(&bitcoind_datadir))
                 .map(|conf| conf.flavor)
                 .unwrap_or(NodeFlavor::Core);
+
+        // Is a managed node already running on this RPC endpoint?
+        if let Ok(running) =
+            coincubed::BitcoinD::new(&config, "internal_bitcoind_start".to_string())
+        {
+            // The managed node is shared by every Vault, so flavour is global.
+            // If the running node already matches the configured flavour, reuse
+            // it. If it doesn't (a global flavour switch — e.g. Core is up for
+            // existing Vaults and the user just picked Knots), stop it so we can
+            // relaunch the configured binary on the same datadir/port; every
+            // Vault then reconnects to the new flavour on the same RPC port.
+            let running_flavor = running
+                .subversion()
+                .map(|sv| NodeFlavor::from_subversion(&sv))
+                .unwrap_or(configured_flavor);
+            if running_flavor == configured_flavor {
+                info!("Internal bitcoind is already running ({running_flavor:?})");
+                return Ok(Bitcoind {
+                    config,
+                    lock: LockFile::create(coincube_datadir.bitcoind_directory(), network)
+                        .map_err(|e| StartInternalBitcoindError::Lock(format!("{:?}", e)))?,
+                });
+            }
+            info!(
+                "Managed node flavour switch {running_flavor:?} → {configured_flavor:?}; \
+                 stopping the running node so the configured binary can take over"
+            );
+            running.stop();
+            wait_for_internal_bitcoind_shutdown(&config);
+        }
         let bitcoind_exe_path = select_managed_bitcoind_exe(coincube_datadir, configured_flavor)
             .ok_or(StartInternalBitcoindError::ExecutableNotFound)?;
         info!(

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -2818,6 +2818,97 @@ mod cube_member_tests {
 }
 
 #[cfg(test)]
+mod plan_tests {
+    use super::*;
+    use crate::services::coincube::PlanTier;
+    use httpmock::{Method as MockMethod, MockServer};
+    use serde_json::json;
+
+    /// Regression guard: decode a `GET /connect/plan` body shaped like the real
+    /// API (numeric `Entitlements` from documentation/PRICING_AND_TIERS.md +
+    /// campaign `planProvenance`). The previous boolean-feature `PlanEntitlements`
+    /// required six fields the API had stopped sending, so this body failed to
+    /// parse and every account silently rendered as Free. The tier and the one
+    /// consumed entitlement (`duress`) must survive the parse.
+    #[tokio::test]
+    async fn get_connect_plan_decodes_api_contract() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET).path("/api/v1/connect/plan");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "plan": "estate",
+                        "status": "active",
+                        "renewalAt": null,
+                        "planProvenance": {
+                            "label": "Free for your first year",
+                            "badge": "",
+                            "expiresAt": null
+                        },
+                        "entitlements": {
+                            "personalKeyLimit": 7,
+                            "cubeLimit": 7,
+                            "recoveryKitLimit": 7,
+                            "avatarRegenerationLimit": null,
+                            "duress": true,
+                            "attachPolicies": true,
+                            "collaborativeInvitations": true,
+                            "duressAlerts": true,
+                            "recoveryAlerts": true
+                        }
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let plan = client
+            .get_connect_plan()
+            .await
+            .expect("API-shaped plan body should decode");
+        mock.assert();
+        assert_eq!(*plan.tier(), PlanTier::Estate);
+        assert_eq!(plan.entitlements.cube_limit, 7);
+        assert!(plan.entitlements.duress);
+        assert!(plan.entitlements.avatar_regeneration_limit.is_none()); // unlimited
+        assert!(plan.plan_provenance.is_some());
+    }
+
+    /// A future entitlement field the desktop doesn't know about must not fail
+    /// the parse and drop the account to Free — every field is `#[serde(default)]`
+    /// and unknown fields are ignored.
+    #[tokio::test]
+    async fn get_connect_plan_tolerates_unknown_and_missing_entitlements() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(MockMethod::GET).path("/api/v1/connect/plan");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "plan": "pro",
+                        "status": "active",
+                        "renewalAt": null,
+                        "entitlements": { "cubeLimit": 4, "someFutureFlag": true }
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let plan = client
+            .get_connect_plan()
+            .await
+            .expect("partial/forward-compat entitlements should still decode");
+        assert_eq!(*plan.tier(), PlanTier::Pro);
+        assert_eq!(plan.entitlements.cube_limit, 4);
+        assert!(!plan.entitlements.duress); // absent → safe default
+    }
+}
+
+#[cfg(test)]
 mod duress_tests {
     use super::*;
     use crate::services::coincube::{DownloadError, EnrollDuressRequest};

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -1245,7 +1245,20 @@ impl CoincubeClient {
         let url = format!("{}/api/v1/connect/duress", self.base_url);
         let res = self.client.get(&url).send().await?;
         let res = res.check_success().await?;
-        let resp: ApiResponse<super::DuressState> = res.json().await?;
+        // Decode via text + serde rather than `res.json()` so a 200 that doesn't
+        // match the contract surfaces as a distinct `Parse` error (reqwest folds
+        // decode failures into an opaque `Network` error) AND so we can log the
+        // offending body. The post-login duress gate fails closed on any error;
+        // without this a single mismatched field is indistinguishable from a
+        // network blip and locks every user out with no diagnostic trail.
+        let body = res.text().await?;
+        let resp: ApiResponse<super::DuressState> = serde_json::from_str(&body).map_err(|e| {
+            log::error!(
+                "[CONNECT] duress state decode failed: {e}; body: {}",
+                body.chars().take(512).collect::<String>()
+            );
+            CoincubeError::Parse(e)
+        })?;
         Ok(resp.data)
     }
 
@@ -2948,6 +2961,35 @@ mod duress_tests {
         assert!(state.enrolled);
         assert!(!state.this_device_registered);
         assert!(state.unlock_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn get_duress_state_decodes_contract_golden() {
+        // Golden body capturing the live API's GET /connect/duress contract. The
+        // matching coincube-api test (TestGetDuressReconciliationPayload) asserts
+        // the handler emits these exact camelCase keys, so the two ends are
+        // pinned to one contract. Unlike the hand-written mock in
+        // `get_duress_state_200_decodes` — which proved nothing when the real API
+        // diverged to snake_case — this guards the desktop side against drift.
+        let server = MockServer::start();
+        let golden = include_str!("testdata/duress_get_response.json");
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET).path("/api/v1/connect/duress");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(golden);
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let state = client
+            .get_duress_state()
+            .await
+            .expect("golden contract body should decode");
+        mock.assert();
+        assert!(state.active);
+        assert!(state.enrolled);
+        assert!(state.unlock_at.is_some());
+        assert!(state.this_device_registered);
     }
 
     #[tokio::test]

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -301,28 +301,45 @@ pub struct PlanProvenance {
     pub badge: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+/// Per-plan entitlements from `GET /connect/plan`, mirroring the API's
+/// `Entitlements` (the canonical model in `documentation/PRICING_AND_TIERS.md`).
+///
+/// EVERY field is `#[serde(default)]` on purpose: an entitlements object that
+/// adds or renames a field must never fail the whole `ConnectPlan` parse and
+/// silently drop the account to the Free tier. That is exactly the regression
+/// this struct replaced — the previous (boolean-feature) model required six
+/// fields the API had stopped sending, so every account rendered as Free. An
+/// absent entitlement defaulting to "off"/0 is the safe direction.
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PlanEntitlements {
-    pub free_signing_key_count: i32,
-    pub policy_editing: bool,
-    pub legacy_invites: bool,
-    pub linked_keychains: bool,
-    pub duress_remote_lock: bool,
-    pub business_orgs: bool,
+    /// Personal (free) signing keys allowed on the tier.
+    #[serde(default)]
+    pub personal_key_limit: u32,
+    /// Cubes allowed on the tier. (The home screen's live limit comes from
+    /// `get_cube_limits`; this is the plan-catalog value.)
+    #[serde(default)]
+    pub cube_limit: u32,
+    #[serde(default)]
+    pub recovery_kit_limit: u32,
+    /// Avatar regenerations allowed: `None` = unlimited (Estate), `Some(0)` =
+    /// disabled (Free).
+    #[serde(default)]
+    pub avatar_regeneration_limit: Option<u32>,
+    /// Whether the tier includes duress — gates the duress enrollment UI.
+    #[serde(default)]
+    pub duress: bool,
+    #[serde(default)]
+    pub attach_policies: bool,
+    #[serde(default)]
+    pub collaborative_invitations: bool,
     /// Estate-only: duress-activation alert contacts (SMS/WhatsApp/email
     /// fan-out when duress fires). See `PLAN-estate-notifications.md` PR 1.
-    ///
-    /// `#[serde(default)]` so a pre-estate-notifications API that doesn't
-    /// emit this field deserialises to `false` rather than failing the
-    /// whole `ConnectPlan` parse — the desktop treats an absent
-    /// entitlement as "not entitled", which is the safe default.
     #[serde(default)]
     pub duress_alerts: bool,
     /// Estate-only: vault recovery-path monitoring (descriptor escrow or
     /// timelock heartbeat → keyholder emails). See
-    /// `PLAN-estate-notifications.md` PR 2. Same forward-compat tolerance
-    /// as [`Self::duress_alerts`].
+    /// `PLAN-estate-notifications.md` PR 2.
     #[serde(default)]
     pub recovery_alerts: bool,
 }

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -1557,8 +1557,9 @@ pub enum DuressCheckOutcome {
     /// logged at the call site. Auto-retrying in a tight loop is futile, but a
     /// manual retry can still recover if the server is hotfixed.
     Incompatible,
-    /// 401 — the session was rejected; bounce to login rather than hold the
-    /// gate closed forever.
+    /// 401/403 — the session/token was definitively rejected; bounce to login
+    /// rather than hold the gate closed forever or retry a credential the
+    /// server won't accept.
     Unauthorized,
 }
 
@@ -1568,9 +1569,61 @@ impl DuressCheckOutcome {
     pub fn from_err(e: &CoincubeError) -> Self {
         match e {
             CoincubeError::Parse(_) => Self::Incompatible,
-            CoincubeError::Unsuccessful(info) if info.status_code == 401 => Self::Unauthorized,
+            // Mirror `CoincubeError::is_auth_error` (401/403): a rejected token
+            // won't recover by retrying, so re-auth instead of backing off as if
+            // the network were down. Keep these in sync to avoid 403 silently
+            // falling through to a futile retry loop.
+            _ if e.is_auth_error() => Self::Unauthorized,
             _ => Self::Unreachable,
         }
+    }
+}
+
+#[cfg(test)]
+mod duress_check_outcome_tests {
+    use super::*;
+    use crate::services::http::NotSuccessResponseInfo;
+
+    fn unsuccessful(status_code: u16) -> CoincubeError {
+        CoincubeError::Unsuccessful(NotSuccessResponseInfo {
+            status_code,
+            text: String::new(),
+        })
+    }
+
+    #[test]
+    fn auth_errors_map_to_unauthorized() {
+        // Both 401 and 403 are "token definitively rejected" (see
+        // is_auth_error) and must re-auth, not retry-with-backoff.
+        assert!(matches!(
+            DuressCheckOutcome::from_err(&unsuccessful(401)),
+            DuressCheckOutcome::Unauthorized
+        ));
+        assert!(matches!(
+            DuressCheckOutcome::from_err(&unsuccessful(403)),
+            DuressCheckOutcome::Unauthorized
+        ));
+    }
+
+    #[test]
+    fn transient_and_decode_errors_classify_distinctly() {
+        // 5xx / rate-limit / other non-auth statuses are transient.
+        assert!(matches!(
+            DuressCheckOutcome::from_err(&unsuccessful(503)),
+            DuressCheckOutcome::Unreachable
+        ));
+        assert!(matches!(
+            DuressCheckOutcome::from_err(&unsuccessful(429)),
+            DuressCheckOutcome::Unreachable
+        ));
+        // A decode failure is a contract mismatch, not transient.
+        let parse_err: CoincubeError = serde_json::from_str::<DuressState>("not json")
+            .unwrap_err()
+            .into();
+        assert!(matches!(
+            DuressCheckOutcome::from_err(&parse_err),
+            DuressCheckOutcome::Incompatible
+        ));
     }
 }
 

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -1520,6 +1520,43 @@ pub struct DuressState {
     pub this_device_registered: bool,
 }
 
+/// Classified result of the post-sign-in duress gate check (Phase 6).
+///
+/// Carried in a `Message`, so it must be `Clone` — `CoincubeError` wraps a
+/// non-`Clone` `reqwest::Error` and can't be. Collapsing every failure to a
+/// bare `None` (as the gate previously did) conflated "the server returned a
+/// body I can't decode" (permanent — retrying is futile) with "the network is
+/// down" (transient — retry) and "my token was rejected" (re-auth), so a
+/// one-field contract typo became a silent, un-retryable lockout. This keeps
+/// just enough to branch correctly.
+#[derive(Debug, Clone)]
+pub enum DuressCheckOutcome {
+    /// Decoded the server's duress state.
+    Ok(DuressState),
+    /// Network / timeout / 5xx / rate-limit — transient; a bounded retry may
+    /// succeed.
+    Unreachable,
+    /// A 200 whose body didn't match the contract (decode error) — the body is
+    /// logged at the call site. Auto-retrying in a tight loop is futile, but a
+    /// manual retry can still recover if the server is hotfixed.
+    Incompatible,
+    /// 401 — the session was rejected; bounce to login rather than hold the
+    /// gate closed forever.
+    Unauthorized,
+}
+
+impl DuressCheckOutcome {
+    /// Classify a failed `get_duress_state` call. (Success is constructed
+    /// directly as [`DuressCheckOutcome::Ok`].)
+    pub fn from_err(e: &CoincubeError) -> Self {
+        match e {
+            CoincubeError::Parse(_) => Self::Incompatible,
+            CoincubeError::Unsuccessful(info) if info.status_code == 401 => Self::Unauthorized,
+            _ => Self::Unreachable,
+        }
+    }
+}
+
 /// Typed failure modes for the password-gated recovery-kit download
 /// (Approach C, Phase 7). The server returns `423 Locked` with a
 /// discriminating `error.code` for both the duress-lock and

--- a/coincube-gui/src/services/coincube/testdata/duress_get_response.json
+++ b/coincube-gui/src/services/coincube/testdata/duress_get_response.json
@@ -1,0 +1,13 @@
+{
+  "success": true,
+  "data": {
+    "active": true,
+    "unlockAt": "2026-06-09T12:00:00Z",
+    "last_activated_at": "2026-06-09T11:00:00Z",
+    "last_cleared_at": null,
+    "enrolled": true,
+    "thisDeviceRegistered": true,
+    "lastTriggeredAt": null,
+    "settings": {}
+  }
+}

--- a/coincubed/src/bitcoin/d/mod.rs
+++ b/coincubed/src/bitcoin/d/mod.rs
@@ -1274,8 +1274,13 @@ impl BitcoinD {
     /// reachable managed node is Core or Knots, possibly while it is shutting
     /// down. Distinct from the internal [`Self::get_bitcoind_subversion`], which
     /// is informational and may panic on a failed request.
+    ///
+    /// Probes with `retry = false`: this is a fail-fast liveness/flavour check,
+    /// so a transient error (or a node mid-shutdown) must return `None` at once
+    /// rather than block the caller for up to `BITCOIND_RETRY_LIMIT` seconds in
+    /// the retry loop.
     pub fn subversion(&self) -> Option<String> {
-        self.make_fallible_node_request("getnetworkinfo", None)
+        self.make_request_inner(&self.node_client, "getnetworkinfo", None, false)
             .ok()
             .and_then(|info| {
                 info.get("subversion")

--- a/coincubed/src/bitcoin/d/mod.rs
+++ b/coincubed/src/bitcoin/d/mod.rs
@@ -1267,6 +1267,22 @@ impl BitcoinD {
     pub fn stop(&self) {
         self.make_node_request("stop", None);
     }
+
+    /// The running node's `getnetworkinfo.subversion` (e.g.
+    /// `/Satoshi:29.3.0(knots20260508)/`), or `None` if the request fails.
+    /// Fallible (never panics) because the desktop calls it to decide whether a
+    /// reachable managed node is Core or Knots, possibly while it is shutting
+    /// down. Distinct from the internal [`Self::get_bitcoind_subversion`], which
+    /// is informational and may panic on a failed request.
+    pub fn subversion(&self) -> Option<String> {
+        self.make_fallible_node_request("getnetworkinfo", None)
+            .ok()
+            .and_then(|info| {
+                info.get("subversion")
+                    .and_then(Json::as_str)
+                    .map(String::from)
+            })
+    }
 }
 
 /// Information about the block chain verification progress.
@@ -1287,6 +1303,13 @@ impl SyncProgress {
             headers,
             blocks,
         }
+    }
+
+    /// The raw verification percentage (0..=1), un-rounded. Read-only accessor
+    /// so the lock-free [`crate::bitcoin::SyncProgressCache`] can round-trip a
+    /// `SyncProgress` through atomics.
+    pub fn percentage(&self) -> f64 {
+        self.percentage
     }
 
     /// Get the verification progress, roundup up to four decimal places. This will not return

--- a/coincubed/src/bitcoin/esplora/client.rs
+++ b/coincubed/src/bitcoin/esplora/client.rs
@@ -1,4 +1,5 @@
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use bdk_electrum::bdk_chain::{
@@ -29,6 +30,12 @@ pub enum Error {
     /// real failure to log at ERROR level. The next tick after any
     /// provider's cooldown expires will see a normal result.
     AllCooling,
+    /// The shared abort flag was set (the daemon is shutting down), so we
+    /// stopped walking the provider chain instead of waiting out requests to
+    /// unreachable providers. Lets `DaemonHandle::stop` return promptly even
+    /// while a scan is in flight against a dead/throttled Esplora — otherwise
+    /// `stop()` joins a poller stuck for the full request/timeout cycle.
+    Aborted,
 }
 
 impl Error {
@@ -50,6 +57,13 @@ impl Error {
 /// poller's special-case branch.
 pub const ALL_COOLING_DISPLAY_MARKER: &str = "All Esplora providers are temporarily backing off";
 
+/// Marker substring in [`Error::Aborted`]'s `Display`. Same rationale as
+/// [`ALL_COOLING_DISPLAY_MARKER`]: the `sync_wallet` trait boundary stringifies
+/// the error, so the poller detects a shutdown-abort by this marker and STOPS
+/// retrying (returns) rather than recursing its 2s retry loop — which would
+/// never return to check for the Shutdown message, leaving `stop()` blocked.
+pub const SCAN_ABORTED_DISPLAY_MARKER: &str = "Esplora scan aborted";
+
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -59,6 +73,13 @@ impl std::fmt::Display for Error {
                 "{} after recent rate limits; the poller will retry once a cooldown expires.",
                 ALL_COOLING_DISPLAY_MARKER,
             ),
+            Error::Aborted => {
+                write!(
+                    f,
+                    "{}: the daemon is shutting down.",
+                    SCAN_ABORTED_DISPLAY_MARKER
+                )
+            }
         }
     }
 }
@@ -76,6 +97,12 @@ impl std::fmt::Display for Error {
 /// `SyncRequest` is consumed by the call and isn't trivially clonable.
 pub struct Client {
     providers: Vec<Provider>,
+    /// Set by `DaemonHandle::stop` so an in-flight scan stops walking the
+    /// provider chain and returns [`Error::Aborted`] promptly, instead of the
+    /// poller (and the `stop()` that joins it) blocking on requests to dead or
+    /// throttled providers. Shared so the stopping thread can flip it while the
+    /// poller is mid-scan.
+    abort: Arc<AtomicBool>,
 }
 
 /// One endpoint in the provider chain, plus the state needed to skip
@@ -176,7 +203,10 @@ impl Client {
     /// Errors from the actual sync calls still surface in the usual
     /// places, so a permanently broken config doesn't get silently
     /// swallowed — it just doesn't block launch.
-    pub fn new(config: &crate::config::EsploraConfig) -> Result<Self, Error> {
+    pub fn new(
+        config: &crate::config::EsploraConfig,
+        abort: Arc<AtomicBool>,
+    ) -> Result<Self, Error> {
         let mut providers = Vec::new();
         providers.push(Provider {
             name: format!("primary {}", config.addr),
@@ -252,7 +282,7 @@ impl Client {
                  the poller will retry on its next tick"
             );
         }
-        Ok(Client { providers })
+        Ok(Client { providers, abort })
     }
 
     /// Run `op` against each provider in order, skipping any that's in a
@@ -264,6 +294,13 @@ impl Client {
     {
         let mut last_result: Option<Result<T, esplora_client::Error>> = None;
         for provider in &self.providers {
+            // Bail out between providers if the daemon is shutting down, so a
+            // dead/throttled provider chain can't keep `stop()` blocked. The
+            // in-flight `op` (one provider) still runs to its timeout; this stops
+            // us from then dialling the rest.
+            if self.abort.load(Ordering::Relaxed) {
+                return Err(Error::Aborted);
+            }
             if provider.is_cooling() {
                 log::debug!(
                     "Esplora skipping {} (cooling down after recent 402/429)",
@@ -467,7 +504,10 @@ mod tests {
     /// real `Builder` / network. Lets us drive `try_in_order` without
     /// hitting an actual Esplora server.
     fn client_with(providers: Vec<Provider>) -> Client {
-        Client { providers }
+        Client {
+            providers,
+            abort: Arc::new(AtomicBool::new(false)),
+        }
     }
 
     /// Provider whose `client` we never use — `op` closures in the
@@ -478,6 +518,24 @@ mod tests {
             client: build_blocking_client("http://127.0.0.1:1", None),
             cooldown_until: Mutex::new(None),
         }
+    }
+
+    /// `try_in_order` must bail with [`Error::Aborted`] — without running `op` —
+    /// once the shared abort flag is set, so `DaemonHandle::stop` doesn't block
+    /// on a poller stuck dialling dead/throttled providers.
+    #[test]
+    fn try_in_order_aborts_when_flag_set() {
+        let client = client_with(vec![fake_provider("p1"), fake_provider("p2")]);
+        client.abort.store(true, Ordering::Relaxed);
+
+        let mut called = false;
+        let result: Result<u32, Error> = client.try_in_order(|_| {
+            called = true;
+            Ok(7)
+        });
+
+        assert!(!called, "op must not run once aborting");
+        assert!(matches!(result, Err(Error::Aborted)));
     }
 
     /// Regression: when the primary returns 429, the cooldown must be

--- a/coincubed/src/bitcoin/mod.rs
+++ b/coincubed/src/bitcoin/mod.rs
@@ -41,6 +41,49 @@ impl fmt::Display for BlockChainTip {
     }
 }
 
+/// Lock-free cache of the latest [`SyncProgress`], published by the poller and
+/// read by `get_info` WITHOUT taking the `BitcoinInterface` mutex.
+///
+/// The poller holds that mutex across a full wallet scan — over Esplora that's
+/// a long sequence of HTTP requests — and `get_info` → `sync_progress` needs
+/// the same lock, so a fresh vault's first scan left `get_info` (and the GUI's
+/// "Starting daemon…" gate, which awaits it) blocked for the entire scan.
+/// Routing the read through these atomics decouples it from that lock. The
+/// three fields are stored independently, so a concurrent reader can briefly
+/// observe a mix of two updates — harmless for a progress indicator, which is
+/// re-read every poll.
+#[derive(Debug, Default)]
+pub struct SyncProgressCache {
+    percentage_bits: sync::atomic::AtomicU64,
+    headers: sync::atomic::AtomicU64,
+    blocks: sync::atomic::AtomicU64,
+}
+
+impl SyncProgressCache {
+    /// Publish the latest progress. Called by the poller right after it reads
+    /// `sync_progress` from the backend (with the backend lock already
+    /// released), so this never runs while the `BitcoinInterface` mutex is held.
+    pub fn store(&self, progress: &SyncProgress) {
+        use sync::atomic::Ordering::Relaxed;
+        self.percentage_bits
+            .store(progress.percentage().to_bits(), Relaxed);
+        self.headers.store(progress.headers, Relaxed);
+        self.blocks.store(progress.blocks, Relaxed);
+    }
+
+    /// Read the latest published progress without locking. Before the poller's
+    /// first publish this returns the zero default (0%), which reads as
+    /// "still syncing" — exactly the right answer during startup.
+    pub fn load(&self) -> SyncProgress {
+        use sync::atomic::Ordering::Relaxed;
+        SyncProgress::new(
+            f64::from_bits(self.percentage_bits.load(Relaxed)),
+            self.headers.load(Relaxed),
+            self.blocks.load(Relaxed),
+        )
+    }
+}
+
 /// Our Bitcoin backend.
 pub trait BitcoinInterface: Send {
     fn genesis_block_timestamp(&self) -> u32;

--- a/coincubed/src/bitcoin/poller/looper.rs
+++ b/coincubed/src/bitcoin/poller/looper.rs
@@ -302,6 +302,15 @@ fn updates(
             // typed `client::Error::AllCooling` variant from here.
             // A regression test in `bitcoin::esplora::client`
             // guards the marker.
+            // A scan aborted by `DaemonHandle::stop` must NOT retry: return so
+            // `poll_forever` regains control and processes the Shutdown message.
+            // Recursing the 2s retry below would re-issue the (now instantly
+            // aborting) scan forever and never let the poller exit — leaving
+            // `stop()` blocked on the join.
+            if e.contains(crate::bitcoin::esplora::client::SCAN_ABORTED_DISPLAY_MARKER) {
+                log::debug!("Esplora poll aborted — daemon shutting down");
+                return;
+            }
             if e.contains(crate::bitcoin::esplora::client::ALL_COOLING_DISPLAY_MARKER) {
                 log::debug!("Esplora poll skipped: {}", e);
                 thread::sleep(time::Duration::from_secs(30));

--- a/coincubed/src/bitcoin/poller/mod.rs
+++ b/coincubed/src/bitcoin/poller/mod.rs
@@ -33,6 +33,10 @@ pub struct Poller {
     secp: secp256k1::Secp256k1<secp256k1::VerifyOnly>,
     // The receive and change descriptors (in this order).
     descs: [descriptors::SinglePathCoincubeDesc; 2],
+    // Lock-free mirror of the latest sync progress, so `get_info` can read it
+    // without contending for the `BitcoinInterface` mutex this poller holds
+    // across a full wallet scan.
+    sync_cache: sync::Arc<crate::bitcoin::SyncProgressCache>,
 }
 
 impl Poller {
@@ -40,6 +44,7 @@ impl Poller {
         bit: sync::Arc<sync::Mutex<dyn BitcoinInterface>>,
         db: sync::Arc<sync::Mutex<dyn DatabaseInterface>>,
         desc: descriptors::CoincubeDescriptor,
+        sync_cache: sync::Arc<crate::bitcoin::SyncProgressCache>,
     ) -> Poller {
         let secp = secp256k1::Secp256k1::verification_only();
         let descs = [
@@ -50,11 +55,19 @@ impl Poller {
         // On first startup the tip may be NULL. Make sure it's set as the poller relies on it.
         looper::maybe_initialize_tip(&bit, &db);
 
+        // NB: we deliberately do NOT read `sync_progress` here to seed the
+        // cache. That would add a backend RPC during construction (which the
+        // scripted `daemon_startup` test doesn't expect, and which would
+        // re-introduce a startup round-trip). The cache's zero default reads as
+        // "still syncing", and the poll loop — whose first tick has no initial
+        // delay — publishes the real value immediately.
+
         Poller {
             bit,
             db,
             secp,
             descs,
+            sync_cache,
         }
     }
 
@@ -72,6 +85,7 @@ impl Poller {
         // committing to a poll.
         if !*synced {
             let progress = self.bit.sync_progress();
+            self.sync_cache.store(&progress);
             log::info!(
                 "Block chain synchronization progress: {:.2}% ({} blocks / {} headers)",
                 progress.rounded_up_progress() * 100.0,
@@ -155,6 +169,7 @@ impl Poller {
             // Don't poll until the Bitcoin backend is fully synced.
             if !synced {
                 let progress = self.bit.sync_progress();
+                self.sync_cache.store(&progress);
                 log::info!(
                     "Block chain synchronization progress: {:.2}% ({} blocks / {} headers)",
                     progress.rounded_up_progress() * 100.0,

--- a/coincubed/src/commands/mod.rs
+++ b/coincubed/src/commands/mod.rs
@@ -386,7 +386,11 @@ impl DaemonControl {
             version: VERSION.to_string(),
             network: self.config.bitcoin_config.network,
             block_height,
-            sync: self.bitcoin.sync_progress().rounded_up_progress(),
+            // Read the poller's lock-free mirror rather than
+            // `self.bitcoin.sync_progress()`, which would block on the
+            // `BitcoinInterface` mutex the poller holds across a full wallet
+            // scan — the cause of the GUI's "Starting daemon…" stall.
+            sync: self.sync_progress_cache.load().rounded_up_progress(),
             descriptors: GetInfoDescriptors {
                 main: self.config.main_descriptor.clone(),
             },

--- a/coincubed/src/config.rs
+++ b/coincubed/src/config.rs
@@ -306,6 +306,16 @@ pub struct Config {
     /// is true (Connect is primary until then); cleared after the switch.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub pending_bitcoind: Option<BitcoindConfig>,
+    /// Whether the app should auto-switch to [`Self::pending_bitcoind`] as soon
+    /// as it is synced. True when the user adopted a node (installed alongside
+    /// Connect, or set one up in Settings) — they want it once ready, even if it
+    /// reused an existing chainstate and was never observed in IBD. False when a
+    /// synced node is merely *parked* (the user switched to Connect, or a
+    /// Bitcoind failure fell back to Esplora), so we don't auto-revert their
+    /// choice. Defaults false for backward compatibility; only written when true
+    /// so existing `daemon.toml` files (and the common parked case) stay clean.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub auto_switch_to_pending: bool,
 }
 
 impl Config {
@@ -325,6 +335,7 @@ impl Config {
             data_dir: None,
             fallback_esplora: None,
             pending_bitcoind: None,
+            auto_switch_to_pending: false,
         }
     }
 

--- a/coincubed/src/config.rs
+++ b/coincubed/src/config.rs
@@ -307,15 +307,22 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub pending_bitcoind: Option<BitcoindConfig>,
     /// Whether the app should auto-switch to [`Self::pending_bitcoind`] as soon
-    /// as it is synced. True when the user adopted a node (installed alongside
-    /// Connect, or set one up in Settings) — they want it once ready, even if it
-    /// reused an existing chainstate and was never observed in IBD. False when a
-    /// synced node is merely *parked* (the user switched to Connect, or a
-    /// Bitcoind failure fell back to Esplora), so we don't auto-revert their
-    /// choice. Defaults false for backward compatibility; only written when true
-    /// so existing `daemon.toml` files (and the common parked case) stay clean.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub auto_switch_to_pending: bool,
+    /// as it is synced.
+    ///
+    /// - `Some(true)` — the user adopted a node (installed alongside Connect, or
+    ///   set one up in Settings); promote it once ready, even if it reused an
+    ///   existing chainstate and was never observed in IBD.
+    /// - `Some(false)` — a synced node is merely *parked* (the user switched to
+    ///   Connect, or a Bitcoind failure fell back to Esplora); do NOT auto-revert.
+    /// - `None` — key absent. Either a fresh config with no pending node, or a
+    ///   *legacy* `daemon.toml` written before this flag existed, where any
+    ///   `pending_bitcoind` was an adopted install-alongside node that the old
+    ///   build promoted on IBD-completion with no flag. So an absent key is
+    ///   treated as "promote" (see the auto-switch check), preserving that
+    ///   behaviour across upgrades. Only the two explicit states are serialized,
+    ///   keeping unaffected `daemon.toml` files clean.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_switch_to_pending: Option<bool>,
 }
 
 impl Config {
@@ -335,7 +342,7 @@ impl Config {
             data_dir: None,
             fallback_esplora: None,
             pending_bitcoind: None,
-            auto_switch_to_pending: false,
+            auto_switch_to_pending: None,
         }
     }
 
@@ -667,6 +674,62 @@ mod tests {
         "#;
         let config_res: Result<Config, toml::de::Error> = toml::from_str(toml_str);
         config_res.expect_err("Deserializing an invalid toml_str");
+    }
+
+    // A legacy `daemon.toml` (written before `auto_switch_to_pending` existed)
+    // carries a `pending_bitcoind` but no flag. It must deserialize to `None`
+    // (interpreted as "promote", preserving the old IBD-completion behaviour),
+    // and the three states must round-trip without polluting clean configs.
+    #[test]
+    fn auto_switch_to_pending_legacy_and_states() {
+        let legacy = r#"
+            data_dir = "/home/user/folder/"
+            log_level = "INFO"
+            main_descriptor = "wsh(andor(pk([aabbccdd]tpubDEN9WSToTyy9ZQfaYqSKfmVqmq1VVLNtYfj3Vkqh67et57eJ5sTKZQBkHqSwPUsoSskJeaYnPttHe2VrkCsKA27kUaN9SDc5zhqeLzKa1rr/<0;1>/*),older(10000),pk([aabbccdd]tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/<0;1>/*)))#dw4ulnrs"
+
+            [bitcoin_config]
+            network = "bitcoin"
+            poll_interval_secs = 18
+
+            [bitcoind_config]
+            cookie_path = "/home/user/.bitcoin/.cookie"
+            addr = "127.0.0.1:8332"
+
+            [pending_bitcoind]
+            cookie_path = "/home/user/.bitcoin/.cookie"
+            addr = "127.0.0.1:8332"
+            "#
+        .trim_start()
+        .replace("            ", "");
+        let parsed = toml::from_str::<Config>(&legacy).expect("Deserializing legacy config");
+        // Absent key => None => legacy adopted node => promoted by the GUI.
+        assert_eq!(parsed.auto_switch_to_pending, None);
+        // A None flag is never serialized, so a clean config stays clean.
+        let serialized = toml::to_string_pretty(&parsed).expect("Serializing");
+        assert!(!serialized.contains("auto_switch_to_pending"));
+
+        // The two explicit states are persisted and round-trip.
+        let mut adopted = parsed.clone();
+        adopted.auto_switch_to_pending = Some(true);
+        let s = toml::to_string_pretty(&adopted).expect("Serializing adopted");
+        assert!(s.contains("auto_switch_to_pending = true"));
+        assert_eq!(
+            toml::from_str::<Config>(&s)
+                .expect("re-parse adopted")
+                .auto_switch_to_pending,
+            Some(true)
+        );
+
+        let mut parked = parsed;
+        parked.auto_switch_to_pending = Some(false);
+        let s = toml::to_string_pretty(&parked).expect("Serializing parked");
+        assert!(s.contains("auto_switch_to_pending = false"));
+        assert_eq!(
+            toml::from_str::<Config>(&s)
+                .expect("re-parse parked")
+                .auto_switch_to_pending,
+            Some(false)
+        );
     }
 
     // Test the format of the bitcoind_config section

--- a/coincubed/src/lib.rs
+++ b/coincubed/src/lib.rs
@@ -331,6 +331,7 @@ fn setup_electrum(
 fn setup_esplora(
     config: &Config,
     db: sync::Arc<sync::Mutex<dyn DatabaseInterface>>,
+    scan_abort: sync::Arc<sync::atomic::AtomicBool>,
 ) -> Result<Esplora, StartupError> {
     let esplora_config = match config.bitcoin_backend.as_ref() {
         Some(config::BitcoinBackend::Esplora(esplora_config)) => esplora_config,
@@ -340,7 +341,7 @@ fn setup_esplora(
         let chain_hash = ChainHash::using_genesis_block(config.bitcoin_config.network);
         BlockHash::from_byte_array(*chain_hash.as_bytes())
     };
-    let client = crate::bitcoin::esplora::client::Client::new(esplora_config)
+    let client = crate::bitcoin::esplora::client::Client::new(esplora_config, scan_abort)
         .map_err(|e| StartupError::Esplora(EsploraError::Client(e)))?;
     let mut db_conn = db.connection();
     let tip = db_conn.chain_tip();
@@ -396,6 +397,10 @@ pub struct DaemonControl {
     // FIXME: Should we require Sync on DatabaseInterface rather than using a Mutex?
     db: sync::Arc<sync::Mutex<dyn DatabaseInterface>>,
     secp: secp256k1::Secp256k1<secp256k1::VerifyOnly>,
+    // Lock-free mirror of the poller's latest sync progress. `get_info` reads
+    // this instead of locking `bitcoin`, so it never blocks behind the poller's
+    // full wallet scan (the "Starting daemon…" stall).
+    sync_progress_cache: sync::Arc<crate::bitcoin::SyncProgressCache>,
 }
 
 impl DaemonControl {
@@ -405,6 +410,7 @@ impl DaemonControl {
         poller_sender: mpsc::SyncSender<poller::PollerMessage>,
         db: sync::Arc<sync::Mutex<dyn DatabaseInterface>>,
         secp: secp256k1::Secp256k1<secp256k1::VerifyOnly>,
+        sync_progress_cache: sync::Arc<crate::bitcoin::SyncProgressCache>,
     ) -> DaemonControl {
         DaemonControl {
             config,
@@ -412,6 +418,7 @@ impl DaemonControl {
             poller_sender,
             db,
             secp,
+            sync_progress_cache,
         }
     }
 
@@ -430,12 +437,18 @@ pub enum DaemonHandle {
         poller_sender: mpsc::SyncSender<poller::PollerMessage>,
         poller_handle: thread::JoinHandle<()>,
         control: DaemonControl,
+        /// Set on `stop` so an in-flight Esplora scan aborts promptly instead of
+        /// blocking the poller join on requests to dead/throttled providers.
+        /// Unused (but harmless) for the bitcoind/electrum backends.
+        scan_abort: sync::Arc<sync::atomic::AtomicBool>,
     },
     Server {
         poller_sender: mpsc::SyncSender<poller::PollerMessage>,
         poller_handle: thread::JoinHandle<()>,
         rpcserver_shutdown: sync::Arc<sync::atomic::AtomicBool>,
         rpcserver_handle: thread::JoinHandle<Result<(), io::Error>>,
+        /// See [`DaemonHandle::Controller::scan_abort`].
+        scan_abort: sync::Arc<sync::atomic::AtomicBool>,
     },
 }
 
@@ -497,6 +510,11 @@ impl DaemonHandle {
             )?)) as sync::Arc<sync::Mutex<dyn DatabaseInterface>>,
         };
 
+        // Shared abort flag: `stop` flips it so an in-flight Esplora scan stops
+        // walking the provider chain and returns promptly, instead of the poller
+        // (and the `stop` that joins it) blocking on dead/throttled providers.
+        let scan_abort = sync::Arc::new(sync::atomic::AtomicBool::new(false));
+
         // Finally set up the Bitcoin backend.
         let bit = match (bitcoin, &config.bitcoin_backend) {
             (Some(bit), _) => sync::Arc::from(sync::Mutex::from(bit)),
@@ -507,16 +525,25 @@ impl DaemonHandle {
             (None, Some(config::BitcoinBackend::Electrum(..))) => {
                 sync::Arc::from(sync::Mutex::from(setup_electrum(&config, db.clone())?))
             }
-            (None, Some(config::BitcoinBackend::Esplora(..))) => {
-                sync::Arc::from(sync::Mutex::from(setup_esplora(&config, db.clone())?))
-            }
+            (None, Some(config::BitcoinBackend::Esplora(..))) => sync::Arc::from(
+                sync::Mutex::from(setup_esplora(&config, db.clone(), scan_abort.clone())?),
+            ),
             (None, None) => Err(StartupError::MissingBitcoinBackendConfig)?,
         };
 
+        // Shared, lock-free sync-progress mirror: the poller publishes into it,
+        // `get_info` reads from it — so `get_info` (and the GUI's startup gate
+        // that awaits it) never blocks behind the poller's full wallet scan.
+        let sync_progress_cache = sync::Arc::new(crate::bitcoin::SyncProgressCache::default());
+
         // Start the poller thread. Keep the thread handle to be able to check if it crashed. Store
         // an atomic to be able to stop it.
-        let mut bitcoin_poller =
-            poller::Poller::new(bit.clone(), db.clone(), config.main_descriptor.clone());
+        let mut bitcoin_poller = poller::Poller::new(
+            bit.clone(),
+            db.clone(),
+            config.main_descriptor.clone(),
+            sync_progress_cache.clone(),
+        );
         let (poller_sender, poller_receiver) = mpsc::sync_channel(1);
         let poller_handle = thread::Builder::new()
             .name("Bitcoin Network poller".to_string())
@@ -532,7 +559,14 @@ impl DaemonHandle {
 
         // Create the API the external world will use to talk to us, either directly through the Rust
         // structure or through the JSONRPC server we may setup below.
-        let control = DaemonControl::new(config, bit, poller_sender.clone(), db, secp);
+        let control = DaemonControl::new(
+            config,
+            bit,
+            poller_sender.clone(),
+            db,
+            secp,
+            sync_progress_cache,
+        );
 
         if with_rpc_server {
             let rpcserver_shutdown = sync::Arc::from(sync::atomic::AtomicBool::from(false));
@@ -552,6 +586,7 @@ impl DaemonHandle {
                 poller_handle,
                 rpcserver_shutdown,
                 rpcserver_handle,
+                scan_abort,
             });
         }
 
@@ -559,6 +594,7 @@ impl DaemonHandle {
             poller_sender,
             poller_handle,
             control,
+            scan_abort,
         })
     }
 
@@ -598,8 +634,12 @@ impl DaemonHandle {
             Self::Controller {
                 poller_sender,
                 poller_handle,
+                scan_abort,
                 ..
             } => {
+                // Abort any in-flight Esplora scan FIRST, then signal shutdown,
+                // so the poller can't be stuck mid-scan when we join it below.
+                scan_abort.store(true, sync::atomic::Ordering::Relaxed);
                 poller_sender
                     .send(poller::PollerMessage::Shutdown)
                     .expect("The other end should never have hung up before this.");
@@ -611,7 +651,9 @@ impl DaemonHandle {
                 poller_handle,
                 rpcserver_shutdown,
                 rpcserver_handle,
+                scan_abort,
             } => {
+                scan_abort.store(true, sync::atomic::Ordering::Relaxed);
                 poller_sender
                     .send(poller::PollerMessage::Shutdown)
                     .expect("The other end should never have hung up before this.");
@@ -809,7 +851,25 @@ mod tests {
     // framework.
     #[test]
     fn daemon_startup() {
-        // TODO: startup might stall, in that scenario the test should fail after a set amount of time
+        // This exercises a startup path with a known thread race: the poller can
+        // begin polling (making an unscripted RPC) before it observes the
+        // `Shutdown` this test sends, which stalls startup. Run the body under a
+        // watchdog so a stall FAILS the test promptly instead of hanging CI
+        // forever (resolving the long-standing TODO this replaced). A panic
+        // inside the body (e.g. the ~1-minute RPC-retry timeout) is surfaced too.
+        let worker = thread::spawn(daemon_startup_inner);
+        let deadline = time::Instant::now() + time::Duration::from_secs(120);
+        while !worker.is_finished() {
+            assert!(
+                time::Instant::now() < deadline,
+                "daemon_startup stalled for >120s (startup race lost) — failing instead of hanging",
+            );
+            thread::sleep(time::Duration::from_millis(50));
+        }
+        worker.join().expect("daemon_startup body panicked");
+    }
+
+    fn daemon_startup_inner() {
         let tmp_dir = tmp_dir();
         fs::create_dir_all(&tmp_dir).unwrap();
         let data_dir: path::PathBuf = [tmp_dir.as_path(), path::Path::new("datadir")]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes core daemon lifecycle (stop/start, concurrent switch races, wallet load), Bitcoin node flavor restarts, and fail-closed Connect duress gating—bugs could strand users without a backend or lock them out of Connect.
> 
> **Overview**
> **Daemon / Bitcoin backend** — Backend switches no longer run `stop`/`start` on the UI thread; they use `spawn_blocking` and `Message::DaemonRestarted` with recovery paths (`Started`, `StartedNotPersisted`, `Failed`, `Panicked`). Guards (`daemon_switch_in_progress`, tick skip, `auto_switch_suppressed`) stop overlapping switches that could race on the watchonly wallet. Auto-promotion to `pending_bitcoind` is driven by new `auto_switch_to_pending` (adopt vs parked node) instead of an IBD transition heuristic; installer and node settings set the flag accordingly.
> 
> **coincubed** — `get_info` reads sync progress from a lock-free `SyncProgressCache` so startup doesn’t stall behind long Esplora scans. Esplora client/poller honor a shutdown abort flag so `stop()` isn’t blocked on provider timeouts; managed bitcoind can stop/restart when the configured flavor doesn’t match the running node’s subversion.
> 
> **Connect** — `PlanEntitlements` matches the live API (`duress`, limits, defaults) so plans don’t decode as Free. Post-login duress checks use `DuressCheckOutcome` (unreachable vs incompatible vs unauthorized) with distinct UI and session teardown on 401. `get_duress_state` logs decode failures from response text.
> 
> **Spark bridge** — Stderr is relayed at embedded log levels (ANSI stripped, empty-event keepalive at TRACE) instead of all `warn!`.
> 
> **Installer / node UI** — Managed install defaults to **Knots** with a Core opt-out; flavor is global across vaults with warnings when changing an existing node.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e63e0c2351a8269a75c0fd9d64c86133d44a9c6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daemon can auto-switch to the pending Bitcoin node after syncing.
  * Choose managed Bitcoin node flavor (Knots vs Core) during installation and managed-node setup.
  * Duress gate now shows richer status (Checking, Unreachable, Incompatible) and handles session expiration cleanly.
* **Bug Fixes**
  * Prevent concurrent daemon backend switches; improved restart handling and config persistence warnings.
  * More reliable duress-state decoding/classification and updated duress entitlement handling.
  * Improved shutdown reliability by canceling in-flight Esplora scans.
  * Better Spark bridge stderr relay with log-level detection and ANSI stripping.
* **Performance**
  * Lock-free sync progress cache reduces blocking during wallet scans.
* **Tests**
  * Added/updated unit tests for duress decoding and duress outcome parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->