### PR TITLE
Fix connect signing issues

### DIFF
--- a/coincube-gui/src/app/cache.rs
+++ b/coincube-gui/src/app/cache.rs
@@ -42,6 +42,17 @@ pub struct Cache {
     pub display_mode: DisplayMode,
     /// Whether the Connect user is authenticated (Dashboard step reached)
     pub connect_authenticated: bool,
+    /// Whether a Connect account session exists for this install — a
+    /// launch-time restore from `connect.json`, or a live remote-backend
+    /// session — *independent of* whether the Connect panel has advanced to
+    /// its `Dashboard` UI step yet. Distinct from `connect_authenticated`,
+    /// which only tracks that panel step and therefore lags a session that
+    /// was restored at launch (or never visited). Surfaces that must treat a
+    /// valid-but-not-yet-active session as signed-in — e.g. the
+    /// keychain-unavailable modal choosing between "Sign in to Connect" and
+    /// "Sign with Connect" — read this, OR'd with `connect_authenticated`.
+    /// Cleared on logout.
+    pub has_connect_session: bool,
     /// Whether this cube has a vault wallet configured
     pub has_vault: bool,
     /// Display name of the current Cube
@@ -143,6 +154,7 @@ impl std::default::Default for Cache {
             bitcoin_unit: BitcoinDisplayUnit::default(),
             display_mode: DisplayMode::default(),
             connect_authenticated: false,
+            has_connect_session: false,
             has_vault: false,
             cube_name: String::new(),
             current_cube_backed_up: false,

--- a/coincube-gui/src/app/message.rs
+++ b/coincube-gui/src/app/message.rs
@@ -209,6 +209,14 @@ pub enum Message {
         email: String,
         cube_uuid: Option<String>,
     },
+    /// On-demand Connect signing bootstrap for an already-authenticated
+    /// session. Fired from the "Sign with Connect" action in the
+    /// keychain-unavailable modal when the user is signed in but the gRPC
+    /// stream/device hasn't been set up (the local-node launch doesn't
+    /// register a signer device). Loads tokens from `connect.json`,
+    /// registers a device via gRPC, and chains `TriggerConnectStreamReady`
+    /// so `cache.connect_*` populate without an app restart.
+    EnsureConnectReady,
     /// Persist a completed duress enrollment (Phases 2 & 8). Emitted by the
     /// Connect panel, which lacks Cube/datadir context; handled by the App,
     /// which writes the active Cube's duress PIN hash and this device's

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -3001,8 +3001,10 @@ impl App {
                     );
                     let is_spend_current =
                         matches!(current, Menu::Vault(crate::app::menu::VaultSubMenu::Send));
-                    let is_recovery_current =
-                        matches!(current, Menu::Vault(crate::app::menu::VaultSubMenu::Recovery));
+                    let is_recovery_current = matches!(
+                        current,
+                        Menu::Vault(crate::app::menu::VaultSubMenu::Recovery)
+                    );
 
                     commands.push(vault_overview.update(
                         Some(daemon.clone()),

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -2247,6 +2247,13 @@ impl App {
         // panel's id.
         self.cache.current_cube_server_id = self.panels.connect.cube.server_cube_id;
 
+        // Keep the Connect auth mirror fresh every tick (not just on
+        // ConnectAccount/ConnectCube messages) so surfaces that read it —
+        // e.g. the keychain-unavailable modal deciding between "Sign in to
+        // Connect" and "Sign with Connect" — never see a stale value after
+        // a launch-time session restore.
+        self.cache.connect_authenticated = self.panels.connect.account.is_authenticated();
+
         // W12 drift detection: SHA-256 over a JSON blob —
         // microseconds — so running it every tick is fine and
         // avoids a separate invalidation pathway tied to wallet
@@ -2530,6 +2537,112 @@ impl App {
                 cube_uuid,
             } => {
                 return connect_stream_ready_task(network, datadir, tokens, email, cube_uuid);
+            }
+            Message::EnsureConnectReady => {
+                // The user is signed in to Connect but the signing stream
+                // isn't ready. Run the same device-registration + stream
+                // bootstrap the in-app login flow does, sourcing tokens
+                // from `connect.json`. The async block decides the next
+                // message itself so we can give accurate feedback: some
+                // networks (e.g. testnet4) have no `grpc_url` in their
+                // ServiceConfig, meaning Connect/Keychain relay signing is
+                // unavailable there no matter how often the user retries —
+                // we say so and point them at local Wi-Fi pairing instead.
+                let network = self.cache.network;
+                let datadir = self.cache.datadir_path.clone();
+                let cube_uuid = if self.cache.cube_id.is_empty() {
+                    None
+                } else {
+                    Some(self.cache.cube_id.clone())
+                };
+                return Task::perform(
+                    async move {
+                        use crate::services::connect::client::cache::ConnectCache;
+                        use crate::services::connect::grpc::bootstrap::ensure_device_registered_best_effort;
+
+                        let info_toast = |msg: &str| {
+                            Message::View(view::Message::ShowToast(
+                                log::Level::Info,
+                                msg.to_string(),
+                            ))
+                        };
+
+                        let network_dir = datadir.network_directory(network);
+                        let Some(account) = ConnectCache::from_file(&network_dir)
+                            .ok()
+                            .and_then(|c| c.accounts.into_iter().next())
+                        else {
+                            tracing::warn!(
+                                "EnsureConnectReady: no cached Connect account in connect.json"
+                            );
+                            return info_toast(
+                                "Couldn't find a Connect session. Sign in to Connect, or pair \
+                                 a phone over Wi-Fi to sign locally.",
+                            );
+                        };
+                        let email = account.email.clone();
+                        let tokens_arc =
+                            std::sync::Arc::new(tokio::sync::RwLock::new(account.tokens));
+
+                        let service_config =
+                            match crate::services::connect::client::get_service_config(network)
+                                .await
+                            {
+                                Ok(c) => c,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "EnsureConnectReady: get_service_config failed: {e}"
+                                    );
+                                    return info_toast(
+                                        "Couldn't reach Connect right now. Try again, or pair a \
+                                         phone over Wi-Fi to sign locally.",
+                                    );
+                                }
+                            };
+                        let Some(grpc_url) = service_config.grpc_url.as_deref() else {
+                            // No gRPC endpoint for this network — Connect
+                            // relay signing can't work here. Don't pretend
+                            // a retry will help.
+                            tracing::info!(
+                                "EnsureConnectReady: ServiceConfig for {network} has no grpc_url \
+                                 — Connect signing unavailable on this network"
+                            );
+                            return info_toast(
+                                "Keychain signing over Connect isn't available on this network. \
+                                 Pair a phone over Wi-Fi to sign locally instead.",
+                            );
+                        };
+
+                        let device_name = std::env::var("HOSTNAME")
+                            .ok()
+                            .filter(|s| !s.is_empty())
+                            .unwrap_or_else(|| {
+                                format!("Coincube Desktop ({})", std::env::consts::OS)
+                            });
+                        ensure_device_registered_best_effort(
+                            grpc_url,
+                            tokens_arc.clone(),
+                            &network_dir,
+                            &email,
+                            device_name,
+                            env!("CARGO_PKG_VERSION").to_string(),
+                            std::env::consts::OS.to_string(),
+                        )
+                        .await;
+
+                        // gRPC is available and the device is registered —
+                        // bring the stream up so the cache fields populate,
+                        // then the user can retry Sign via Keychain.
+                        Message::TriggerConnectStreamReady {
+                            network,
+                            datadir,
+                            tokens: tokens_arc,
+                            email,
+                            cube_uuid,
+                        }
+                    },
+                    |m| m,
+                );
             }
             Message::InstallStats(_) => {
                 if let Some(panel) = self.panels.current_mut() {
@@ -2872,6 +2985,8 @@ impl App {
                     );
                     let is_spend_current =
                         matches!(current, Menu::Vault(crate::app::menu::VaultSubMenu::Send));
+                    let is_recovery_current =
+                        matches!(current, Menu::Vault(crate::app::menu::VaultSubMenu::Recovery));
 
                     commands.push(vault_overview.update(
                         Some(daemon.clone()),
@@ -2892,6 +3007,17 @@ impl App {
                             Some(daemon.clone()),
                             &cache,
                             Message::UpdatePanelCache(is_spend_current),
+                        ));
+                    }
+
+                    // The recovery panel is a separate CreateSpendPanel and must
+                    // be refreshed too, otherwise its sync status and balance stay
+                    // frozen at the value captured when it was constructed.
+                    if let Some(recovery) = self.panels.recovery.as_mut() {
+                        commands.push(recovery.update(
+                            Some(daemon.clone()),
+                            &cache,
+                            Message::UpdatePanelCache(is_recovery_current),
                         ));
                     }
                 }

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1265,6 +1265,13 @@ impl App {
         let mut cache_with_vault = cache;
         cache_with_vault.has_vault = true;
         cache_with_vault.has_p2p = panels.p2p.is_some();
+        // A restored on-disk session (or a threaded remote-backend one) means
+        // the user is signed in to Connect even though the Connect panel won't
+        // reach its `Dashboard` step — and so won't flip `connect_authenticated`
+        // — until its keyring session check completes. Mirror it now so the
+        // keychain-unavailable modal offers "Sign with Connect" rather than a
+        // "Sign in to Connect" that would no-op.
+        cache_with_vault.has_connect_session = connect_auth_arc.is_some();
         (
             Self {
                 panels,
@@ -2355,6 +2362,7 @@ impl App {
                 // PLAN comment near `mod.rs:2374`.
                 self.connect_email = Some(email.clone());
                 self.cache.connect_email = Some(email.clone());
+                self.cache.has_connect_session = true;
 
                 let network = self.cache.network;
                 let datadir = self.cache.datadir_path.clone();
@@ -3270,6 +3278,7 @@ impl App {
                     self.cache.connect_tokens = None;
                     self.cache.connect_device_id = None;
                     self.cache.connect_email = None;
+                    self.cache.has_connect_session = false;
                     self.cache.connect_stream_status = ConnectionStatus::Inactive;
                     // Drop the previous session's vault-monitoring config so
                     // it can't leak into the next account and so the

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -2563,7 +2563,14 @@ impl App {
                 } else {
                     Some(self.cache.cube_id.clone())
                 };
-                return Task::perform(
+                // The device/stream bootstrap below populates grpc_url /
+                // tokens / device_id but NOT the cube's server-side id. When
+                // that id is the missing Keychain prerequisite, this is the
+                // only thing that unblocks signing — so drive cube
+                // registration in parallel rather than dead-looping the user
+                // on a "Sign with Connect" that can never resolve it.
+                let cube_registration = self.panels.connect.ensure_cube_registered();
+                let bootstrap = Task::perform(
                     async move {
                         use crate::services::connect::client::cache::ConnectCache;
                         use crate::services::connect::grpc::bootstrap::ensure_device_registered_best_effort;
@@ -2651,6 +2658,7 @@ impl App {
                     },
                     |m| m,
                 );
+                return Task::batch([cube_registration, bootstrap]);
             }
             Message::InstallStats(_) => {
                 if let Some(panel) = self.panels.current_mut() {

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -2565,11 +2565,56 @@ impl App {
                 };
                 // The device/stream bootstrap below populates grpc_url /
                 // tokens / device_id but NOT the cube's server-side id. When
-                // that id is the missing Keychain prerequisite, this is the
-                // only thing that unblocks signing — so drive cube
-                // registration in parallel rather than dead-looping the user
-                // on a "Sign with Connect" that can never resolve it.
-                let cube_registration = self.panels.connect.ensure_cube_registered();
+                // that id is the missing Keychain prerequisite, register it
+                // here too — otherwise "Sign with Connect" can never resolve
+                // it. A live panel session registers through its authenticated
+                // client; a restored connect.json (or remote) session whose
+                // panel hasn't reached Dashboard has no panel client, so the
+                // panel path would no-op — register directly from the restored
+                // tokens (the same source the device bootstrap uses) and feed
+                // the result back through the normal `CubeRegistered` path so
+                // `current_cube_server_id` still populates.
+                let cube_registration = if self.cache.current_cube_server_id.is_some() {
+                    Task::none()
+                } else if self.panels.connect.account.is_authenticated() {
+                    self.panels.connect.ensure_cube_registered()
+                } else {
+                    let datadir = datadir.clone();
+                    let net_str = settings::network_to_api_string(network);
+                    let cube_name = self.cube_settings.name.clone();
+                    let cube_uuid = cube_uuid.clone();
+                    Task::perform(
+                        async move {
+                            use crate::services::coincube::{CoincubeClient, RegisterCubeRequest};
+                            use crate::services::connect::client::cache::ConnectCache;
+                            let uuid = cube_uuid.ok_or_else(|| "no cube uuid".to_string())?;
+                            let account =
+                                ConnectCache::from_file(&datadir.network_directory(network))
+                                    .ok()
+                                    .and_then(|c| c.accounts.into_iter().next())
+                                    .ok_or_else(|| {
+                                        "EnsureConnectReady: no cached Connect session to \
+                                         register the cube"
+                                            .to_string()
+                                    })?;
+                            let mut client = CoincubeClient::new();
+                            client.set_token(&account.tokens.access_token);
+                            client
+                                .register_cube(RegisterCubeRequest {
+                                    uuid,
+                                    name: cube_name,
+                                    network: net_str,
+                                })
+                                .await
+                                .map_err(|e| e.to_string())
+                        },
+                        |r| {
+                            Message::View(view::Message::ConnectCube(
+                                view::ConnectCubeMessage::CubeRegistered(r),
+                            ))
+                        },
+                    )
+                };
                 let bootstrap = Task::perform(
                     async move {
                         use crate::services::connect::client::cache::ConnectCache;

--- a/coincube-gui/src/app/state/connect/mod.rs
+++ b/coincube-gui/src/app/state/connect/mod.rs
@@ -177,6 +177,27 @@ impl ConnectPanel {
         iced::Task::none()
     }
 
+    /// Best-effort: make sure the active Cube is registered with Connect so
+    /// `server_cube_id` (mirrored to `cache.current_cube_server_id`) becomes
+    /// available. The stream/device bootstrap behind `EnsureConnectReady`
+    /// brings up grpc_url / tokens / device_id but never registers the cube,
+    /// so when that numeric id is the missing Keychain prerequisite this is
+    /// what unblocks "Sign with Connect". No-op once the id is known. With a
+    /// live session we register directly (covers a registration that errored
+    /// or is still in flight); otherwise we kick the session check, whose
+    /// Dashboard transition auto-registers (see `update`).
+    pub fn ensure_cube_registered(&mut self) -> iced::Task<Message> {
+        if self.cube.server_cube_id.is_some() {
+            return iced::Task::none();
+        }
+        if self.account.is_authenticated() {
+            self.sync_client();
+            self.cube.register_cube()
+        } else {
+            self.ensure_session_check()
+        }
+    }
+
     /// Check if avatar should be loaded and return task if so.
     pub fn check_and_load_avatar(&self) -> iced::Task<Message> {
         if let Some(task) = self.cube.load_avatar_if_needed() {

--- a/coincube-gui/src/app/state/connect/mod.rs
+++ b/coincube-gui/src/app/state/connect/mod.rs
@@ -177,25 +177,26 @@ impl ConnectPanel {
         iced::Task::none()
     }
 
-    /// Best-effort: make sure the active Cube is registered with Connect so
-    /// `server_cube_id` (mirrored to `cache.current_cube_server_id`) becomes
-    /// available. The stream/device bootstrap behind `EnsureConnectReady`
-    /// brings up grpc_url / tokens / device_id but never registers the cube,
-    /// so when that numeric id is the missing Keychain prerequisite this is
-    /// what unblocks "Sign with Connect". No-op once the id is known. With a
-    /// live session we register directly (covers a registration that errored
-    /// or is still in flight); otherwise we kick the session check, whose
-    /// Dashboard transition auto-registers (see `update`).
+    /// Register the active Cube through the panel's **authenticated** client
+    /// so `server_cube_id` (mirrored to `cache.current_cube_server_id`)
+    /// becomes available — the stream/device bootstrap behind
+    /// `EnsureConnectReady` brings up grpc_url / tokens / device_id but never
+    /// registers the cube, so this is what unblocks "Sign with Connect" when
+    /// the numeric id is the missing Keychain prerequisite. Registering
+    /// directly (rather than waiting on the Dashboard auto-register) also
+    /// recovers a registration that errored or is still in flight.
+    ///
+    /// No-op when the id is already known or the panel has no live session.
+    /// The `EnsureConnectReady` caller handles the no-live-session case (a
+    /// restored connect.json session whose panel hasn't reached Dashboard, so
+    /// `is_authenticated()` is false and no panel client exists) by
+    /// registering from the restored tokens directly.
     pub fn ensure_cube_registered(&mut self) -> iced::Task<Message> {
-        if self.cube.server_cube_id.is_some() {
+        if self.cube.server_cube_id.is_some() || !self.account.is_authenticated() {
             return iced::Task::none();
         }
-        if self.account.is_authenticated() {
-            self.sync_client();
-            self.cube.register_cube()
-        } else {
-            self.ensure_session_check()
-        }
+        self.sync_client();
+        self.cube.register_cube()
     }
 
     /// Check if avatar should be loaded and return task if so.

--- a/coincube-gui/src/app/state/vault/keychain_sign.rs
+++ b/coincube-gui/src/app/state/vault/keychain_sign.rs
@@ -1647,7 +1647,12 @@ impl Modal for KeychainSignModal {
 /// registered cube keys are actually part of this wallet.
 fn descriptor_fingerprints(descriptor: &CoincubeDescriptor) -> HashSet<Fingerprint> {
     let policy = descriptor.policy();
-    let mut fps: HashSet<Fingerprint> = policy.primary_path().thresh_origins().1.into_keys().collect();
+    let mut fps: HashSet<Fingerprint> = policy
+        .primary_path()
+        .thresh_origins()
+        .1
+        .into_keys()
+        .collect();
     for path in policy.recovery_paths().values() {
         fps.extend(path.thresh_origins().1.into_keys());
     }

--- a/coincube-gui/src/app/state/vault/keychain_sign.rs
+++ b/coincube-gui/src/app/state/vault/keychain_sign.rs
@@ -23,9 +23,10 @@
 //! confidentiality from TLS but the API can technically inspect the
 //! transaction. The Final-step PR description should call this out.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use coincube_core::descriptors::CoincubeDescriptor;
 use coincube_core::miniscript::bitcoin::{bip32::Fingerprint, psbt::Psbt};
 use iced::{Subscription, Task};
 use tokio::sync::RwLock;
@@ -52,7 +53,10 @@ use crate::{
     },
     daemon::{model::SpendTx, Daemon},
     services::{
-        coincube::{CoincubeClient, ConnectVaultResponse, CubeKeyRaw, User},
+        coincube::{
+            AddVaultMemberRequest, CoincubeClient, ConnectVaultResponse, ContactRole, CubeKeyRaw,
+            User, VaultMemberRole,
+        },
         connect::{
             client::auth::AccessTokenResponse,
             grpc::{
@@ -528,6 +532,23 @@ impl KeychainSignModal {
                     }
                 })?;
                 let self_user_id: u64 = user.id.into();
+                // COIN-373: self-heal a vault left memberless (or partially
+                // populated) by a Vault Builder sync whose `add_vault_member`
+                // fan-out failed and was swallowed into a warning. Attach any
+                // descriptor signer that is a registered cube key — owned by
+                // this user or by a keyholder contact — but isn't yet a vault
+                // member, then continue with the refreshed member list. Without
+                // this, such a vault permanently reports "no Keychain signers
+                // required" with no in-app recovery.
+                let vault = reconcile_vault_members(
+                    &client,
+                    cube_server_id,
+                    vault,
+                    &cube_keys,
+                    &wallet.main_descriptor,
+                    self_user_id,
+                )
+                .await;
                 let index: KeychainSignerIndex =
                     build_keychain_index(&vault.members, &cube_keys, self_user_id);
                 let required =
@@ -555,12 +576,30 @@ impl KeychainSignModal {
             .iter()
             .filter(|r| r.is_keychain())
             .count();
+        // Summarize the classified signers (fingerprint + Local/Keychain) so
+        // a "no Keychain signers required" outcome is diagnosable: it tells us
+        // whether the wrong spend path was chosen (e.g. primary instead of
+        // recovery) or whether the right key was selected but didn't join to a
+        // cube key and so fell back to Local.
+        let required_summary = classified
+            .required
+            .iter()
+            .map(|r| {
+                format!(
+                    "{}:{}",
+                    r.fingerprint(),
+                    if r.is_keychain() { "keychain" } else { "local" }
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",");
         self.classified = Some(classified);
         if !has_keychain {
             tracing::info!(
                 target: "coincube_gui::signing",
                 vault_id = vault_id,
                 phase = "classified",
+                required = %required_summary,
                 "No Keychain signers required for this transaction"
             );
             self.phase = Phase::AllDone;
@@ -576,6 +615,7 @@ impl KeychainSignModal {
             vault_id = vault_id,
             phase = "classified",
             keychain_signers = keychain_count,
+            required = %required_summary,
             "Classification complete, resolving signer devices"
         );
         // Stash vault_id now that we have it.
@@ -1602,6 +1642,138 @@ impl Modal for KeychainSignModal {
 /// the generic "Other" path — the user still sees the original
 /// message, they just don't get the "session expired" closed-modal
 /// path.
+/// Every signer fingerprint the descriptor uses, across the primary path
+/// and all recovery paths. Used by the COIN-373 reconcile to decide which
+/// registered cube keys are actually part of this wallet.
+fn descriptor_fingerprints(descriptor: &CoincubeDescriptor) -> HashSet<Fingerprint> {
+    let policy = descriptor.policy();
+    let mut fps: HashSet<Fingerprint> = policy.primary_path().thresh_origins().1.into_keys().collect();
+    for path in policy.recovery_paths().values() {
+        fps.extend(path.thresh_origins().1.into_keys());
+    }
+    fps
+}
+
+/// Best-effort reconcile of vault membership before classification
+/// (COIN-373). A Vault Builder run whose `add_vault_member` fan-out failed
+/// can leave the backend vault with missing keyholder members, which makes
+/// `build_keychain_index` blind to a descriptor signer and dead-ends the
+/// Keychain sign flow ("no Keychain signers required") with no recovery.
+///
+/// Here we attach any cube key that (a) is a signer in this wallet's
+/// descriptor and (b) isn't already a vault member, resolving the owner to a
+/// `contact_id` for keyholder-contact keys (or `None` for the user's own
+/// keys). Returns the vault re-fetched when at least one member was added.
+/// Failures (including an owner we can't map to a keyholder contact) are
+/// logged and skipped — classification then proceeds with whatever members
+/// exist, exactly as before.
+async fn reconcile_vault_members(
+    client: &CoincubeClient,
+    cube_server_id: u64,
+    vault: ConnectVaultResponse,
+    cube_keys: &[CubeKeyRaw],
+    descriptor: &CoincubeDescriptor,
+    self_user_id: u64,
+) -> ConnectVaultResponse {
+    let descriptor_fps = descriptor_fingerprints(descriptor);
+    let existing_key_ids: HashSet<u64> = vault.members.iter().filter_map(|m| m.key_id).collect();
+
+    // Registered cube keys this wallet uses that aren't yet attached.
+    let candidates: Vec<&CubeKeyRaw> = cube_keys
+        .iter()
+        .filter(|k| !existing_key_ids.contains(&k.id))
+        .filter(|k| {
+            k.fingerprint
+                .parse::<Fingerprint>()
+                .map(|fp| descriptor_fps.contains(&fp))
+                .unwrap_or(false)
+        })
+        .collect();
+    if candidates.is_empty() {
+        return vault;
+    }
+
+    // Needed to resolve a contact-owned key's `contact_id`. If this fails we
+    // can still attach self-owned keys (which need no contact_id).
+    let contacts = client.get_contacts().await.unwrap_or_default();
+
+    let mut added = 0usize;
+    for key in candidates {
+        let owner_id = key.effective_owner_user_id();
+        let is_own = key.is_own_key || owner_id == self_user_id;
+        let contact_id = if is_own {
+            None
+        } else {
+            match contacts.iter().find(|c| {
+                c.effective_contact_user_id() == Some(owner_id) && c.role == ContactRole::Keyholder
+            }) {
+                Some(c) => Some(c.id),
+                None => {
+                    // Owner isn't a keyholder contact we can address — sending
+                    // this without a contact_id would 400 ("Key does not belong
+                    // to the specified user"), so skip and let classification
+                    // surface it as Local.
+                    tracing::warn!(
+                        target: "coincube_gui::signing",
+                        key_id = key.id,
+                        owner_user_id = owner_id,
+                        "Reconcile: descriptor cube key has no keyholder-contact owner — skipping attach",
+                    );
+                    continue;
+                }
+            }
+        };
+        match client
+            .add_vault_member(
+                cube_server_id,
+                AddVaultMemberRequest {
+                    contact_id,
+                    key_id: Some(key.id),
+                    role: VaultMemberRole::Keyholder,
+                },
+            )
+            .await
+        {
+            Ok(_) => {
+                added += 1;
+                tracing::info!(
+                    target: "coincube_gui::signing",
+                    key_id = key.id,
+                    contact_id = ?contact_id,
+                    "Reconcile: attached missing keychain key to vault (COIN-373)",
+                );
+            }
+            Err(e) => {
+                // Best-effort: a failure here just means this signer stays
+                // unattached and classification falls back to Local, the prior
+                // behavior. Don't fail the whole sign flow.
+                tracing::warn!(
+                    target: "coincube_gui::signing",
+                    key_id = key.id,
+                    "Reconcile: failed to attach keychain key to vault: {}",
+                    e,
+                );
+            }
+        }
+    }
+
+    if added == 0 {
+        return vault;
+    }
+    // Re-fetch so the returned member list reflects the attachments.
+    match client.get_connect_vault(cube_server_id).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                target: "coincube_gui::signing",
+                "Reconcile: re-fetch of vault after attaching members failed: {}",
+                e,
+            );
+            vault
+        }
+    }
+}
+
 fn is_rest_auth_failure(msg: &str) -> bool {
     let lower = msg.to_ascii_lowercase();
     lower.contains("401")
@@ -1710,5 +1882,27 @@ fn event_type_from_i32(v: i32) -> crate::services::connect::grpc::connect_v1::Ev
         11 => EventType::DeviceOnline,
         12 => EventType::DeviceOffline,
         _ => EventType::Unspecified,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    // Primary signer `f5acc2fd`; recovery signer `8a64f2a9` behind a CSV.
+    // Same fixture used by the `signers` classification tests.
+    const RECOVERY_DESC: &str = "wsh(or_d(pk([f5acc2fd]tpubD6NzVbkrYhZ4YgUx2ZLNt2rLYAMTdYysCRzKoLu2BeSHKvzqPaBDvf17GeBPnExUVPkuBpx4kniP964e2MxyzzazcXLptxLXModSVCVEV1T/<0;1>/*),and_v(v:pkh([8a64f2a9]tpubD6NzVbkrYhZ4WmzFjvQrp7sDa4ECUxTi9oby8K4FZkd3XCBtEdKwUiQyYJaxiJo5y42gyDWEczrFpozEjeLxMPxjf2WtkfcbpUdfvNnozWF/<0;1>/*),older(10))))#d72le4dr";
+
+    #[test]
+    fn descriptor_fingerprints_covers_primary_and_recovery() {
+        let desc = CoincubeDescriptor::from_str(RECOVERY_DESC).unwrap();
+        let fps = descriptor_fingerprints(&desc);
+        // The recovery signer must be included — dropping recovery-path
+        // fingerprints would make the COIN-373 reconcile blind to exactly
+        // the contact-owned recovery keys it exists to attach.
+        assert!(fps.contains(&Fingerprint::from_str("f5acc2fd").unwrap()));
+        assert!(fps.contains(&Fingerprint::from_str("8a64f2a9").unwrap()));
+        assert_eq!(fps.len(), 2);
     }
 }

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -332,7 +332,14 @@ impl PsbtState {
                         // device is registered). When signed in, the modal
                         // offers "Sign with Connect" (on-demand bootstrap)
                         // rather than a sign-in that would no-op.
-                        signed_in: cache.connect_authenticated,
+                        //
+                        // `connect_authenticated` only tracks the Connect
+                        // panel's `Dashboard` step, which lags a session
+                        // restored from `connect.json` at launch (or never set
+                        // if the panel isn't visited). `has_connect_session`
+                        // covers that restored/remote session, so OR them to
+                        // avoid offering "Sign in" to an already-signed-in user.
+                        signed_in: cache.connect_authenticated || cache.has_connect_session,
                     }));
                     return Task::none();
                 }

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -24,6 +24,7 @@ use crate::{
     app::{
         cache::Cache,
         error::Error,
+        menu::{Menu, VaultSubMenu},
         message::Message,
         state::vault::label::{label_item_from_str, LabelsEdited},
         view,
@@ -71,6 +72,10 @@ pub enum PsbtModal {
     /// so the local-only "Sign" path can broadcast as today once every
     /// path threshold is met.
     KeychainSign(super::keychain_sign::KeychainSignModal),
+    /// Shown when "Sign via Keychain" is pressed but Connect isn't ready.
+    /// Offers Connect sign-in or local Wi-Fi pairing as ways forward,
+    /// instead of dead-ending on a technical "missing field" toast.
+    KeychainUnavailable(KeychainUnavailableModal),
     Broadcast(BroadcastModal),
     Delete(DeleteModal),
     Export(VaultExportModal),
@@ -82,6 +87,7 @@ impl<'a> AsRef<dyn Modal + 'a> for PsbtModal {
             Self::Save(a) => a,
             Self::Sign(a) => a,
             Self::KeychainSign(a) => a,
+            Self::KeychainUnavailable(a) => a,
             Self::Broadcast(a) => a,
             Self::Delete(a) => a,
             Self::Export(a) => a,
@@ -95,6 +101,7 @@ impl<'a> AsMut<dyn Modal + 'a> for PsbtModal {
             Self::Save(a) => a,
             Self::Sign(a) => a,
             Self::KeychainSign(a) => a,
+            Self::KeychainUnavailable(a) => a,
             Self::Broadcast(a) => a,
             Self::Delete(a) => a,
             Self::Export(a) => a,
@@ -235,6 +242,30 @@ impl PsbtState {
                 // Broadcast.
                 return cancel;
             }
+            Message::View(view::Message::Spend(view::SpendTxMessage::KeychainConnectSignIn)) => {
+                // From the "Keychain needs Connect" modal: close it and
+                // hand off to the Connect sign-in flow (handled at the
+                // tab level, which jumps to the Home tab when needed).
+                self.modal = None;
+                return Task::done(Message::View(view::Message::OpenConnectSignIn));
+            }
+            Message::View(view::Message::Spend(view::SpendTxMessage::KeychainEnsureConnect)) => {
+                // From the modal when already signed in: close it and run
+                // the on-demand Connect bootstrap so the signing stream
+                // comes up (device registration + stream), after which
+                // "Sign via Keychain" works on retry.
+                self.modal = None;
+                return Task::done(Message::EnsureConnectReady);
+            }
+            Message::View(view::Message::Spend(view::SpendTxMessage::KeychainPairPhone)) => {
+                // From the "Keychain needs Connect" modal: close it and
+                // navigate to Vault → Settings → Pair so the user can
+                // pair a phone over Wi-Fi and sign locally.
+                self.modal = None;
+                return Task::done(Message::View(view::Message::Menu(Menu::Vault(
+                    VaultSubMenu::Settings(Some(crate::app::menu::SettingsOption::LocalSigning)),
+                ))));
+            }
             Message::View(view::Message::Spend(view::SpendTxMessage::Delete)) => {
                 self.modal = Some(PsbtModal::Delete(DeleteModal::default()));
             }
@@ -285,12 +316,25 @@ impl PsbtState {
                 .filter_map(|(name, is_missing)| is_missing.then_some(*name))
                 .collect();
                 if !missing.is_empty() {
-                    let msg = format!(
-                        "Sign via Keychain is unavailable: Connect is not ready yet \
-                         (missing {}).",
+                    // Connect isn't ready. Rather than dead-end on a
+                    // technical "missing field" toast, open a modal that
+                    // explains the requirement and offers both ways
+                    // forward: sign in to Connect (relay signing) or pair
+                    // a phone over Wi-Fi (local signing, no Connect). The
+                    // technical detail still goes to the log for support.
+                    tracing::info!(
+                        "Sign via Keychain unavailable: Connect not ready (missing {})",
                         missing.join(", ")
                     );
-                    return Task::done(Message::View(view::Message::ShowError(msg)));
+                    self.modal = Some(PsbtModal::KeychainUnavailable(KeychainUnavailableModal {
+                        // Reflect the real Connect account session, not the
+                        // stream-bootstrap fields (which stay unset until a
+                        // device is registered). When signed in, the modal
+                        // offers "Sign with Connect" (on-demand bootstrap)
+                        // rather than a sign-in that would no-op.
+                        signed_in: cache.connect_authenticated,
+                    }));
+                    return Task::none();
                 }
                 let grpc_url = cache.connect_grpc_url.clone().expect("checked above");
                 let tokens = cache.connect_tokens.clone().expect("checked above");
@@ -656,6 +700,27 @@ impl Modal for BroadcastModal {
             ),
         )
         .on_blur(on_blur)
+        .into()
+    }
+}
+
+/// "Keychain signing needs Connect" dialog. Pure UI — its two actions
+/// (sign in / pair a phone) are handled in `PsbtState::update`, which
+/// clears this modal and emits the matching navigation message.
+pub struct KeychainUnavailableModal {
+    /// Whether the user already has Connect tokens. When true the blocker
+    /// is device/stream readiness rather than a missing sign-in, which the
+    /// view uses to adjust its wording.
+    pub signed_in: bool,
+}
+
+impl Modal for KeychainUnavailableModal {
+    fn view<'a>(&'a self, content: Element<'a, view::Message>) -> Element<'a, view::Message> {
+        modal::Modal::new(
+            content,
+            view::vault::psbt::keychain_unavailable_action(self.signed_in),
+        )
+        .on_blur(Some(view::Message::Spend(view::SpendTxMessage::Cancel)))
         .into()
     }
 }

--- a/coincube-gui/src/app/state/vault/signers.rs
+++ b/coincube-gui/src/app/state/vault/signers.rs
@@ -169,6 +169,41 @@ pub fn build_keychain_index(
             },
         );
     }
+    // Diagnostic summary of the join: when a descriptor signer ends up
+    // classified `local` despite being expected on a phone, this shows
+    // whether the key was absent from the cube key list, present but
+    // unreferenced by any vault member, or referenced by a member that
+    // carries no `key_id`. Built lazily so it costs nothing unless the
+    // `coincube_gui::signing` target is at DEBUG.
+    if tracing::enabled!(target: "coincube_gui::signing", tracing::Level::DEBUG) {
+        let cube_keys_summary = cube_keys
+            .iter()
+            .map(|k| format!("{}#{}", k.fingerprint, k.id))
+            .collect::<Vec<_>>()
+            .join(",");
+        let members_summary = members
+            .iter()
+            .map(|m| {
+                format!(
+                    "m{}(key_id={:?},contact_id={:?})",
+                    m.id, m.key_id, m.contact_id
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        let index_summary = index
+            .keys()
+            .map(|fp| fp.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        tracing::debug!(
+            target: "coincube_gui::signing",
+            cube_keys = %cube_keys_summary,
+            vault_members = %members_summary,
+            keychain_index = %index_summary,
+            "Built keychain signer index"
+        );
+    }
     index
 }
 
@@ -178,9 +213,11 @@ pub fn build_keychain_index(
 /// 1. Compute `PartialSpendInfo` on the PSBT. The primary path is always
 ///    available; recovery paths only show up when the input nSequence
 ///    matches their CSV timelock.
-/// 2. Pick the first path whose `sigs_count < threshold` (prefer primary,
-///    fall back to recovery in timelock-asc order — that's the same
-///    order `BTreeMap::iter` already gives).
+/// 2. Pick the path the transaction was built to spend through: an available
+///    recovery path (under threshold, timelock-asc order) wins, since its
+///    presence means the PSBT's nSequence was set for recovery; otherwise
+///    fall back to the primary path. Preferring the always-available primary
+///    path would misclassify every recovery spend.
 /// 3. Enumerate the descriptor's path-info fingerprints, subtract the
 ///    set that already signed, classify each survivor against the
 ///    `keychain_index`.
@@ -197,31 +234,39 @@ pub fn classify_signers(
     let policy: CoincubePolicy = descriptor.policy();
 
     // Pick the path the user is actively trying to spend through.
-    // Primary first, then recovery paths in ascending timelock order
-    // (which is the iteration order of the BTreeMap).
+    //
+    // A recovery path appears in `PartialSpendInfo` only when the PSBT's
+    // input nSequence satisfies its CSV timelock — i.e. the transaction was
+    // deliberately built as a recovery spend (see `partial_spend_info_txin`).
+    // When one is present it is the route the user is taking, so it wins over
+    // the primary path even though the primary is still under threshold: the
+    // primary path is *always* "available" (its branch carries no timelock),
+    // so a "prefer primary while under threshold" rule would misclassify
+    // every recovery spend against the primary signers and wrongly report
+    // "no Keychain signers required" for a recovery that needs a Keychain
+    // signer. Recovery paths are tried in ascending timelock order (BTreeMap
+    // iteration); fall back to the primary path for ordinary spends, where no
+    // recovery path is available.
+    let recovery_choice = info
+        .recovery_paths()
+        .iter()
+        .find(|(_, spend)| spend.sigs_count < spend.threshold);
     let primary_under_threshold = info.primary_path().sigs_count < info.primary_path().threshold;
-    let (path_info, path_spend_info) = if primary_under_threshold {
-        (policy.primary_path(), info.primary_path())
-    } else {
-        let recovery_choice = info
-            .recovery_paths()
-            .iter()
-            .find(|(_, spend)| spend.sigs_count < spend.threshold);
-        match recovery_choice {
-            Some((timelock, spend)) => {
-                let path = policy
-                    .recovery_paths()
-                    .get(timelock)
-                    .ok_or_else(|| {
-                        ClassifyError::PsbtAnalysis(format!(
-                            "Recovery path with timelock {} present in PSBT analysis but not in descriptor policy",
-                            timelock,
-                        ))
-                    })?;
-                (path, spend)
-            }
-            None => return Err(ClassifyError::NoSpendablePath),
+    let (path_info, path_spend_info) = match recovery_choice {
+        Some((timelock, spend)) => {
+            let path = policy
+                .recovery_paths()
+                .get(timelock)
+                .ok_or_else(|| {
+                    ClassifyError::PsbtAnalysis(format!(
+                        "Recovery path with timelock {} present in PSBT analysis but not in descriptor policy",
+                        timelock,
+                    ))
+                })?;
+            (path, spend)
         }
+        None if primary_under_threshold => (policy.primary_path(), info.primary_path()),
+        None => return Err(ClassifyError::NoSpendablePath),
     };
 
     let (threshold, origins) = path_info.thresh_origins();
@@ -399,5 +444,77 @@ mod tests {
         ];
         let index = build_keychain_index(&members, &cube_keys, 100);
         assert_eq!(index.len(), 1);
+    }
+
+    // `or_d(pk(primary), and_v(v:pkh(recovery), older(10)))`: primary path is
+    // the single key `f5acc2fd`; the recovery path is the single key
+    // `8a64f2a9` behind a 10-block CSV. Reused from
+    // `coincube_core::descriptors` analysis fixtures.
+    const RECOVERY_DESC: &str = "wsh(or_d(pk([f5acc2fd]tpubD6NzVbkrYhZ4YgUx2ZLNt2rLYAMTdYysCRzKoLu2BeSHKvzqPaBDvf17GeBPnExUVPkuBpx4kniP964e2MxyzzazcXLptxLXModSVCVEV1T/<0;1>/*),and_v(v:pkh([8a64f2a9]tpubD6NzVbkrYhZ4WmzFjvQrp7sDa4ECUxTi9oby8K4FZkd3XCBtEdKwUiQyYJaxiJo5y42gyDWEczrFpozEjeLxMPxjf2WtkfcbpUdfvNnozWF/<0;1>/*),older(10))))#d72le4dr";
+    // Unsigned single-input/single-output PSBT for the descriptor above, with
+    // a default (non-recovery) nSequence.
+    const UNSIGNED_PSBT_B64: &str = "cHNidP8BAHECAAAAAUSHuliRtuCX1S6JxRuDRqDCKkWfKmWL5sV9ukZ/wzvfAAAAAAD9////AogTAAAAAAAAFgAUIxe7UY6LJ6y5mFBoWTOoVispDmdwFwAAAAAAABYAFKqO83TK+t/KdpAt21z2HGC7/Z2FAAAAAAABASsQJwAAAAAAACIAIIIySQjGCTeyx/rKUQx8qobjhJeNCiVCliBJPdyRX6XKAQVBIQI2cqWpc9UAW2gZt2WkKjvi8KoMCui00pRlL6wG32uKDKxzZHapFNYASzIYkEdH9bJz6nnqUG3uBB8kiK1asmgiBgI2cqWpc9UAW2gZt2WkKjvi8KoMCui00pRlL6wG32uKDAz1rML9AAAAAG8AAAAiBgMLcbOxsfLe6+3r1UcjQo77HY0As8OKE4l37yj0/qhIyQyKZPKpAAAAAG8AAAAAAAA=";
+
+    fn primary_fg() -> Fingerprint {
+        "f5acc2fd".parse().unwrap()
+    }
+    fn recovery_fg() -> Fingerprint {
+        "8a64f2a9".parse().unwrap()
+    }
+
+    /// Index marking the recovery key `8a64f2a9` as a Keychain signer.
+    fn recovery_keychain_index() -> KeychainSignerIndex {
+        let mut index = KeychainSignerIndex::new();
+        index.insert(
+            recovery_fg(),
+            KeychainSignerInfo {
+                key_id: 7,
+                owner_user_id: 100,
+                name: "testnet4 keychain".to_string(),
+                owner_email: None,
+                contact_id: None,
+            },
+        );
+        index
+    }
+
+    #[test]
+    fn classify_targets_recovery_keychain_for_recovery_spend() {
+        use coincube_core::miniscript::bitcoin::Sequence;
+        use std::str::FromStr;
+
+        let desc = CoincubeDescriptor::from_str(RECOVERY_DESC).unwrap();
+        let mut psbt = Psbt::from_str(UNSIGNED_PSBT_B64).unwrap();
+        // Build it as a recovery spend: nSequence satisfies the older(10) CSV,
+        // so `partial_spend_info` surfaces the recovery path.
+        psbt.unsigned_tx.input[0].sequence = Sequence::from_height(10);
+
+        let required =
+            classify_signers(&psbt, &desc, &recovery_keychain_index(), &HashMap::new()).unwrap();
+
+        // Regression: the primary path is always "available", so the old
+        // "prefer primary while under threshold" rule classified this against
+        // `f5acc2fd` and reported no Keychain signers. The recovery keychain
+        // signer is the one actually required.
+        assert_eq!(required.len(), 1);
+        assert!(required[0].is_keychain());
+        assert_eq!(required[0].fingerprint(), recovery_fg());
+    }
+
+    #[test]
+    fn classify_targets_primary_for_ordinary_spend() {
+        use std::str::FromStr;
+
+        let desc = CoincubeDescriptor::from_str(RECOVERY_DESC).unwrap();
+        // Default nSequence — no recovery path is available, so the primary
+        // path is the spend route.
+        let psbt = Psbt::from_str(UNSIGNED_PSBT_B64).unwrap();
+
+        let required =
+            classify_signers(&psbt, &desc, &recovery_keychain_index(), &HashMap::new()).unwrap();
+
+        assert_eq!(required.len(), 1);
+        assert!(!required[0].is_keychain());
+        assert_eq!(required[0].fingerprint(), primary_fg());
     }
 }

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -248,6 +248,18 @@ pub enum SpendTxMessage {
     /// Retry a single signer whose session expired or was rejected.
     /// Carries the per-signer position in `KeychainSignModal::pending`.
     RetryKeychainSigner(usize),
+    /// From the "Keychain signing needs Connect" modal: dismiss it and
+    /// route the user to the Connect sign-in flow.
+    KeychainConnectSignIn,
+    /// From the modal when the user is already signed in to Connect but the
+    /// signing stream isn't ready: dismiss it and kick off the on-demand
+    /// Connect bootstrap (device registration + stream) via
+    /// `Message::EnsureConnectReady`.
+    KeychainEnsureConnect,
+    /// From the "Keychain signing needs Connect" modal: dismiss it and
+    /// jump to Vault → Settings → Pair so the user can pair a phone over
+    /// Wi-Fi and sign locally without Connect.
+    KeychainPairPhone,
     Broadcast,
     Save,
     Confirm,

--- a/coincube-gui/src/app/view/vault/psbt.rs
+++ b/coincube-gui/src/app/view/vault/psbt.rs
@@ -310,6 +310,60 @@ pub fn delete_action<'a>(deleted: bool) -> Element<'a, Message> {
     }
 }
 
+/// Modal shown when the user presses "Sign via Keychain" but Connect
+/// isn't ready. Explains the requirement and offers the two ways forward:
+/// sign in to Connect (enables Keychain relay signing), or pair a phone
+/// over Wi-Fi (local signing, no Connect needed). `signed_in` tweaks the
+/// wording — once tokens exist, the blocker is device/stream readiness
+/// rather than a missing sign-in.
+pub fn keychain_unavailable_action<'a>(signed_in: bool) -> Element<'a, Message> {
+    let body = if signed_in {
+        "Connect hasn't finished setting up this device for Keychain \
+         signing. Set it up now, or pair a phone over Wi-Fi to sign \
+         locally without Connect."
+    } else {
+        "To sign with a Keychain phone through Connect, sign in to \
+         COINCUBE Connect. Or pair a phone over Wi-Fi to sign locally — \
+         no Connect required."
+    };
+    // When already signed in, the primary action bootstraps Connect
+    // signing on demand ("Sign with Connect"); otherwise it routes to
+    // sign-in. Fixed-width buttons keep their labels on one line.
+    let (primary_label, primary_msg) = if signed_in {
+        ("Sign with Connect", SpendTxMessage::KeychainEnsureConnect)
+    } else {
+        ("Sign in to Connect", SpendTxMessage::KeychainConnectSignIn)
+    };
+    card::simple(
+        Column::new()
+            .spacing(15)
+            .push(text("Keychain signing needs Connect").bold())
+            .push(text(body).style(theme::text::secondary))
+            .push(
+                Row::new()
+                    .spacing(10)
+                    .push(Column::new().width(Length::Fill))
+                    .push(
+                        button::transparent(None, "Cancel")
+                            .on_press(Message::Spend(SpendTxMessage::Cancel)),
+                    )
+                    .push(
+                        button::secondary(None, "Pair a phone")
+                            .on_press(Message::Spend(SpendTxMessage::KeychainPairPhone))
+                            .width(Length::Fixed(140.0)),
+                    )
+                    .push(
+                        button::primary(None, primary_label)
+                            .on_press(Message::Spend(primary_msg))
+                            .width(Length::Fixed(190.0)),
+                    )
+                    .align_y(Alignment::Center),
+            ),
+    )
+    .width(Length::Fixed(600.0))
+    .into()
+}
+
 pub fn spend_header<'a>(
     tx: &'a SpendTx,
     labels_editing: &'a HashMap<String, form::Value<String>>,

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -987,6 +987,31 @@ impl Tab {
                     restored_from_backup,
                     cube_settings,
                 } => {
+                    // Restore Connect auth cached at `<network>/connect.json`
+                    // by a prior sign-in, mirroring the remote-backend path
+                    // (which threads its live tokens in). Without this, every
+                    // local-node launch discards persisted Connect auth and
+                    // `connect_stream_ready_task` never runs, leaving
+                    // Connect-dependent features — Sign via Keychain in
+                    // particular — unavailable until the user re-signs in via
+                    // the Connect tab. We read the same file
+                    // `duress_state_check_task` already consults at launch.
+                    // (The stream bootstrap still no-ops until a `device_id`
+                    // is registered for the account; the Connect-tab sign-in
+                    // flow handles that registration.)
+                    let connect_auth =
+                        crate::services::connect::client::cache::ConnectCache::from_file(
+                            &datadir.network_directory(cache.network),
+                        )
+                        .ok()
+                        .and_then(|c| c.accounts.into_iter().next())
+                        .map(|account| {
+                            (
+                                Arc::new(tokio::sync::RwLock::new(account.tokens)),
+                                account.email,
+                            )
+                        });
+
                     let (app, command) = App::new(
                         cache,
                         wallet,
@@ -998,11 +1023,7 @@ impl Tab {
                         bitcoind,
                         restored_from_backup,
                         cube_settings,
-                        // Local daemon path has no Connect tokens at this
-                        // stage; the user may sign in to Connect later
-                        // via the Connect tab — that flow handles its own
-                        // gRPC bootstrap.
-                        None,
+                        connect_auth,
                     );
                     self.state = State::App(app);
                     command.map(Message::Run)

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -1966,6 +1966,9 @@ pub fn create_app_with_remote_backend(
             node_bitcoind_ibd: None,
             node_bitcoind_last_log: None,
             connect_authenticated: false,
+            // Remote backend implies an authenticated Connect session from the
+            // start, even before the Connect panel reaches its Dashboard step.
+            has_connect_session: true,
             has_vault: true,
             cube_name: cube_settings.name.clone(),
             current_cube_backed_up: cube_settings.backed_up,

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -2306,7 +2306,7 @@ fn create_cube_form<'a>(
         .push(h4_bold("Create a new Cube"))
         .push(
             p1_regular(
-                "A Cube is your account which can contain a Liquid wallet, a Vault wallet and other features.",
+                "A Cube is your account which can contain a Spark wallet, a Liquid wallet, a Vault wallet and other features.",
             )
             .style(theme::text::secondary),
         );

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -2281,7 +2281,7 @@ fn create_cube_form<'a>(
         .push(h4_bold("Create a new Cube"))
         .push(
             p1_regular(
-                "A Cube is your account which can contain a Liquid wallet, a Vault wallet and other features.",
+                "A Cube is your account which can contain a Spark wallet, a Liquid wallet, a Vault wallet and other features.",
             )
             .style(theme::text::secondary),
         );

--- a/coincube-gui/src/loader.rs
+++ b/coincube-gui/src/loader.rs
@@ -613,6 +613,9 @@ pub async fn load_application(
         node_bitcoind_ibd: None,
         node_bitcoind_last_log: None,
         connect_authenticated: false,
+        // Local-daemon launch has no Connect session until the user signs in
+        // via the Connect tab; `App::new` flips this on if it restores one.
+        has_connect_session: false,
         has_vault: true,
         cube_name: config.cube_settings.name.clone(),
         current_cube_backed_up: config.cube_settings.backed_up,

--- a/coincube-gui/src/services/connect/client/mod.rs
+++ b/coincube-gui/src/services/connect/client/mod.rs
@@ -91,9 +91,12 @@ async fn coincube_grpc_url() -> Option<String> {
 /// used only when the service-config endpoint is unreachable. `None` when not
 /// baked in.
 fn buildtime_grpc_url_default() -> Option<String> {
-    option_env!("COINCUBE_CONNECT_GRPC_URL")
-        .map(|v| v.trim().trim_end_matches('/').to_string())
-        .filter(|v| !v.is_empty())
+    // Normalize like the service-config path so a baked bare `host:port`
+    // still enables TLS in `create_channel` (which keys on the `https://`
+    // prefix). A scheme-qualified value is passed through unchanged;
+    // default to TLS otherwise — plaintext dev endpoints must spell out
+    // `http://`.
+    option_env!("COINCUBE_CONNECT_GRPC_URL").and_then(|v| normalize_grpc_url(v, true))
 }
 
 /// Normalize a gRPC endpoint to a scheme-qualified URL tonic accepts. Returns
@@ -114,11 +117,15 @@ fn normalize_grpc_url(raw: &str, tls: bool) -> Option<String> {
 }
 
 fn runtime_grpc_url_override() -> Option<String> {
+    // Normalize like the service-config path so a bare `host:port` from the
+    // env override still enables TLS in `create_channel` (which keys on the
+    // `https://` prefix). Scheme-qualified values pass through unchanged;
+    // default to TLS otherwise — plaintext/local endpoints must spell out
+    // `http://`.
     std::env::var(CONNECT_GRPC_URL_ENV)
         .ok()
         .or_else(|| std::env::var(LEGACY_GRPC_URL_ENV).ok())
-        .map(|v| v.trim().trim_end_matches('/').to_string())
-        .filter(|v| !v.is_empty())
+        .and_then(|v| normalize_grpc_url(&v, true))
 }
 
 fn runtime_backend_api_url_override() -> Option<String> {

--- a/coincube-gui/src/services/connect/client/mod.rs
+++ b/coincube-gui/src/services/connect/client/mod.rs
@@ -15,7 +15,18 @@ const LEGACY_GRPC_URL_ENV: &str = "COINCUBE_GRPC_URL";
 struct ServiceConfigResource {
     pub auth_api_url: String,
     pub auth_api_public_key: String,
-    pub grpc_url: Option<String>,
+}
+
+/// COINCUBE-owned Connect service config (`GET /api/v1/connect/service-config`).
+/// Source of the Connect signing gRPC endpoint for **all** networks — replaces
+/// the per-network lianalite `grpc_url`. The endpoint is network-agnostic (one
+/// gRPC deployment serves every network), so we don't pass a `network` query.
+#[derive(Debug, Clone, Deserialize)]
+struct CoincubeServiceConfig {
+    #[serde(rename = "grpcUrl")]
+    grpc_url: Option<String>,
+    #[serde(default)]
+    tls: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -34,12 +45,26 @@ pub async fn get_service_config(
     } else {
         LIANALITE_SIGNET_URL
     };
+    // NOTE: the lianalite `/v1/desktop` call remains only for the auth +
+    // remote-backend fields, which are tracked for removal separately
+    // (see plans/liana-api-removal-rust.md). The signing `grpc_url` no
+    // longer comes from lianalite.
     let res: ServiceConfigResource =
         reqwest::get(format!("{}/v1/desktop", default_backend_api_url))
             .await?
             .json()
             .await?;
-    let grpc_url = runtime_grpc_url_override().or(res.grpc_url);
+    // gRPC endpoint discovery, COINCUBE-only, in precedence order:
+    //   1. runtime env override (staging/local),
+    //   2. COINCUBE service-config endpoint (env-specific, all networks),
+    //   3. compile-time baked default (resilience if the endpoint is down).
+    let grpc_url = match runtime_grpc_url_override() {
+        Some(u) => Some(u),
+        None => match coincube_grpc_url().await {
+            Some(u) => Some(u),
+            None => buildtime_grpc_url_default(),
+        },
+    };
     Ok(ServiceConfig {
         auth_api_url: res.auth_api_url,
         auth_api_public_key: res.auth_api_public_key,
@@ -47,6 +72,45 @@ pub async fn get_service_config(
             .unwrap_or_else(|| default_backend_api_url.to_string()),
         grpc_url,
     })
+}
+
+/// Fetch the Connect signing gRPC URL from coincube-api. Best-effort: any
+/// network/parse failure yields `None` so the caller can fall back, and we
+/// never fall back to lianalite. The returned URL is normalized to a
+/// tonic-ready form (`https://…` when TLS, `http://…` otherwise) so
+/// `create_channel` enables TLS correctly.
+async fn coincube_grpc_url() -> Option<String> {
+    let base = crate::services::coincube_api_base_url();
+    let url = format!("{base}/api/v1/connect/service-config");
+    let cfg: CoincubeServiceConfig = reqwest::get(url).await.ok()?.json().await.ok()?;
+    let raw = cfg.grpc_url?;
+    normalize_grpc_url(&raw, cfg.tls)
+}
+
+/// Compile-time baked gRPC URL (`COINCUBE_CONNECT_GRPC_URL` at build time),
+/// used only when the service-config endpoint is unreachable. `None` when not
+/// baked in.
+fn buildtime_grpc_url_default() -> Option<String> {
+    option_env!("COINCUBE_CONNECT_GRPC_URL")
+        .map(|v| v.trim().trim_end_matches('/').to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Normalize a gRPC endpoint to a scheme-qualified URL tonic accepts. Returns
+/// `None` for an empty value. An already-qualified `http(s)://` value is kept
+/// as-is; otherwise the scheme is chosen from `tls`.
+fn normalize_grpc_url(raw: &str, tls: bool) -> Option<String> {
+    let raw = raw.trim().trim_end_matches('/');
+    if raw.is_empty() {
+        return None;
+    }
+    if raw.starts_with("http://") || raw.starts_with("https://") {
+        Some(raw.to_string())
+    } else if tls {
+        Some(format!("https://{raw}"))
+    } else {
+        Some(format!("http://{raw}"))
+    }
 }
 
 fn runtime_grpc_url_override() -> Option<String> {
@@ -62,4 +126,43 @@ fn runtime_backend_api_url_override() -> Option<String> {
         .ok()
         .map(|v| v.trim().trim_end_matches('/').to_string())
         .filter(|v| !v.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_grpc_url;
+
+    #[test]
+    fn normalize_adds_https_when_tls() {
+        assert_eq!(
+            normalize_grpc_url("grpc.coincube.io:443", true).as_deref(),
+            Some("https://grpc.coincube.io:443")
+        );
+    }
+
+    #[test]
+    fn normalize_adds_http_when_not_tls() {
+        assert_eq!(
+            normalize_grpc_url("localhost:50051", false).as_deref(),
+            Some("http://localhost:50051")
+        );
+    }
+
+    #[test]
+    fn normalize_keeps_existing_scheme_and_trims_slash() {
+        assert_eq!(
+            normalize_grpc_url("https://grpc.coincube.io:443/", false).as_deref(),
+            Some("https://grpc.coincube.io:443")
+        );
+        assert_eq!(
+            normalize_grpc_url("http://host:1/", true).as_deref(),
+            Some("http://host:1")
+        );
+    }
+
+    #[test]
+    fn normalize_rejects_empty() {
+        assert_eq!(normalize_grpc_url("   ", true), None);
+        assert_eq!(normalize_grpc_url("", false), None);
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes touch Connect auth restoration, on-demand gRPC/device bootstrap, and vault membership mutations during signing; failures are mostly best-effort with user-facing fallbacks, but mis-synced session state could still affect signing availability.
> 
> **Overview**
> Fixes **Sign via Keychain** and Connect signing when a session exists on disk or the Connect panel hasn’t finished bootstrapping yet.
> 
> **Connect session & bootstrap:** Local launch now restores tokens from `connect.json` (like the remote path). Cache adds **`has_connect_session`** (session on disk vs. Connect panel “Dashboard” **`connect_authenticated`**) and keeps **`connect_authenticated`** in sync each tick. New **`EnsureConnectReady`** registers the device, optionally registers the cube when **`current_cube_server_id`** is missing, and chains **`TriggerConnectStreamReady`**—with toasts when there’s no session, no gRPC for the network, or the API is unreachable. gRPC URLs come from **coincube-api** `service-config` (env/build-time fallbacks) instead of lianalite.
> 
> **UX when Connect isn’t ready:** Missing grpc/tokens/device/server id opens a **`KeychainUnavailable`** modal (sign in, **Sign with Connect**, or pair locally) instead of an error toast.
> 
> **Signing correctness:** **`classify_signers`** prefers an active **recovery** path when the PSBT’s nSequence matches CSV, so recovery Keychain spends aren’t misclassified as primary. **COIN-373** **`reconcile_vault_members`** best-effort attaches descriptor cube keys missing from vault members before classification. Recovery **`CreateSpendPanel`** now gets daemon cache updates like send.
> 
> Minor copy: new Cube text mentions Spark wallet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec96922a820d3a9c25862c7fe97deea91b363c68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Sign via Keychain" support for authenticated users without restarting the app
  * New modal interface when Connect signing prerequisites are unavailable, with options to sign in, trigger Connect setup, or pair a phone
  * Automatic Connect authentication restoration on app startup
  * Improved Connect gRPC endpoint discovery with environment and fallback configuration

* **Documentation**
  * Updated Cube creation descriptions to include Spark wallet alongside Liquid and Vault wallets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->