### PR TITLE
Clean up contacts and duress screens

### DIFF
--- a/coincube-gui/src/app/message.rs
+++ b/coincube-gui/src/app/message.rs
@@ -224,10 +224,6 @@ pub enum Message {
 /// `Message` enums (which relay this from their Connect panels) derive `Clone`.
 #[derive(Clone)]
 pub struct DuressEnrollmentPayload {
-    /// The user's re-typed regular PIN. Carried so the persist step can verify
-    /// it against each Cube's ACTUAL stored PIN (the wizard can only check the
-    /// re-typed value) before arming the duress PIN.
-    pub regular_pin: Zeroizing<String>,
     pub duress_pin: Zeroizing<String>,
     pub duress_code: Zeroizing<String>,
     /// Connect account id, persisted so the unauth activation POST can address
@@ -239,7 +235,6 @@ pub struct DuressEnrollmentPayload {
 impl std::fmt::Debug for DuressEnrollmentPayload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DuressEnrollmentPayload")
-            .field("regular_pin", &"<redacted>")
             .field("duress_pin", &"<redacted>")
             .field("duress_code", &"<redacted>")
             .field("gen", &self.gen)

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -846,7 +846,6 @@ async fn rollback_duress_pin_writes(
 
 pub(crate) async fn persist_duress_enrollment(
     datadir: CoincubeDirectory,
-    regular_pin: zeroize::Zeroizing<String>,
     duress_pin: zeroize::Zeroizing<String>,
     duress_code: zeroize::Zeroizing<String>,
     account_id: Option<String>,
@@ -865,13 +864,14 @@ pub(crate) async fn persist_duress_enrollment(
         );
     }
 
-    // 0. Guard against arming a near-miss duress PIN, across ALL networks,
-    //    BEFORE writing anything. The wizard could only check the duress PIN
-    //    against the *re-typed* regular PIN; verify that re-typed value against
-    //    each Cube's ACTUAL stored PIN and re-check distinctness against the
-    //    real one. If the user mistyped their PIN (so the wizard's check was
-    //    meaningless) or the duress PIN is within one edit of a real unlock
-    //    PIN, refuse — otherwise a fat-fingered unlock could trip a wipe.
+    // 0. Guard against a duress PIN that collides with a real unlock PIN,
+    //    across ALL networks, BEFORE writing anything. The same duress PIN
+    //    hash is armed on every Cube, and at unlock a Cube checks its real PIN
+    //    first and the duress PIN second — so if the duress PIN equals any
+    //    Cube's actual unlock PIN, either that Cube could never trip duress, or
+    //    (worse) that PIN would trip a wipe on a *different* Cube. Each Cube can
+    //    have its own PIN, so we verify the candidate duress PIN against every
+    //    Cube's stored PIN hash and refuse on any match.
     let mut prior_settings: Vec<crate::app::settings::Settings> =
         Vec::with_capacity(network_dirs.len());
     let mut total_cubes = 0usize;
@@ -883,16 +883,14 @@ pub(crate) async fn persist_duress_enrollment(
             .map_err(|e| format!("Couldn't read your Cube settings to verify your PIN: {e}"))?;
         for cube in &settings.cubes {
             total_cubes += 1;
-            if cube.has_pin() {
-                if !cube.verify_pin(&regular_pin) {
-                    return Err(
-                        "That PIN doesn't match your Cube PIN. Enter your real PIN so the \
-                         duress PIN can be safely checked against it. (All your Cubes must \
-                         share the same PIN to enable duress.)"
-                            .to_string(),
-                    );
-                }
-                crate::services::duress::enroll::validate_duress_pin(&regular_pin, &duress_pin)?;
+            // `verify_pin` returns true for a Cube with no PIN, so gate on
+            // `has_pin()` first — a PIN-less Cube can't collide.
+            if cube.has_pin() && cube.verify_pin(&duress_pin) {
+                return Err(
+                    "That duress PIN is already the unlock PIN of one of your Cubes. Choose a \
+                     PIN you don't use to unlock any Cube."
+                        .to_string(),
+                );
             }
         }
         // Snapshot the pre-write state so a later failure can roll back.
@@ -2773,7 +2771,6 @@ impl App {
                 // and Launcher surfaces, which also host the Connect Duress
                 // panel (see `persist_duress_enrollment`).
                 let crate::app::message::DuressEnrollmentPayload {
-                    regular_pin,
                     duress_pin,
                     duress_code,
                     account_id,
@@ -2781,13 +2778,7 @@ impl App {
                 } = payload;
                 let datadir = self.datadir.clone();
                 return Task::perform(
-                    persist_duress_enrollment(
-                        datadir,
-                        regular_pin,
-                        duress_pin,
-                        duress_code,
-                        account_id,
-                    ),
+                    persist_duress_enrollment(datadir, duress_pin, duress_code, account_id),
                     |res| match res {
                         Ok(()) => Message::CacheUpdated,
                         Err(e) => {

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -823,6 +823,57 @@ fn duress_enroll_network_dirs(root: &std::path::Path) -> Vec<crate::dir::Network
     dirs
 }
 
+/// User-facing message when the candidate duress PIN equals a Cube's real
+/// unlock PIN. A shared constant so the pre-flight wizard check and
+/// `persist_duress_enrollment` can't drift apart.
+pub(crate) const DURESS_PIN_COLLIDES_MSG: &str =
+    "That duress PIN is already the unlock PIN of one of your Cubes. Choose a \
+     PIN you don't use to unlock any Cube.";
+
+/// User-facing message when there are no Cubes on the device to arm.
+pub(crate) const DURESS_NO_CUBES_MSG: &str =
+    "Couldn't find any Cubes on this device to protect with duress mode.";
+
+/// Verify the candidate duress PIN does not collide with any Cube's real unlock
+/// PIN across every network under `root`. `Err` on a collision, when there are
+/// no Cubes to arm, or when settings can't be read.
+///
+/// The same duress PIN hash is armed on every Cube, and at unlock a Cube checks
+/// its real PIN first and the duress PIN second — so a duress PIN equal to any
+/// Cube's unlock PIN either can't trip duress on that Cube or trips a wipe on a
+/// *different* one. Each Cube can have its own PIN, hence the per-Cube check.
+///
+/// Run this BEFORE any server enrollment: Connect tiers enroll server-side
+/// first, so checking the (deterministic, user-entered) collision only in the
+/// later local persist would let a bad PIN enroll on the server and then fail
+/// locally — leaving the account server-enrolled with no Cube armed.
+pub(crate) fn duress_pin_collision_check(
+    root: &std::path::Path,
+    duress_pin: &str,
+) -> Result<(), String> {
+    let network_dirs = duress_enroll_network_dirs(root);
+    if network_dirs.is_empty() {
+        return Err(DURESS_NO_CUBES_MSG.to_string());
+    }
+    let mut total_cubes = 0usize;
+    for network_dir in &network_dirs {
+        let settings = crate::app::settings::Settings::from_file(network_dir)
+            .map_err(|e| format!("Couldn't read your Cube settings to verify your PIN: {e}"))?;
+        for cube in &settings.cubes {
+            total_cubes += 1;
+            // `verify_pin` returns true for a Cube with no PIN, so gate on
+            // `has_pin()` first — a PIN-less Cube can't collide.
+            if cube.has_pin() && cube.verify_pin(duress_pin) {
+                return Err(DURESS_PIN_COLLIDES_MSG.to_string());
+            }
+        }
+    }
+    if total_cubes == 0 {
+        return Err(DURESS_NO_CUBES_MSG.to_string());
+    }
+    Ok(())
+}
+
 /// Best-effort restore of the first `count` networks' settings to their
 /// pre-enrollment snapshot, undoing the duress PIN hashes written in step 1.
 /// Used when a later step (another network, or the local-state save) fails, so
@@ -859,50 +910,27 @@ pub(crate) async fn persist_duress_enrollment(
     // data directory couldn't be read). Fail loud instead of marking duress
     // "enabled" with no duress PIN written anywhere.
     if network_dirs.is_empty() {
-        return Err(
-            "Couldn't find any Cubes on this device to protect with duress mode.".to_string(),
-        );
+        return Err(DURESS_NO_CUBES_MSG.to_string());
     }
 
-    // 0. Guard against a duress PIN that collides with a real unlock PIN,
-    //    across ALL networks, BEFORE writing anything. The same duress PIN
-    //    hash is armed on every Cube, and at unlock a Cube checks its real PIN
-    //    first and the duress PIN second — so if the duress PIN equals any
-    //    Cube's actual unlock PIN, either that Cube could never trip duress, or
-    //    (worse) that PIN would trip a wipe on a *different* Cube. Each Cube can
-    //    have its own PIN, so we verify the candidate duress PIN against every
-    //    Cube's stored PIN hash and refuse on any match.
+    // 0. Guard against a duress PIN that collides with a real unlock PIN, and
+    //    against having no Cubes to arm, BEFORE writing anything. This mirrors
+    //    the wizard's pre-flight check (which runs before any server enroll);
+    //    re-running it here is the authoritative guard against an on-disk Cube
+    //    set that changed since the pre-flight.
+    duress_pin_collision_check(&root, &duress_pin)?;
+
+    // Snapshot the pre-write state of every network so a later step can roll
+    // back. (The collision / no-Cubes guards above already validated the set.)
     let mut prior_settings: Vec<crate::app::settings::Settings> =
         Vec::with_capacity(network_dirs.len());
-    let mut total_cubes = 0usize;
     for network_dir in &network_dirs {
         // We enumerated this dir because it HAS a settings.json. If it now
         // can't be read (corrupt/parse/IO, or a race), fail loud rather than
-        // skip the safety check and arm an unverified duress PIN anyway.
+        // arm an unverified duress PIN anyway.
         let settings = crate::app::settings::Settings::from_file(network_dir)
             .map_err(|e| format!("Couldn't read your Cube settings to verify your PIN: {e}"))?;
-        for cube in &settings.cubes {
-            total_cubes += 1;
-            // `verify_pin` returns true for a Cube with no PIN, so gate on
-            // `has_pin()` first — a PIN-less Cube can't collide.
-            if cube.has_pin() && cube.verify_pin(&duress_pin) {
-                return Err(
-                    "That duress PIN is already the unlock PIN of one of your Cubes. Choose a \
-                     PIN you don't use to unlock any Cube."
-                        .to_string(),
-                );
-            }
-        }
-        // Snapshot the pre-write state so a later failure can roll back.
         prior_settings.push(settings);
-    }
-    // Settings files exist but hold no Cubes — the write below would set
-    // duress_pin_hash on nothing. Don't mark duress "enabled" when no Cube is
-    // actually armed and no PIN path can trip a wipe.
-    if total_cubes == 0 {
-        return Err(
-            "Couldn't find any Cubes on this device to protect with duress mode.".to_string(),
-        );
     }
 
     // 1. Duress PIN hash → every Cube on every network. Sequential file writes

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -2779,16 +2779,26 @@ impl App {
                 let datadir = self.datadir.clone();
                 return Task::perform(
                     persist_duress_enrollment(datadir, duress_pin, duress_code, account_id),
-                    |res| match res {
-                        Ok(()) => Message::CacheUpdated,
-                        Err(e) => {
-                            log::error!("duress: failed to persist enrollment: {e}");
-                            Message::View(view::Message::ShowError(format!(
-                                "Couldn't finish enabling duress mode: {e}. Please try again."
-                            )))
-                        }
-                    },
-                );
+                    |res| res,
+                )
+                .then(|res| match res {
+                    Ok(()) => Task::batch([
+                        // Reflect the enabled state only now that the duress PIN
+                        // is actually armed on every Cube.
+                        Task::done(Message::View(view::Message::ConnectAccount(
+                            view::ConnectAccountMessage::Duress(
+                                view::DuressMessage::EnrollmentPersisted,
+                            ),
+                        ))),
+                        Task::done(Message::CacheUpdated),
+                    ]),
+                    Err(e) => {
+                        log::error!("duress: failed to persist enrollment: {e}");
+                        Task::done(Message::View(view::Message::ShowError(format!(
+                            "Couldn't finish enabling duress mode: {e}. Please try again."
+                        ))))
+                    }
+                });
             }
             Message::RecoveryHeartbeatSent(res) => {
                 // Fire-and-forget: the heartbeat must never affect app state

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -2581,6 +2581,15 @@ impl ConnectAccountPanel {
                             if active
                                 && !matches!(self.step, ConnectFlowStep::DuressRecovery { .. })
                             {
+                                // Tear down any open enrollment wizard before
+                                // routing to recovery: recovery supersedes it,
+                                // and `duress_ux` prioritizes a `Some`
+                                // `duress_enroll` over the intro/enabled view —
+                                // so a leftover wizard would re-appear (possibly
+                                // mid-submit) when the user returns to the tab
+                                // after clearing. Also scrubs the wizard's
+                                // in-memory secrets (PINs / passphrases).
+                                self.clear_duress_enroll();
                                 self.step = ConnectFlowStep::DuressRecovery {
                                     unlock_at,
                                     passphrase: String::new(),

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -655,13 +655,16 @@ impl ConnectAccountPanel {
         load_duress_state(&self.client, self.session_generation)
     }
 
-    /// Reflect a just-completed duress enrollment in the locally-cached
+    /// Reflect a just-*persisted* duress enrollment in the locally-cached
     /// `duress_state` so the Duress intro flips from the setup flow to the
-    /// enabled state immediately. Connect tiers would otherwise keep showing
-    /// setup until the next server fetch, and Sovereign tiers never fetch at
-    /// all — so without this the enabled view could stay hidden despite an
-    /// armed duress PIN. Preserves `active`/`unlock_at` if a prior fetch
-    /// populated them (e.g. another device already enrolled the account).
+    /// enabled state immediately. Called only from the `EnrollmentPersisted`
+    /// handler — i.e. after `persist_duress_enrollment` has actually armed the
+    /// duress PIN on every Cube — never on the optimistic pre-persist path,
+    /// where a later collision / disk failure would otherwise leave a false
+    /// "enabled" view with no Cube armed. Connect tiers would otherwise keep
+    /// showing setup until the next server fetch, and Sovereign tiers never
+    /// fetch at all. Preserves `active`/`unlock_at` if a prior fetch populated
+    /// them (e.g. another device already enrolled the account).
     fn mark_duress_enrolled(&mut self) {
         match &mut self.duress_state {
             Some(s) => {
@@ -2387,11 +2390,11 @@ impl ConnectAccountPanel {
 
                 if tier == EnrollTier::Sovereign {
                     // No Connect call — local wipe + cryptic only. Persist now.
+                    // The cached state is flipped to "enrolled" only once persist
+                    // succeeds (via `EnrollmentPersisted`), so a failed persist
+                    // doesn't leave a false "enabled" view with no Cube armed.
                     let duress_pin = e.duress_pin.clone();
                     self.clear_duress_enroll();
-                    // No server state to fetch here, so flip the cached state
-                    // ourselves or the intro never leaves the setup flow.
-                    self.mark_duress_enrolled();
                     return iced::Task::done(Message::CompleteDuressEnrollment(
                         crate::app::message::DuressEnrollmentPayload {
                             duress_pin: zeroize::Zeroizing::new(duress_pin),
@@ -2495,10 +2498,13 @@ impl ConnectAccountPanel {
                         });
                         if let Some(payload) = payload {
                             self.clear_duress_enroll();
-                            // Server confirmed enrollment; reflect it in the
-                            // cached state now so the intro shows the enabled
-                            // view without waiting for another fetch.
-                            self.mark_duress_enrolled();
+                            // The server accepted enrollment, but the duress PIN
+                            // still has to be armed locally on every Cube. Defer
+                            // marking the cached state "enrolled" to the persist
+                            // success path (`EnrollmentPersisted`) — otherwise a
+                            // local failure (PIN collision, no Cubes, disk error)
+                            // would leave a false "enabled" view while no Cube is
+                            // actually armed.
                             return iced::Task::done(Message::CompleteDuressEnrollment(payload));
                         }
                     }
@@ -2520,11 +2526,33 @@ impl ConnectAccountPanel {
                 }
             }
             DuressMessage::StateLoaded(st, gen) => {
-                // Only overwrite on a successful fetch (`Some`), so a transient
-                // failure doesn't blank a previously-loaded state.
-                if gen == self.session_generation && st.is_some() {
-                    self.duress_state = st;
+                if gen == self.session_generation {
+                    if let Some(new) = st {
+                        // Don't let a stale fetch downgrade a locally-confirmed
+                        // enrollment. `reload_duress_state` is fired on opening
+                        // the tab; a slow one issued *before* the user finished
+                        // enrolling could return pre-enrollment data after
+                        // `EnrollmentPersisted` and clobber the enabled view back
+                        // to the setup flow. Enrolled is monotonic within a
+                        // session (there is no un-enroll path), so a fetch that
+                        // flips it true→false can only be stale — drop it.
+                        let downgrades_enrollment = self
+                            .duress_state
+                            .as_ref()
+                            .is_some_and(|cur| cur.enrolled && !new.enrolled);
+                        if !downgrades_enrollment {
+                            self.duress_state = Some(new);
+                        }
+                    }
+                    // `None` = the fetch failed; keep the prior state rather than
+                    // blanking it.
                 }
+            }
+            DuressMessage::EnrollmentPersisted => {
+                // Local persistence succeeded (duress PIN armed on every Cube),
+                // so it's now safe to reflect the enabled state in the cached
+                // view. This is the only place that flips it on enrollment.
+                self.mark_duress_enrolled();
             }
         }
         iced::Task::none()

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -126,6 +126,15 @@ pub struct InviteCubeOption {
     pub network: String,
 }
 
+/// One mainnet cube shown in the Duress intro screen's "set up a Cube
+/// Recovery Kit for each Cube" checklist, with whether it currently has a
+/// recovery kit on the server. Lightweight — only what the row renders.
+#[derive(Debug, Clone)]
+pub struct DuressCube {
+    pub name: String,
+    pub has_recovery_kit: bool,
+}
+
 /// State for the Contacts section within ConnectAccountPanel.
 pub struct ContactsState {
     pub step: ContactsStep,
@@ -371,9 +380,9 @@ pub enum DuressEnrollStep {
 pub struct DuressEnrollState {
     pub tier: EnrollTier,
     pub step: DuressEnrollStep,
-    /// The user's regular PIN, re-entered so distinctness can be validated.
-    pub regular_pin: String,
     pub duress_pin: String,
+    /// Re-entry of `duress_pin` so a memorized typo is caught at enrollment.
+    pub duress_pin_confirm: String,
     pub all_clear: String,
     pub crk_password: String,
     pub delay: crate::services::duress::enroll::DuressDelay,
@@ -394,8 +403,8 @@ impl DuressEnrollState {
     /// down — e.g. on logout, where the rest of the session is reset.
     fn zeroize_secrets(&mut self) {
         use zeroize::Zeroize;
-        self.regular_pin.zeroize();
         self.duress_pin.zeroize();
+        self.duress_pin_confirm.zeroize();
         self.all_clear.zeroize();
         self.crk_password.zeroize();
         self.sovereign_confirm.zeroize();
@@ -526,6 +535,15 @@ pub struct ConnectAccountPanel {
     pub duress_enroll: Option<DuressEnrollState>,
     /// Duress "Emergency contacts" section (Estate Notifications — PR 1).
     pub duress_contacts: DuressContactsState,
+    /// Mainnet cubes + recovery-kit status for the Duress intro screen's
+    /// per-Cube recovery-kit checklist. `None` until the first fetch on
+    /// entering the Duress tab. Only mainnet cubes are tracked — testnet
+    /// cubes hold no value, so their backup state doesn't matter here.
+    pub duress_cubes: Option<Vec<DuressCube>>,
+    /// Server-side duress state (enrolled / active), loaded on entering the
+    /// Duress tab so the screen reflects the enabled state instead of the
+    /// setup flow once duress is enrolled. `None` until the first fetch.
+    pub duress_state: Option<crate::services::coincube::DuressState>,
     /// Whether the user dismissed the pre-expiry renewal banner this
     /// session (D1). Not persisted — re-shows on next launch while the
     /// plan is still within its renewal window.
@@ -562,6 +580,8 @@ impl ConnectAccountPanel {
             show_billing_history: false,
             duress_enroll: None,
             duress_contacts: DuressContactsState::default(),
+            duress_cubes: None,
+            duress_state: None,
             renewal_banner_dismissed: false,
             campaign_redeem: CampaignRedeemState::default(),
             register_campaign_code: String::new(),
@@ -600,6 +620,39 @@ impl ConnectAccountPanel {
         self.duress_contacts.error = None;
         self.duress_contacts.loading = true;
         load_duress_alert_contacts(&self.client, self.session_generation)
+    }
+
+    /// Reload the mainnet cube list + recovery-kit status for the Duress
+    /// intro screen's per-Cube recovery-kit checklist. No-op for accounts
+    /// without the duress entitlement (the checklist isn't rendered for
+    /// them, so the fetch would be wasted). Best-effort: a failed fetch
+    /// leaves the list empty and the screen falls back to generic copy.
+    pub fn reload_duress_cubes(&mut self) -> iced::Task<Message> {
+        let entitled = self
+            .plan
+            .as_ref()
+            .map(|p| p.entitlements.duress)
+            .unwrap_or(false);
+        if !entitled {
+            return iced::Task::none();
+        }
+        load_duress_cubes(&self.client, self.session_generation)
+    }
+
+    /// Reload server-side duress state (enrolled / active) for the Duress
+    /// intro screen, so it can show the enabled state instead of the setup
+    /// flow. No-op for accounts without the duress entitlement. Best-effort:
+    /// a failed fetch leaves the state `None` and the setup flow is shown.
+    pub fn reload_duress_state(&mut self) -> iced::Task<Message> {
+        let entitled = self
+            .plan
+            .as_ref()
+            .map(|p| p.entitlements.duress)
+            .unwrap_or(false);
+        if !entitled {
+            return iced::Task::none();
+        }
+        load_duress_state(&self.client, self.session_generation)
     }
 
     /// Returns a clone of the authenticated client (with JWT set).
@@ -1748,8 +1801,8 @@ impl ConnectAccountPanel {
         self.duress_enroll = Some(DuressEnrollState {
             tier,
             step,
-            regular_pin: String::new(),
             duress_pin: String::new(),
+            duress_pin_confirm: String::new(),
             all_clear: String::new(),
             crk_password: String::new(),
             delay: crate::services::duress::enroll::DuressDelay::default(),
@@ -1787,6 +1840,8 @@ impl ConnectAccountPanel {
         self.selected_billing_cycle = BillingCycle::Monthly;
         self.contacts_state.clear();
         self.duress_contacts.clear();
+        self.duress_cubes = None;
+        self.duress_state = None;
         // Scrub any in-flight enrollment wizard secrets (PINs, passphrases,
         // generated code) and the recovery all-clear passphrase before
         // dropping them, so they don't survive the session reset.
@@ -2213,14 +2268,14 @@ impl ConnectAccountPanel {
             DuressMessage::CancelEnrollment => {
                 self.clear_duress_enroll();
             }
-            DuressMessage::RegularPinChanged(v) => {
-                if let Some(e) = &mut self.duress_enroll {
-                    e.regular_pin = v;
-                }
-            }
             DuressMessage::DuressPinChanged(v) => {
                 if let Some(e) = &mut self.duress_enroll {
                     e.duress_pin = v;
+                }
+            }
+            DuressMessage::DuressPinConfirmChanged(v) => {
+                if let Some(e) = &mut self.duress_enroll {
+                    e.duress_pin_confirm = v;
                 }
             }
             DuressMessage::AllClearChanged(v) => {
@@ -2283,12 +2338,10 @@ impl ConnectAccountPanel {
 
                 if tier == EnrollTier::Sovereign {
                     // No Connect call — local wipe + cryptic only. Persist now.
-                    let regular_pin = e.regular_pin.clone();
                     let duress_pin = e.duress_pin.clone();
                     self.clear_duress_enroll();
                     return iced::Task::done(Message::CompleteDuressEnrollment(
                         crate::app::message::DuressEnrollmentPayload {
-                            regular_pin: zeroize::Zeroizing::new(regular_pin),
                             duress_pin: zeroize::Zeroizing::new(duress_pin),
                             duress_code: zeroize::Zeroizing::new(code),
                             account_id: None,
@@ -2380,7 +2433,6 @@ impl ConnectAccountPanel {
                         // password, sovereign_confirm) unzeroized.
                         let payload = self.duress_enroll.as_ref().map(|e| {
                             crate::app::message::DuressEnrollmentPayload {
-                                regular_pin: zeroize::Zeroizing::new(e.regular_pin.clone()),
                                 duress_pin: zeroize::Zeroizing::new(e.duress_pin.clone()),
                                 duress_code: zeroize::Zeroizing::new(
                                     e.pending_code.clone().unwrap_or_default(),
@@ -2402,6 +2454,18 @@ impl ConnectAccountPanel {
                             e.error = Some(msg);
                         }
                     }
+                }
+            }
+            DuressMessage::CubesLoaded(cubes, gen) => {
+                if gen == self.session_generation {
+                    self.duress_cubes = Some(cubes);
+                }
+            }
+            DuressMessage::StateLoaded(st, gen) => {
+                // Only overwrite on a successful fetch (`Some`), so a transient
+                // failure doesn't blank a previously-loaded state.
+                if gen == self.session_generation && st.is_some() {
+                    self.duress_state = st;
                 }
             }
         }
@@ -3188,6 +3252,54 @@ pub fn load_duress_alert_contacts(client: &CoincubeClient, generation: u64) -> i
     )
 }
 
+/// Fetch the user's mainnet cubes + recovery-kit status for the Duress
+/// intro screen's per-Cube checklist. Filters to mainnet — testnet cubes
+/// hold no value, so their backup state is irrelevant here. Best-effort:
+/// any error resolves to an empty list (indistinguishable from "no
+/// mainnet cubes"), and the screen keeps its generic recovery-kit copy.
+fn load_duress_cubes(client: &CoincubeClient, generation: u64) -> iced::Task<Message> {
+    let client = client.clone();
+    iced::Task::perform(
+        async move {
+            client
+                .list_cubes()
+                .await
+                .map(|cubes| {
+                    cubes
+                        .into_iter()
+                        .filter(|c| c.network == "mainnet")
+                        .map(|c| DuressCube {
+                            name: c.name,
+                            has_recovery_kit: c.has_recovery_kit,
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default()
+        },
+        move |cubes| {
+            Message::View(view::Message::ConnectAccount(
+                ConnectAccountMessage::Duress(DuressMessage::CubesLoaded(cubes, generation)),
+            ))
+        },
+    )
+}
+
+/// Fetch server-side duress state (enrolled / active) for the Duress intro
+/// screen. Best-effort: any error resolves to `None`, which the handler
+/// leaves as the prior value, so a transient failure just shows the last
+/// known state (or the setup flow before the first successful fetch).
+fn load_duress_state(client: &CoincubeClient, generation: u64) -> iced::Task<Message> {
+    let client = client.clone();
+    iced::Task::perform(
+        async move { client.get_duress_state().await.ok() },
+        move |state| {
+            Message::View(view::Message::ConnectAccount(
+                ConnectAccountMessage::Duress(DuressMessage::StateLoaded(state, generation)),
+            ))
+        },
+    )
+}
+
 /// Load the user's cubes for the W12 invite-form multi-select, mapping
 /// the raw `CubeResponse`s into lightweight `InviteCubeOption`s. Used by
 /// both the initial `ShowInviteForm` load and the `InviteCubeForbidden`
@@ -3555,17 +3667,12 @@ fn validate_enroll_step(e: &DuressEnrollState) -> Result<(), String> {
             }
         }
         DuressEnrollStep::SetDuressPin => {
-            enroll::validate_duress_pin(&e.regular_pin, &e.duress_pin)
+            enroll::validate_duress_pin(&e.duress_pin, &e.duress_pin_confirm)
         }
-        DuressEnrollStep::SetAllClear => {
-            enroll::validate_all_clear(&e.all_clear, &e.regular_pin, &e.duress_pin)
+        DuressEnrollStep::SetAllClear => enroll::validate_all_clear(&e.all_clear, &e.duress_pin),
+        DuressEnrollStep::SetCrkPassword => {
+            enroll::validate_duress_crk_password(&e.crk_password, &e.duress_pin, &e.all_clear)
         }
-        DuressEnrollStep::SetCrkPassword => enroll::validate_duress_crk_password(
-            &e.crk_password,
-            &e.regular_pin,
-            &e.duress_pin,
-            &e.all_clear,
-        ),
         DuressEnrollStep::PickDelay => Ok(()),
         DuressEnrollStep::Confirm => {
             if e.memorized {
@@ -3585,8 +3692,8 @@ mod duress_enroll_tests {
         DuressEnrollState {
             tier,
             step,
-            regular_pin: "1234".to_string(),
             duress_pin: String::new(),
+            duress_pin_confirm: String::new(),
             all_clear: String::new(),
             crk_password: String::new(),
             delay: crate::services::duress::enroll::DuressDelay::default(),
@@ -3601,7 +3708,6 @@ mod duress_enroll_tests {
     #[test]
     fn zeroize_secrets_clears_all_sensitive_fields() {
         let mut s = state(EnrollTier::Tier1, DuressEnrollStep::Confirm);
-        s.regular_pin = "1234".to_string();
         s.duress_pin = "8765".to_string();
         s.all_clear = "correct horse battery".to_string();
         s.crk_password = "a-long-crk-password".to_string();
@@ -3610,7 +3716,6 @@ mod duress_enroll_tests {
 
         s.zeroize_secrets();
 
-        assert!(s.regular_pin.is_empty());
         assert!(s.duress_pin.is_empty());
         assert!(s.all_clear.is_empty());
         assert!(s.crk_password.is_empty());
@@ -3660,11 +3765,17 @@ mod duress_enroll_tests {
     }
 
     #[test]
-    fn validate_rejects_close_duress_pin() {
+    fn validate_duress_pin_step_requires_non_empty_and_matching_confirm() {
+        // The "distance from your regular PIN" rule is gone — any non-empty
+        // PIN entered twice passes the step. Collision with a real Cube PIN is
+        // enforced at persist time (`persist_duress_enrollment`), where Cube
+        // PIN hashes are available.
         let mut s = state(EnrollTier::Tier1, DuressEnrollStep::SetDuressPin);
-        s.duress_pin = "1235".to_string(); // Levenshtein 1
         assert!(validate_enroll_step(&s).is_err());
-        s.duress_pin = "8765".to_string();
+        s.duress_pin = "1235".to_string();
+        // Confirmation still empty → mismatch.
+        assert!(validate_enroll_step(&s).is_err());
+        s.duress_pin_confirm = "1235".to_string();
         assert!(validate_enroll_step(&s).is_ok());
     }
 

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -544,6 +544,13 @@ pub struct ConnectAccountPanel {
     /// Duress tab so the screen reflects the enabled state instead of the
     /// setup flow once duress is enrolled. `None` until the first fetch.
     pub duress_state: Option<crate::services::coincube::DuressState>,
+    /// Whether THIS device has actually armed the duress PIN on its Cubes
+    /// (mirrors `DuressLocalState.enrolled`). Distinct from the server's
+    /// account-level `enrolled`: only this can honestly say "armed on this
+    /// device", since the account can be enrolled elsewhere or after a failed
+    /// local persist. Refreshed on entering the Duress tab and set on a
+    /// successful local persist (`EnrollmentPersisted`).
+    pub duress_locally_armed: bool,
     /// Whether the user dismissed the pre-expiry renewal banner this
     /// session (D1). Not persisted — re-shows on next launch while the
     /// plan is still within its renewal window.
@@ -582,6 +589,7 @@ impl ConnectAccountPanel {
             duress_contacts: DuressContactsState::default(),
             duress_cubes: None,
             duress_state: None,
+            duress_locally_armed: false,
             renewal_banner_dismissed: false,
             campaign_redeem: CampaignRedeemState::default(),
             register_campaign_code: String::new(),
@@ -652,6 +660,17 @@ impl ConnectAccountPanel {
         if !entitled {
             return iced::Task::none();
         }
+        // Refresh the authoritative LOCAL arm signal (whether THIS device wrote
+        // Cube duress hashes) from `DuressLocalState`. Server `enrolled` is
+        // account-wide and can be true on a device that never armed, so the
+        // "armed on this device" view keys off this, not the server. A read
+        // failure resolves to `false` — the safe direction (never falsely
+        // claim "armed here").
+        self.duress_locally_armed = crate::dir::CoincubeDirectory::active()
+            .ok()
+            .and_then(|dir| crate::services::duress::DuressLocalState::load(dir.path()).ok())
+            .map(|st| st.enrolled)
+            .unwrap_or(false);
         load_duress_state(&self.client, self.session_generation)
     }
 
@@ -1879,6 +1898,7 @@ impl ConnectAccountPanel {
         self.duress_contacts.clear();
         self.duress_cubes = None;
         self.duress_state = None;
+        self.duress_locally_armed = false;
         // Scrub any in-flight enrollment wizard secrets (PINs, passphrases,
         // generated code) and the recovery all-clear passphrase before
         // dropping them, so they don't survive the session reset.
@@ -2531,6 +2551,19 @@ impl ConnectAccountPanel {
                             // actually armed.
                             return iced::Task::done(Message::CompleteDuressEnrollment(payload));
                         }
+                        // No wizard to build a payload from: it was torn down
+                        // mid-flight (same session — a cross-session teardown
+                        // bumps `session_generation` and is caught by the guard
+                        // above). All same-session teardowns now preserve a
+                        // submitting wizard (Cancel is blocked while submitting;
+                        // the active-duress routing skips a submitting wizard),
+                        // so this should be unreachable — log loudly if it ever
+                        // fires, since it means the account is server-enrolled
+                        // with no local arming.
+                        log::error!(
+                            "[CONNECT] duress EnrollResult(Ok) with no wizard to persist — \
+                             account may be server-enrolled but not armed locally"
+                        );
                     }
                     Err(msg) => {
                         // No local state was written — just surface the error
@@ -2589,7 +2622,16 @@ impl ConnectAccountPanel {
                                 // mid-submit) when the user returns to the tab
                                 // after clearing. Also scrubs the wizard's
                                 // in-memory secrets (PINs / passphrases).
-                                self.clear_duress_enroll();
+                                //
+                                // EXCEPT while a server enroll is in flight
+                                // (`submitting`): its `EnrollResult` reads the
+                                // wizard to run local persist, then clears it.
+                                // Dropping it here would orphan that enroll
+                                // (server enrolled, no local arm). Leave it; the
+                                // in-flight result tears it down.
+                                if self.duress_enroll.as_ref().is_none_or(|e| !e.submitting) {
+                                    self.clear_duress_enroll();
+                                }
                                 self.step = ConnectFlowStep::DuressRecovery {
                                     unlock_at,
                                     passphrase: String::new(),
@@ -2604,9 +2646,11 @@ impl ConnectAccountPanel {
                 }
             }
             DuressMessage::EnrollmentPersisted => {
-                // Local persistence succeeded (duress PIN armed on every Cube),
-                // so it's now safe to reflect the enabled state in the cached
-                // view. This is the only place that flips it on enrollment.
+                // Local persistence succeeded (duress PIN armed on every Cube on
+                // THIS device), so it's now safe to reflect the enabled state.
+                // `duress_locally_armed` drives the "armed on this device" view;
+                // `mark_duress_enrolled` mirrors the account-level server state.
+                self.duress_locally_armed = true;
                 self.mark_duress_enrolled();
             }
         }

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -655,6 +655,30 @@ impl ConnectAccountPanel {
         load_duress_state(&self.client, self.session_generation)
     }
 
+    /// Reflect a just-completed duress enrollment in the locally-cached
+    /// `duress_state` so the Duress intro flips from the setup flow to the
+    /// enabled state immediately. Connect tiers would otherwise keep showing
+    /// setup until the next server fetch, and Sovereign tiers never fetch at
+    /// all — so without this the enabled view could stay hidden despite an
+    /// armed duress PIN. Preserves `active`/`unlock_at` if a prior fetch
+    /// populated them (e.g. another device already enrolled the account).
+    fn mark_duress_enrolled(&mut self) {
+        match &mut self.duress_state {
+            Some(s) => {
+                s.enrolled = true;
+                s.this_device_registered = true;
+            }
+            None => {
+                self.duress_state = Some(crate::services::coincube::DuressState {
+                    active: false,
+                    unlock_at: None,
+                    enrolled: true,
+                    this_device_registered: true,
+                });
+            }
+        }
+    }
+
     /// Returns a clone of the authenticated client (with JWT set).
     /// Used by ConnectCubePanel to make API calls.
     pub fn authenticated_client(&self) -> Option<CoincubeClient> {
@@ -1691,17 +1715,27 @@ impl ConnectAccountPanel {
                             submitting: false,
                             cleared: false,
                         };
+                        // Cache the authoritative state we just fetched so the
+                        // Duress tab paints from it immediately instead of
+                        // flashing the setup flow while a fresh fetch is in
+                        // flight (see `duress_ux`).
+                        self.duress_state = Some(s);
                     }
                     // Confirmed not in duress — NOW reveal the dashboard.
                     DuressCheckOutcome::Ok(s) => {
                         self.step = ConnectFlowStep::Dashboard;
+                        // Cache the fetched state before any early return, so the
+                        // Duress tab reflects the enabled state on its first paint
+                        // rather than briefly showing enrollment CTAs.
+                        let needs_device_register = s.enrolled && !s.this_device_registered;
+                        self.duress_state = Some(s);
                         // Phase 0: a signed-in device on an already-enrolled
                         // account that isn't yet registered server-side mints +
                         // registers its OWN duress code (per-device, never
                         // shared), so it can fire trigger-with-code on its own
                         // activation. Fire-and-forget; idempotent (skips if this
                         // device already holds a code).
-                        if s.enrolled && !s.this_device_registered {
+                        if needs_device_register {
                             if let Some(account_id) = self.user.as_ref().map(|u| u.id.to_string()) {
                                 return register_device_duress_task(
                                     self.client.clone(),
@@ -2266,7 +2300,15 @@ impl ConnectAccountPanel {
                 };
             }
             DuressMessage::CancelEnrollment => {
-                self.clear_duress_enroll();
+                // Ignore cancel while a server enroll_duress is in flight:
+                // clear_duress_enroll zeroizes the duress PIN/code, so the
+                // EnrollResult success handler would have nothing left to
+                // persist — leaving the server enrolled but this device
+                // un-armed. The Cancel button is disabled in this state too;
+                // this is the authoritative backstop.
+                if self.duress_enroll.as_ref().is_none_or(|e| !e.submitting) {
+                    self.clear_duress_enroll();
+                }
             }
             DuressMessage::DuressPinChanged(v) => {
                 if let Some(e) = &mut self.duress_enroll {
@@ -2323,6 +2365,13 @@ impl ConnectAccountPanel {
                 let Some(e) = &mut self.duress_enroll else {
                     return iced::Task::none();
                 };
+                // Reject re-entrant submits: a second enroll while one is in
+                // flight would fire a duplicate server call and replace the
+                // stashed pending_code out from under the first. The button is
+                // disabled while submitting; this is the backstop.
+                if e.submitting {
+                    return iced::Task::none();
+                }
                 if let Err(msg) = validate_enroll_step(e) {
                     e.error = Some(msg);
                     return iced::Task::none();
@@ -2340,6 +2389,9 @@ impl ConnectAccountPanel {
                     // No Connect call — local wipe + cryptic only. Persist now.
                     let duress_pin = e.duress_pin.clone();
                     self.clear_duress_enroll();
+                    // No server state to fetch here, so flip the cached state
+                    // ourselves or the intro never leaves the setup flow.
+                    self.mark_duress_enrolled();
                     return iced::Task::done(Message::CompleteDuressEnrollment(
                         crate::app::message::DuressEnrollmentPayload {
                             duress_pin: zeroize::Zeroizing::new(duress_pin),
@@ -2443,6 +2495,10 @@ impl ConnectAccountPanel {
                         });
                         if let Some(payload) = payload {
                             self.clear_duress_enroll();
+                            // Server confirmed enrollment; reflect it in the
+                            // cached state now so the intro shows the enabled
+                            // view without waiting for another fetch.
+                            self.mark_duress_enrolled();
                             return iced::Task::done(Message::CompleteDuressEnrollment(payload));
                         }
                     }
@@ -2457,8 +2513,10 @@ impl ConnectAccountPanel {
                 }
             }
             DuressMessage::CubesLoaded(cubes, gen) => {
-                if gen == self.session_generation {
-                    self.duress_cubes = Some(cubes);
+                // Only overwrite on a successful fetch (`Some`), so a transient
+                // failure doesn't blank a previously-loaded checklist.
+                if gen == self.session_generation && cubes.is_some() {
+                    self.duress_cubes = cubes;
                 }
             }
             DuressMessage::StateLoaded(st, gen) => {
@@ -3255,8 +3313,9 @@ pub fn load_duress_alert_contacts(client: &CoincubeClient, generation: u64) -> i
 /// Fetch the user's mainnet cubes + recovery-kit status for the Duress
 /// intro screen's per-Cube checklist. Filters to mainnet — testnet cubes
 /// hold no value, so their backup state is irrelevant here. Best-effort:
-/// any error resolves to an empty list (indistinguishable from "no
-/// mainnet cubes"), and the screen keeps its generic recovery-kit copy.
+/// any error resolves to `None` (the handler then keeps any previously
+/// loaded list rather than blanking it), and an absent list leaves the
+/// screen on its generic recovery-kit copy.
 fn load_duress_cubes(client: &CoincubeClient, generation: u64) -> iced::Task<Message> {
     let client = client.clone();
     iced::Task::perform(
@@ -3274,7 +3333,7 @@ fn load_duress_cubes(client: &CoincubeClient, generation: u64) -> iced::Task<Mes
                         })
                         .collect::<Vec<_>>()
                 })
-                .unwrap_or_default()
+                .ok()
         },
         move |cubes| {
             Message::View(view::Message::ConnectAccount(

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -2379,6 +2379,30 @@ impl ConnectAccountPanel {
                     e.error = Some(msg);
                     return iced::Task::none();
                 }
+                // Pre-flight: reject a duress PIN that collides with any Cube's
+                // real unlock PIN BEFORE anything irreversible. Connect tiers
+                // enroll on the server first, so catching the collision only in
+                // the later local persist would leave the account
+                // server-enrolled with no Cube armed. The collision is
+                // deterministic from the entered PIN, so we can check it up
+                // front against the local Cube set. (Persist re-checks as the
+                // authoritative guard.)
+                match crate::dir::CoincubeDirectory::active() {
+                    Ok(dir) => {
+                        if let Err(msg) =
+                            crate::app::duress_pin_collision_check(dir.path(), &e.duress_pin)
+                        {
+                            e.error = Some(msg);
+                            return iced::Task::none();
+                        }
+                    }
+                    Err(err) => {
+                        e.error = Some(format!(
+                            "Couldn't access your Cube data to verify the duress PIN: {err}"
+                        ));
+                        return iced::Task::none();
+                    }
+                }
                 e.submitting = true;
                 e.error = None;
                 let tier = e.tier;
@@ -2541,7 +2565,29 @@ impl ConnectAccountPanel {
                             .as_ref()
                             .is_some_and(|cur| cur.enrolled && !new.enrolled);
                         if !downgrades_enrollment {
+                            let active = new.active;
+                            let unlock_at = new.unlock_at;
                             self.duress_state = Some(new);
+                            // If the server reports the account is in ACTIVE
+                            // duress, route this (signed-in, trusted) device to
+                            // the all-clear recovery screen — same as the
+                            // post-sign-in `DuressStateChecked` gate. Covers
+                            // duress activated by another device after this
+                            // session passed the sign-in gate. Skip if already
+                            // in recovery so an in-flight all-clear entry isn't
+                            // wiped. Like the gate, this does NOT persist
+                            // `DuressLocalState.active` (that flag is owned by
+                            // the paths that actually lock this device).
+                            if active
+                                && !matches!(self.step, ConnectFlowStep::DuressRecovery { .. })
+                            {
+                                self.step = ConnectFlowStep::DuressRecovery {
+                                    unlock_at,
+                                    passphrase: String::new(),
+                                    submitting: false,
+                                    cleared: false,
+                                };
+                            }
                         }
                     }
                     // `None` = the fetch failed; keep the prior state rather than

--- a/coincube-gui/src/app/state/connect/cube_members.rs
+++ b/coincube-gui/src/app/state/connect/cube_members.rs
@@ -357,6 +357,7 @@ mod tests {
             network: "bitcoin".to_string(),
             lightning_address: None,
             status: "active".to_string(),
+            has_recovery_kit: false,
             members,
             pending_invites,
             vault: None,

--- a/coincube-gui/src/app/state/connect/mod.rs
+++ b/coincube-gui/src/app/state/connect/mod.rs
@@ -83,8 +83,9 @@ pub(crate) fn delete_connect_secret(user_key: &str) {
 
 pub use account::{
     AddToCubeDialog, CheckoutPhase, CheckoutState, ConnectAccountPanel, ConnectFlowStep,
-    ContactsState, ContactsStep, DuressContactsState, DuressContactsStep, DuressEnrollState,
-    DuressEnrollStep, DuressGateStatus, EnrollTier, InviteCubeOption, PlanLifecycle,
+    ContactsState, ContactsStep, DuressContactsState, DuressContactsStep, DuressCube,
+    DuressEnrollState, DuressEnrollStep, DuressGateStatus, EnrollTier, InviteCubeOption,
+    PlanLifecycle,
 };
 pub use cube::ConnectCubePanel;
 pub use cube_members::ConnectCubeMembersState;

--- a/coincube-gui/src/app/view/connect/duress_enroll.rs
+++ b/coincube-gui/src/app/view/connect/duress_enroll.rs
@@ -241,22 +241,23 @@ fn duress_pin_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessa
             .push(text::p1_bold("Set your duress PIN").style(theme::text::primary))
             .push(
                 text::p2_regular(
-                    "Your duress PIN must be at least 2 character changes from your regular PIN. \
-                 This prevents accidental activation.",
+                    "Choose a PIN you don't use to unlock any of your Cubes. Entering it at any \
+                 Cube's unlock screen triggers a duress wipe, so it can't be one of your real \
+                 unlock PINs.",
                 )
                 .color(color::GREY_3),
             )
-            .push(text::p2_regular("Confirm your regular PIN").color(color::GREY_3))
-            .push(
-                TextInput::new("Regular PIN", &state.regular_pin)
-                    .on_input(|v| msg(DuressMessage::RegularPinChanged(v)))
-                    .secure(true)
-                    .padding(15),
-            )
-            .push(text::p2_regular("New duress PIN").color(color::GREY_3))
+            .push(text::p2_regular("Duress PIN").color(color::GREY_3))
             .push(
                 TextInput::new("Duress PIN", &state.duress_pin)
                     .on_input(|v| msg(DuressMessage::DuressPinChanged(v)))
+                    .secure(true)
+                    .padding(15),
+            )
+            .push(text::p2_regular("Confirm duress PIN").color(color::GREY_3))
+            .push(
+                TextInput::new("Confirm duress PIN", &state.duress_pin_confirm)
+                    .on_input(|v| msg(DuressMessage::DuressPinConfirmChanged(v)))
                     .secure(true)
                     .padding(15),
             ),

--- a/coincube-gui/src/app/view/connect/duress_enroll.rs
+++ b/coincube-gui/src/app/view/connect/duress_enroll.rs
@@ -168,8 +168,11 @@ pub fn enroll_ux(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage
                 )
                 .push(iced::widget::Space::new().width(Length::Fill))
                 .push(
-                    button::transparent(None, "Cancel")
-                        .on_press(msg(DuressMessage::CancelEnrollment)),
+                    // Disabled while submitting: cancelling mid-enroll would
+                    // zeroize the duress secrets before the server result lands.
+                    button::transparent(None, "Cancel").on_press_maybe(
+                        (!state.submitting).then(|| msg(DuressMessage::CancelEnrollment)),
+                    ),
                 )
                 .push(primary),
         );

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -1618,13 +1618,8 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
             .into();
     }
 
-    let delays: String = DuressDelay::ALL
-        .iter()
-        .map(|d| d.label())
-        .collect::<Vec<_>>()
-        .join(" · ");
-
-    // What duress activation does — stated plainly, no fine print.
+    // What duress activation does — stated plainly, no fine print. Shown in
+    // both the enrolled and not-yet-enrolled states.
     col = col.push(
         container(
             Column::new()
@@ -1632,9 +1627,10 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
                 .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
                 .push(
                     text::p2_regular(
-                        "When you unlock a Cube with your duress PIN, this device erases every \
-                     Cube on it and signals Connect to lock your account. The device then \
-                     shows a dead-end screen until you clear duress from another trusted device.",
+                        "Unlocking any one Cube with your duress PIN wipes every Cube on this \
+                     device and signals Connect to lock your entire account — this locks all \
+                     of your Cubes, not just the one you opened. The device then shows a \
+                     dead-end screen until you clear duress from another trusted device.",
                     )
                     .color(color::GREY_3),
                 )
@@ -1647,84 +1643,143 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
 
     col = col.push(iced::widget::Space::new().height(Length::Fixed(12.0)));
 
-    // Credentials the user will set during enrollment.
-    col = col.push(
-        container(
-            Column::new()
-                .push(text::p1_bold("You'll set").style(theme::text::primary))
-                .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
-                .push(
-                    text::p2_regular(
-                        "• A duress PIN — at least 2 character changes from your regular PIN.",
-                    )
-                    .color(color::GREY_3),
-                )
-                .push(
-                    text::p2_regular(format!(
-                        "• An all-clear passphrase — at least {} characters, used to unlock your \
-                     account from a trusted device.",
-                        MIN_ALL_CLEAR_LEN
-                    ))
-                    .color(color::GREY_3),
-                )
-                .push(
-                    text::p2_regular(
-                        "• A duress recovery-kit password (Tier 1) — covers all your Cubes.",
-                    )
-                    .color(color::GREY_3),
-                )
-                .push(
-                    text::p2_regular(format!("• An unlock delay: {}.", delays))
+    // Once duress is enrolled (server-authoritative), show the enabled state
+    // instead of the setup flow. `None` (state not yet loaded, or the account
+    // genuinely hasn't enrolled) falls through to the setup flow.
+    let enrolled = state
+        .duress_state
+        .as_ref()
+        .map(|s| s.enrolled)
+        .unwrap_or(false);
+
+    if enrolled {
+        col = col.push(
+            container(
+                Column::new()
+                    .push(text::p1_bold("Duress mode is enabled").color(color::GREEN))
+                    .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+                    .push(
+                        text::p2_regular(
+                            "Your duress PIN is armed on every Cube on this device. Entering it \
+                         at any Cube's unlock screen triggers a duress wipe and locks your \
+                         account.",
+                        )
                         .color(color::GREY_3),
-                )
-                .padding(20)
-                .spacing(4),
-        )
-        .style(card_style)
-        .width(Length::Fill),
-    );
+                    )
+                    .padding(20)
+                    .spacing(2),
+            )
+            .style(card_style)
+            .width(Length::Fill),
+        );
 
-    col = col.push(iced::widget::Space::new().height(Length::Fixed(12.0)));
+        col = col.push(iced::widget::Space::new().height(Length::Fixed(16.0)));
+        // Reset is intentionally inert for now: there is no un-enroll path yet
+        // (the backend has no disable endpoint), so we surface the action as a
+        // disabled button with a note rather than hide it.
+        col = col.push(
+            button::secondary(None, "Reset Duress Mode")
+                .width(Length::Fixed(240.0))
+                .on_press_maybe(None),
+        );
+        col = col.push(iced::widget::Space::new().height(Length::Fixed(6.0)));
+        col = col.push(
+            text::p2_regular("Disabling duress mode isn't available yet.").color(color::GREY_3),
+        );
+    } else {
+        let delays: String = DuressDelay::ALL
+            .iter()
+            .map(|d| d.label())
+            .collect::<Vec<_>>()
+            .join(" · ");
 
-    // Tier 2 BIG warning — shown whenever the account has no recovery kit yet.
-    // We can't see per-Cube CRK state from this panel, so we surface the
-    // warning unconditionally; the wizard refines it per tier.
-    col = col.push(
-        container(
-            Column::new()
+        // Credentials the user will set during enrollment.
+        col = col.push(
+            container(
+                Column::new()
+                    .push(text::p1_bold("You'll set").style(theme::text::primary))
+                    .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+                    .push(
+                        text::p2_regular(
+                            "• A duress PIN — one you don't use to unlock any of your Cubes.",
+                        )
+                        .color(color::GREY_3),
+                    )
+                    .push(
+                        text::p2_regular(format!(
+                            "• An all-clear passphrase — at least {} characters, used to unlock \
+                         your account from a trusted device.",
+                            MIN_ALL_CLEAR_LEN
+                        ))
+                        .color(color::GREY_3),
+                    )
+                    .push(
+                        text::p2_regular(
+                            "• A duress recovery-kit password — covers all your Cubes.",
+                        )
+                        .color(color::GREY_3),
+                    )
+                    .push(
+                        text::p2_regular(format!("• An unlock delay: {}.", delays))
+                            .color(color::GREY_3),
+                    )
+                    .padding(20)
+                    .spacing(4),
+            )
+            .style(card_style)
+            .width(Length::Fill),
+        );
+
+        col = col.push(iced::widget::Space::new().height(Length::Fixed(12.0)));
+
+        // Per-Cube recovery-kit checklist. A duress wipe is only reversible
+        // from Connect for Cubes that have a Recovery Kit, so we list the
+        // user's mainnet Cubes with their backup state and nudge them to back
+        // up each one first. The list is additive — when it hasn't loaded (or
+        // there are no mainnet Cubes) the card still shows its guidance copy.
+        col = col.push({
+            let mut card_col = Column::new()
                 .push(
-                    text::p1_bold("Set up a Cube Recovery Kit first")
+                    text::p1_bold("Set up a Cube Recovery Kit for each Cube")
                         .style(theme::text::warning),
                 )
                 .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
-                .push(text::p2_regular(
-                    "Without a Cube Recovery Kit, a duress wipe is irreversible from Connect — \
-                     you would need your seed-phrase backup to restore. We strongly recommend \
-                     setting up a Cube Recovery Kit before enabling duress mode.",
-                ).color(color::GREY_3))
-                .padding(20)
-                .spacing(2),
-        )
-        .style(card_style)
-        .width(Length::Fill),
-    );
+                .push(
+                    text::p2_regular(
+                        "Without a Cube Recovery Kit, a duress wipe is irreversible from Connect \
+                         — you would need that Cube's seed-phrase backup and the Vault wallet \
+                         descriptor backup to restore it. Set up a Recovery Kit for each of your \
+                         Cubes before enabling duress mode.",
+                    )
+                    .color(color::GREY_3),
+                );
+            if let Some(list) = duress_recovery_kit_list(state) {
+                card_col = card_col
+                    .push(iced::widget::Space::new().height(Length::Fixed(14.0)))
+                    .push(list);
+            }
+            container(card_col.padding(20).spacing(2))
+                .style(card_style)
+                .width(Length::Fill)
+        });
 
-    col = col.push(iced::widget::Space::new().height(Length::Fixed(16.0)));
-    col = col.push(
-        button::primary(None, "Set up Duress Mode")
-            .width(Length::Fixed(240.0))
-            .on_press(ConnectAccountMessage::Duress(
-                DuressMessage::StartEnrollment,
-            )),
-    );
-    // Tier 2 (Connect, no recovery kit) — the plan's Task 2.1 secondary path.
-    // The panel can't see per-Cube CRK state, so the user picks: this skips the
-    // duress recovery-kit password step.
-    col = col.push(
-        button::transparent(None, "Continue without a recovery kit (advanced)").on_press(
-            ConnectAccountMessage::Duress(DuressMessage::StartEnrollmentWithoutCrk),
-        ),
-    );
+        col = col.push(iced::widget::Space::new().height(Length::Fixed(16.0)));
+        col = col.push(
+            button::primary(None, "Set up Duress Mode")
+                .width(Length::Fixed(240.0))
+                .on_press(ConnectAccountMessage::Duress(
+                    DuressMessage::StartEnrollment,
+                )),
+        );
+        // Tier 2 (Connect, no recovery kit) — the plan's Task 2.1 secondary
+        // path. The panel can't see per-Cube CRK state, so the user picks:
+        // this skips the duress recovery-kit password step.
+        col = col.push(
+            button::transparent(None, "Continue without a recovery kit (advanced)").on_press(
+                ConnectAccountMessage::Duress(DuressMessage::StartEnrollmentWithoutCrk),
+            ),
+        );
+    }
 
     // Emergency contacts (Estate Notifications — PR 1). Rendered below the
     // enrollment surface as its own section; Estate-gated inside `section`.
@@ -1734,6 +1789,54 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
     col = col.push(duress_contacts::section(state));
 
     col.width(Length::Fill).into()
+}
+
+/// The per-Cube recovery-kit checklist rendered inside the duress intro's
+/// "Set up a Cube Recovery Kit for each Cube" card. `None` until the
+/// mainnet cube list has loaded, and when there are no mainnet Cubes — in
+/// either case the card shows only its guidance copy. Each row names the
+/// Cube and shows whether it currently has a Recovery Kit (backed up) or
+/// not. Informational for now (not clickable).
+fn duress_recovery_kit_list<'a>(
+    state: &'a ConnectAccountPanel,
+) -> Option<Element<'a, ConnectAccountMessage>> {
+    let cubes = state.duress_cubes.as_deref()?;
+    if cubes.is_empty() {
+        return None;
+    }
+
+    let mut col = Column::new().spacing(8);
+    for cube in cubes {
+        let (label, badge_color) = if cube.has_recovery_kit {
+            ("Backed up", color::GREEN)
+        } else {
+            ("No recovery kit", color::RED)
+        };
+        let badge = container(text::caption(label).color(badge_color))
+            .padding(iced::Padding {
+                top: 2.0,
+                bottom: 2.0,
+                left: 8.0,
+                right: 8.0,
+            })
+            .style(move |_t| container::Style {
+                border: iced::Border {
+                    color: badge_color,
+                    width: 0.5,
+                    radius: 6.0.into(),
+                },
+                ..Default::default()
+            });
+        col = col.push(
+            Row::new()
+                .spacing(10)
+                .align_y(Alignment::Center)
+                .push(text::p2_regular(cube.name.as_str()).style(theme::text::primary))
+                .push(iced::widget::Space::new().width(Length::Fill))
+                .push(badge),
+        );
+    }
+    Some(col.into())
 }
 
 /// A thin full-width horizontal rule used to separate panel sections.

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -1646,13 +1646,20 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
     // Once duress is enrolled (server-authoritative), show the enabled state
     // instead of the setup flow. `None` (state not yet loaded, or the account
     // genuinely hasn't enrolled) falls through to the setup flow.
-    let enrolled = state
+    // Account-level state from the server vs. whether THIS device actually
+    // armed the duress PIN on its Cubes. They differ: the account can be
+    // enrolled (on another device, or after a local persist that failed) while
+    // this device wrote no Cube hashes — in which case entering the duress PIN
+    // here does nothing. Only `locally_armed` (from `DuressLocalState`) can
+    // honestly claim "armed on this device".
+    let server_enrolled = state
         .duress_state
         .as_ref()
         .map(|s| s.enrolled)
         .unwrap_or(false);
+    let locally_armed = state.duress_locally_armed;
 
-    if enrolled {
+    if locally_armed {
         col = col.push(
             container(
                 Column::new()
@@ -1685,6 +1692,34 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
         col = col.push(iced::widget::Space::new().height(Length::Fixed(6.0)));
         col = col.push(
             text::p2_regular("Disabling duress mode isn't available yet.").color(color::GREY_3),
+        );
+    } else if server_enrolled {
+        // Enrolled on the account but not armed on THIS device (set up on
+        // another device, or a local persist that didn't complete). Be honest:
+        // the duress PIN does nothing here. No setup CTA — re-enrolling an
+        // already-enrolled account is rejected server-side, and this device
+        // can't arm without the duress PIN it never had.
+        col = col.push(
+            container(
+                Column::new()
+                    .push(
+                        text::p1_bold("Duress mode is enabled on your account")
+                            .style(theme::text::primary),
+                    )
+                    .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+                    .push(
+                        text::p2_regular(
+                            "It was set up on another device, so it is not armed on this one — \
+                         entering your duress PIN here will not trigger a wipe. Manage duress \
+                         mode from the device where you enabled it.",
+                        )
+                        .color(color::GREY_3),
+                    )
+                    .padding(20)
+                    .spacing(2),
+            )
+            .style(card_style)
+            .width(Length::Fill),
         );
     } else {
         let delays: String = DuressDelay::ALL

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1264,6 +1264,12 @@ pub enum DuressMessage {
     /// Duress tab so the screen can show the enabled state instead of the
     /// setup flow. `None` when the fetch failed. Carries `session_generation`.
     StateLoaded(Option<crate::services::coincube::DuressState>, u64),
+    /// Local persistence of the enrollment succeeded (the duress PIN was armed
+    /// on every Cube and `DuressLocalState` written). Emitted by the persist
+    /// step's success path so the panel reflects the enabled state only once
+    /// it's actually true — never on the optimistic pre-persist path, where a
+    /// later collision / disk failure would leave a false "enabled" view.
+    EnrollmentPersisted,
 }
 
 impl std::fmt::Debug for DuressMessage {
@@ -1302,6 +1308,7 @@ impl std::fmt::Debug for DuressMessage {
                 gen
             ),
             StateLoaded(s, gen) => write!(f, "StateLoaded({:?}, {})", s, gen),
+            EnrollmentPersisted => write!(f, "EnrollmentPersisted"),
         }
     }
 }

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1245,8 +1245,8 @@ pub enum DuressMessage {
     CancelEnrollment,
     EnrollBack,
     EnrollNext,
-    RegularPinChanged(String),
     DuressPinChanged(String),
+    DuressPinConfirmChanged(String),
     AllClearChanged(String),
     CrkPasswordChanged(String),
     DelaySelected(crate::services::duress::enroll::DuressDelay),
@@ -1254,6 +1254,14 @@ pub enum DuressMessage {
     MemorizedToggled(bool),
     SubmitEnrollment,
     EnrollResult(Result<(), String>, u64),
+    /// Mainnet cubes + per-cube recovery-kit status, loaded for the duress
+    /// intro screen's "set up a Recovery Kit for each Cube" checklist.
+    /// Carries `session_generation` for stale-response guarding.
+    CubesLoaded(Vec<crate::app::state::connect::DuressCube>, u64),
+    /// Server-side duress state (enrolled / active), loaded on entering the
+    /// Duress tab so the screen can show the enabled state instead of the
+    /// setup flow. `None` when the fetch failed. Carries `session_generation`.
+    StateLoaded(Option<crate::services::coincube::DuressState>, u64),
 }
 
 impl std::fmt::Debug for DuressMessage {
@@ -1262,8 +1270,8 @@ impl std::fmt::Debug for DuressMessage {
         match self {
             // Sensitive — never print the typed secret.
             RecoveryPassphraseChanged(_) => write!(f, "RecoveryPassphraseChanged(<redacted>)"),
-            RegularPinChanged(_) => write!(f, "RegularPinChanged(<redacted>)"),
             DuressPinChanged(_) => write!(f, "DuressPinChanged(<redacted>)"),
+            DuressPinConfirmChanged(_) => write!(f, "DuressPinConfirmChanged(<redacted>)"),
             AllClearChanged(_) => write!(f, "AllClearChanged(<redacted>)"),
             CrkPasswordChanged(_) => write!(f, "CrkPasswordChanged(<redacted>)"),
             SovereignConfirmChanged(_) => write!(f, "SovereignConfirmChanged(<redacted>)"),
@@ -1283,6 +1291,8 @@ impl std::fmt::Debug for DuressMessage {
             MemorizedToggled(b) => write!(f, "MemorizedToggled({})", b),
             SubmitEnrollment => write!(f, "SubmitEnrollment"),
             EnrollResult(res, gen) => write!(f, "EnrollResult({:?}, {})", res, gen),
+            CubesLoaded(cubes, gen) => write!(f, "CubesLoaded({} cubes, {})", cubes.len(), gen),
+            StateLoaded(s, gen) => write!(f, "StateLoaded({:?}, {})", s, gen),
         }
     }
 }
@@ -1932,8 +1942,8 @@ mod duress_message_debug_tests {
     fn sensitive_variants_are_redacted() {
         let sensitive = [
             DuressMessage::RecoveryPassphraseChanged(CANARY.to_string()),
-            DuressMessage::RegularPinChanged(CANARY.to_string()),
             DuressMessage::DuressPinChanged(CANARY.to_string()),
+            DuressMessage::DuressPinConfirmChanged(CANARY.to_string()),
             DuressMessage::AllClearChanged(CANARY.to_string()),
             DuressMessage::CrkPasswordChanged(CANARY.to_string()),
             DuressMessage::SovereignConfirmChanged(CANARY.to_string()),

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1256,8 +1256,10 @@ pub enum DuressMessage {
     EnrollResult(Result<(), String>, u64),
     /// Mainnet cubes + per-cube recovery-kit status, loaded for the duress
     /// intro screen's "set up a Recovery Kit for each Cube" checklist.
-    /// Carries `session_generation` for stale-response guarding.
-    CubesLoaded(Vec<crate::app::state::connect::DuressCube>, u64),
+    /// `None` when the fetch failed, so a transient error doesn't blank a
+    /// previously-loaded list. Carries `session_generation` for stale-response
+    /// guarding.
+    CubesLoaded(Option<Vec<crate::app::state::connect::DuressCube>>, u64),
     /// Server-side duress state (enrolled / active), loaded on entering the
     /// Duress tab so the screen can show the enabled state instead of the
     /// setup flow. `None` when the fetch failed. Carries `session_generation`.
@@ -1291,7 +1293,14 @@ impl std::fmt::Debug for DuressMessage {
             MemorizedToggled(b) => write!(f, "MemorizedToggled({})", b),
             SubmitEnrollment => write!(f, "SubmitEnrollment"),
             EnrollResult(res, gen) => write!(f, "EnrollResult({:?}, {})", res, gen),
-            CubesLoaded(cubes, gen) => write!(f, "CubesLoaded({} cubes, {})", cubes.len(), gen),
+            CubesLoaded(cubes, gen) => write!(
+                f,
+                "CubesLoaded({}, {})",
+                cubes
+                    .as_ref()
+                    .map_or_else(|| "<none>".to_string(), |c| format!("{} cubes", c.len())),
+                gen
+            ),
             StateLoaded(s, gen) => write!(f, "StateLoaded({:?}, {})", s, gen),
         }
     }

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1514,19 +1514,29 @@ impl Home {
                         duress_code,
                         account_id,
                     ),
-                    |res| match res {
-                        Ok(()) => Message::View(ViewMessage::Check),
-                        Err(e) => {
-                            log::error!("duress: failed to persist enrollment: {e}");
-                            // Surface via the Connect panel's error display.
-                            Message::View(ViewMessage::ConnectAccount(
-                                ConnectAccountMessage::Error(format!(
-                                    "Couldn't finish enabling duress mode: {e}. Please try again."
-                                )),
-                            ))
-                        }
-                    },
+                    |res| res,
                 )
+                .then(|res| match res {
+                    Ok(()) => Task::batch([
+                        // Reflect the enabled state only now that the duress PIN
+                        // is actually armed on every Cube.
+                        Task::done(Message::View(ViewMessage::ConnectAccount(
+                            ConnectAccountMessage::Duress(
+                                app::view::DuressMessage::EnrollmentPersisted,
+                            ),
+                        ))),
+                        Task::done(Message::View(ViewMessage::Check)),
+                    ]),
+                    Err(e) => {
+                        log::error!("duress: failed to persist enrollment: {e}");
+                        // Surface via the Connect panel's error display.
+                        Task::done(Message::View(ViewMessage::ConnectAccount(
+                            ConnectAccountMessage::Error(format!(
+                                "Couldn't finish enabling duress mode: {e}. Please try again."
+                            )),
+                        )))
+                    }
+                })
             }
             Message::View(ViewMessage::ConnectAccount(msg)) => {
                 // The banner CTAs navigate the panel to Plan & Billing by

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1405,7 +1405,15 @@ impl Home {
                     HomeSection::Connect(app::menu::ConnectSubMenu::Duress)
                 ) && self.connect_account.is_authenticated()
                 {
-                    return map_connect_task(self.connect_account.reload_duress_contacts());
+                    // Load the Emergency-contacts list, the per-Cube
+                    // recovery-kit checklist, and the server-side duress state
+                    // (so the screen reflects the enabled state); each no-ops
+                    // for accounts that lack the relevant entitlement.
+                    return map_connect_task(iced::Task::batch([
+                        self.connect_account.reload_duress_contacts(),
+                        self.connect_account.reload_duress_cubes(),
+                        self.connect_account.reload_duress_state(),
+                    ]));
                 }
                 Task::none()
             }
@@ -1494,7 +1502,6 @@ impl Home {
                     return Task::none();
                 }
                 let app::message::DuressEnrollmentPayload {
-                    regular_pin,
                     duress_pin,
                     duress_code,
                     account_id,
@@ -1503,7 +1510,6 @@ impl Home {
                 Task::perform(
                     app::persist_duress_enrollment(
                         self.datadir_path.clone(),
-                        regular_pin,
                         duress_pin,
                         duress_code,
                         account_id,
@@ -1904,7 +1910,14 @@ impl Home {
                                         .filter(|rc| rc.network == current_net_str)
                                         .collect();
 
-                                    let mut col = Column::new().spacing(20);
+                                    // Center the children: the create form below
+                                    // is a `center_x(Fill)` container, so without
+                                    // this the form spans/centers full width while
+                                    // the shrink-width remote-cube rows default to
+                                    // the left edge — leaving the list and form
+                                    // misaligned.
+                                    let mut col =
+                                        Column::new().spacing(20).align_x(Alignment::Center);
                                     for rc in &remote_for_net {
                                         col = col.push(remote_cube_list_item(rc));
                                     }

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -1504,19 +1504,29 @@ impl Launcher {
                         duress_code,
                         account_id,
                     ),
-                    |res| match res {
-                        Ok(()) => Message::View(ViewMessage::Check),
-                        Err(e) => {
-                            log::error!("duress: failed to persist enrollment: {e}");
-                            // Surface via the Connect panel's error display.
-                            Message::View(ViewMessage::ConnectAccount(
-                                ConnectAccountMessage::Error(format!(
-                                    "Couldn't finish enabling duress mode: {e}. Please try again."
-                                )),
-                            ))
-                        }
-                    },
-                );
+                    |res| res,
+                )
+                .then(|res| match res {
+                    Ok(()) => Task::batch([
+                        // Reflect the enabled state only now that the duress PIN
+                        // is actually armed on every Cube.
+                        Task::done(Message::View(ViewMessage::ConnectAccount(
+                            ConnectAccountMessage::Duress(
+                                app::view::DuressMessage::EnrollmentPersisted,
+                            ),
+                        ))),
+                        Task::done(Message::View(ViewMessage::Check)),
+                    ]),
+                    Err(e) => {
+                        log::error!("duress: failed to persist enrollment: {e}");
+                        // Surface via the Connect panel's error display.
+                        Task::done(Message::View(ViewMessage::ConnectAccount(
+                            ConnectAccountMessage::Error(format!(
+                                "Couldn't finish enabling duress mode: {e}. Please try again."
+                            )),
+                        )))
+                    }
+                });
             }
             Message::View(ViewMessage::ConnectAccount(msg)) => {
                 // The banner CTAs navigate the panel to Plan & Billing by

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -1395,7 +1395,15 @@ impl Launcher {
                     LauncherSection::Connect(app::menu::ConnectSubMenu::Duress)
                 ) && self.connect_account.is_authenticated()
                 {
-                    return map_connect_task(self.connect_account.reload_duress_contacts());
+                    // Load the Emergency-contacts list, the per-Cube
+                    // recovery-kit checklist, and the server-side duress state
+                    // (so the screen reflects the enabled state); each no-ops
+                    // for accounts that lack the relevant entitlement.
+                    return map_connect_task(iced::Task::batch([
+                        self.connect_account.reload_duress_contacts(),
+                        self.connect_account.reload_duress_cubes(),
+                        self.connect_account.reload_duress_state(),
+                    ]));
                 }
                 Task::none()
             }
@@ -1484,7 +1492,6 @@ impl Launcher {
                     return Task::none();
                 }
                 let app::message::DuressEnrollmentPayload {
-                    regular_pin,
                     duress_pin,
                     duress_code,
                     account_id,
@@ -1493,7 +1500,6 @@ impl Launcher {
                 return Task::perform(
                     app::persist_duress_enrollment(
                         self.datadir_path.clone(),
-                        regular_pin,
                         duress_pin,
                         duress_code,
                         account_id,
@@ -1882,7 +1888,14 @@ impl Launcher {
                                         .filter(|rc| rc.network == current_net_str)
                                         .collect();
 
-                                    let mut col = Column::new().spacing(20);
+                                    // Center the children: the create form below
+                                    // is a `center_x(Fill)` container, so without
+                                    // this the form spans/centers full width while
+                                    // the shrink-width remote-cube rows default to
+                                    // the left edge — leaving the list and form
+                                    // misaligned.
+                                    let mut col =
+                                        Column::new().spacing(20).align_x(Alignment::Center);
                                     for rc in &remote_for_net {
                                         col = col.push(remote_cube_list_item(rc));
                                     }

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -538,6 +538,12 @@ pub struct CubeResponse {
     pub network: String,
     pub lightning_address: Option<String>,
     pub status: String,
+    /// Whether the cube has a Cube Recovery Kit on the server. Sent by both
+    /// `list_cubes()` and `GET /connect/cubes/{id}` (Go `hasRecoveryKit`,
+    /// set from `RecoveryKit != nil`). `#[serde(default)]` keeps older
+    /// payloads parsing (treated as no kit).
+    #[serde(default)]
+    pub has_recovery_kit: bool,
     /// Populated by `GET /connect/cubes/{id}` (not by `list_cubes`). Defaults
     /// to empty so existing list-based code paths keep working.
     #[serde(default)]

--- a/coincube-gui/src/services/duress/enroll.rs
+++ b/coincube-gui/src/services/duress/enroll.rs
@@ -2,10 +2,11 @@
 //!
 //! These are the pure, testable rules behind the enrollment wizard:
 //!
-//!   * the duress PIN must be meaningfully distinct from the regular PIN so it
-//!     can't be entered by accident under stress,
+//!   * the duress PIN just needs to be non-empty here — it must not collide
+//!     with any Cube's real unlock PIN, but that's enforced in
+//!     `persist_duress_enrollment` where the Cube PIN hashes are available,
 //!   * the all-clear passphrase must be long enough to survive months of
-//!     disuse and distinct from both PINs,
+//!     disuse and distinct from the duress PIN,
 //!   * each desktop generates its **own** ~128-bit duress code with a CSPRNG and
 //!     only ever sends the argon2id hash to the server.
 //!
@@ -17,9 +18,6 @@ use argon2::{
     Argon2, Params,
 };
 use rand::RngCore;
-
-/// Minimum Levenshtein distance the duress PIN must be from the regular PIN.
-pub const MIN_PIN_DISTANCE: usize = 2;
 
 /// Minimum all-clear passphrase length (characters).
 pub const MIN_ALL_CLEAR_LEN: usize = 12;
@@ -37,12 +35,6 @@ const ARGON_P_COST: u32 = 1;
 
 /// Bits of entropy in this desktop's generated duress code.
 const DURESS_CODE_BITS: usize = 128;
-
-/// The error string shown when the duress PIN is too close to the regular PIN.
-/// Kept as a constant so the wizard and its tests agree on the exact copy.
-pub const DURESS_PIN_TOO_CLOSE: &str =
-    "Your duress PIN must be at least 2 character changes from your regular PIN. \
-     This prevents accidental activation.";
 
 /// The five unlock-delay choices offered as chips in the wizard. `H24` is the
 /// default.
@@ -89,48 +81,46 @@ impl DuressDelay {
     }
 }
 
-/// Validates a candidate duress PIN against the user's regular PIN.
+/// Validates a candidate duress PIN, client-side, before enrollment.
 ///
-/// Rejects PINs that are within [`MIN_PIN_DISTANCE`] edits of the regular PIN
-/// and obvious near-miss patterns (the reversed regular PIN, or an off-by-one
-/// in every digit) that a stressed user could enter by accident.
-pub fn validate_duress_pin(regular_pin: &str, duress_pin: &str) -> Result<(), String> {
+/// There is no longer a "distance from your regular PIN" rule: each Cube can
+/// have its own PIN, so there's no single regular PIN to compare against. The
+/// only hard requirement — that the duress PIN not collide with any Cube's
+/// real unlock PIN — is enforced where the Cube PIN hashes are available, in
+/// `persist_duress_enrollment`. Here we require a non-empty value entered
+/// identically twice (the confirmation guards against memorizing a typo).
+pub fn validate_duress_pin(duress_pin: &str, confirm: &str) -> Result<(), String> {
     if duress_pin.is_empty() {
         return Err("Enter a duress PIN.".to_string());
     }
-    if duress_pin == regular_pin
-        || levenshtein(regular_pin, duress_pin) < MIN_PIN_DISTANCE
-        || is_near_miss(regular_pin, duress_pin)
-    {
-        return Err(DURESS_PIN_TOO_CLOSE.to_string());
+    if duress_pin != confirm {
+        return Err("The duress PINs don't match.".to_string());
     }
     Ok(())
 }
 
 /// Validates the all-clear passphrase: minimum length and distinctness from
-/// both the regular and duress PINs.
-pub fn validate_all_clear(
-    passphrase: &str,
-    regular_pin: &str,
-    duress_pin: &str,
-) -> Result<(), String> {
+/// the duress PIN.
+pub fn validate_all_clear(passphrase: &str, duress_pin: &str) -> Result<(), String> {
     if passphrase.chars().count() < MIN_ALL_CLEAR_LEN {
         return Err(format!(
             "Your all-clear passphrase must be at least {} characters.",
             MIN_ALL_CLEAR_LEN
         ));
     }
-    if passphrase == regular_pin || passphrase == duress_pin {
-        return Err("Your all-clear passphrase must be different from your PINs.".to_string());
+    if passphrase == duress_pin {
+        return Err(
+            "Your all-clear passphrase must be different from your duress PIN.".to_string(),
+        );
     }
     Ok(())
 }
 
 /// Validates the account-level duress CRK decryption password (Approach C,
-/// Tier 1 only): minimum length and distinctness from the PINs and all-clear.
+/// Tier 1 only): minimum length and distinctness from the duress PIN and
+/// all-clear passphrase.
 pub fn validate_duress_crk_password(
     password: &str,
-    regular_pin: &str,
     duress_pin: &str,
     all_clear: &str,
 ) -> Result<(), String> {
@@ -140,7 +130,7 @@ pub fn validate_duress_crk_password(
             MIN_ALL_CLEAR_LEN
         ));
     }
-    if password == regular_pin || password == duress_pin || password == all_clear {
+    if password == duress_pin || password == all_clear {
         return Err(
             "Your duress recovery password must be different from your other credentials."
                 .to_string(),
@@ -195,125 +185,38 @@ pub fn hash_duress_secret(secret: &str) -> Result<String, String> {
     Ok(hash.to_string())
 }
 
-/// Classic Wagner–Fischer Levenshtein edit distance over Unicode scalar values.
-pub fn levenshtein(a: &str, b: &str) -> usize {
-    let a: Vec<char> = a.chars().collect();
-    let b: Vec<char> = b.chars().collect();
-    if a.is_empty() {
-        return b.len();
-    }
-    if b.is_empty() {
-        return a.len();
-    }
-    let mut prev: Vec<usize> = (0..=b.len()).collect();
-    let mut curr = vec![0usize; b.len() + 1];
-    for (i, &ca) in a.iter().enumerate() {
-        curr[0] = i + 1;
-        for (j, &cb) in b.iter().enumerate() {
-            let cost = if ca == cb { 0 } else { 1 };
-            curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
-        }
-        std::mem::swap(&mut prev, &mut curr);
-    }
-    prev[b.len()]
-}
-
-/// Detects "near-miss" patterns that aren't caught by raw edit distance but a
-/// stressed user could still fat-finger: the regular PIN reversed, or every
-/// digit shifted by ±1 (mod 10) from the regular PIN.
-fn is_near_miss(regular: &str, duress: &str) -> bool {
-    if regular.is_empty() || regular.chars().count() != duress.chars().count() {
-        return false;
-    }
-    // Reversed regular PIN.
-    let reversed: String = regular.chars().rev().collect();
-    if duress == reversed {
-        return true;
-    }
-    // Uniform ±1 shift in every digit position (only meaningful for all-digit
-    // PINs).
-    if regular.chars().all(|c| c.is_ascii_digit()) && duress.chars().all(|c| c.is_ascii_digit()) {
-        let off_by_one_everywhere = regular.chars().zip(duress.chars()).all(|(r, d)| {
-            let r = r.to_digit(10).unwrap() as i32;
-            let d = d.to_digit(10).unwrap() as i32;
-            let diff = (r - d).rem_euclid(10);
-            diff == 1 || diff == 9
-        });
-        if off_by_one_everywhere {
-            return true;
-        }
-    }
-    false
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn levenshtein_basic() {
-        assert_eq!(levenshtein("1234", "1234"), 0);
-        assert_eq!(levenshtein("1234", "1235"), 1);
-        assert_eq!(levenshtein("1234", "1245"), 2);
-        assert_eq!(levenshtein("", "abc"), 3);
-    }
-
-    #[test]
-    fn duress_pin_rejects_identical() {
-        let err = validate_duress_pin("1234", "1234").unwrap_err();
-        assert_eq!(err, DURESS_PIN_TOO_CLOSE);
-    }
-
-    #[test]
-    fn duress_pin_rejects_levenshtein_one() {
-        // Spec negative test: one edit away → rejected with the exact string.
-        let err = validate_duress_pin("1234", "1235").unwrap_err();
-        assert_eq!(err, DURESS_PIN_TOO_CLOSE);
-    }
-
-    #[test]
-    fn duress_pin_rejects_reversed() {
-        let err = validate_duress_pin("1234", "4321").unwrap_err();
-        assert_eq!(err, DURESS_PIN_TOO_CLOSE);
-    }
-
-    #[test]
-    fn duress_pin_rejects_off_by_one_everywhere() {
-        // 1234 -> 2345 (every digit +1)
-        let err = validate_duress_pin("1234", "2345").unwrap_err();
-        assert_eq!(err, DURESS_PIN_TOO_CLOSE);
-        // wrap-around: 9 -> 0
-        assert!(validate_duress_pin("1239", "2340").is_err());
-    }
-
-    #[test]
-    fn duress_pin_accepts_distinct() {
-        // Two independent edits, not a uniform shift, not reversed.
-        assert!(validate_duress_pin("1234", "1278").is_ok());
-        assert!(validate_duress_pin("0000", "9182").is_ok());
+    fn duress_pin_requires_non_empty_and_matching_confirm() {
+        assert!(validate_duress_pin("", "").is_err());
+        // Mismatched confirmation is rejected.
+        assert!(validate_duress_pin("1234", "1235").is_err());
+        // Any non-empty PIN entered twice passes here — collision with a real
+        // Cube PIN is enforced later, in `persist_duress_enrollment`.
+        assert!(validate_duress_pin("1234", "1234").is_ok());
+        assert!(validate_duress_pin("1235", "1235").is_ok());
     }
 
     #[test]
     fn all_clear_length_and_distinctness() {
-        assert!(validate_all_clear("short", "1234", "5678").is_err());
-        assert!(validate_all_clear("correct horse battery", "1234", "5678").is_ok());
-        // Must differ from PINs (edge: a 12+ char string equal to a PIN can't
-        // happen with 4-digit PINs, but the rule still holds for parity).
-        assert!(validate_all_clear("1234", "1234", "5678").is_err());
+        assert!(validate_all_clear("short", "5678").is_err());
+        assert!(validate_all_clear("correct horse battery", "5678").is_ok());
+        // Must differ from the duress PIN (edge: a 12+ char string equal to a
+        // PIN can't happen with short PINs, but the rule still holds).
+        assert!(validate_all_clear("1234", "1234").is_err());
     }
 
     #[test]
     fn crk_password_distinct_from_everything() {
-        assert!(validate_duress_crk_password(
-            "a-very-long-password",
-            "1234",
-            "5678",
-            "all clear phrase"
-        )
-        .is_ok());
+        assert!(
+            validate_duress_crk_password("a-very-long-password", "5678", "all clear phrase")
+                .is_ok()
+        );
         assert!(validate_duress_crk_password(
             "all clear phrase here",
-            "1234",
             "5678",
             "all clear phrase here"
         )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes duress PIN validation, enrollment ordering, and when wipe-capable PINs are written—security-sensitive—but adds pre-flight collision checks and defers “enabled” UI until Cubes are armed locally.
> 
> **Overview**
> **Duress enrollment** drops re-entry of the regular unlock PIN and the Levenshtein/near-miss rules; the wizard now collects a **duress PIN + confirmation** only. Collision with any Cube’s real unlock PIN is centralized in `duress_pin_collision_check`, run **before** Connect server enroll and again in `persist_duress_enrollment`, so server enrollment can’t succeed while local arming would fail.
> 
> The **Connect Duress tab** loads server duress state, per-mainnet-cube recovery-kit status, and local “armed on this device” (`DuressLocalState`). The intro shows enabled vs account-only-enrolled vs setup flows, a per-cube recovery-kit checklist (`has_recovery_kit` on `CubeResponse`), and clearer copy. **Enabled UI updates only after** local persist via `EnrollmentPersisted`, not optimistically after server enroll. Cancel is blocked while submitting; stale fetches can’t downgrade enrolled state; active duress from a late fetch can route to recovery.
> 
> Minor: Home/Launcher remote-cube list alignment fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1341795c8f99c13e0fe711257305a0e25580a91d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duress mode enrollment now uses confirm-only Duress PIN entry and updates the recovery-kit checklist with per-cube status.
  * Duress dashboard now distinguishes server-authoritative enrollment from whether this device is locally armed, including guided messaging for non-armed devices.
* **Bug Fixes**
  * Improved duress PIN safety by removing near-miss/regular-PIN checks and adding stronger collision detection before saving.
  * Cancel is disabled during duress enrollment submission; duress submenu refreshes emergency contacts, cubes, and server state together.
* **Tests**
  * Updated tests for confirm-only validation and PIN scrubbing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->