### PR TITLE
fix: wrap email text in sidebar to prevent overflow

### DIFF
--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -2225,6 +2225,7 @@ fn home_sidebar<'a>(home: &'a Home) -> Element<'a, Message> {
             Container::new(
                 txt::caption(&user.email)
                     .color(color::GREY_3)
+                    .wrapping(iced::widget::text::Wrapping::WordOrGlyph)
                     .align_x(Alignment::Center),
             )
             .padding(10)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text wrapping for long email addresses displayed in the user profile sidebar to ensure they break across lines properly without overflowing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->