### PR TITLE
Feature cleanup

### DIFF
--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -82,7 +82,12 @@ pub const PLAN_RENEWAL_BANNER_DAYS: i64 = 7;
 /// Highest pricing-schema version this build can fully render. A
 /// `/connect/features` payload advertising a higher version triggers the
 /// soft "update available" note in the plan picker (D4).
-pub const SUPPORTED_PRICING_SCHEMA_VERSION: u32 = 1;
+///
+/// v2 (cubes terminology, `estate` tier, `IncludedLinkedParticipants`
+/// dropped) is the current API schema and the model this build renders —
+/// bumped from 1 so the desktop stops flagging the live pricing as
+/// "newer than supported".
+pub const SUPPORTED_PRICING_SCHEMA_VERSION: u32 = 2;
 
 /// Where the user's plan sits in its lifecycle, derived from the
 /// `/connect/plan` response plus the current time. Drives the renewal
@@ -492,6 +497,12 @@ pub struct ConnectAccountPanel {
     pub plan: Option<ConnectPlan>,
     pub verified_devices: Option<Vec<VerifiedDevice>>,
     pub login_activity: Option<Vec<LoginActivity>>,
+    /// Account Overview summary counts, fetched on entering the Overview
+    /// tab (kept separate from `contacts_state` so the count doesn't
+    /// disturb the Contacts tab's own load/step state). `None` = not yet
+    /// loaded or the fetch failed; the row hides in either case.
+    pub overview_contact_count: Option<usize>,
+    pub overview_cube_count: Option<usize>,
     pub contacts_state: ContactsState,
     pub error: Option<String>,
     /// Incremented on each login/logout so stale async completions can be discarded.
@@ -535,6 +546,8 @@ impl ConnectAccountPanel {
             plan: None,
             verified_devices: None,
             login_activity: None,
+            overview_contact_count: None,
+            overview_cube_count: None,
             contacts_state: ContactsState::new(),
             error: None,
             session_generation: 0,
@@ -689,6 +702,17 @@ impl ConnectAccountPanel {
         self.contacts_state.error = None;
         self.contacts_state.loading = true;
         load_contacts_data(&self.client, self.session_generation)
+    }
+
+    /// Fetch the Account Overview summary counts (contacts + cubes) on
+    /// demand when the Overview tab is opened. Cheap and best-effort —
+    /// a failed fetch just leaves the count `None` and the row hidden.
+    pub fn reload_overview(&mut self) -> iced::Task<Message> {
+        load_overview_counts(
+            &self.client,
+            self.session_generation,
+            self.contacts_state.active_network.clone(),
+        )
     }
 
     fn load_session_from_keyring(&self) -> Option<StoredSession> {
@@ -881,6 +905,24 @@ impl ConnectAccountPanel {
                         self.selected_billing_cycle = cycle;
                     }
                     self.plan = plan;
+                }
+            }
+
+            ConnectAccountMessage::OverviewCountsLoaded {
+                contacts,
+                cubes,
+                generation,
+            } => {
+                if generation == self.session_generation {
+                    // Only overwrite a field when its fetch succeeded, so a
+                    // partial failure doesn't blank out a previously-loaded
+                    // count.
+                    if contacts.is_some() {
+                        self.overview_contact_count = contacts;
+                    }
+                    if cubes.is_some() {
+                        self.overview_cube_count = cubes;
+                    }
                 }
             }
 
@@ -1728,6 +1770,8 @@ impl ConnectAccountPanel {
         self.plan = None;
         self.verified_devices = None;
         self.login_activity = None;
+        self.overview_contact_count = None;
+        self.overview_cube_count = None;
         self.features = None;
         self.checkout = None;
         self.billing_history = None;
@@ -3021,6 +3065,48 @@ impl ConnectAccountPanel {
             .map(|v| v > SUPPORTED_PRICING_SCHEMA_VERSION)
             .unwrap_or(false)
     }
+}
+
+/// Fetch the Account Overview summary counts. Runs the contacts and
+/// cubes list calls back-to-back and reports their lengths; an error on
+/// either resolves to `None` for that count so the Overview row hides
+/// rather than surfacing a transient failure on a glanceable summary.
+///
+/// The cube count is scoped to `active_network` when set (same
+/// convention as `load_invite_cubes`: `None` counts cubes on every
+/// network, e.g. on a Connect-only surface with no active cube).
+fn load_overview_counts(
+    client: &CoincubeClient,
+    generation: u64,
+    active_network: Option<String>,
+) -> iced::Task<Message> {
+    let client = client.clone();
+    iced::Task::perform(
+        async move {
+            let contacts = client.get_contacts().await.ok().map(|c| c.len());
+            let cubes = client.list_cubes().await.ok().map(|cubes| {
+                cubes
+                    .into_iter()
+                    .filter(|c| {
+                        active_network
+                            .as_deref()
+                            .map(|net| c.network == net)
+                            .unwrap_or(true)
+                    })
+                    .count()
+            });
+            (contacts, cubes)
+        },
+        move |(contacts, cubes)| {
+            Message::View(view::Message::ConnectAccount(
+                ConnectAccountMessage::OverviewCountsLoaded {
+                    contacts,
+                    cubes,
+                    generation,
+                },
+            ))
+        },
+    )
 }
 
 /// Load Contacts tab data (contacts + invites).

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -499,8 +499,12 @@ pub struct ConnectAccountPanel {
     pub login_activity: Option<Vec<LoginActivity>>,
     /// Account Overview summary counts, fetched on entering the Overview
     /// tab (kept separate from `contacts_state` so the count doesn't
-    /// disturb the Contacts tab's own load/step state). `None` = not yet
-    /// loaded or the fetch failed; the row hides in either case.
+    /// disturb the Contacts tab's own load/step state). `None` until the
+    /// first successful fetch (and again after logout) — the row stays
+    /// hidden until then. A *later* failed refresh deliberately keeps the
+    /// last successful value rather than reverting to `None`, so a
+    /// transient error doesn't blank the row (see the
+    /// `OverviewCountsLoaded` handler).
     pub overview_contact_count: Option<usize>,
     pub overview_cube_count: Option<usize>,
     pub contacts_state: ContactsState,
@@ -3069,8 +3073,9 @@ impl ConnectAccountPanel {
 
 /// Fetch the Account Overview summary counts. Runs the contacts and
 /// cubes list calls back-to-back and reports their lengths; an error on
-/// either resolves to `None` for that count so the Overview row hides
-/// rather than surfacing a transient failure on a glanceable summary.
+/// either resolves to `None` for that count, signalling "no fresh value"
+/// — the handler then keeps any prior value rather than surfacing a
+/// transient failure on a glanceable summary.
 ///
 /// The cube count is scoped to `active_network` when set (same
 /// convention as `load_invite_cubes`: `None` counts cubes on every

--- a/coincube-gui/src/app/view/connect/contacts.rs
+++ b/coincube-gui/src/app/view/connect/contacts.rs
@@ -587,6 +587,7 @@ fn contact_detail_ux<'a>(
             .push(iced::widget::Space::new().height(Length::Fixed(6.0)))
             .push(text::p2_regular(format!("Connected {}", connected_date)).color(color::GREY_3))
             .align_x(Alignment::Center)
+            .width(Length::Fill)
             .padding(20)
             .spacing(0),
     )
@@ -618,83 +619,71 @@ fn contact_detail_ux<'a>(
             .color(color::GREY_3)
             .into(),
         Some(cubes) => {
-            let mut cube_col = Column::new().spacing(6);
+            let mut cube_col = Column::new().spacing(12);
             for cube in cubes {
+                // Network rendered as a muted pill so it reads as
+                // metadata rather than crowding the cube name.
+                let network_pill = container(text::caption(cube.network.as_str()).color(color::GREY_3))
+                    .padding(iced::Padding {
+                        top: 2.0,
+                        bottom: 2.0,
+                        left: 8.0,
+                        right: 8.0,
+                    })
+                    .style(|_t| container::Style {
+                        border: iced::Border {
+                            color: color::GREY_5,
+                            width: 0.5,
+                            radius: 6.0.into(),
+                        },
+                        ..Default::default()
+                    });
+
                 let mut row = Row::new()
+                    .spacing(10)
+                    .align_y(Alignment::Center)
                     .push(text::p1_regular(cube.name.as_str()).style(theme::text::primary))
-                    .push(iced::widget::Space::new().width(Length::Fixed(12.0)))
-                    .push(text::p2_regular(cube.network.as_str()).color(color::GREY_3));
+                    .push(network_pill)
+                    // Push any trailing badge to the right edge so the
+                    // rows line up cleanly regardless of name length.
+                    .push(iced::widget::Space::new().width(Length::Fill));
                 if cube.has_recovery_kit {
-                    row = row
-                        .push(iced::widget::Space::new().width(Length::Fixed(12.0)))
-                        .push(
-                            container(text::caption("Recovery Kit").color(color::ORANGE))
-                                .padding(iced::Padding {
-                                    top: 2.0,
-                                    bottom: 2.0,
-                                    left: 6.0,
-                                    right: 6.0,
-                                })
-                                .style(|_t| container::Style {
-                                    border: iced::Border {
-                                        color: color::ORANGE,
-                                        width: 0.5,
-                                        radius: 6.0.into(),
-                                    },
-                                    ..Default::default()
-                                }),
-                        );
+                    row = row.push(
+                        container(text::caption("Recovery Kit").color(color::ORANGE))
+                            .padding(iced::Padding {
+                                top: 2.0,
+                                bottom: 2.0,
+                                left: 6.0,
+                                right: 6.0,
+                            })
+                            .style(|_t| container::Style {
+                                border: iced::Border {
+                                    color: color::ORANGE,
+                                    width: 0.5,
+                                    radius: 6.0.into(),
+                                },
+                                ..Default::default()
+                            }),
+                    );
                 }
-                row = row.align_y(Alignment::Center);
                 cube_col = cube_col.push(row);
             }
             cube_col.into()
         }
     };
 
-    // W14: entry points for "add this contact to a cube". Only rendered
+    // W14: entry point for adding this contact to a cube. Only rendered
     // when the contact has a linked user — an orphaned contact can't be
-    // added to a cube anyway.
+    // added to a cube anyway. The multi-select "Add to Cube(s)…" dialog
+    // is the single action: the one-click "Add to Current Cube" shortcut
+    // was removed as it's no longer a valid option.
     let can_add = contact.contact_user.is_some();
-    // Hide the "Add to Current Cube" button entirely when the contact
-    // is already a member of the loaded cube — the Associated Cubes
-    // list right above already communicates the state, and clicking
-    // would only 409 on duplicate. The multi-select "Add to Cube(s)…"
-    // stays available so the user can still attach them to *other*
-    // cubes they own.
-    let show_add_current = !cs.contact_is_in_active_cube(contact_id);
-    let current_cube_err = cs.add_to_current_cube_errors.get(&contact_id);
     let add_actions: Option<Element<ConnectAccountMessage>> = can_add.then(|| {
-        let mut row = Row::new().spacing(8).align_y(Alignment::Center);
-        if show_add_current {
-            row = row.push(
-                // One-click "Add to Current Cube" — primary action,
-                // gated on having the active cube's server-side id
-                // resolved (populated post `register_cube`). Works
-                // regardless of how many other cubes the user owns on
-                // the same network — the action targets the specific
-                // loaded cube, not a network-matching guess.
-                button::primary(None, "Add to Current Cube").on_press_maybe(
-                    (cs.active_cube_server_id.is_some()
-                        && !cs.add_to_current_cube_pending.contains(&contact_id))
-                    .then_some(ConnectAccountMessage::Contacts(
-                        ContactsMessage::AddContactToCurrentCube(contact_id),
-                    )),
-                ),
-            );
-        }
-        row = row.push(
-            // Multi-select — secondary action, always available.
-            button::secondary(None, "Add to Cube(s)…").on_press(ConnectAccountMessage::Contacts(
+        button::primary(None, "Add to Cube(s)…")
+            .on_press(ConnectAccountMessage::Contacts(
                 ContactsMessage::OpenAddToCubeDialog(contact_id),
-            )),
-        );
-        if let Some(err) = current_cube_err {
-            row = row
-                .push(iced::widget::Space::new().width(Length::Fixed(12.0)))
-                .push(text::p2_regular(err.clone()).color(color::RED));
-        }
-        row.into()
+            ))
+            .into()
     });
 
     let add_to_cube_dialog = cs
@@ -730,8 +719,7 @@ fn contact_detail_ux<'a>(
 
     // Cap the panel width so the profile/cubes cards read as a focused
     // detail column instead of stretching edge-to-edge on wide windows.
-    // Matches the `.max_width(500)` the Invite form uses below, bumped
-    // slightly to comfortably fit the two side-by-side action buttons.
+    // Matches the `.max_width(500)` the Invite form uses below.
     col.spacing(0).max_width(520).width(Length::Fill).into()
 }
 

--- a/coincube-gui/src/app/view/connect/contacts.rs
+++ b/coincube-gui/src/app/view/connect/contacts.rs
@@ -623,21 +623,22 @@ fn contact_detail_ux<'a>(
             for cube in cubes {
                 // Network rendered as a muted pill so it reads as
                 // metadata rather than crowding the cube name.
-                let network_pill = container(text::caption(cube.network.as_str()).color(color::GREY_3))
-                    .padding(iced::Padding {
-                        top: 2.0,
-                        bottom: 2.0,
-                        left: 8.0,
-                        right: 8.0,
-                    })
-                    .style(|_t| container::Style {
-                        border: iced::Border {
-                            color: color::GREY_5,
-                            width: 0.5,
-                            radius: 6.0.into(),
-                        },
-                        ..Default::default()
-                    });
+                let network_pill =
+                    container(text::caption(cube.network.as_str()).color(color::GREY_3))
+                        .padding(iced::Padding {
+                            top: 2.0,
+                            bottom: 2.0,
+                            left: 8.0,
+                            right: 8.0,
+                        })
+                        .style(|_t| container::Style {
+                            border: iced::Border {
+                                color: color::GREY_5,
+                                width: 0.5,
+                                radius: 6.0.into(),
+                            },
+                            ..Default::default()
+                        });
 
                 let mut row = Row::new()
                     .spacing(10)

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -454,8 +454,15 @@ fn overview_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccount
 
     // Renewal / access date — only meaningful on a paid plan with a
     // server-provided date (Free tier omits it). A canceled plan keeps
-    // access until the date, so the label reflects that.
-    if let Some(plan) = state.plan.as_ref() {
+    // access until the date, so the label reflects that. A past-due plan
+    // reads as Expired (the renewal banner above already states "Your
+    // plan expired on …"); a "Renews" row carrying the same lapsed date
+    // would contradict it, so skip the row entirely in that state.
+    if let Some(plan) = state
+        .plan
+        .as_ref()
+        .filter(|_| !matches!(state.plan_lifecycle(), PlanLifecycle::Expired))
+    {
         if let Some(date) = plan.renewal_at.as_deref().map(format_date) {
             let label = match plan.status {
                 crate::services::coincube::PlanStatus::Canceled => "Access until",

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -20,7 +20,6 @@ use iced::{
 use crate::{
     app::{
         menu::ConnectSubMenu,
-        settings::global::AccountTier,
         state::connect::{
             AvatarFlowStep, CheckoutPhase, ConnectAccountPanel, ConnectCubePanel, ConnectFlowStep,
             ConnectPanel, DuressContactsStep, DuressGateStatus, PlanLifecycle,
@@ -538,14 +537,6 @@ fn plan_tier_color(tier: &PlanTier) -> iced::Color {
     }
 }
 
-fn cube_limit_for(tier: &PlanTier) -> usize {
-    match tier {
-        PlanTier::Free => AccountTier::Free.cube_limit(),
-        PlanTier::Pro => AccountTier::Pro.cube_limit(),
-        PlanTier::Estate => AccountTier::Estate.cube_limit(),
-    }
-}
-
 // ── Renewal reminder / expired prompt banner (D1 / D3) ──────────────────────
 
 /// Pre-expiry renewal reminder (D1) or, for a lapsed plan, an expired
@@ -911,12 +902,14 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
                         },
                         None => "Free".to_string(),
                     };
-                    let mut features = vec![format!("{} cubes per network", cube_limit_for(&tier))];
-                    features.extend(info.features.iter().cloned());
+                    // Render the server's feature bullets verbatim — the
+                    // `/connect/features` list is the single source of truth
+                    // (including the per-network cube count), so the desktop
+                    // no longer prepends its own cube-count line.
                     Some(PlanCardData {
                         name: tier.to_string(),
                         tier,
-                        features,
+                        features: info.features.clone(),
                         price_label,
                     })
                 })

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -421,22 +421,11 @@ fn otp_ux<'a>(
 
 fn overview_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMessage> {
     let email = state.user.as_ref().map(|u| u.email.as_str()).unwrap_or("—");
-    let verified = state
-        .user
-        .as_ref()
-        .and_then(|u| u.email_verified)
-        .unwrap_or(false);
     let plan_label = state
         .plan
         .as_ref()
         .map(|p| p.tier().to_string())
         .unwrap_or_else(|| "Free".to_string());
-
-    let verification_badge: Element<ConnectAccountMessage> = if verified {
-        text::p2_regular("✓ Verified").color(color::ORANGE).into()
-    } else {
-        text::p2_regular("✗ Unverified").color(color::GREY_3).into()
-    };
 
     let mut col = Column::new()
         .push(text::h4_bold("Account Overview").style(theme::text::primary))
@@ -449,51 +438,96 @@ fn overview_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccount
             .push(iced::widget::Space::new().height(Length::Fixed(12.0)));
     }
 
+    // Build the rows incrementally so the optional renewal/usage lines
+    // only appear when their data is present. Each row is a label on the
+    // left, value pushed to the right edge.
+    let gap = || iced::widget::Space::new().height(Length::Fixed(8.0));
+    let mut card = Column::new()
+        .push(overview_info_row(
+            "Email",
+            text::p1_regular(email).style(theme::text::primary).into(),
+        ))
+        .push(gap())
+        .push(overview_info_row(
+            "Plan",
+            text::p1_bold(plan_label).color(color::ORANGE).into(),
+        ));
+
+    // Renewal / access date — only meaningful on a paid plan with a
+    // server-provided date (Free tier omits it). A canceled plan keeps
+    // access until the date, so the label reflects that.
+    if let Some(plan) = state.plan.as_ref() {
+        if let Some(date) = plan.renewal_at.as_deref().map(format_date) {
+            let label = match plan.status {
+                crate::services::coincube::PlanStatus::Canceled => "Access until",
+                _ => "Renews",
+            };
+            let value = match plan.billing_cycle {
+                Some(cycle) => format!("{date} · {cycle}"),
+                None => date,
+            };
+            card = card.push(gap()).push(overview_info_row(
+                label,
+                text::p1_regular(value).style(theme::text::primary).into(),
+            ));
+        }
+    }
+
+    // Summary counts — fetched on entering the tab; each row hides until
+    // (and unless) its count lands.
+    if let Some(n) = state.overview_contact_count {
+        card = card.push(gap()).push(overview_info_row(
+            "Contacts",
+            text::p1_regular(n.to_string())
+                .style(theme::text::primary)
+                .into(),
+        ));
+    }
+    if let Some(n) = state.overview_cube_count {
+        card = card.push(gap()).push(overview_info_row(
+            "Cubes",
+            text::p1_regular(n.to_string())
+                .style(theme::text::primary)
+                .into(),
+        ));
+    }
+
+    let card = card
+        .push(iced::widget::Space::new().height(Length::Fixed(20.0)))
+        .push(button::secondary(None, "Sign Out").on_press(ConnectAccountMessage::LogOut))
+        .padding(20)
+        .spacing(2);
+
     col.push(
-        container(
-            Column::new()
-                .push(
-                    Row::new()
-                        .push(text::p1_medium("Email").color(color::GREY_3))
-                        .push(iced::widget::Space::new().width(Length::Fill))
-                        .push(text::p1_regular(email).style(theme::text::primary))
-                        .align_y(Alignment::Center),
-                )
-                .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
-                .push(
-                    Row::new()
-                        .push(text::p1_medium("Status").color(color::GREY_3))
-                        .push(iced::widget::Space::new().width(Length::Fill))
-                        .push(verification_badge)
-                        .align_y(Alignment::Center),
-                )
-                .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
-                .push(
-                    Row::new()
-                        .push(text::p1_medium("Plan").color(color::GREY_3))
-                        .push(iced::widget::Space::new().width(Length::Fill))
-                        .push(text::p1_bold(plan_label).color(color::ORANGE))
-                        .align_y(Alignment::Center),
-                )
-                .push(iced::widget::Space::new().height(Length::Fixed(20.0)))
-                .push(button::secondary(None, "Sign Out").on_press(ConnectAccountMessage::LogOut))
-                .padding(20)
-                .spacing(2),
-        )
-        .style(|t| container::Style {
-            background: Some(iced::Background::Color(t.colors.cards.simple.background)),
-            border: iced::Border {
-                color: color::ORANGE,
-                width: 0.2,
-                radius: 20.0.into(),
-            },
-            ..Default::default()
-        })
-        .width(Length::Fill),
+        container(card)
+            .style(|t| container::Style {
+                background: Some(iced::Background::Color(t.colors.cards.simple.background)),
+                border: iced::Border {
+                    color: color::ORANGE,
+                    width: 0.2,
+                    radius: 20.0.into(),
+                },
+                ..Default::default()
+            })
+            .width(Length::Fill),
     )
     .spacing(0)
     .width(Length::Fill)
     .into()
+}
+
+/// One label/value line in the Account Overview card: muted label on the
+/// left, value pushed to the right edge.
+fn overview_info_row<'a>(
+    label: &'a str,
+    value: Element<'a, ConnectAccountMessage>,
+) -> Element<'a, ConnectAccountMessage> {
+    Row::new()
+        .push(text::p1_medium(label).color(color::GREY_3))
+        .push(iced::widget::Space::new().width(Length::Fill))
+        .push(value)
+        .align_y(Alignment::Center)
+        .into()
 }
 
 fn plan_tier_color(tier: &PlanTier) -> iced::Color {
@@ -1093,7 +1127,10 @@ fn plan_selection_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectA
                 ..Default::default()
             })
             .width(Length::Fill),
-        );
+        )
+        // Breathing room beneath the final block so it doesn't sit flush
+        // against the bottom of the scroll area.
+        .push(iced::widget::Space::new().height(Length::Fixed(20.0)));
 
     col.spacing(0).width(Length::Fill).into()
 }

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1082,6 +1082,15 @@ pub enum ConnectAccountMessage {
         plan: Option<crate::services::coincube::ConnectPlan>,
     },
     PlanLoaded(Option<crate::services::coincube::ConnectPlan>, u64),
+    /// Lightweight Account Overview counts (contacts, cubes), fetched on
+    /// entering the Overview tab. Each is `None` when its fetch failed —
+    /// the row simply hides rather than surfacing an error. Carries
+    /// `session_generation` for stale-response guarding.
+    OverviewCountsLoaded {
+        contacts: Option<usize>,
+        cubes: Option<usize>,
+        generation: u64,
+    },
     RefreshFailed(String),
     LogOut,
     EmailChanged(String),

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1381,6 +1381,14 @@ impl Home {
                         ),
                     );
                 }
+                // Load Overview summary counts on demand
+                if matches!(
+                    self.active_section,
+                    HomeSection::Connect(app::menu::ConnectSubMenu::Overview)
+                ) && self.connect_account.is_authenticated()
+                {
+                    return map_connect_task(self.connect_account.reload_overview());
+                }
                 // Load Contacts data on demand
                 if matches!(
                     self.active_section,

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -1372,6 +1372,14 @@ impl Launcher {
                         ),
                     );
                 }
+                // Load Overview summary counts on demand
+                if matches!(
+                    self.active_section,
+                    LauncherSection::Connect(app::menu::ConnectSubMenu::Overview)
+                ) && self.connect_account.is_authenticated()
+                {
+                    return map_connect_task(self.connect_account.reload_overview());
+                }
                 // Load Contacts data on demand
                 if matches!(
                     self.active_section,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly Connect account UI and display logic; async overview loads are guarded by session generation and failures degrade gracefully without auth or billing flow changes.
> 
> **Overview**
> Aligns Connect with **pricing schema v2** by bumping `SUPPORTED_PRICING_SCHEMA_VERSION` to **2**, so live `/connect/features` no longer triggers the “update available” note. Plan picker cards now show **only** server-provided feature bullets instead of prepending a desktop-derived cubes-per-network line.
> 
> **Account Overview** is reworked: email verification status is dropped; paid plans get a contextual **Renews** / **Access until** row (hidden when expired); **Contacts** and **Cubes** summary rows appear after an on-demand fetch when opening Overview (`reload_overview` from home/launcher), with session-generation guards and partial-failure behavior that keeps the last good count.
> 
> **Contact detail** drops the one-click **Add to Current Cube** action in favor of a single **Add to Cube(s)…** primary button, restyles associated-cube rows (network pill, aligned recovery badge), and tightens header width. Minor plan/billing scroll padding at the bottom.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 149ef128767cc76791caadd9ecfeb9b0e7977ed1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account Overview tab now loads and refreshes contact and cube count summaries on demand when opened.
  * Updated pricing schema support to version 2 for plan display behavior.
* **Bug Fixes**
  * Prevents stale async overview results from updating counts after state changes.
* **Style**
  * Refreshed Contact detail layout (wider header, restyled cube rows with network/recovery “pills”).
  * Removed the “Add to Current Cube” quick action; users now use “Add to Cube(s)…”.
  * Simplified Account Overview by removing the email verification badge row.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->