### PR TITLE
Cleanup Duress

### DIFF
--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -156,7 +156,18 @@ fn build_duress_drainer(
     if queue.is_empty().unwrap_or(true) {
         return None;
     }
-    let cipher = DeviceKey::load_or_create(root).ok()?;
+    // Load-only: never mint a fresh key here (see `build_duress_orchestrator`).
+    // No usable key → don't drain now; keep the queued entry for a later launch
+    // once the original key is readable, rather than minting a key that would
+    // drop the entry as undecryptable.
+    let cipher = match DeviceKey::load(root) {
+        Ok(Some(cipher)) => cipher,
+        Ok(None) => return None,
+        Err(e) => {
+            tracing::warn!("duress: device key unreadable; deferring activation drain: {e}");
+            return None;
+        }
+    };
     let client: std::sync::Arc<dyn DuressTrigger> =
         std::sync::Arc::new(crate::services::coincube::CoincubeClient::new());
     Some(DuressDrainer::new(queue, cipher, client))
@@ -232,9 +243,19 @@ fn build_duress_orchestrator(
     let journal = WipeJournal::new(root);
     let queue = DuressQueue::new(root);
     let wipe = CubeWiper::new(duress_wipe_targets(root), journal.clone());
-    // A genuine read error leaves the cipher absent (POST skipped); the wipe
-    // never depends on it.
-    let cipher = DeviceKey::load_or_create(root).ok();
+    // Load-only: NEVER mint a fresh key on the activation path. A fresh key
+    // can't decrypt a `duress_code` sealed under the original, and minting one
+    // would let the drainer drop the queued POST as undecryptable (and clobber
+    // the key slot, defeating recovery if the original key later returns).
+    // Absent or unreadable key → cipher = None → the POST is left for the
+    // launch-time drainer once the key is back; the wipe never depends on it.
+    let cipher = match DeviceKey::load(root) {
+        Ok(cipher) => cipher,
+        Err(e) => {
+            error!("duress: device key unreadable at activation; server POST deferred: {e}");
+            None
+        }
+    };
     let client: std::sync::Arc<dyn DuressTrigger> =
         std::sync::Arc::new(crate::services::coincube::CoincubeClient::new());
 
@@ -1368,6 +1389,25 @@ impl Tab {
                             // Update local state and exit into the normal flow.
                             if let Some(datadir) = screen.datadir().cloned() {
                                 let root = datadir.path();
+                                // A server clear must NEVER drop us into the normal
+                                // app with un-wiped Cube data. If the activation
+                                // wipe failed all its retries (or was interrupted),
+                                // the journal is still pending — finish it first,
+                                // and if it STILL can't complete, stay locked (the
+                                // launch-time reconcile retries on next start).
+                                // This is the same invariant `State::new` enforces.
+                                let journal =
+                                    crate::services::duress::journal::WipeJournal::new(root);
+                                if journal.is_pending() {
+                                    complete_pending_wipe(root, &journal);
+                                    if journal.is_pending() {
+                                        screen.checking = false;
+                                        screen.error = Some(
+                                            "Duress mode is active. Try again later.".to_string(),
+                                        );
+                                        return Task::none();
+                                    }
+                                }
                                 // Skip the write on a real read error rather than
                                 // clobbering valid state with a default; the next
                                 // poll re-clears once the file is readable again.

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use iced::{Subscription, Task};
-use tracing::{error, info, warn};
+use tracing::{error, info};
 extern crate serde;
 extern crate serde_json;
 
@@ -162,22 +162,6 @@ fn build_duress_drainer(
     Some(DuressDrainer::new(queue, cipher, client))
 }
 
-/// Spawns the activation drainer as a fire-and-forget background task (used from
-/// the update context, which has a Tokio runtime). No-op if the queue is empty
-/// or no runtime is available — the launch-time `duress_drain_task` then picks
-/// it up.
-fn spawn_duress_drainer(root: &std::path::Path) {
-    let Some(drainer) = build_duress_drainer(root) else {
-        return;
-    };
-    match tokio::runtime::Handle::try_current() {
-        Ok(handle) => {
-            handle.spawn(async move { drainer.run_until_empty().await });
-        }
-        Err(_) => warn!("duress: no runtime to drain activation queue now; queued for next launch"),
-    }
-}
-
 /// Launch-time drainer as an Iced `Task` (runs in Iced's executor, where
 /// `Handle::try_current` may not be available yet). Resumes any pending
 /// activation POSTs left by a prior session.
@@ -212,137 +196,74 @@ fn duress_state_check_task(datadir: CoincubeDirectory, network: bitcoin::Network
     )
 }
 
-/// Activates duress from the local PIN path and returns the cryptic screen to
-/// lock into. Follows the orchestrator's sacred ordering so the Connect account
-/// lock and offline retry are NOT bypassed on this — the primary — activation
-/// path:
+/// Builds the [`DuressOrchestrator`] for this data directory — the single
+/// production trust anchor for local duress activation (journal → enqueue →
+/// spawn POST → wipe → persist; see
+/// `services/duress/orchestrator.rs::activate`). Do NOT re-inline that sequence
+/// here: keeping it in one place is the whole point of this consolidation.
 ///
-///   1. journal marker (records the account id for relaunch completion),
-///   2. durable queue commit (Connect tiers) — the source of truth that the
-///      POST eventually fires, committed BEFORE the wipe,
-///   3. fire the unauthenticated `trigger-with-code` POST in the background,
-///   4. atomic wipe IN PARALLEL — never gated on the network,
-///   5. persist `active` for relaunch reconcile.
-///
-/// Sovereign devices (no `account_id`) skip steps 2–3 and wipe locally with no
-/// server signal. The duress stores at the data-dir root (`duress-state.json`,
-/// `duress-queue.json`, `duress.key`, the journal) are outside the wiped tree
-/// and survive by construction, so the queued code + key remain available for
-/// the POST (and the Phase 4 drain loop) after the wipe.
-fn activate_local_duress(
-    datadir: CoincubeDirectory,
-    network: bitcoin::Network,
-) -> crate::app::view::duress::active_screen::DuressActiveScreen {
-    use crate::app::view::duress::active_screen::DuressActiveScreen;
+/// Infallible by design: if the device key can't be read the orchestrator is
+/// still built (with no cipher) so the wipe — the on-device trust anchor —
+/// always runs; only the server POST is skipped. The wipe target set is every
+/// network's Cube material, matching the launch-time reconcile, so a PIN unlock
+/// on one network can't leave another network's Cubes on disk.
+fn build_duress_orchestrator(
+    root: &std::path::Path,
+) -> crate::services::duress::orchestrator::DuressOrchestrator {
     use crate::services::duress::{
-        journal::WipeJournal, queue::DuressQueue, wipe::CubeWiper, DuressLocalState,
-        PendingActivation,
+        cipher::DeviceKey,
+        journal::WipeJournal,
+        orchestrator::{DuressOrchestrator, DuressTrigger},
+        queue::DuressQueue,
+        wipe::CubeWiper,
+        DuressLocalState,
     };
 
-    let root = datadir.path().to_path_buf();
-    let root = root.as_path();
-
-    // Load enrollment state up front: the encrypted duress code + Connect
-    // account id drive the server activation POST. A real read error (vs a
-    // missing file) is surfaced, not silently defaulted: it means the server
-    // POST can't be addressed, but we still wipe + lock locally — the local
-    // lock takes priority over preserving an already-unreadable file.
-    let mut st = match DuressLocalState::load(root) {
-        Ok(st) => st,
-        Err(e) => {
-            error!(
-                "duress: reading duress state failed during activation; the server lock \
-                 may be skipped, but wiping and locking locally anyway: {e}"
-            );
-            DuressLocalState::default()
-        }
-    };
-    let account_id = st.account_id.clone();
-    let encrypted_code = st.duress_code.clone();
-
-    // 1. Journal marker FIRST. The recorded account id lets the launch-time
-    //    reconcile finish an interrupted wipe.
-    let journal = WipeJournal::new(root);
-    if let Err(e) = journal.mark_pending_activation(account_id.as_deref().unwrap_or("")) {
-        error!("duress: failed to write wipe journal: {e}");
-    }
-
-    // 2 + 3. Connect tiers: durably enqueue BEFORE the wipe, then start the
-    //    activation drainer in the background, in parallel with the wipe. The
-    //    drainer fires the POST immediately and KEEPS retrying with backoff
-    //    until it lands (Phase 4), so a coerced account is still locked even if
-    //    the first attempt is offline and the user never leaves this screen.
-    let queue = DuressQueue::new(root);
-    if let (Some(acct), Some(enc)) = (account_id.as_ref(), encrypted_code.as_ref()) {
-        let pending = PendingActivation {
-            account_id: acct.clone(),
-            // Stored encrypted, as everywhere else; the POST decrypts in-flight.
-            duress_code: enc.clone(),
-            enqueued_at: chrono::Utc::now(),
-            attempts: 0,
-        };
-        // This queue entry is the ONLY thing that drives the server-side lock —
-        // the drainer fires trigger-with-code from it and the launch reconcile
-        // re-drains it. A dropped enqueue means the account is never locked
-        // server-side, so retry the durable commit on a transient IO error.
-        // enqueue is atomic and idempotent per account (it replaces any existing
-        // entry), so retrying can't duplicate. We never gate the wipe/lock on
-        // this: the device locks into the cryptic screen regardless.
-        let mut enqueued = false;
-        for attempt in 1..=3 {
-            match queue.enqueue(pending.clone()) {
-                Ok(()) => {
-                    enqueued = true;
-                    break;
-                }
-                Err(e) => error!("duress: enqueue activation attempt {attempt}/3 failed: {e}"),
-            }
-        }
-        if !enqueued {
-            error!("duress: activation not durably queued; server-side lock may not fire");
-        }
-        spawn_duress_drainer(root);
-    }
-
-    // 4. Wipe (anchor) — runs in parallel with the POST above. Targets EVERY
-    //    network's Cube data, matching the launch-time reconcile, so a PIN
-    //    unlock on one network can't leave another network's Cubes on disk.
-    //    Retry on failure so a transient lock/IO error doesn't leave Cube seeds
-    //    or PIN material on disk. CubeWiper does NOT clear the journal on a
-    //    failed pass, so even if every attempt here fails, the launch-time
-    //    reconcile (complete_pending_wipe) finishes the wipe on next launch.
-    //    The device still locks into the cryptic screen regardless — showing a
-    //    normal app with Cube data after a duress trigger would be far worse.
-    let wiper = CubeWiper::new(duress_wipe_targets(root), journal);
-    let mut wiped = false;
-    for attempt in 1..=3 {
-        match wiper.execute_atomic() {
-            Ok(()) => {
-                wiped = true;
-                break;
-            }
-            Err(e) => error!("duress: wipe attempt {attempt}/3 failed: {e}"),
-        }
-    }
-    if !wiped {
+    // load() maps a missing file to default; a real read error is logged and we
+    // proceed with a default so the wipe + lock still happen (the local lock
+    // takes priority over preserving an already-unreadable file).
+    let local_state = DuressLocalState::load(root).unwrap_or_else(|e| {
         error!(
-            "duress: Cube data may remain on disk; journal retained, wipe will be \
-             retried on next launch"
+            "duress: reading duress state failed during activation; the server lock \
+             may be skipped, but wiping and locking locally anyway: {e}"
+        );
+        DuressLocalState::default()
+    });
+    let journal = WipeJournal::new(root);
+    let queue = DuressQueue::new(root);
+    let wipe = CubeWiper::new(duress_wipe_targets(root), journal.clone());
+    // A genuine read error leaves the cipher absent (POST skipped); the wipe
+    // never depends on it.
+    let cipher = DeviceKey::load_or_create(root).ok();
+    let client: std::sync::Arc<dyn DuressTrigger> =
+        std::sync::Arc::new(crate::services::coincube::CoincubeClient::new());
+
+    DuressOrchestrator::new(
+        local_state,
+        root.to_path_buf(),
+        journal,
+        queue,
+        wipe,
+        cipher,
+        client,
+        // No event channel: the caller transitions to the cryptic screen when
+        // the activation task completes, not via DuressEvent.
+        None,
+    )
+}
+
+/// Drives a local duress activation to completion through the orchestrator.
+/// Errors are logged, never propagated — the caller locks into the cryptic
+/// screen regardless (a wipe that failed every retry leaves the journal for the
+/// launch-time reconcile to finish).
+async fn run_local_duress_activation(root: &std::path::Path, account_id: Option<String>) {
+    let mut orchestrator = build_duress_orchestrator(root);
+    if let Err(e) = orchestrator.activate(account_id).await {
+        error!(
+            "duress: activation reported an error (device still locks into the cryptic \
+             screen; the wipe is retried on next launch): {e}"
         );
     }
-
-    // 5. Persist active state so launch-time reconcile re-enters the cryptic
-    //    screen.
-    st.active = true;
-    st.last_activation_attempt = Some(chrono::Utc::now());
-    if let Err(e) = st.save(root) {
-        error!("duress: failed to persist active state: {e}");
-    }
-
-    let queue_pending = queue.is_empty().map(|empty| !empty).unwrap_or(false);
-    let mut screen = DuressActiveScreen::with_context(datadir.clone(), Some(network));
-    screen.queue_pending = queue_pending;
-    screen
 }
 
 #[derive(Debug)]
@@ -358,6 +279,14 @@ pub enum Message {
     /// The background activation-queue drainer finished (queue emptied). No-op
     /// at the UI level — the drainer did its work as a side effect.
     DuressDrainComplete,
+    /// Local duress activation finished (orchestrator returned): lock into the
+    /// cryptic screen. The wipe has already run inside the activation task, so
+    /// no Cube data reaches this transition.
+    DuressActivated {
+        datadir: CoincubeDirectory,
+        network: bitcoin::Network,
+        queue_pending: bool,
+    },
     RemoteBackendBreezLoaded {
         wallet_settings: WalletSettings,
         backend_client: BackendWalletClient,
@@ -570,6 +499,17 @@ impl Tab {
                             })
                     });
 
+                    // Carry this device's enrolled Connect duress account id into
+                    // the PIN-entry path so a duress trigger hands it to the
+                    // orchestrator explicitly (Task A.1). `None` for sovereign
+                    // enrollment or an unreadable state file — the orchestrator
+                    // falls back to its own persisted copy, so the server lock is
+                    // never silently dropped.
+                    let duress_account_id =
+                        crate::services::duress::DuressLocalState::load(datadir_path.path())
+                            .map(|st| st.account_id)
+                            .unwrap_or(None);
+
                     let on_success = crate::pin_entry::PinEntrySuccess::LoadApp {
                         datadir: datadir_path,
                         config: cfg,
@@ -579,7 +519,11 @@ impl Tab {
                         wallet_settings,
                     };
 
-                    self.state = State::PinEntry(crate::pin_entry::PinEntry::new(cube, on_success));
+                    self.state = State::PinEntry(crate::pin_entry::PinEntry::new(
+                        cube,
+                        on_success,
+                        duress_account_id,
+                    ));
                     Task::none()
                 }
                 home::Message::View(home::ViewMessage::ToggleTheme) => {
@@ -1357,22 +1301,42 @@ impl Tab {
                     self.state = State::Home(home);
                     command.map(Message::Launch)
                 }
-                crate::pin_entry::Message::DuressDetected => {
-                    // Duress PIN entered at Cube unlock. The on-device trust
-                    // anchor is the atomic local wipe — run it now, BEFORE
-                    // rendering anything, then lock into the cryptic screen.
-                    // (The activation POST/queue is driven by the duress
-                    // orchestrator engine; threading the Connect account context
-                    // into this surface so it can fire here is a follow-up.)
+                crate::pin_entry::Message::DuressDetected { account_id } => {
+                    // Duress PIN entered at Cube unlock. Delegate to the single
+                    // trust anchor — `DuressOrchestrator::activate`
+                    // (services/duress/orchestrator.rs) — which journals,
+                    // enqueues the server POST, drives it in the background, and
+                    // runs the atomic wipe in parallel (never gated on the
+                    // network). It is async (spawns the POST), so drive it from a
+                    // Task rather than re-inlining the sequence here. `account_id`
+                    // is the explicitly-threaded enrolled Connect account, `None`
+                    // for sovereign (Task A.1). The PinEntry is already showing
+                    // its neutral loading screen, so no Cube data is visible
+                    // during the brief gap; we lock into the cryptic screen the
+                    // instant activation returns (the wipe completes within it).
                     let network = pin_entry.cube().network;
                     let datadir = match &pin_entry.on_success {
                         crate::pin_entry::PinEntrySuccess::LoadApp { datadir, .. } => {
                             datadir.clone()
                         }
                     };
-                    let screen = activate_local_duress(datadir, network);
-                    self.state = State::DuressActive(screen);
-                    Task::none()
+                    Task::perform(
+                        async move {
+                            let root = datadir.path().to_path_buf();
+                            run_local_duress_activation(&root, account_id).await;
+                            let queue_pending =
+                                crate::services::duress::queue::DuressQueue::new(&root)
+                                    .is_empty()
+                                    .map(|empty| !empty)
+                                    .unwrap_or(false);
+                            (datadir, network, queue_pending)
+                        },
+                        |(datadir, network, queue_pending)| Message::DuressActivated {
+                            datadir,
+                            network,
+                            queue_pending,
+                        },
+                    )
                 }
                 m => pin_entry.update(m).map(Message::PinEntry),
             },
@@ -1438,6 +1402,25 @@ impl Tab {
                     }
                 }
             },
+            (
+                _,
+                Message::DuressActivated {
+                    datadir,
+                    network,
+                    queue_pending,
+                },
+            ) => {
+                // Local activation finished in the background task — the wipe
+                // has run. Lock into the cryptic "Duress Mode Activated" screen.
+                let mut screen =
+                    crate::app::view::duress::active_screen::DuressActiveScreen::with_context(
+                        datadir,
+                        Some(network),
+                    );
+                screen.queue_pending = queue_pending;
+                self.state = State::DuressActive(screen);
+                Task::none()
+            }
             (
                 _,
                 Message::RemoteBackendBreezLoaded {

--- a/coincube-gui/src/pin_entry.rs
+++ b/coincube-gui/src/pin_entry.rs
@@ -21,6 +21,11 @@ pub struct PinEntry {
     loading: bool,
     // Store what to do after successful PIN entry
     pub on_success: PinEntrySuccess,
+    /// This device's enrolled Connect duress account id, captured at
+    /// construction so it can be carried explicitly through `DuressDetected`
+    /// (Task A.1) rather than re-derived deep inside activation. `None` for a
+    /// sovereign (no-Connect) enrollment.
+    duress_account_id: Option<String>,
     loading_quote: Quote,
     loading_image_handle: image::Handle,
 }
@@ -44,10 +49,16 @@ pub enum Message {
     Back,
     PinVerified,
     /// The submitted PIN matched this Cube's **duress** PIN. Bubbles up to the
-    /// tab state machine, which wipes Cube data and locks into the cryptic
-    /// "Duress Mode Activated" screen. The parent intercepts this; it is never
-    /// handled inside `PinEntry::update`.
-    DuressDetected,
+    /// tab state machine, which delegates to the duress orchestrator (wipe Cube
+    /// data + server POST) and locks into the cryptic "Duress Mode Activated"
+    /// screen. The parent intercepts this; it is never handled inside
+    /// `PinEntry::update`.
+    ///
+    /// Carries this device's enrolled Connect duress `account_id` (`None` for
+    /// sovereign) so the orchestrator receives it explicitly — see Task A.1.
+    DuressDetected {
+        account_id: Option<String>,
+    },
 }
 
 /// Classification of a submitted PIN at Cube unlock.
@@ -58,7 +69,11 @@ enum PinOutcome {
 }
 
 impl PinEntry {
-    pub fn new(cube: CubeSettings, on_success: PinEntrySuccess) -> Self {
+    pub fn new(
+        cube: CubeSettings,
+        on_success: PinEntrySuccess,
+        duress_account_id: Option<String>,
+    ) -> Self {
         let loading_quote = quote_display::random_quote("loading");
         let loading_image_handle = quote_display::image_handle_for_context("loading");
         Self {
@@ -67,6 +82,7 @@ impl PinEntry {
             error: None,
             loading: false,
             on_success,
+            duress_account_id,
             loading_quote,
             loading_image_handle,
         }
@@ -129,11 +145,16 @@ impl PinEntry {
                         Task::perform(async {}, |_| Message::PinVerified)
                     }
                     PinOutcome::Duress => {
-                        // Clear the buffer and bubble up — the cryptic screen
-                        // reveals the duress signal regardless, so a fake-success
-                        // delay buys nothing.
+                        // Clear the buffer and bubble up the enrolled account id
+                        // so the parent can drive the orchestrator. Show the
+                        // neutral loading screen during the brief async
+                        // activation gap: it's identical to a normal unlock (so
+                        // it reveals nothing to an onlooker) and blocks further
+                        // input until we lock into the cryptic screen.
                         self.pin_input.clear();
-                        Task::perform(async {}, |_| Message::DuressDetected)
+                        self.loading = true;
+                        let account_id = self.duress_account_id.clone();
+                        Task::done(Message::DuressDetected { account_id })
                     }
                     PinOutcome::Wrong => {
                         self.error = Some("Incorrect PIN. Please try again.".to_string());
@@ -144,7 +165,7 @@ impl PinEntry {
             }
             // `DuressDetected` is intercepted by the parent (tab state machine);
             // if it ever reaches here it's a no-op.
-            Message::Back | Message::PinVerified | Message::DuressDetected => Task::none(),
+            Message::Back | Message::PinVerified | Message::DuressDetected { .. } => Task::none(),
         }
     }
 

--- a/coincube-gui/src/services/duress/cipher.rs
+++ b/coincube-gui/src/services/duress/cipher.rs
@@ -29,28 +29,46 @@ pub struct DeviceKey {
 }
 
 impl DeviceKey {
-    /// Loads the device key from `coincube_dir/duress.key`, generating and
-    /// persisting a fresh CSPRNG key on first use. The key file is created with
-    /// `0o600` permissions on Unix.
-    pub fn load_or_create(coincube_dir: &Path) -> io::Result<Self> {
+    /// Loads the device key from `coincube_dir/duress.key` **without** creating
+    /// one. Returns `Ok(None)` when the file is absent — the device never
+    /// enrolled, or the key was removed/not-yet-restored. `Err` only on a
+    /// present-but-unreadable or wrong-length file.
+    ///
+    /// This is the read-only accessor for the activation and drain paths, which
+    /// must NEVER mint a fresh key: a new key can't decrypt a `duress_code`
+    /// sealed under the original, so minting one would make the drainer drop the
+    /// queued activation as "undecryptable" and clobber the slot, defeating
+    /// recovery if the original key later returns. Key creation belongs to the
+    /// enrollment/registration paths via [`load_or_create`](Self::load_or_create).
+    pub fn load(coincube_dir: &Path) -> io::Result<Option<Self>> {
         let path = Self::path(coincube_dir);
         match std::fs::read(&path) {
             Ok(bytes) if bytes.len() == KEY_LEN => {
                 let mut key = [0u8; KEY_LEN];
                 key.copy_from_slice(&bytes);
-                Ok(Self { key })
+                Ok(Some(Self { key }))
             }
             Ok(_) => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "duress.key has unexpected length",
             )),
-            Err(e) if e.kind() == io::ErrorKind::NotFound => {
-                let key: [u8; KEY_LEN] = rand::random();
-                write_key(&path, &key)?;
-                Ok(Self { key })
-            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
             Err(e) => Err(e),
         }
+    }
+
+    /// Loads the device key, generating and persisting a fresh CSPRNG key on
+    /// first use. The key file is created with `0o600` permissions on Unix.
+    ///
+    /// Only the enrollment / device-registration paths may create a key — see
+    /// [`load`](Self::load) for why activation and drain must not.
+    pub fn load_or_create(coincube_dir: &Path) -> io::Result<Self> {
+        if let Some(existing) = Self::load(coincube_dir)? {
+            return Ok(existing);
+        }
+        let key: [u8; KEY_LEN] = rand::random();
+        write_key(&Self::path(coincube_dir), &key)?;
+        Ok(Self { key })
     }
 
     /// Constructs a key from raw bytes (test helper / explicit injection).
@@ -148,6 +166,31 @@ mod tests {
         // Reload must read the same key and decrypt prior ciphertext.
         let k2 = DeviceKey::load_or_create(&dir).unwrap();
         assert_eq!(k2.decrypt(&ct).unwrap(), "x");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_returns_none_when_absent_and_never_creates() {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-duress-key-loadonly-{}-{:p}",
+            std::process::id(),
+            &0u8
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // Absent → None, and the call must NOT mint a key file.
+        assert!(DeviceKey::load(&dir).unwrap().is_none());
+        assert!(
+            !DeviceKey::path(&dir).exists(),
+            "load() must not create duress.key"
+        );
+        // After a create, load() reads the same key (decrypts prior ciphertext).
+        let created = DeviceKey::load_or_create(&dir).unwrap();
+        let ct = created.encrypt("y").unwrap();
+        let loaded = DeviceKey::load(&dir)
+            .unwrap()
+            .expect("present after create");
+        assert_eq!(loaded.decrypt(&ct).unwrap(), "y");
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/coincube-gui/src/services/duress/orchestrator.rs
+++ b/coincube-gui/src/services/duress/orchestrator.rs
@@ -20,13 +20,13 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::Utc;
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::cipher::DeviceKey;
+use super::drain::DuressDrainer;
 use super::journal::WipeJournal;
 use super::queue::DuressQueue;
 use super::wipe::CubeWiper;
@@ -72,9 +72,17 @@ impl DuressTrigger for crate::services::coincube::CoincubeClient {
     }
 }
 
-/// The wall-clock budget the *background* POST task is given before it gives up
-/// and leaves the entry for the drain loop. The wipe never waits on this.
-const POST_TIMEOUT: Duration = Duration::from_secs(5);
+/// How many times the durable enqueue is retried on a transient IO error. The
+/// queue entry is the only thing that drives the server-side lock, so a dropped
+/// commit means the account is never locked — worth a few retries. enqueue is
+/// atomic and idempotent per account, so retrying can never duplicate.
+const ENQUEUE_RETRIES: u32 = 3;
+
+/// How many times the atomic wipe is retried on a transient lock/IO error
+/// before giving up for this session. CubeWiper never clears the journal on a
+/// failed pass, so even if every attempt fails the launch-time reconcile
+/// finishes the wipe on next launch.
+const WIPE_RETRIES: u32 = 3;
 
 #[derive(Debug)]
 pub enum DuressError {
@@ -108,7 +116,10 @@ pub struct DuressOrchestrator {
     journal: WipeJournal,
     queue: DuressQueue,
     wipe: CubeWiper,
-    cipher: DeviceKey,
+    /// Device key for decrypting the queued duress code before the POST. `None`
+    /// when the key is unreadable — construction stays infallible so the wipe
+    /// (the trust anchor) always runs; only the server POST is skipped.
+    cipher: Option<DeviceKey>,
     client: Arc<dyn DuressTrigger>,
     event_tx: Option<UnboundedSender<DuressEvent>>,
 }
@@ -121,7 +132,7 @@ impl DuressOrchestrator {
         journal: WipeJournal,
         queue: DuressQueue,
         wipe: CubeWiper,
-        cipher: DeviceKey,
+        cipher: Option<DeviceKey>,
         client: Arc<dyn DuressTrigger>,
         event_tx: Option<UnboundedSender<DuressEvent>>,
     ) -> Self {
@@ -137,83 +148,136 @@ impl DuressOrchestrator {
         }
     }
 
-    /// Activates duress: durably records intent, kicks off the POST in the
-    /// background, wipes in parallel, persists `active = true`, and emits
-    /// [`DuressEvent::Activated`].
-    pub async fn activate(&mut self, account_id: String) -> Result<(), DuressError> {
-        // The code is read from local state, NOT passed in by the caller — the
-        // user never sees or types it. It's stored encrypted at rest; decrypt
-        // to a short-lived plaintext for the POST only.
-        let encrypted = self
-            .local_state
-            .duress_code
-            .clone()
-            .ok_or(DuressError::NotEnrolledLocally)?;
-        let plaintext = self
-            .cipher
-            .decrypt(&encrypted)
-            .map_err(DuressError::Decrypt)?;
+    /// Activates duress: durably records intent, kicks off the server POST in
+    /// the background (Connect enrollments only), wipes Cube data in parallel,
+    /// persists `active = true`, and emits [`DuressEvent::Activated`].
+    ///
+    /// **This is the single production trust anchor for local duress
+    /// activation** — the GUI's PIN-entry path delegates here (see
+    /// `gui/tab.rs`). Do NOT re-introduce an inline copy of this sequence:
+    /// drift between two copies of a security-critical path is exactly what this
+    /// consolidation removed.
+    ///
+    /// `account_id` is the enrolled Connect account, threaded explicitly from
+    /// the PIN-entry success path (`None` for sovereign / no-Connect
+    /// enrollment). It is cross-checked against the locally-persisted enrollment
+    /// id, and the device falls back to the persisted id if the threaded value
+    /// is missing, so the server-side lock is never silently skipped.
+    ///
+    /// The ordering is sacred: journal → enqueue → spawn POST → wipe. The wipe
+    /// is the anchor and runs **regardless** of whether the journal write,
+    /// enqueue, or POST succeed — never gated on any network condition. Showing
+    /// a normal app with Cube data after a duress trigger would be far worse
+    /// than a missed server signal, so only a wipe that fails every retry is
+    /// surfaced as an error (the journal is retained so the launch-time
+    /// reconcile finishes it); the caller locks into the cryptic screen either
+    /// way.
+    pub async fn activate(&mut self, account_id: Option<String>) -> Result<(), DuressError> {
+        // Prefer the explicitly-threaded account id; fall back to the enrolled
+        // id in local state so a failed read at PIN-entry time can't silently
+        // drop the server lock. Warn (don't fail) if the two ever diverge — they
+        // shouldn't, there is one Connect account per desktop.
+        let enrolled = self.local_state.account_id.clone();
+        if let (Some(passed), Some(enrolled)) = (account_id.as_ref(), enrolled.as_ref()) {
+            if passed != enrolled {
+                log::warn!(
+                    "duress: activation account id {passed} differs from the enrolled id \
+                     {enrolled}; using the threaded value"
+                );
+            }
+        }
+        let account_id = account_id.or(enrolled);
 
-        // 1. Journal marker FIRST. Synchronous, fast, durable.
-        self.journal
-            .mark_pending_activation(&account_id)
-            .map_err(DuressError::Io)?;
+        // 1. Journal marker FIRST. Fast, local, durable. The recorded account id
+        //    lets the launch-time reconcile finish an interrupted wipe. A failure
+        //    here is logged, never fatal — the wipe (step 4) must still run.
+        if let Err(e) = self
+            .journal
+            .mark_pending_activation(account_id.as_deref().unwrap_or(""))
+        {
+            log::error!("duress: failed to write wipe journal: {e}");
+        }
 
-        // 2. Enqueue (store the *encrypted* code, never plaintext). Durable
-        //    source of truth — survives a power-pull in the next millisecond.
-        self.queue
-            .enqueue(PendingActivation {
-                account_id: account_id.clone(),
+        // 2 + 3. Connect tiers only — a Some account, a stored code, AND a usable
+        //    device key. Durably enqueue the *encrypted* code (never plaintext)
+        //    BEFORE the wipe, then drive the POST from the background drainer IN
+        //    PARALLEL with the wipe. The drainer fires immediately and KEEPS
+        //    retrying with backoff until it lands, so a coerced account is locked
+        //    even if the first attempt is offline and the user never leaves the
+        //    cryptic screen. The wipe never waits on any of this. Sovereign
+        //    devices skip straight to the wipe with no server signal.
+        if let (Some(acct), Some(encrypted), Some(cipher)) = (
+            account_id.as_ref(),
+            self.local_state.duress_code.clone(),
+            self.cipher.clone(),
+        ) {
+            let pending = PendingActivation {
+                account_id: acct.clone(),
                 duress_code: encrypted,
                 enqueued_at: Utc::now(),
                 attempts: 0,
-            })
-            .map_err(DuressError::Io)?;
+            };
+            let mut enqueued = false;
+            for attempt in 1..=ENQUEUE_RETRIES {
+                match self.queue.enqueue(pending.clone()) {
+                    Ok(()) => {
+                        enqueued = true;
+                        break;
+                    }
+                    Err(e) => log::error!(
+                        "duress: enqueue activation attempt {attempt}/{ENQUEUE_RETRIES} failed: {e}"
+                    ),
+                }
+            }
+            if !enqueued {
+                log::error!("duress: activation not durably queued; server-side lock may not fire");
+            }
+            // Fire-and-forget background POST driver. Decrypts each queued entry
+            // in-flight, retries with backoff until the queue drains, and is
+            // never awaited here.
+            let drainer = DuressDrainer::new(self.queue.clone(), cipher, self.client.clone());
+            tokio::spawn(async move { drainer.run_until_empty().await });
+        }
 
-        // 3. Kick off the POST in the BACKGROUND. Fire-and-forget. The wipe
-        //    (step 4) does NOT wait for this. An attacker who controls the
-        //    network MUST NOT be able to delay the wipe.
-        let client = self.client.clone();
-        let queue = self.queue.clone();
-        let acct = account_id.clone();
-        tokio::spawn(async move {
-            Self::run_post(client, queue, acct, plaintext).await;
-        });
+        // 4. Wipe (anchor) — runs IN PARALLEL with the POST above; starts
+        //    immediately and is never gated on any network condition. Retry so a
+        //    transient lock/IO error doesn't leave Cube seeds or PIN material on
+        //    disk.
+        let mut wiped = false;
+        let mut last_err = None;
+        for attempt in 1..=WIPE_RETRIES {
+            match self.wipe.execute_atomic() {
+                Ok(()) => {
+                    wiped = true;
+                    break;
+                }
+                Err(e) => {
+                    log::error!("duress: wipe attempt {attempt}/{WIPE_RETRIES} failed: {e}");
+                    last_err = Some(e);
+                }
+            }
+        }
 
-        // 4. Wipe runs IN PARALLEL with the POST above. Starts immediately;
-        //    never gated on any network condition.
-        self.wipe.execute_atomic().map_err(DuressError::Io)?;
-
-        // 5. Persist active state (the file survives the wipe, so on relaunch
-        //    we route straight to the cryptic screen).
+        // 5. Persist active state (the file survives the wipe, so on relaunch we
+        //    route straight to the cryptic screen). Logged-not-fatal: the journal
+        //    already guards an interrupted wipe.
         self.local_state.active = true;
         self.local_state.last_activation_attempt = Some(Utc::now());
-        self.local_state
-            .save(&self.data_dir)
-            .map_err(DuressError::Io)?;
+        if let Err(e) = self.local_state.save(&self.data_dir) {
+            log::error!("duress: failed to persist active state: {e}");
+        }
 
         // 6. Transition UI to the cryptic activation screen.
         if let Some(tx) = &self.event_tx {
             let _ = tx.send(DuressEvent::Activated);
         }
-        Ok(())
-    }
 
-    /// The fire-and-forget POST attempt: time-boxed, dequeues on success, leaves
-    /// the entry for the drain loop on failure/timeout. Also used directly by
-    /// tests to assert the success/failure → queue behaviour deterministically.
-    pub async fn run_post(
-        client: Arc<dyn DuressTrigger>,
-        queue: DuressQueue,
-        account_id: String,
-        plaintext_code: String,
-    ) {
-        let result =
-            tokio::time::timeout(POST_TIMEOUT, client.trigger(&account_id, &plaintext_code)).await;
-        if let Ok(Ok(())) = result {
-            let _ = queue.dequeue(&account_id);
+        match (wiped, last_err) {
+            (true, _) => Ok(()),
+            (false, Some(e)) => Err(DuressError::Io(e)),
+            // Unreachable: WIPE_RETRIES >= 1, so a non-wipe leaves an error.
+            (false, None) => Ok(()),
         }
-        // else: leave in queue; the Phase 4 drain loop retries.
     }
 
     /// Remote activation received over the gRPC stream (Phase 7b). Locks the
@@ -254,10 +318,11 @@ impl DuressOrchestrator {
 mod tests {
     use super::*;
     use std::sync::Mutex;
+    use std::time::Duration;
     use tokio::sync::Notify;
 
     /// Mock trigger that records calls and can be configured to succeed, fail,
-    /// or hang past the POST timeout.
+    /// or hang past any reasonable timeout.
     struct MockTrigger {
         calls: Arc<Mutex<Vec<String>>>,
         notify: Arc<Notify>,
@@ -280,7 +345,8 @@ mod tests {
                 Behavior::Ok => Ok(()),
                 Behavior::Err => Err(TriggerError::Retriable),
                 Behavior::Hang => {
-                    // Sleep well past POST_TIMEOUT so the timeout fires.
+                    // Sleep effectively forever so a caller that (wrongly)
+                    // awaited the POST would hang with it.
                     tokio::time::sleep(Duration::from_secs(3600)).await;
                     Ok(())
                 }
@@ -341,7 +407,7 @@ mod tests {
             journal,
             queue,
             wipe,
-            cipher,
+            Some(cipher),
             client,
             Some(tx),
         );
@@ -357,7 +423,7 @@ mod tests {
     #[tokio::test]
     async fn activate_wipes_and_emits_event() {
         let mut h = build(Behavior::Ok);
-        h.orch.activate("acct_1".to_string()).await.unwrap();
+        h.orch.activate(Some("acct_1".to_string())).await.unwrap();
 
         // Cube data gone.
         assert!(!h.dir.join("bitcoin").join("data").exists());
@@ -366,7 +432,7 @@ mod tests {
         assert!(reloaded.active);
         // Activated event emitted.
         assert_eq!(h.rx.recv().await, Some(DuressEvent::Activated));
-        // POST eventually fired and drained the queue.
+        // Background drainer fired the POST and drained the queue.
         h.notify.notified().await;
         // Give the spawned dequeue a moment to land.
         for _ in 0..50 {
@@ -382,7 +448,7 @@ mod tests {
     #[tokio::test]
     async fn activate_with_post_error_retains_queue_entry() {
         let mut h = build(Behavior::Err);
-        h.orch.activate("acct_2".to_string()).await.unwrap();
+        h.orch.activate(Some("acct_2".to_string())).await.unwrap();
         assert!(
             !h.dir.join("bitcoin").join("data").exists(),
             "wipe still ran"
@@ -400,21 +466,47 @@ mod tests {
         let mut h = build(Behavior::Hang);
         // activate() must return promptly even though the POST hangs forever —
         // the wipe is not gated on the network.
-        h.orch.activate("acct_3".to_string()).await.unwrap();
+        h.orch.activate(Some("acct_3".to_string())).await.unwrap();
         assert!(!h.dir.join("bitcoin").join("data").exists());
         assert!(DuressLocalState::load(&h.dir).unwrap().active);
         let _ = std::fs::remove_dir_all(&h.dir);
     }
 
     #[tokio::test]
-    async fn activate_without_code_errors() {
+    async fn activate_without_code_still_wipes() {
+        // A duress signal MUST wipe even with no server code to POST — the local
+        // wipe is the trust anchor; an absent code just means no server signal
+        // fires. (Contrast the old behaviour, which bailed without wiping.)
         let mut h = build(Behavior::Ok);
         h.orch.local_state.duress_code = None;
-        let err = h.orch.activate("acct_x".to_string()).await.unwrap_err();
-        assert!(matches!(err, DuressError::NotEnrolledLocally));
-        // Nothing wiped, no journal left dangling.
-        assert!(h.dir.join("bitcoin").join("data").exists());
+        h.orch.activate(Some("acct_x".to_string())).await.unwrap();
+        assert!(
+            !h.dir.join("bitcoin").join("data").exists(),
+            "wipe still ran without a code"
+        );
+        // Nothing enqueued (no code → no POST), journal cleared after the wipe.
+        assert!(
+            h.orch_queue_empty(),
+            "no server POST enqueued without a code"
+        );
         assert!(!h.orch.journal.is_pending());
+        let _ = std::fs::remove_dir_all(&h.dir);
+    }
+
+    #[tokio::test]
+    async fn activate_sovereign_wipes_without_server_post() {
+        // Sovereign (no account id): wipe locally with no enqueue and no POST.
+        let mut h = build(Behavior::Ok);
+        h.orch.activate(None).await.unwrap();
+        assert!(!h.dir.join("bitcoin").join("data").exists());
+        assert!(DuressLocalState::load(&h.dir).unwrap().active);
+        assert_eq!(h.rx.recv().await, Some(DuressEvent::Activated));
+        assert!(
+            h.orch_queue_empty(),
+            "sovereign never enqueues a server POST"
+        );
+        // The trigger was never spawned/called.
+        assert!(h.calls.lock().unwrap().is_empty());
         let _ = std::fs::remove_dir_all(&h.dir);
     }
 

--- a/coincube-gui/src/services/duress/orchestrator.rs
+++ b/coincube-gui/src/services/duress/orchestrator.rs
@@ -72,6 +72,13 @@ impl DuressTrigger for crate::services::coincube::CoincubeClient {
     }
 }
 
+/// How many times the wipe-journal marker write is retried on a transient IO
+/// error. The marker is the durability anchor that lets the launch-time
+/// reconcile finish an interrupted wipe, so a dropped write removes the
+/// crash-recovery safety net — worth a few retries. The write is idempotent (it
+/// re-creates the same marker), so retrying can never corrupt it.
+const JOURNAL_RETRIES: u32 = 3;
+
 /// How many times the durable enqueue is retried on a transient IO error. The
 /// queue entry is the only thing that drives the server-side lock, so a dropped
 /// commit means the account is never locked — worth a few retries. enqueue is
@@ -180,37 +187,66 @@ impl DuressOrchestrator {
         let enrolled = self.local_state.account_id.clone();
         if let (Some(passed), Some(enrolled)) = (account_id.as_ref(), enrolled.as_ref()) {
             if passed != enrolled {
+                // Don't log the raw account ids — keep identifiers out of
+                // warn-level logs (which surface in support bundles); the values
+                // live in duress-state.json if ever needed for debugging. This is
+                // a should-never-happen divergence (one Connect account per
+                // desktop); we proceed with the explicitly-threaded value.
                 log::warn!(
-                    "duress: activation account id {passed} differs from the enrolled id \
-                     {enrolled}; using the threaded value"
+                    "duress: activation account id differs from the enrolled id; \
+                     using the threaded value"
                 );
             }
         }
         let account_id = account_id.or(enrolled);
 
         // 1. Journal marker FIRST. Fast, local, durable. The recorded account id
-        //    lets the launch-time reconcile finish an interrupted wipe. A failure
-        //    here is logged, never fatal — the wipe (step 4) must still run.
-        if let Err(e) = self
-            .journal
-            .mark_pending_activation(account_id.as_deref().unwrap_or(""))
-        {
-            log::error!("duress: failed to write wipe journal: {e}");
+        //    lets the launch-time reconcile finish an interrupted wipe, so it's
+        //    the crash-recovery anchor — retry it on a transient error. A total
+        //    failure is logged distinctly but never fatal: the wipe (step 4)
+        //    still runs (showing Cube data after a duress trigger is worse than a
+        //    non-recoverable partial wipe), but operators must know that an
+        //    interrupted wipe will NOT be auto-completed on next launch.
+        let mut journaled = false;
+        for attempt in 1..=JOURNAL_RETRIES {
+            match self
+                .journal
+                .mark_pending_activation(account_id.as_deref().unwrap_or(""))
+            {
+                Ok(()) => {
+                    journaled = true;
+                    break;
+                }
+                Err(e) => log::error!(
+                    "duress: wipe-journal write attempt {attempt}/{JOURNAL_RETRIES} failed: {e}"
+                ),
+            }
+        }
+        if !journaled {
+            log::error!(
+                "duress: wipe journal could not be persisted; the wipe will still run, but an \
+                 interrupted wipe will NOT be auto-completed on next launch"
+            );
         }
 
-        // 2 + 3. Connect tiers only — a Some account, a stored code, AND a usable
-        //    device key. Durably enqueue the *encrypted* code (never plaintext)
-        //    BEFORE the wipe, then drive the POST from the background drainer IN
-        //    PARALLEL with the wipe. The drainer fires immediately and KEEPS
-        //    retrying with backoff until it lands, so a coerced account is locked
-        //    even if the first attempt is offline and the user never leaves the
-        //    cryptic screen. The wipe never waits on any of this. Sovereign
-        //    devices skip straight to the wipe with no server signal.
-        if let (Some(acct), Some(encrypted), Some(cipher)) = (
-            account_id.as_ref(),
-            self.local_state.duress_code.clone(),
-            self.cipher.clone(),
-        ) {
+        // 2 + 3. Connect tiers only — a Some account AND a stored code. Durably
+        //    enqueue the *encrypted* code (never plaintext) BEFORE the wipe, then
+        //    drive the POST from the background drainer IN PARALLEL with the
+        //    wipe. The drainer fires immediately and KEEPS retrying with backoff
+        //    until it lands, so a coerced account is locked even if the first
+        //    attempt is offline and the user never leaves the cryptic screen. The
+        //    wipe never waits on any of this. Sovereign devices skip straight to
+        //    the wipe with no server signal.
+        //
+        //    The enqueue stores the already-encrypted code, so it needs NO device
+        //    key — the durable queue entry (the only thing that drives the
+        //    server-side lock) is committed even when the key is missing or
+        //    transiently unreadable. Only the in-session drainer needs the key to
+        //    decrypt in-flight; without it, the launch-time drainer fires the
+        //    POST on a later launch once the key is readable again.
+        if let (Some(acct), Some(encrypted)) =
+            (account_id.as_ref(), self.local_state.duress_code.clone())
+        {
             let pending = PendingActivation {
                 account_id: acct.clone(),
                 duress_code: encrypted,
@@ -232,11 +268,35 @@ impl DuressOrchestrator {
             if !enqueued {
                 log::error!("duress: activation not durably queued; server-side lock may not fire");
             }
-            // Fire-and-forget background POST driver. Decrypts each queued entry
-            // in-flight, retries with backoff until the queue drains, and is
-            // never awaited here.
-            let drainer = DuressDrainer::new(self.queue.clone(), cipher, self.client.clone());
-            tokio::spawn(async move { drainer.run_until_empty().await });
+            // Fire-and-forget background POST driver — only when the device key
+            // is available to decrypt the queued code in-flight. It retries with
+            // backoff until the queue drains and is never awaited here. With no
+            // key, the durable entry above waits for the launch-time drainer.
+            match self.cipher.clone() {
+                Some(cipher) => {
+                    let drainer =
+                        DuressDrainer::new(self.queue.clone(), cipher, self.client.clone());
+                    // Guard the spawn: in some executor contexts there is no
+                    // current Tokio runtime, and a bare `tokio::spawn` would
+                    // PANIC — unwinding `activate` before the wipe (step 4)
+                    // runs. No runtime → skip the in-session drain; the durable
+                    // queue entry is already committed, so the launch-time
+                    // drainer fires the POST on next start.
+                    match tokio::runtime::Handle::try_current() {
+                        Ok(handle) => {
+                            handle.spawn(async move { drainer.run_until_empty().await });
+                        }
+                        Err(_) => log::warn!(
+                            "duress: no Tokio runtime to start the activation drainer now; \
+                             server POST left for the launch-time drainer"
+                        ),
+                    }
+                }
+                None => log::warn!(
+                    "duress: device key unavailable at activation; server POST left for the \
+                     launch-time drainer to fire once the key is readable"
+                ),
+            }
         }
 
         // 4. Wipe (anchor) — runs IN PARALLEL with the POST above; starts
@@ -490,6 +550,34 @@ mod tests {
             "no server POST enqueued without a code"
         );
         assert!(!h.orch.journal.is_pending());
+        let _ = std::fs::remove_dir_all(&h.dir);
+    }
+
+    #[tokio::test]
+    async fn activate_enqueues_even_without_device_key() {
+        // Regression: a missing/transiently-unreadable device key must NOT drop
+        // the durable server-lock entry. The encrypted code is already in local
+        // state, so the queue commit needs no cipher; the launch-time drainer
+        // fires the POST once the key is readable again.
+        let mut h = build(Behavior::Ok);
+        h.orch.cipher = None;
+        h.orch.activate(Some("acct_k".to_string())).await.unwrap();
+        assert!(
+            !h.dir.join("bitcoin").join("data").exists(),
+            "wipe still ran"
+        );
+        // Durable entry committed despite the absent key.
+        assert!(
+            !h.orch_queue_empty(),
+            "server lock queued without a device key"
+        );
+        // No in-session drainer could be spawned (no key to decrypt), so the
+        // POST was not attempted now — it waits for the launch-time drainer.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(
+            h.calls.lock().unwrap().is_empty(),
+            "no POST without the device key"
+        );
         let _ = std::fs::remove_dir_all(&h.dir);
     }
 

--- a/coincube-gui/tests/duress_e2e.rs
+++ b/coincube-gui/tests/duress_e2e.rs
@@ -65,11 +65,11 @@ async fn full_local_duress_cycle() {
         journal.clone(),
         queue.clone(),
         wipe,
-        cipher,
+        Some(cipher),
         Arc::new(OkTrigger),
         Some(tx),
     );
-    orch.activate("acct_e2e".to_string()).await.unwrap();
+    orch.activate(Some("acct_e2e".to_string())).await.unwrap();
 
     // Cube data is gone; the cryptic-screen event fired; state is durable.
     assert!(!dir.join("bitcoin").join("data").exists());


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes the security-critical duress activation, wipe, and Connect lock ordering; mistakes could leave Cube data on disk or drop server-side locks, though retries and load-only keys are explicitly aimed at reducing those failure modes.
> 
> **Overview**
> **Consolidates local duress activation** by removing the inlined journal → enqueue → POST → wipe sequence from `tab.rs` and routing PIN-entry triggers through `build_duress_orchestrator` / `run_local_duress_activation`, with the UI transitioning on `Message::DuressActivated` after an Iced `Task` completes (neutral loading screen during the gap).
> 
> **Hardens crypto and server-lock durability:** `DeviceKey::load` never creates `duress.key` on activation or launch drain (avoids undecryptable queue entries); the orchestrator keeps `cipher: Option<DeviceKey>` so **wipes still run** when the key is missing while encrypted queue commits and launch-time draining handle the Connect POST. Activation POSTs move from a short timeout helper to **`DuressDrainer`** with retried journal/enqueue/wipe writes; `activate` accepts optional Connect `account_id` (threaded from `PinEntry`) with fallback to persisted enrollment.
> 
> **Behavior fixes:** missing duress code no longer aborts activation without wiping; exiting the cryptic screen after server clear **finishes a pending wipe journal** before returning to Home; sovereign enrollments wipe locally with no server POST.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c459f0fb0a021268418bd8fa7fb818e4fc564c79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved duress activation resilience when server connectivity is unavailable; local security measures now execute reliably regardless of network status.

* **Refactor**
  * Restructured duress handling to separate local activation logic from server communication, enhancing overall robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->