### PR TITLE
Network Feature Gating

### DIFF
--- a/coincube-gui/src/app/breez_liquid/client.rs
+++ b/coincube-gui/src/app/breez_liquid/client.rs
@@ -194,6 +194,21 @@ impl BreezClient {
         }
     }
 
+    /// Disconnected client that still carries the master signer.
+    ///
+    /// Used on networks where the Liquid SDK isn't connected but the seed is
+    /// still needed by other features — e.g. P2P/Mostro identity derives its
+    /// Nostr key from the same mnemonic, and the P2P panel only mounts when a
+    /// signer is present ([`Self::liquid_signer`]). SDK methods still return
+    /// `NetworkNotSupported`, so the Liquid wallet UI stays gated.
+    pub fn disconnected_with_signer(network: Network, signer: Arc<Mutex<MasterSigner>>) -> Self {
+        Self {
+            sdk: None,
+            signer: Some(signer),
+            network,
+        }
+    }
+
     /// Returns a reference to the inner SDK, or `NetworkNotSupported` if disconnected.
     fn get_sdk(&self) -> Result<&Arc<breez::LiquidSdk>, BreezError> {
         self.sdk

--- a/coincube-gui/src/app/breez_liquid/config.rs
+++ b/coincube-gui/src/app/breez_liquid/config.rs
@@ -16,6 +16,13 @@ impl BreezConfig {
         network: bitcoin::Network,
         datadir: &std::path::Path,
     ) -> Result<Self, BreezError> {
+        // Defense in depth: only build a config for networks with a real
+        // Liquid Esplora backend (mainnet, testnet, signet). The loader
+        // guards this too, but rejecting here guarantees `sdk_config`
+        // never has to invent a localhost fallback URL.
+        if !crate::app::features::liquid(network).is_available() {
+            return Err(BreezError::NetworkNotSupported(network));
+        }
         Ok(Self {
             api_key: env!("BREEZ_API_KEY"),
             network,
@@ -28,26 +35,29 @@ impl BreezConfig {
         // runtime `.env` overrides apply consistently with the REST/SSE clients.
         let coincube_base = crate::services::coincube_api_base_url();
 
+        // `from_env` rejects every network without a real backend, so only
+        // Bitcoin / Testnet / Signet reach here. The Testnet4 + Regtest arms
+        // exist only to keep the match exhaustive — they route to the
+        // Coincube-hosted testnet Esplora rather than a localhost fallback,
+        // and are never hit in practice.
         let liquid_explorer_url = match self.network {
             bitcoin::Network::Bitcoin => format!("{}/api/v1/esplora/liquid/mainnet", coincube_base),
-            bitcoin::Network::Testnet => {
-                format!("{}/api/v1/esplora/liquid/testnet", coincube_base)
-            }
             bitcoin::Network::Signet => "https://blockstream.info/liquidtestnet/api".to_string(),
-            bitcoin::Network::Regtest | bitcoin::Network::Testnet4 => {
-                "http://localhost:4003/api".to_string()
+            bitcoin::Network::Testnet
+            | bitcoin::Network::Testnet4
+            | bitcoin::Network::Regtest => {
+                format!("{}/api/v1/esplora/liquid/testnet", coincube_base)
             }
         };
         let bitcoin_explorer_url = match self.network {
             bitcoin::Network::Bitcoin => {
                 format!("{}/api/v1/esplora/bitcoin/mainnet", coincube_base)
             }
-            bitcoin::Network::Testnet => {
-                format!("{}/api/v1/esplora/bitcoin/testnet", coincube_base)
-            }
             bitcoin::Network::Signet => "https://blockstream.info/signet/api".to_string(),
-            bitcoin::Network::Regtest | bitcoin::Network::Testnet4 => {
-                "http://localhost:4002/api".to_string()
+            bitcoin::Network::Testnet
+            | bitcoin::Network::Testnet4
+            | bitcoin::Network::Regtest => {
+                format!("{}/api/v1/esplora/bitcoin/testnet", coincube_base)
             }
         };
 
@@ -63,11 +73,12 @@ impl BreezConfig {
             working_dir: self.working_dir.to_string_lossy().to_string(),
             network: match self.network {
                 bitcoin::Network::Bitcoin => breez::LiquidNetwork::Mainnet,
-                bitcoin::Network::Testnet | bitcoin::Network::Signet => {
-                    breez::LiquidNetwork::Testnet
-                }
-                bitcoin::Network::Testnet4 => breez::LiquidNetwork::Testnet,
-                bitcoin::Network::Regtest => breez::LiquidNetwork::Regtest,
+                // Testnet + Signet (and the unreachable Testnet4/Regtest arms)
+                // all map to the Breez Testnet network.
+                bitcoin::Network::Testnet
+                | bitcoin::Network::Signet
+                | bitcoin::Network::Testnet4
+                | bitcoin::Network::Regtest => breez::LiquidNetwork::Testnet,
             },
             payment_timeout_sec: 60,
             sync_service_url: None,         // Use default

--- a/coincube-gui/src/app/breez_liquid/config.rs
+++ b/coincube-gui/src/app/breez_liquid/config.rs
@@ -35,11 +35,11 @@ impl BreezConfig {
         // runtime `.env` overrides apply consistently with the REST/SSE clients.
         let coincube_base = crate::services::coincube_api_base_url();
 
-        // `from_env` rejects every network without a real backend, so only
-        // Bitcoin / Testnet / Signet reach here. The Testnet4 + Regtest arms
-        // exist only to keep the match exhaustive — they route to the
-        // Coincube-hosted testnet Esplora rather than a localhost fallback,
-        // and are never hit in practice.
+        // `from_env` rejects every network without a real backend (see
+        // `features::liquid` — mainnet only), so only Bitcoin reaches here.
+        // The remaining arms exist solely to keep the match exhaustive: they
+        // route to the Coincube-hosted testnet Esplora rather than a localhost
+        // fallback, and are never hit in practice.
         let liquid_explorer_url = match self.network {
             bitcoin::Network::Bitcoin => format!("{}/api/v1/esplora/liquid/mainnet", coincube_base),
             bitcoin::Network::Signet => "https://blockstream.info/liquidtestnet/api".to_string(),

--- a/coincube-gui/src/app/breez_liquid/config.rs
+++ b/coincube-gui/src/app/breez_liquid/config.rs
@@ -43,9 +43,7 @@ impl BreezConfig {
         let liquid_explorer_url = match self.network {
             bitcoin::Network::Bitcoin => format!("{}/api/v1/esplora/liquid/mainnet", coincube_base),
             bitcoin::Network::Signet => "https://blockstream.info/liquidtestnet/api".to_string(),
-            bitcoin::Network::Testnet
-            | bitcoin::Network::Testnet4
-            | bitcoin::Network::Regtest => {
+            bitcoin::Network::Testnet | bitcoin::Network::Testnet4 | bitcoin::Network::Regtest => {
                 format!("{}/api/v1/esplora/liquid/testnet", coincube_base)
             }
         };
@@ -54,9 +52,7 @@ impl BreezConfig {
                 format!("{}/api/v1/esplora/bitcoin/mainnet", coincube_base)
             }
             bitcoin::Network::Signet => "https://blockstream.info/signet/api".to_string(),
-            bitcoin::Network::Testnet
-            | bitcoin::Network::Testnet4
-            | bitcoin::Network::Regtest => {
+            bitcoin::Network::Testnet | bitcoin::Network::Testnet4 | bitcoin::Network::Regtest => {
                 format!("{}/api/v1/esplora/bitcoin/testnet", coincube_base)
             }
         };

--- a/coincube-gui/src/app/breez_liquid/mod.rs
+++ b/coincube-gui/src/app/breez_liquid/mod.rs
@@ -42,50 +42,73 @@ impl std::fmt::Display for BreezError {
 impl std::error::Error for BreezError {}
 
 /// Load BreezClient from datadir using the master signer fingerprint.
-/// Returns `Err(BreezError::NetworkNotSupported)` on networks without a
-/// real Liquid backend (Testnet4, Regtest) so the caller can create a
-/// disconnected `BreezClient` instead of an error.
+///
+/// The master signer is always loaded — its mnemonic backs seed-derived
+/// features (Spark, and P2P/Mostro identity) that work on networks where the
+/// Liquid SDK doesn't. The Liquid SDK itself is only *connected* where a real
+/// Liquid Esplora backend exists (`crate::app::features::liquid` — mainnet,
+/// testnet, signet). On the rest (Testnet4, Regtest) it returns a
+/// disconnected client that still carries the signer, so the Liquid wallet UI
+/// stays gated (no localhost Esplora) without taking down P2P.
 pub async fn load_breez_client(
     datadir: &Path,
     network: Network,
     master_signer_fingerprint: Fingerprint,
     password: &str,
 ) -> Result<Arc<BreezClient>, BreezError> {
-    // Liquid is only enabled where a real Liquid Esplora backend exists —
-    // mainnet, testnet and signet (see `crate::app::features::liquid`, the
-    // single source of truth for the network gate). Testnet4 and regtest
-    // would otherwise point Breez at a localhost Esplora normal users don't
-    // run, so skip SDK init and return NetworkNotSupported; the caller can
-    // create a disconnected client and keep the rest of the app running.
-    if !crate::app::features::liquid(network).is_available() {
-        return Err(BreezError::NetworkNotSupported(network));
-    }
+    let liquid_supported = crate::app::features::liquid(network).is_available();
 
-    // Load only the specific signer by fingerprint (more efficient and secure)
-    let liquid_signer = MasterSigner::from_datadir_by_fingerprint(
+    // Load only the specific signer by fingerprint (more efficient and secure).
+    let liquid_signer = match MasterSigner::from_datadir_by_fingerprint(
         datadir,
         network,
         master_signer_fingerprint,
         Some(password),
-    )
-    .map_err(|e| match e {
-        coincube_core::signer::SignerError::MnemonicStorage(io_err)
-            if io_err.kind() == std::io::ErrorKind::NotFound =>
-        {
-            BreezError::SignerNotFound(master_signer_fingerprint)
+    ) {
+        Ok(signer) => Arc::new(Mutex::new(signer)),
+        // On a network where Liquid isn't connected, a missing signer isn't
+        // fatal — return a plain disconnected client so a seed-less cube
+        // (e.g. watch-only) still loads. On a supported network the signer is
+        // required to connect, so the error propagates.
+        Err(e) if !liquid_supported => {
+            log::info!(
+                "No master signer for disconnected cube on {network}: {e}; \
+                 using a signer-less disconnected client"
+            );
+            return Ok(Arc::new(BreezClient::disconnected(network)));
         }
-        coincube_core::signer::SignerError::SignerNotFound(fingerprint) => {
-            BreezError::SignerNotFound(fingerprint)
+        Err(e) => {
+            return Err(match e {
+                coincube_core::signer::SignerError::MnemonicStorage(io_err)
+                    if io_err.kind() == std::io::ErrorKind::NotFound =>
+                {
+                    BreezError::SignerNotFound(master_signer_fingerprint)
+                }
+                coincube_core::signer::SignerError::SignerNotFound(fingerprint) => {
+                    BreezError::SignerNotFound(fingerprint)
+                }
+                _ => BreezError::SignerError(e.to_string()),
+            });
         }
-        _ => BreezError::SignerError(e.to_string()),
-    })?;
+    };
+
+    // Liquid is only enabled where a real Liquid Esplora backend exists (see
+    // `features::liquid`, the single source of truth for the gate). On
+    // unsupported networks return a disconnected client that still carries
+    // the signer — the Liquid UI stays gated (rail greyed, panels show
+    // disconnected) while the mnemonic remains available to P2P/Spark.
+    if !liquid_supported {
+        return Ok(Arc::new(BreezClient::disconnected_with_signer(
+            network,
+            liquid_signer,
+        )));
+    }
 
     // Create Breez config
     let breez_config = BreezConfig::from_env(network, datadir)?;
 
     // Connect to Breez SDK with the signer
-    let breez_client =
-        BreezClient::connect_with_signer(breez_config, Arc::new(Mutex::new(liquid_signer))).await?;
+    let breez_client = BreezClient::connect_with_signer(breez_config, liquid_signer).await?;
 
     Ok(Arc::new(breez_client))
 }

--- a/coincube-gui/src/app/breez_liquid/mod.rs
+++ b/coincube-gui/src/app/breez_liquid/mod.rs
@@ -42,20 +42,23 @@ impl std::fmt::Display for BreezError {
 impl std::error::Error for BreezError {}
 
 /// Load BreezClient from datadir using the master signer fingerprint.
-/// Returns `Err(BreezError::NetworkNotSupported)` for non-mainnet/retest networks so
-/// the caller can create a disconnected `BreezClient` instead of an error.
+/// Returns `Err(BreezError::NetworkNotSupported)` on networks without a
+/// real Liquid backend (Testnet4, Regtest) so the caller can create a
+/// disconnected `BreezClient` instead of an error.
 pub async fn load_breez_client(
     datadir: &Path,
     network: Network,
     master_signer_fingerprint: Fingerprint,
     password: &str,
 ) -> Result<Arc<BreezClient>, BreezError> {
-    // Breez SDK (Liquid) supports mainnet and regtest.  Testnet, Testnet4 and
-    // Signet are not supported — return NetworkNotSupported so the caller can
-    // create a disconnected client and keep the rest of the app running normally.
-    match network {
-        Network::Bitcoin | Network::Regtest => {}
-        _ => return Err(BreezError::NetworkNotSupported(network)),
+    // Liquid is only enabled where a real Liquid Esplora backend exists —
+    // mainnet, testnet and signet (see `crate::app::features::liquid`, the
+    // single source of truth for the network gate). Testnet4 and regtest
+    // would otherwise point Breez at a localhost Esplora normal users don't
+    // run, so skip SDK init and return NetworkNotSupported; the caller can
+    // create a disconnected client and keep the rest of the app running.
+    if !crate::app::features::liquid(network).is_available() {
+        return Err(BreezError::NetworkNotSupported(network));
     }
 
     // Load only the specific signer by fingerprint (more efficient and secure)

--- a/coincube-gui/src/app/breez_liquid/mod.rs
+++ b/coincube-gui/src/app/breez_liquid/mod.rs
@@ -45,11 +45,11 @@ impl std::error::Error for BreezError {}
 ///
 /// The master signer is always loaded — its mnemonic backs seed-derived
 /// features (Spark, and P2P/Mostro identity) that work on networks where the
-/// Liquid SDK doesn't. The Liquid SDK itself is only *connected* where a real
-/// Liquid Esplora backend exists (`crate::app::features::liquid` — mainnet,
-/// testnet, signet). On the rest (Testnet4, Regtest) it returns a
-/// disconnected client that still carries the signer, so the Liquid wallet UI
-/// stays gated (no localhost Esplora) without taking down P2P.
+/// Liquid SDK doesn't. The Liquid SDK itself is only *connected* where it has
+/// a usable backend (`crate::app::features::liquid` — mainnet only; the SDK
+/// rejects `LiquidNetwork::Testnet` and regtest needs a localhost Esplora).
+/// On every other network it returns a disconnected client that still carries
+/// the signer, so the Liquid wallet UI stays gated without taking down P2P.
 pub async fn load_breez_client(
     datadir: &Path,
     network: Network,
@@ -66,19 +66,8 @@ pub async fn load_breez_client(
         Some(password),
     ) {
         Ok(signer) => Arc::new(Mutex::new(signer)),
-        // On a network where Liquid isn't connected, a missing signer isn't
-        // fatal — return a plain disconnected client so a seed-less cube
-        // (e.g. watch-only) still loads. On a supported network the signer is
-        // required to connect, so the error propagates.
-        Err(e) if !liquid_supported => {
-            log::info!(
-                "No master signer for disconnected cube on {network}: {e}; \
-                 using a signer-less disconnected client"
-            );
-            return Ok(Arc::new(BreezClient::disconnected(network)));
-        }
         Err(e) => {
-            return Err(match e {
+            let mapped = match e {
                 coincube_core::signer::SignerError::MnemonicStorage(io_err)
                     if io_err.kind() == std::io::ErrorKind::NotFound =>
                 {
@@ -88,7 +77,20 @@ pub async fn load_breez_client(
                     BreezError::SignerNotFound(fingerprint)
                 }
                 _ => BreezError::SignerError(e.to_string()),
-            });
+            };
+            // A genuinely *absent* signer (seed-less / watch-only cube) is not
+            // fatal on a network where Liquid isn't connected — degrade to a
+            // signer-less disconnected client so the cube still loads. Every
+            // other failure (wrong PIN, decryption, IO errors) propagates so
+            // it surfaces as a real error rather than being silently masked.
+            if !liquid_supported && matches!(mapped, BreezError::SignerNotFound(_)) {
+                log::info!(
+                    "No master signer for disconnected cube on {network}: {mapped}; \
+                     using a signer-less disconnected client"
+                );
+                return Ok(Arc::new(BreezClient::disconnected(network)));
+            }
+            return Err(mapped);
         }
     };
 

--- a/coincube-gui/src/app/cache.rs
+++ b/coincube-gui/src/app/cache.rs
@@ -63,6 +63,13 @@ pub struct Cache {
     pub current_cube_is_passkey: bool,
     /// Whether the P2P panel is available (requires a valid mnemonic)
     pub has_p2p: bool,
+    /// Resolved P2P test-coordinator gate for [`Self::network`]: a
+    /// test-network Mostro coordinator is configured *and* the network has a
+    /// usable Lightning rail for escrow (effectively Regtest). Drives the
+    /// P2P nav-rail gate via [`crate::app::features::p2p`]. Mirrored from the
+    /// P2P panel's `MostroConfig` (`view::p2p::config`), since the stateless
+    /// sidebar view can't reach the panel.
+    pub p2p_test_coordinator: bool,
     /// Current theme mode (dark/light) — used for theme-aware widget rendering
     pub theme_mode: coincube_ui::theme::palette::ThemeMode,
     /// BTC price in USD, always fetched regardless of the user's selected fiat
@@ -149,6 +156,7 @@ impl std::default::Default for Cache {
             backup_warning_dismissed: false,
             current_cube_is_passkey: false,
             has_p2p: false,
+            p2p_test_coordinator: false,
             theme_mode: coincube_ui::theme::palette::ThemeMode::default(),
             btc_usd_price: None,
             show_direction_badges: true,

--- a/coincube-gui/src/app/cache.rs
+++ b/coincube-gui/src/app/cache.rs
@@ -64,11 +64,12 @@ pub struct Cache {
     /// Whether the P2P panel is available (requires a valid mnemonic)
     pub has_p2p: bool,
     /// Resolved P2P test-coordinator gate for [`Self::network`]: a
-    /// test-network Mostro coordinator is configured *and* the network has a
-    /// usable Lightning rail for escrow (effectively Regtest). Drives the
-    /// P2P nav-rail gate via [`crate::app::features::p2p`]. Mirrored from the
-    /// P2P panel's `MostroConfig` (`view::p2p::config`), since the stateless
-    /// sidebar view can't reach the panel.
+    /// test-network Mostro coordinator is configured, the network has a usable
+    /// Lightning rail for escrow (effectively Regtest), *and* a Spark backend
+    /// is actually connected (escrow is paid over Spark). Drives the P2P
+    /// nav-rail gate via [`crate::app::features::p2p`]. Mirrored from the P2P
+    /// panel (`P2PPanel::has_test_coordinator`), since the stateless sidebar
+    /// view can't reach the panel.
     pub p2p_test_coordinator: bool,
     /// Current theme mode (dark/light) — used for theme-aware widget rendering
     pub theme_mode: coincube_ui::theme::palette::ThemeMode,

--- a/coincube-gui/src/app/features.rs
+++ b/coincube-gui/src/app/features.rs
@@ -10,7 +10,7 @@
 //! this module — the nav rails, the Liquid SDK loader, etc. — so the
 //! matrix lives in exactly one place. See `plans/PLAN-network-feature-gating.md`.
 
-use crate::app::menu::{MarketplaceSubMenu, Menu};
+use crate::app::menu::{MarketplaceSubMenu, Menu, P2PSubMenu};
 use coincube_core::miniscript::bitcoin::Network;
 
 /// Whether a feature is usable on the current network, plus the human
@@ -87,9 +87,13 @@ pub fn p2p(net: Network, has_test_coordinator: bool) -> Availability {
     match net {
         Network::Bitcoin => Availability::Available,
         _ if has_test_coordinator => Availability::Available,
+        // `has_test_coordinator` collapses two requirements (a configured test
+        // coordinator *and* a connected Spark escrow wallet), so state both
+        // rather than misattribute the block to a missing coordinator when the
+        // coordinator is present but Spark is down.
         other => Availability::Unavailable {
             reason: format!(
-                "P2P trading on {} needs a test Mostro coordinator.",
+                "P2P trading on {} needs a test Mostro coordinator and a connected Spark wallet.",
                 net_label(other)
             ),
         },
@@ -106,6 +110,11 @@ pub fn route_availability(menu: &Menu, net: Network, p2p_test_coordinator: bool)
         Menu::Spark(_) => spark(net),
         Menu::Liquid(_) => liquid(net),
         Menu::Marketplace(MarketplaceSubMenu::BuySell) => buy_sell(net),
+        // P2P Settings stays reachable even when trading is gated, so users
+        // can configure a coordinator to lift the gate — otherwise it's a
+        // catch-22 (you'd need a working coordinator to reach the page that
+        // adds one, and removing the last test node would lock you out).
+        Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Settings)) => Availability::Available,
         Menu::Marketplace(MarketplaceSubMenu::P2P(_)) => p2p(net, p2p_test_coordinator),
         _ => Availability::Available,
     }
@@ -188,7 +197,7 @@ mod tests {
         );
         assert_eq!(
             p2p(Network::Testnet, false).reason(),
-            Some("P2P trading on Testnet needs a test Mostro coordinator.")
+            Some("P2P trading on Testnet needs a test Mostro coordinator and a connected Spark wallet.")
         );
         assert_eq!(spark(Network::Bitcoin).reason(), None);
     }

--- a/coincube-gui/src/app/features.rs
+++ b/coincube-gui/src/app/features.rs
@@ -1,0 +1,193 @@
+//! Network-aware feature availability — the single source of truth for
+//! which wallet/marketplace features work on which Bitcoin network.
+//!
+//! On each network the launcher supports (mainnet, testnet, testnet4,
+//! signet, regtest) only some features have a real backend. Rather than
+//! hiding unsupported features, the nav renders them disabled / greyed
+//! out with a hover popover whose text comes from [`Availability::reason`].
+//!
+//! Everything that needs to know "is feature X usable on network Y" asks
+//! this module — the nav rails, the Liquid SDK loader, etc. — so the
+//! matrix lives in exactly one place. See `plans/PLAN-network-feature-gating.md`.
+
+use crate::app::menu::{MarketplaceSubMenu, Menu};
+use coincube_core::miniscript::bitcoin::Network;
+
+/// Whether a feature is usable on the current network, plus the human
+/// reason to show when it isn't.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Availability {
+    Available,
+    /// Shown verbatim in the disabled item's popover.
+    Unavailable {
+        reason: String,
+    },
+}
+
+impl Availability {
+    pub fn is_available(&self) -> bool {
+        matches!(self, Availability::Available)
+    }
+
+    /// The popover text, or `None` when the feature is available.
+    pub fn reason(&self) -> Option<&str> {
+        match self {
+            Availability::Unavailable { reason } => Some(reason),
+            Availability::Available => None,
+        }
+    }
+}
+
+/// Display name for a network, used in popover text.
+fn net_label(n: Network) -> &'static str {
+    match n {
+        Network::Bitcoin => "Mainnet",
+        Network::Testnet => "Testnet",
+        Network::Testnet4 => "Testnet4",
+        Network::Signet => "Signet",
+        Network::Regtest => "Regtest",
+    }
+}
+
+/// Spark wallet. Backed only on mainnet and regtest — matches the SDK,
+/// which rejects every other network (`breez_spark::config::SparkConfig`).
+pub fn spark(net: Network) -> Availability {
+    match net {
+        Network::Bitcoin | Network::Regtest => Availability::Available,
+        other => unavailable("Spark", other),
+    }
+}
+
+/// Liquid wallet. Enabled only where a real Liquid Esplora backend
+/// exists: mainnet + testnet (Coincube-hosted) and signet (Blockstream).
+/// Testnet4 and regtest would point Breez at a localhost Esplora normal
+/// users don't run, so they're disabled.
+pub fn liquid(net: Network) -> Availability {
+    match net {
+        Network::Bitcoin | Network::Testnet | Network::Signet => Availability::Available,
+        other => unavailable("Liquid", other), // Testnet4, Regtest
+    }
+}
+
+/// Buy/Sell (fiat on/off-ramp). Real fiat ↔ real BTC, so mainnet only.
+pub fn buy_sell(net: Network) -> Availability {
+    match net {
+        Network::Bitcoin => Availability::Available,
+        other => unavailable("Buy/Sell", other),
+    }
+}
+
+/// P2P trading. Always available on mainnet; on a test network only when
+/// a test Mostro coordinator is configured with a usable escrow rail (see
+/// `view::p2p::config::MostroConfig::has_test_coordinator`, which resolves
+/// the `has_test_coordinator` flag passed here).
+pub fn p2p(net: Network, has_test_coordinator: bool) -> Availability {
+    match net {
+        Network::Bitcoin => Availability::Available,
+        _ if has_test_coordinator => Availability::Available,
+        other => Availability::Unavailable {
+            reason: format!(
+                "P2P trading on {} needs a test Mostro coordinator.",
+                net_label(other)
+            ),
+        },
+    }
+}
+
+/// Availability of whatever feature `menu` belongs to. Used to guard the
+/// content area so a restored or deep-linked route onto a network-disabled
+/// feature renders the shared "unavailable" placeholder instead of a live
+/// panel (the rail items themselves are already greyed and inert). Routes
+/// not tied to a gated feature are always available.
+pub fn route_availability(menu: &Menu, net: Network, p2p_test_coordinator: bool) -> Availability {
+    match menu {
+        Menu::Spark(_) => spark(net),
+        Menu::Liquid(_) => liquid(net),
+        Menu::Marketplace(MarketplaceSubMenu::BuySell) => buy_sell(net),
+        Menu::Marketplace(MarketplaceSubMenu::P2P(_)) => p2p(net, p2p_test_coordinator),
+        _ => Availability::Available,
+    }
+}
+
+fn unavailable(feature: &str, net: Network) -> Availability {
+    Availability::Unavailable {
+        reason: format!("{} isn't available on {}.", feature, net_label(net)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NETWORKS: [Network; 5] = [
+        Network::Bitcoin,
+        Network::Testnet,
+        Network::Testnet4,
+        Network::Signet,
+        Network::Regtest,
+    ];
+
+    /// Regression guard for the §2 support matrix. If a decision changes,
+    /// this is the one place to update alongside the matching `fn`.
+    #[test]
+    fn support_matrix() {
+        // (network, spark, liquid, buy_sell, p2p_without_coordinator)
+        let expected = [
+            (Network::Bitcoin, true, true, true, true),
+            (Network::Testnet, false, true, false, false),
+            (Network::Testnet4, false, false, false, false),
+            (Network::Signet, false, true, false, false),
+            (Network::Regtest, true, false, false, false),
+        ];
+
+        for (net, spark_ok, liquid_ok, buy_sell_ok, p2p_ok) in expected {
+            assert_eq!(spark(net).is_available(), spark_ok, "spark on {}", net);
+            assert_eq!(liquid(net).is_available(), liquid_ok, "liquid on {}", net);
+            assert_eq!(
+                buy_sell(net).is_available(),
+                buy_sell_ok,
+                "buy_sell on {}",
+                net
+            );
+            assert_eq!(
+                p2p(net, false).is_available(),
+                p2p_ok,
+                "p2p (no coordinator) on {}",
+                net
+            );
+        }
+    }
+
+    #[test]
+    fn test_coordinator_enables_p2p_on_test_networks() {
+        for net in NETWORKS {
+            // With a test coordinator, P2P is available everywhere.
+            assert!(
+                p2p(net, true).is_available(),
+                "p2p with coordinator on {}",
+                net
+            );
+        }
+    }
+
+    #[test]
+    fn unavailable_reasons_read_correctly() {
+        assert_eq!(
+            spark(Network::Testnet4).reason(),
+            Some("Spark isn't available on Testnet4.")
+        );
+        assert_eq!(
+            liquid(Network::Regtest).reason(),
+            Some("Liquid isn't available on Regtest.")
+        );
+        assert_eq!(
+            buy_sell(Network::Signet).reason(),
+            Some("Buy/Sell isn't available on Signet.")
+        );
+        assert_eq!(
+            p2p(Network::Testnet, false).reason(),
+            Some("P2P trading on Testnet needs a test Mostro coordinator.")
+        );
+        assert_eq!(spark(Network::Bitcoin).reason(), None);
+    }
+}

--- a/coincube-gui/src/app/features.rs
+++ b/coincube-gui/src/app/features.rs
@@ -58,14 +58,16 @@ pub fn spark(net: Network) -> Availability {
     }
 }
 
-/// Liquid wallet. Enabled only where a real Liquid Esplora backend
-/// exists: mainnet + testnet (Coincube-hosted) and signet (Blockstream).
-/// Testnet4 and regtest would point Breez at a localhost Esplora normal
-/// users don't run, so they're disabled.
+/// Liquid wallet. Mainnet only. The Breez Liquid SDK (0.12.2) connects
+/// solely on `LiquidNetwork::Mainnet` and `Regtest` — it hard-rejects
+/// `LiquidNetwork::Testnet` at `connect_with_signer`, which is what
+/// testnet *and* signet map to. Regtest would point Breez at a localhost
+/// Esplora normal users don't run. So mainnet is the only network with a
+/// usable Liquid backend.
 pub fn liquid(net: Network) -> Availability {
     match net {
-        Network::Bitcoin | Network::Testnet | Network::Signet => Availability::Available,
-        other => unavailable("Liquid", other), // Testnet4, Regtest
+        Network::Bitcoin => Availability::Available,
+        other => unavailable("Liquid", other),
     }
 }
 
@@ -134,9 +136,9 @@ mod tests {
         // (network, spark, liquid, buy_sell, p2p_without_coordinator)
         let expected = [
             (Network::Bitcoin, true, true, true, true),
-            (Network::Testnet, false, true, false, false),
+            (Network::Testnet, false, false, false, false),
             (Network::Testnet4, false, false, false, false),
-            (Network::Signet, false, true, false, false),
+            (Network::Signet, false, false, false, false),
             (Network::Regtest, true, false, false, false),
         ];
 

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -3945,14 +3945,6 @@ impl App {
                 view::Message::DismissReceivedCelebration,
             );
             view::dashboard(&self.panels.current, &self.cache, celebration)
-        } else if let Some(content) = self.connect_settings_content() {
-            // Connect-dependent settings sub-pages (Spark → Settings →
-            // Lightning Address, Cube → Settings → Avatar / Members)
-            // need both the relevant panel state and the
-            // ConnectCubePanel. The State trait's `view` only sees the
-            // active panel + Cache, so the dispatch lives here — App
-            // owns every panel.
-            view::dashboard(&self.panels.current, &self.cache, content)
         } else if let Some(reason) = features::route_availability(
             &self.panels.current,
             self.cache.network,
@@ -3964,12 +3956,24 @@ impl App {
             // The active route targets a feature that isn't available on
             // this network (a restored or deep-linked route onto an item
             // that renders greyed in the rail). Show the shared
-            // "unavailable" placeholder rather than a live panel.
+            // "unavailable" placeholder rather than a live panel. Checked
+            // before `connect_settings_content` so a gated route that also
+            // happens to be a Connect-settings page (e.g. Spark → Settings →
+            // Lightning Address on a network where Spark is unavailable)
+            // shows the placeholder instead of the live Connect UI.
             view::dashboard(
                 &self.panels.current,
                 &self.cache,
                 view::feature_unavailable_panel(reason),
             )
+        } else if let Some(content) = self.connect_settings_content() {
+            // Connect-dependent settings sub-pages (Spark → Settings →
+            // Lightning Address, Cube → Settings → Avatar / Members)
+            // need both the relevant panel state and the
+            // ConnectCubePanel. The State trait's `view` only sees the
+            // active panel + Cache, so the dispatch lives here — App
+            // owns every panel.
+            view::dashboard(&self.panels.current, &self.cache, content)
         } else {
             self.panels
                 .current()

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -3,6 +3,7 @@ pub mod breez_spark;
 pub mod cache;
 pub mod config;
 pub mod error;
+pub mod features;
 pub mod menu;
 pub mod message;
 pub mod settings;
@@ -233,6 +234,7 @@ impl Panels {
                         spark_backend.clone(),
                         mnemonic,
                         default_fiat_currency,
+                        network,
                     ))
                 }
                 _ => {
@@ -389,6 +391,7 @@ impl Panels {
                         spark_backend.clone(),
                         mnemonic,
                         default_fiat_currency,
+                        cache.network,
                     ))
                 }
                 _ => {
@@ -1265,6 +1268,10 @@ impl App {
         let mut cache_with_vault = cache;
         cache_with_vault.has_vault = true;
         cache_with_vault.has_p2p = panels.p2p.is_some();
+        cache_with_vault.p2p_test_coordinator = panels
+            .p2p
+            .as_ref()
+            .is_some_and(|p| p.has_test_coordinator());
         (
             Self {
                 panels,
@@ -1362,6 +1369,10 @@ impl App {
         );
         let mut cache = cache;
         cache.has_p2p = panels.p2p.is_some();
+        cache.p2p_test_coordinator = panels
+            .p2p
+            .as_ref()
+            .is_some_and(|p| p.has_test_coordinator());
 
         let cmd = iced::Task::batch([
             panels.connect.ensure_session_check(),
@@ -3638,7 +3649,16 @@ impl App {
             // so real-time trade updates are processed even when viewing other panels.
             msg @ Message::View(view::Message::P2P(_)) => {
                 if let Some(p2p) = self.panels.p2p.as_mut() {
-                    return p2p.update(self.daemon.clone(), &self.cache, msg);
+                    let task = p2p.update(self.daemon.clone(), &self.cache, msg);
+                    // A P2P message may have changed the Mostro config (e.g.
+                    // adding/selecting a test coordinator in Settings), so
+                    // refresh the rail gate flag the sidebar reads.
+                    self.cache.p2p_test_coordinator = self
+                        .panels
+                        .p2p
+                        .as_ref()
+                        .is_some_and(|p| p.has_test_coordinator());
+                    return task;
                 }
             }
 
@@ -3933,6 +3953,23 @@ impl App {
             // active panel + Cache, so the dispatch lives here — App
             // owns every panel.
             view::dashboard(&self.panels.current, &self.cache, content)
+        } else if let Some(reason) = features::route_availability(
+            &self.panels.current,
+            self.cache.network,
+            self.cache.p2p_test_coordinator,
+        )
+        .reason()
+        .map(str::to_string)
+        {
+            // The active route targets a feature that isn't available on
+            // this network (a restored or deep-linked route onto an item
+            // that renders greyed in the rail). Show the shared
+            // "unavailable" placeholder rather than a live panel.
+            view::dashboard(
+                &self.panels.current,
+                &self.cache,
+                view::feature_unavailable_panel(reason),
+            )
         } else {
             self.panels
                 .current()

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1739,6 +1739,9 @@ pub enum P2PMessage {
     MostroRemoveRelay(String),
     MostroNodeNameInputEdited(String),
     MostroNodePubkeyInputEdited(String),
+    /// Toggle whether the node being added is a test-network coordinator
+    /// (`true`) or a mainnet coordinator (`false`).
+    MostroNodeNetworkToggled(bool),
     MostroAddNode,
     MostroRemoveNode(String),
     MostroSelectActiveNode(String),

--- a/coincube-gui/src/app/view/mod.rs
+++ b/coincube-gui/src/app/view/mod.rs
@@ -147,6 +147,8 @@ pub fn dashboard_with_info<'a, T: Into<Element<'a, Message>>>(
     let nav_ctx = nav::NavContext {
         has_vault,
         has_p2p,
+        network: cache.network,
+        p2p_test_coordinator: cache.p2p_test_coordinator,
         cube_name,
         lightning_address,
         avatar: avatar_handle,
@@ -250,6 +252,47 @@ pub fn placeholder<'a, T: Into<Element<'a, Message>>>(
         .push(text(title).style(theme::text::secondary).bold())
         .push(
             text(subtitle)
+                .size(P2_SIZE)
+                .style(theme::text::secondary)
+                .align_x(Alignment::Center),
+        )
+        .spacing(16)
+        .align_x(Alignment::Center);
+
+    Container::new(content)
+        .width(Length::Fill)
+        .padding(60)
+        .center_x(Length::Fill)
+        .style(|t| container::Style {
+            background: Some(iced::Background::Color(t.colors.cards.simple.background)),
+            border: iced::Border {
+                radius: 20.0.into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .into()
+}
+
+/// Full-panel placeholder for a route whose feature isn't available on the
+/// current network — e.g. a restored or deep-linked route onto a rail item
+/// that renders greyed out. Mirrors [`placeholder`] but owns its subtitle so
+/// it can be built from a transient reason string (see
+/// [`crate::app::features::route_availability`]).
+pub fn feature_unavailable_panel(reason: String) -> Element<'static, Message> {
+    let content = Column::new()
+        .push(
+            coincube_ui::icon::plug_icon()
+                .size(48)
+                .style(theme::text::secondary),
+        )
+        .push(
+            text("Not available on this network")
+                .style(theme::text::secondary)
+                .bold(),
+        )
+        .push(
+            text(reason)
                 .size(P2_SIZE)
                 .style(theme::text::secondary)
                 .align_x(Alignment::Center),

--- a/coincube-gui/src/app/view/nav/cube.rs
+++ b/coincube-gui/src/app/view/nav/cube.rs
@@ -6,17 +6,17 @@ use coincube_ui::icon::{home_icon, settings_icon};
 /// Clicking Settings lands on General (first third-rail option).
 pub fn items(_ctx: &NavContext) -> Vec<SubItem> {
     vec![
-        SubItem {
-            label: "Overview",
-            icon: home_icon,
-            route: Menu::Cube(CubeSubMenu::Overview),
-            matches: |m| matches!(m, Menu::Cube(CubeSubMenu::Overview)),
-        },
-        SubItem {
-            label: "Settings",
-            icon: settings_icon,
-            route: Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::General)),
-            matches: |m| matches!(m, Menu::Cube(CubeSubMenu::Settings(_))),
-        },
+        SubItem::new(
+            "Overview",
+            home_icon,
+            Menu::Cube(CubeSubMenu::Overview),
+            |m| matches!(m, Menu::Cube(CubeSubMenu::Overview)),
+        ),
+        SubItem::new(
+            "Settings",
+            settings_icon,
+            Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::General)),
+            |m| matches!(m, Menu::Cube(CubeSubMenu::Settings(_))),
+        ),
     ]
 }

--- a/coincube-gui/src/app/view/nav/items.rs
+++ b/coincube-gui/src/app/view/nav/items.rs
@@ -20,6 +20,36 @@ pub struct SubItem {
     pub icon: fn() -> Text<'static>,
     pub route: Menu,
     pub matches: fn(&Menu) -> bool,
+    /// `Some(reason)` => the item is greyed out and inert, with `reason`
+    /// shown in a hover popover. Used for network-gated features (e.g.
+    /// Buy/Sell off mainnet). `None` => a normal, clickable item.
+    pub disabled_reason: Option<String>,
+}
+
+impl SubItem {
+    /// A normal, enabled rail item.
+    pub fn new(
+        label: &'static str,
+        icon: fn() -> Text<'static>,
+        route: Menu,
+        matches: fn(&Menu) -> bool,
+    ) -> Self {
+        Self {
+            label,
+            icon,
+            route,
+            matches,
+            disabled_reason: None,
+        }
+    }
+
+    /// Mark the item disabled with the given popover reason when `reason`
+    /// is `Some`. `None` leaves it enabled — convenient for piping an
+    /// [`crate::app::features::Availability`] reason straight through.
+    pub fn disabled(mut self, reason: Option<String>) -> Self {
+        self.disabled_reason = reason;
+        self
+    }
 }
 
 // Sizing shared by the secondary and tertiary rails. The two rails
@@ -35,7 +65,9 @@ const LABEL_SIZE: f32 = 10.0;
 /// on the active row. Shared by the secondary and tertiary rails so
 /// their rows stay visually identical.
 pub fn render_item_row<'a>(menu: &Menu, item: &SubItem, rail_width: f32) -> Element<'a, Message> {
-    let active = (item.matches)(menu);
+    let disabled = item.disabled_reason.is_some();
+    // A disabled item is inert and never reads as the active route.
+    let active = !disabled && (item.matches)(menu);
 
     // "General" items use a hand-authored stroke-only SVG because the Bootstrap
     // `wrench` glyph is a solid silhouette with no outline twin in the font.
@@ -55,26 +87,35 @@ pub fn render_item_row<'a>(menu: &Menu, item: &SubItem, rail_width: f32) -> Elem
     .align_x(Alignment::Center)
     .width(Length::Fill);
 
-    let on_press = if menu == &item.route {
-        Message::Reload
-    } else {
-        Message::Menu(item.route.clone())
-    };
+    let button_inner = container(body)
+        .padding([8, 0])
+        .width(Length::Fill)
+        .center_x(Length::Fill);
 
-    let button: Button<Message> = Button::new(
-        container(body)
-            .padding([8, 0])
+    // A disabled item drops `on_press` (iced renders a press-less Button
+    // disabled) and uses the greyed rail style; otherwise it's a normal
+    // clickable rail item.
+    let button: Button<Message> = if disabled {
+        Button::new(button_inner)
             .width(Length::Fill)
-            .center_x(Length::Fill),
-    )
-    .width(Length::Fill)
-    .height(Length::Fixed(RAIL_ITEM_HEIGHT))
-    .style(if active {
-        theme::button::rail_active
+            .height(Length::Fixed(RAIL_ITEM_HEIGHT))
+            .style(theme::button::rail_disabled)
     } else {
-        theme::button::rail
-    })
-    .on_press(on_press);
+        let on_press = if menu == &item.route {
+            Message::Reload
+        } else {
+            Message::Menu(item.route.clone())
+        };
+        Button::new(button_inner)
+            .width(Length::Fill)
+            .height(Length::Fixed(RAIL_ITEM_HEIGHT))
+            .style(if active {
+                theme::button::rail_active
+            } else {
+                theme::button::rail
+            })
+            .on_press(on_press)
+    };
 
     // Orange strip on the trailing (right) edge for the active item —
     // mirror of the primary rail's leading-edge strip.
@@ -93,5 +134,21 @@ pub fn render_item_row<'a>(menu: &Menu, item: &SubItem, rail_width: f32) -> Elem
     };
 
     let r: Row<Message> = row![button, highlight].width(Length::Fixed(rail_width));
-    r.into()
+
+    // Hover popover explaining why the feature is unavailable on this
+    // network — same tooltip widget as the Connect status dot.
+    match &item.disabled_reason {
+        Some(reason) => iced::widget::tooltip(
+            r,
+            // Padded, bordered popover so the text reads as a floating
+            // bubble instead of overlapping the adjacent rail icons.
+            container(coincube_ui::component::text::caption(reason.clone()))
+                .padding([6, 10])
+                .style(theme::container::border_grey),
+            iced::widget::tooltip::Position::Right,
+        )
+        .gap(6)
+        .into(),
+        None => r.into(),
+    }
 }

--- a/coincube-gui/src/app/view/nav/liquid.rs
+++ b/coincube-gui/src/app/view/nav/liquid.rs
@@ -7,29 +7,26 @@ use coincube_ui::icon::{home_icon, receipt_icon, receive_icon, send_icon};
 /// worth surfacing in the rail.
 pub fn items(_ctx: &NavContext) -> Vec<SubItem> {
     vec![
-        SubItem {
-            label: "Overview",
-            icon: home_icon,
-            route: Menu::Liquid(LiquidSubMenu::Overview),
-            matches: |m| matches!(m, Menu::Liquid(LiquidSubMenu::Overview)),
-        },
-        SubItem {
-            label: "Send",
-            icon: send_icon,
-            route: Menu::Liquid(LiquidSubMenu::Send),
-            matches: |m| matches!(m, Menu::Liquid(LiquidSubMenu::Send)),
-        },
-        SubItem {
-            label: "Receive",
-            icon: receive_icon,
-            route: Menu::Liquid(LiquidSubMenu::Receive),
-            matches: |m| matches!(m, Menu::Liquid(LiquidSubMenu::Receive)),
-        },
-        SubItem {
-            label: "Transactions",
-            icon: receipt_icon,
-            route: Menu::Liquid(LiquidSubMenu::Transactions(None)),
-            matches: |m| matches!(m, Menu::Liquid(LiquidSubMenu::Transactions(_))),
-        },
+        SubItem::new(
+            "Overview",
+            home_icon,
+            Menu::Liquid(LiquidSubMenu::Overview),
+            |m| matches!(m, Menu::Liquid(LiquidSubMenu::Overview)),
+        ),
+        SubItem::new("Send", send_icon, Menu::Liquid(LiquidSubMenu::Send), |m| {
+            matches!(m, Menu::Liquid(LiquidSubMenu::Send))
+        }),
+        SubItem::new(
+            "Receive",
+            receive_icon,
+            Menu::Liquid(LiquidSubMenu::Receive),
+            |m| matches!(m, Menu::Liquid(LiquidSubMenu::Receive)),
+        ),
+        SubItem::new(
+            "Transactions",
+            receipt_icon,
+            Menu::Liquid(LiquidSubMenu::Transactions(None)),
+            |m| matches!(m, Menu::Liquid(LiquidSubMenu::Transactions(_))),
+        ),
     ]
 }

--- a/coincube-gui/src/app/view/nav/marketplace.rs
+++ b/coincube-gui/src/app/view/nav/marketplace.rs
@@ -1,4 +1,5 @@
 use super::{NavContext, SubItem};
+use crate::app::features;
 use crate::app::menu::{MarketplaceSubMenu, Menu, P2PSubMenu};
 use coincube_ui::icon::{bitcoin_icon, person_icon};
 
@@ -8,16 +9,28 @@ use coincube_ui::icon::{bitcoin_icon, person_icon};
 /// (Overview / My Trades / Chat / Create Order / Settings) are NOT in
 /// the rail — they render as a tab bar inside the P2P content panel
 /// (plan §12, decision Q1-B).
+///
+/// On top of those structural gates, each item carries a network gate
+/// (via [`crate::app::features`]): rather than being hidden on networks
+/// where the feature has no backend, it stays in the rail but renders
+/// greyed out with an explanatory popover.
 pub fn items(ctx: &NavContext) -> Vec<SubItem> {
     let mut items = Vec::new();
 
     if ctx.has_p2p {
-        items.push(SubItem {
-            label: "P2P",
-            icon: person_icon,
-            route: Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Overview)),
-            matches: |m| matches!(m, Menu::Marketplace(MarketplaceSubMenu::P2P(_))),
-        });
+        items.push(
+            SubItem::new(
+                "P2P",
+                person_icon,
+                Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Overview)),
+                |m| matches!(m, Menu::Marketplace(MarketplaceSubMenu::P2P(_))),
+            )
+            .disabled(
+                features::p2p(ctx.network, ctx.p2p_test_coordinator)
+                    .reason()
+                    .map(str::to_string),
+            ),
+        );
     }
 
     // Buy/Sell requires a constructed `BuySellPanel`, which in turn
@@ -25,12 +38,15 @@ pub fn items(ctx: &NavContext) -> Vec<SubItem> {
     // vault" placeholder without a wallet, keep it gated here so
     // users aren't sent to an orphan route.
     if ctx.has_vault {
-        items.push(SubItem {
-            label: "Buy/Sell",
-            icon: bitcoin_icon,
-            route: Menu::Marketplace(MarketplaceSubMenu::BuySell),
-            matches: |m| matches!(m, Menu::Marketplace(MarketplaceSubMenu::BuySell)),
-        });
+        items.push(
+            SubItem::new(
+                "Buy/Sell",
+                bitcoin_icon,
+                Menu::Marketplace(MarketplaceSubMenu::BuySell),
+                |m| matches!(m, Menu::Marketplace(MarketplaceSubMenu::BuySell)),
+            )
+            .disabled(features::buy_sell(ctx.network).reason().map(str::to_string)),
+        );
     }
 
     items

--- a/coincube-gui/src/app/view/nav/mod.rs
+++ b/coincube-gui/src/app/view/nav/mod.rs
@@ -135,9 +135,7 @@ fn identity_block<'a>(ctx: &NavContext<'a>) -> Element<'a, Message> {
     let avatar_button: Element<'a, Message> = Button::new(avatar)
         .style(theme::button::transparent)
         .on_press(Message::Menu(Menu::Cube(
-            crate::app::menu::CubeSubMenu::Settings(
-                crate::app::menu::CubeSettingsOption::Avatar,
-            ),
+            crate::app::menu::CubeSubMenu::Settings(crate::app::menu::CubeSettingsOption::Avatar),
         )))
         .into();
 

--- a/coincube-gui/src/app/view/nav/mod.rs
+++ b/coincube-gui/src/app/view/nav/mod.rs
@@ -129,10 +129,15 @@ fn identity_block<'a>(ctx: &NavContext<'a>) -> Element<'a, Message> {
             .into()
     };
 
+    // The avatar is managed on Cube → Settings → Avatar, so clicking it
+    // jumps straight there (rather than Cube → Overview, where there's
+    // nothing to do with it).
     let avatar_button: Element<'a, Message> = Button::new(avatar)
         .style(theme::button::transparent)
         .on_press(Message::Menu(Menu::Cube(
-            crate::app::menu::CubeSubMenu::Overview,
+            crate::app::menu::CubeSubMenu::Settings(
+                crate::app::menu::CubeSettingsOption::Avatar,
+            ),
         )))
         .into();
 
@@ -242,6 +247,13 @@ fn connect_status_dot<'a>(status: &'a crate::app::ConnectionStatus) -> Element<'
 pub struct NavContext<'a> {
     pub has_vault: bool,
     pub has_p2p: bool,
+    /// Active Bitcoin network. Drives per-feature availability gating
+    /// (Spark/Liquid on the primary rail, Buy/Sell + P2P in Marketplace)
+    /// via [`crate::app::features`].
+    pub network: coincube_core::miniscript::bitcoin::Network,
+    /// Whether a non-mainnet Mostro coordinator is configured. Only
+    /// affects P2P on test networks (mainnet P2P is always available).
+    pub p2p_test_coordinator: bool,
     pub cube_name: &'a str,
     pub lightning_address: Option<&'a str>,
     pub avatar: Option<&'a iced::widget::image::Handle>,

--- a/coincube-gui/src/app/view/nav/primary.rs
+++ b/coincube-gui/src/app/view/nav/primary.rs
@@ -7,6 +7,7 @@
 
 use super::NavContext;
 use crate::app::{
+    features,
     menu::{MarketplaceSubMenu, Menu, P2PSubMenu, TopLevel},
     view::Message,
 };
@@ -35,7 +36,14 @@ pub fn rail<'a>(menu: &Menu, ctx: &NavContext<'a>) -> Element<'a, Message> {
 
     let mut top: Column<Message> = Column::new().width(Length::Fixed(RAIL_WIDTH)).spacing(0);
     for &t in &[TopLevel::Cube, TopLevel::Spark, TopLevel::Liquid] {
-        top = top.push(item(t, current == t));
+        // Spark and Liquid are network-gated: greyed out with a popover
+        // on networks where they have no backend. Cube is always enabled.
+        let disabled_reason = match t {
+            TopLevel::Spark => features::spark(ctx.network).reason().map(str::to_string),
+            TopLevel::Liquid => features::liquid(ctx.network).reason().map(str::to_string),
+            _ => None,
+        };
+        top = top.push(item(t, current == t, disabled_reason));
     }
 
     // Vault slot: regular nav item when a vault exists, otherwise a
@@ -43,7 +51,7 @@ pub fn rail<'a>(menu: &Menu, ctx: &NavContext<'a>) -> Element<'a, Message> {
     // slot always occupied means the vault-aligned secondary/tertiary
     // offsets stay stable across cube configurations.
     if ctx.has_vault {
-        top = top.push(item(TopLevel::Vault, current == TopLevel::Vault));
+        top = top.push(item(TopLevel::Vault, current == TopLevel::Vault, None));
     } else {
         top = top.push(setup_vault_item());
     }
@@ -52,12 +60,15 @@ pub fn rail<'a>(menu: &Menu, ctx: &NavContext<'a>) -> Element<'a, Message> {
     // vault — those are the only two surfaces it can link into, and
     // `TopLevel::Marketplace.default_menu()` would otherwise route the
     // user to a P2P Overview panel that isn't mounted (blank content).
+    // Marketplace itself is never network-gated — its *children*
+    // (Buy/Sell, P2P) carry the per-feature gate in the secondary rail.
     if ctx.has_p2p || ctx.has_vault {
         let landing = marketplace_landing_menu(ctx);
         top = top.push(item_with_route(
             TopLevel::Marketplace,
             current == TopLevel::Marketplace,
             landing,
+            None,
         ));
     }
 
@@ -68,11 +79,20 @@ pub fn rail<'a>(menu: &Menu, ctx: &NavContext<'a>) -> Element<'a, Message> {
         .into()
 }
 
-fn item<'a>(t: TopLevel, active: bool) -> Element<'a, Message> {
-    item_with_route(t, active, t.default_menu())
+fn item<'a>(t: TopLevel, active: bool, disabled_reason: Option<String>) -> Element<'a, Message> {
+    item_with_route(t, active, t.default_menu(), disabled_reason)
 }
 
-fn item_with_route<'a>(t: TopLevel, active: bool, route: Menu) -> Element<'a, Message> {
+fn item_with_route<'a>(
+    t: TopLevel,
+    active: bool,
+    route: Menu,
+    disabled_reason: Option<String>,
+) -> Element<'a, Message> {
+    let disabled = disabled_reason.is_some();
+    // A disabled item is inert and never reads as the active section.
+    let active = active && !disabled;
+
     // Marketplace uses a hand-authored outline SVG (Bootstrap only ships its
     // `currency-exchange` glyph filled); every other rail item is a font glyph.
     let icon_el: Element<'a, Message> = match t {
@@ -90,20 +110,30 @@ fn item_with_route<'a>(t: TopLevel, active: bool, route: Menu) -> Element<'a, Me
     .align_x(Alignment::Center)
     .width(Length::Fill);
 
-    let button: Button<Message> = Button::new(
-        container(body)
-            .padding([8, 0])
+    let button_inner = container(body)
+        .padding([8, 0])
+        .width(Length::Fill)
+        .center_x(Length::Fill);
+
+    // A disabled item drops `on_press` (iced renders a press-less Button
+    // disabled) and uses the greyed rail style — kept visually consistent
+    // with the secondary rail's `render_item_row`.
+    let button: Button<Message> = if disabled {
+        Button::new(button_inner)
             .width(Length::Fill)
-            .center_x(Length::Fill),
-    )
-    .width(Length::Fill)
-    .height(Length::Fixed(ITEM_HEIGHT))
-    .style(if active {
-        theme::button::rail_active
+            .height(Length::Fixed(ITEM_HEIGHT))
+            .style(theme::button::rail_disabled)
     } else {
-        theme::button::rail
-    })
-    .on_press(Message::Menu(route));
+        Button::new(button_inner)
+            .width(Length::Fill)
+            .height(Length::Fixed(ITEM_HEIGHT))
+            .style(if active {
+                theme::button::rail_active
+            } else {
+                theme::button::rail
+            })
+            .on_press(Message::Menu(route))
+    };
 
     let highlight: Element<'a, Message> = if active {
         container(Space::new().width(Length::Fixed(HIGHLIGHT_WIDTH)))
@@ -120,24 +150,53 @@ fn item_with_route<'a>(t: TopLevel, active: bool, route: Menu) -> Element<'a, Me
     };
 
     let r: Row<Message> = row![highlight, button].width(Length::Fixed(RAIL_WIDTH));
-    r.into()
+
+    // Hover popover explaining the network gate — mirrors the secondary
+    // rail and the Connect status dot tooltip.
+    match disabled_reason {
+        Some(reason) => iced::widget::tooltip(
+            r,
+            // Padded, bordered popover so the text reads as a floating
+            // bubble instead of overlapping the adjacent rail icons.
+            container(coincube_ui::component::text::caption(reason))
+                .padding([6, 10])
+                .style(theme::container::border_grey),
+            iced::widget::tooltip::Position::Right,
+        )
+        .gap(6)
+        .into(),
+        None => r.into(),
+    }
 }
 
 /// Landing route for a Marketplace rail click.
 ///
 /// The secondary rail only surfaces P2P when `has_p2p` is set and
-/// Buy/Sell when `has_vault` is set. Picking the first available entry
-/// keeps the click consistent with what the user will actually see in
-/// the secondary rail. Callers must gate the Marketplace button
-/// themselves — this helper assumes at least one is available and
-/// falls back to P2P to match `TopLevel::default_menu`.
+/// Buy/Sell when `has_vault` is set. We prefer landing on a child that
+/// is both structurally present *and* available on the current network,
+/// so the click never drops the user onto a network-disabled panel when
+/// an enabled sibling exists. If every available child is also
+/// network-disabled we still pick a structurally-present one (its panel
+/// shows the section, the rail item stays greyed) and finally fall back
+/// to P2P to match `TopLevel::default_menu`.
 fn marketplace_landing_menu(ctx: &NavContext<'_>) -> Menu {
-    if ctx.has_p2p {
-        Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Overview))
+    let p2p = Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Overview));
+    let buy_sell = Menu::Marketplace(MarketplaceSubMenu::BuySell);
+
+    let p2p_enabled =
+        ctx.has_p2p && features::p2p(ctx.network, ctx.p2p_test_coordinator).is_available();
+    let buy_sell_enabled = ctx.has_vault && features::buy_sell(ctx.network).is_available();
+
+    if p2p_enabled {
+        p2p
+    } else if buy_sell_enabled {
+        buy_sell
+    } else if ctx.has_p2p {
+        p2p
     } else if ctx.has_vault {
-        Menu::Marketplace(MarketplaceSubMenu::BuySell)
+        buy_sell
     } else {
-        Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Overview))
+        p2p
     }
 }
 

--- a/coincube-gui/src/app/view/nav/primary.rs
+++ b/coincube-gui/src/app/view/nav/primary.rs
@@ -181,6 +181,12 @@ fn item_with_route<'a>(
 /// to P2P to match `TopLevel::default_menu`.
 fn marketplace_landing_menu(ctx: &NavContext<'_>) -> Menu {
     let p2p = Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Overview));
+    // P2P Settings stays reachable even when trading is gated (see
+    // `features::route_availability`), so it's the landing for a gated-but-
+    // present P2P section — that's where the user adds a coordinator to lift
+    // the gate. The greyed secondary-rail P2P item is otherwise inert, so this
+    // is the path that avoids a configure catch-22.
+    let p2p_settings = Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Settings));
     let buy_sell = Menu::Marketplace(MarketplaceSubMenu::BuySell);
 
     let p2p_enabled =
@@ -192,11 +198,11 @@ fn marketplace_landing_menu(ctx: &NavContext<'_>) -> Menu {
     } else if buy_sell_enabled {
         buy_sell
     } else if ctx.has_p2p {
-        p2p
+        p2p_settings
     } else if ctx.has_vault {
         buy_sell
     } else {
-        p2p
+        p2p_settings
     }
 }
 

--- a/coincube-gui/src/app/view/nav/spark.rs
+++ b/coincube-gui/src/app/view/nav/spark.rs
@@ -5,35 +5,32 @@ use coincube_ui::icon::{home_icon, receipt_icon, receive_icon, send_icon, settin
 /// Secondary-rail items for the Spark wallet section.
 pub fn items(_ctx: &NavContext) -> Vec<SubItem> {
     vec![
-        SubItem {
-            label: "Overview",
-            icon: home_icon,
-            route: Menu::Spark(SparkSubMenu::Overview),
-            matches: |m| matches!(m, Menu::Spark(SparkSubMenu::Overview)),
-        },
-        SubItem {
-            label: "Send",
-            icon: send_icon,
-            route: Menu::Spark(SparkSubMenu::Send),
-            matches: |m| matches!(m, Menu::Spark(SparkSubMenu::Send)),
-        },
-        SubItem {
-            label: "Receive",
-            icon: receive_icon,
-            route: Menu::Spark(SparkSubMenu::Receive),
-            matches: |m| matches!(m, Menu::Spark(SparkSubMenu::Receive)),
-        },
-        SubItem {
-            label: "Transactions",
-            icon: receipt_icon,
-            route: Menu::Spark(SparkSubMenu::Transactions(None)),
-            matches: |m| matches!(m, Menu::Spark(SparkSubMenu::Transactions(_))),
-        },
-        SubItem {
-            label: "Settings",
-            icon: settings_icon,
-            route: Menu::Spark(SparkSubMenu::Settings(Some(SparkSettingsOption::General))),
-            matches: |m| matches!(m, Menu::Spark(SparkSubMenu::Settings(_))),
-        },
+        SubItem::new(
+            "Overview",
+            home_icon,
+            Menu::Spark(SparkSubMenu::Overview),
+            |m| matches!(m, Menu::Spark(SparkSubMenu::Overview)),
+        ),
+        SubItem::new("Send", send_icon, Menu::Spark(SparkSubMenu::Send), |m| {
+            matches!(m, Menu::Spark(SparkSubMenu::Send))
+        }),
+        SubItem::new(
+            "Receive",
+            receive_icon,
+            Menu::Spark(SparkSubMenu::Receive),
+            |m| matches!(m, Menu::Spark(SparkSubMenu::Receive)),
+        ),
+        SubItem::new(
+            "Transactions",
+            receipt_icon,
+            Menu::Spark(SparkSubMenu::Transactions(None)),
+            |m| matches!(m, Menu::Spark(SparkSubMenu::Transactions(_))),
+        ),
+        SubItem::new(
+            "Settings",
+            settings_icon,
+            Menu::Spark(SparkSubMenu::Settings(Some(SparkSettingsOption::General))),
+            |m| matches!(m, Menu::Spark(SparkSubMenu::Settings(_))),
+        ),
     ]
 }

--- a/coincube-gui/src/app/view/nav/tertiary.rs
+++ b/coincube-gui/src/app/view/nav/tertiary.rs
@@ -66,66 +66,66 @@ pub fn rail<'a>(menu: &Menu, ctx: &NavContext<'a>) -> Option<Element<'a, Message
 
 fn cube_settings_items() -> Vec<SubItem> {
     let mut items = vec![
-        SubItem {
-            label: "General",
-            icon: wrench_icon,
-            route: Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::General)),
-            matches: |m| {
+        SubItem::new(
+            "General",
+            wrench_icon,
+            Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::General)),
+            |m| {
                 matches!(
                     m,
                     Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::General))
                 )
             },
-        },
-        SubItem {
-            label: "About",
-            icon: tooltip_icon,
-            route: Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::About)),
-            matches: |m| {
+        ),
+        SubItem::new(
+            "About",
+            tooltip_icon,
+            Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::About)),
+            |m| {
                 matches!(
                     m,
                     Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::About))
                 )
             },
-        },
-        SubItem {
-            label: "Stats",
-            icon: graph_icon,
-            route: Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::Stats)),
-            matches: |m| {
+        ),
+        SubItem::new(
+            "Stats",
+            graph_icon,
+            Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::Stats)),
+            |m| {
                 matches!(
                     m,
                     Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::Stats))
                 )
             },
-        },
-        SubItem {
-            label: "Avatar",
-            // Placeholder icon — the per-Cube Connect rail used a stacked-coins
-            // glyph; swap to a face icon when one exists.
-            icon: coins_outline_icon,
-            route: Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::Avatar)),
-            matches: |m| {
+        ),
+        // Placeholder icon — the per-Cube Connect rail used a stacked-coins
+        // glyph; swap to a face icon when one exists.
+        SubItem::new(
+            "Avatar",
+            coins_outline_icon,
+            Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::Avatar)),
+            |m| {
                 matches!(
                     m,
                     Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::Avatar))
                 )
             },
-        },
+        ),
     ];
 
     if crate::feature_flags::CUBE_MEMBERS_UI_ENABLED {
-        items.push(SubItem {
-            label: "Members",
-            icon: person_icon,
-            route: Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::Members)),
-            matches: |m| {
+        items.push(SubItem::new(
+            "Members",
+            person_icon,
+            Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::Members)),
+            |m| {
                 matches!(
                     m,
                     Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::Members))
                 )
             },
-        });
+        ));
     }
 
     items
@@ -133,13 +133,13 @@ fn cube_settings_items() -> Vec<SubItem> {
 
 fn spark_settings_items() -> Vec<SubItem> {
     vec![
-        SubItem {
-            label: "General",
-            icon: wrench_icon,
-            route: Menu::Spark(SparkSubMenu::Settings(Some(SparkSettingsOption::General))),
-            // `None` is treated as General by `set_current_panel`, so the
-            // landing route (Settings(None) from a deep link) highlights here.
-            matches: |m| {
+        // `None` is treated as General by `set_current_panel`, so the
+        // landing route (Settings(None) from a deep link) highlights here.
+        SubItem::new(
+            "General",
+            wrench_icon,
+            Menu::Spark(SparkSubMenu::Settings(Some(SparkSettingsOption::General))),
+            |m| {
                 matches!(
                     m,
                     Menu::Spark(SparkSubMenu::Settings(
@@ -147,14 +147,14 @@ fn spark_settings_items() -> Vec<SubItem> {
                     ))
                 )
             },
-        },
-        SubItem {
-            label: "Lightning Address",
-            icon: lightning_outline_icon,
-            route: Menu::Spark(SparkSubMenu::Settings(Some(
+        ),
+        SubItem::new(
+            "Lightning Address",
+            lightning_outline_icon,
+            Menu::Spark(SparkSubMenu::Settings(Some(
                 SparkSettingsOption::LightningAddress,
             ))),
-            matches: |m| {
+            |m| {
                 matches!(
                     m,
                     Menu::Spark(SparkSubMenu::Settings(Some(
@@ -162,116 +162,116 @@ fn spark_settings_items() -> Vec<SubItem> {
                     )))
                 )
             },
-        },
+        ),
     ]
 }
 
 fn p2p_items() -> Vec<SubItem> {
     vec![
-        SubItem {
-            label: "Book",
-            icon: home_icon,
-            route: Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Overview)),
-            matches: |m| {
+        SubItem::new(
+            "Book",
+            home_icon,
+            Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Overview)),
+            |m| {
                 matches!(
                     m,
                     Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Overview))
                 )
             },
-        },
-        SubItem {
-            label: "My Trades",
-            icon: receipt_icon,
-            route: Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::MyTrades)),
-            matches: |m| {
+        ),
+        SubItem::new(
+            "My Trades",
+            receipt_icon,
+            Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::MyTrades)),
+            |m| {
                 matches!(
                     m,
                     Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::MyTrades))
                 )
             },
-        },
-        SubItem {
-            label: "Chat",
-            icon: chat_icon,
-            route: Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Chat)),
-            matches: |m| {
+        ),
+        SubItem::new(
+            "Chat",
+            chat_icon,
+            Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Chat)),
+            |m| {
                 matches!(
                     m,
                     Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Chat))
                 )
             },
-        },
-        SubItem {
-            label: "Create",
-            icon: plus_icon,
-            route: Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::CreateOrder)),
-            matches: |m| {
+        ),
+        SubItem::new(
+            "Create",
+            plus_icon,
+            Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::CreateOrder)),
+            |m| {
                 matches!(
                     m,
                     Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::CreateOrder))
                 )
             },
-        },
-        SubItem {
-            label: "Settings",
-            icon: settings_icon,
-            route: Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Settings)),
-            matches: |m| {
+        ),
+        SubItem::new(
+            "Settings",
+            settings_icon,
+            Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Settings)),
+            |m| {
                 matches!(
                     m,
                     Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Settings))
                 )
             },
-        },
+        ),
     ]
 }
 
 fn vault_settings_items() -> Vec<SubItem> {
     vec![
-        SubItem {
-            label: "Node",
-            icon: bitcoin_icon,
-            route: Menu::Vault(VaultSubMenu::Settings(Some(SettingsOption::Node))),
-            matches: |m| {
+        SubItem::new(
+            "Node",
+            bitcoin_icon,
+            Menu::Vault(VaultSubMenu::Settings(Some(SettingsOption::Node))),
+            |m| {
                 matches!(
                     m,
                     Menu::Vault(VaultSubMenu::Settings(Some(SettingsOption::Node)))
                         | Menu::Vault(VaultSubMenu::Settings(None))
                 )
             },
-        },
-        SubItem {
-            label: "Wallet",
-            icon: wallet_icon,
-            route: Menu::Vault(VaultSubMenu::Settings(Some(SettingsOption::Wallet))),
-            matches: |m| {
+        ),
+        SubItem::new(
+            "Wallet",
+            wallet_icon,
+            Menu::Vault(VaultSubMenu::Settings(Some(SettingsOption::Wallet))),
+            |m| {
                 matches!(
                     m,
                     Menu::Vault(VaultSubMenu::Settings(Some(SettingsOption::Wallet)))
                 )
             },
-        },
-        SubItem {
-            label: "Import/Export",
-            icon: wallet_icon,
-            route: Menu::Vault(VaultSubMenu::Settings(Some(SettingsOption::ImportExport))),
-            matches: |m| {
+        ),
+        SubItem::new(
+            "Import/Export",
+            wallet_icon,
+            Menu::Vault(VaultSubMenu::Settings(Some(SettingsOption::ImportExport))),
+            |m| {
                 matches!(
                     m,
                     Menu::Vault(VaultSubMenu::Settings(Some(SettingsOption::ImportExport)))
                 )
             },
-        },
-        SubItem {
-            label: "Pair",
-            icon: phone_icon,
-            route: Menu::Vault(VaultSubMenu::Settings(Some(SettingsOption::LocalSigning))),
-            matches: |m| {
+        ),
+        SubItem::new(
+            "Pair",
+            phone_icon,
+            Menu::Vault(VaultSubMenu::Settings(Some(SettingsOption::LocalSigning))),
+            |m| {
                 matches!(
                     m,
                     Menu::Vault(VaultSubMenu::Settings(Some(SettingsOption::LocalSigning)))
                 )
             },
-        },
+        ),
     ]
 }

--- a/coincube-gui/src/app/view/nav/vault.rs
+++ b/coincube-gui/src/app/view/nav/vault.rs
@@ -8,55 +8,52 @@ use coincube_ui::icon::{
 /// Secondary-rail items for the Vault wallet section.
 pub fn items(_ctx: &NavContext) -> Vec<SubItem> {
     vec![
-        SubItem {
-            label: "Overview",
-            icon: home_icon,
-            route: Menu::Vault(VaultSubMenu::Overview),
-            matches: |m| matches!(m, Menu::Vault(VaultSubMenu::Overview)),
-        },
-        SubItem {
-            label: "Send",
-            icon: send_icon,
-            route: Menu::Vault(VaultSubMenu::Send),
-            matches: |m| matches!(m, Menu::Vault(VaultSubMenu::Send)),
-        },
-        SubItem {
-            label: "Receive",
-            icon: receive_icon,
-            route: Menu::Vault(VaultSubMenu::Receive),
-            matches: |m| matches!(m, Menu::Vault(VaultSubMenu::Receive)),
-        },
-        SubItem {
-            label: "Coins",
-            icon: coins_outline_icon,
-            route: Menu::Vault(VaultSubMenu::Coins(None)),
-            matches: |m| matches!(m, Menu::Vault(VaultSubMenu::Coins(_))),
-        },
-        SubItem {
-            label: "Transactions",
-            icon: receipt_icon,
-            route: Menu::Vault(VaultSubMenu::Transactions(None)),
-            matches: |m| matches!(m, Menu::Vault(VaultSubMenu::Transactions(_))),
-        },
-        SubItem {
-            label: "PSBTs",
-            icon: receipt_icon,
-            route: Menu::Vault(VaultSubMenu::PSBTs(None)),
-            matches: |m| matches!(m, Menu::Vault(VaultSubMenu::PSBTs(_))),
-        },
-        SubItem {
-            label: "Recovery",
-            icon: recovery_icon,
-            route: Menu::Vault(VaultSubMenu::Recovery),
-            matches: |m| matches!(m, Menu::Vault(VaultSubMenu::Recovery)),
-        },
-        SubItem {
-            label: "Settings",
-            icon: settings_icon,
-            route: Menu::Vault(VaultSubMenu::Settings(Some(
+        SubItem::new(
+            "Overview",
+            home_icon,
+            Menu::Vault(VaultSubMenu::Overview),
+            |m| matches!(m, Menu::Vault(VaultSubMenu::Overview)),
+        ),
+        SubItem::new("Send", send_icon, Menu::Vault(VaultSubMenu::Send), |m| {
+            matches!(m, Menu::Vault(VaultSubMenu::Send))
+        }),
+        SubItem::new(
+            "Receive",
+            receive_icon,
+            Menu::Vault(VaultSubMenu::Receive),
+            |m| matches!(m, Menu::Vault(VaultSubMenu::Receive)),
+        ),
+        SubItem::new(
+            "Coins",
+            coins_outline_icon,
+            Menu::Vault(VaultSubMenu::Coins(None)),
+            |m| matches!(m, Menu::Vault(VaultSubMenu::Coins(_))),
+        ),
+        SubItem::new(
+            "Transactions",
+            receipt_icon,
+            Menu::Vault(VaultSubMenu::Transactions(None)),
+            |m| matches!(m, Menu::Vault(VaultSubMenu::Transactions(_))),
+        ),
+        SubItem::new(
+            "PSBTs",
+            receipt_icon,
+            Menu::Vault(VaultSubMenu::PSBTs(None)),
+            |m| matches!(m, Menu::Vault(VaultSubMenu::PSBTs(_))),
+        ),
+        SubItem::new(
+            "Recovery",
+            recovery_icon,
+            Menu::Vault(VaultSubMenu::Recovery),
+            |m| matches!(m, Menu::Vault(VaultSubMenu::Recovery)),
+        ),
+        SubItem::new(
+            "Settings",
+            settings_icon,
+            Menu::Vault(VaultSubMenu::Settings(Some(
                 crate::app::menu::SettingsOption::Node,
             ))),
-            matches: |m| matches!(m, Menu::Vault(VaultSubMenu::Settings(_))),
-        },
+            |m| matches!(m, Menu::Vault(VaultSubMenu::Settings(_))),
+        ),
     ]
 }

--- a/coincube-gui/src/app/view/p2p/config.rs
+++ b/coincube-gui/src/app/view/p2p/config.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use coincube_core::miniscript::bitcoin;
 use serde::{Deserialize, Serialize};
 
 /// Compile-time fallbacks — overridden at runtime by env vars.
@@ -10,42 +11,112 @@ const FALLBACK_NODES: &[(&str, &str)] = &[(
 
 const FALLBACK_RELAYS: &[&str] = &["wss://relay.mostro.network"];
 
+/// Current on-disk schema version. Bumped when the persisted shape changes
+/// so future migrations have a clean signal. Version 0 (the implicit value
+/// for `config.json` written before network tagging) is treated as legacy
+/// on load — every node without a `network` field is assumed `Mainnet`.
+const CONFIG_VERSION: u32 = 1;
+
+/// Which Bitcoin network a Mostro coordinator (and its relays) serve.
+///
+/// Coordinators escrow real funds, so a mainnet coordinator must never be
+/// silently used on a test network (or vice-versa). Collapsing the five
+/// Bitcoin networks to two kinds is enough for coordinator selection — a
+/// coordinator is either for real money or for testing.
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum NetworkKind {
+    Mainnet,
+    Test,
+}
+
+impl Default for NetworkKind {
+    /// Legacy configs (and the official fallback) are mainnet.
+    fn default() -> Self {
+        NetworkKind::Mainnet
+    }
+}
+
+impl NetworkKind {
+    pub fn of(net: bitcoin::Network) -> Self {
+        match net {
+            bitcoin::Network::Bitcoin => NetworkKind::Mainnet,
+            _ => NetworkKind::Test,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            NetworkKind::Mainnet => "Mainnet",
+            NetworkKind::Test => "Test",
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct MostroNode {
     pub name: String,
     pub pubkey_hex: String,
+    /// Which network this coordinator serves. Absent in legacy configs, in
+    /// which case it defaults to `Mainnet` (the official coordinator).
+    #[serde(default)]
+    pub network: NetworkKind,
+}
+
+/// A coordinator + relay set resolved for a specific Bitcoin network.
+/// Built by [`MostroConfig::active_for`] so callers never have to repeat
+/// the "which node/relays apply on this network" logic.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedCoordinator {
+    pub pubkey_hex: String,
+    pub relays: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct MostroConfig {
+    /// On-disk schema version; see [`CONFIG_VERSION`]. Missing on legacy
+    /// files (`#[serde(default)]` → 0).
+    #[serde(default)]
+    pub version: u32,
     pub nodes: Vec<MostroNode>,
     pub active_node_pubkey: String,
     pub relays: Vec<String>,
+    /// Relays used when the wallet is on a test network. Falls back to
+    /// `relays` when empty. Kept separate so a test relay set can be seeded
+    /// (via `MOSTRO_TESTNET_RELAYS`) without disturbing the mainnet relays.
+    #[serde(default)]
+    pub test_relays: Vec<String>,
     #[serde(default)]
     pub blossom_url: Option<String>,
 }
 
-/// Build default nodes from `MOSTRO_NODES` env var or compile-time fallbacks.
+/// Parse `name=pubkey` comma-separated pairs into nodes tagged `kind`.
+fn parse_nodes(val: &str, kind: NetworkKind) -> Vec<MostroNode> {
+    val.split(',')
+        .filter_map(|entry| {
+            let (name, pubkey) = entry.split_once('=')?;
+            let name = name.trim();
+            let pubkey = pubkey.trim();
+            if name.is_empty() || pubkey.is_empty() {
+                return None;
+            }
+            Some(MostroNode {
+                name: name.to_string(),
+                pubkey_hex: pubkey.to_string(),
+                network: kind,
+            })
+        })
+        .collect()
+}
+
+/// Build default mainnet nodes from `MOSTRO_NODES` env var or compile-time
+/// fallbacks.
 ///
 /// Env format: comma-separated `name=pubkey` pairs, e.g.
 /// `MOSTRO_NODES="Mostro (Official)=82fa8c...,TestNode=aabbcc..."`
 fn default_nodes() -> Vec<MostroNode> {
     if let Ok(val) = std::env::var("MOSTRO_NODES") {
-        let nodes: Vec<MostroNode> = val
-            .split(',')
-            .filter_map(|entry| {
-                let (name, pubkey) = entry.split_once('=')?;
-                let name = name.trim();
-                let pubkey = pubkey.trim();
-                if name.is_empty() || pubkey.is_empty() {
-                    return None;
-                }
-                Some(MostroNode {
-                    name: name.to_string(),
-                    pubkey_hex: pubkey.to_string(),
-                })
-            })
-            .collect();
+        let nodes = parse_nodes(&val, NetworkKind::Mainnet);
         if !nodes.is_empty() {
             return nodes;
         }
@@ -55,21 +126,36 @@ fn default_nodes() -> Vec<MostroNode> {
         .map(|(name, pubkey)| MostroNode {
             name: name.to_string(),
             pubkey_hex: pubkey.to_string(),
+            network: NetworkKind::Mainnet,
         })
         .collect()
 }
 
-/// Build default relays from `MOSTRO_RELAYS` env var or compile-time fallbacks.
+/// Build test-network coordinator nodes from `MOSTRO_TESTNET_NODES`.
 ///
-/// Env format: comma-separated URLs, e.g.
-/// `MOSTRO_RELAYS="wss://relay.mostro.network,wss://relay2.example.com"`
+/// Same `name=pubkey` format as [`default_nodes`], but every node is tagged
+/// `NetworkKind::Test`. There is no compile-time fallback — a test
+/// coordinator must be explicitly provided (this is what gates P2P on test
+/// networks, see [`MostroConfig::has_test_coordinator`]).
+fn default_test_nodes() -> Vec<MostroNode> {
+    match std::env::var("MOSTRO_TESTNET_NODES") {
+        Ok(val) => parse_nodes(&val, NetworkKind::Test),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Parse comma-separated relay URLs.
+fn parse_relays(val: &str) -> Vec<String> {
+    val.split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Build default mainnet relays from `MOSTRO_RELAYS` env var or fallbacks.
 fn default_relays() -> Vec<String> {
     if let Ok(val) = std::env::var("MOSTRO_RELAYS") {
-        let relays: Vec<String> = val
-            .split(',')
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-            .collect();
+        let relays = parse_relays(&val);
         if !relays.is_empty() {
             return relays;
         }
@@ -77,14 +163,30 @@ fn default_relays() -> Vec<String> {
     FALLBACK_RELAYS.iter().map(|s| s.to_string()).collect()
 }
 
+/// Build test-network relays from `MOSTRO_TESTNET_RELAYS` (no fallback).
+fn default_test_relays() -> Vec<String> {
+    match std::env::var("MOSTRO_TESTNET_RELAYS") {
+        Ok(val) => parse_relays(&val),
+        Err(_) => Vec::new(),
+    }
+}
+
 impl Default for MostroConfig {
     fn default() -> Self {
-        let nodes = default_nodes();
-        let active = nodes[0].pubkey_hex.clone();
+        let mut nodes = default_nodes();
+        nodes.extend(default_test_nodes());
+        let active = nodes
+            .iter()
+            .find(|n| n.network == NetworkKind::Mainnet)
+            .or_else(|| nodes.first())
+            .map(|n| n.pubkey_hex.clone())
+            .unwrap_or_default();
         Self {
+            version: CONFIG_VERSION,
             nodes,
             active_node_pubkey: active,
             relays: default_relays(),
+            test_relays: default_test_relays(),
             blossom_url: None,
         }
     }
@@ -97,6 +199,7 @@ impl MostroConfig {
                 name: "Mostro (Default)".to_string(),
                 pubkey_hex: "82fa8cb978b43c79b2156585bac2c011176a21d2aead6d9f7c575c005be88390"
                     .to_string(),
+                network: NetworkKind::Mainnet,
             });
         self.nodes
             .iter()
@@ -115,10 +218,76 @@ impl MostroConfig {
             .unwrap_or("https://blossom.primal.net")
     }
 
-    /// Ensure there is always at least one node and one relay.
+    /// Relay set for `kind` — the dedicated test relays when on a test
+    /// network and any are configured, otherwise the shared relay set.
+    fn relays_for(&self, kind: NetworkKind) -> Vec<String> {
+        match kind {
+            NetworkKind::Mainnet => self.relays.clone(),
+            NetworkKind::Test if !self.test_relays.is_empty() => self.test_relays.clone(),
+            NetworkKind::Test => self.relays.clone(),
+        }
+    }
+
+    /// Resolve the coordinator + relays to use on `net`.
+    ///
+    /// Prefers the active node when it matches the network kind; otherwise
+    /// falls back to the first node of that kind. Returns `None` when no
+    /// coordinator is configured for the network — e.g. a test network with
+    /// no test coordinator, which is exactly the case the P2P rail gate
+    /// disables.
+    pub fn active_for(&self, net: bitcoin::Network) -> Option<ResolvedCoordinator> {
+        let kind = NetworkKind::of(net);
+        let node = self
+            .nodes
+            .iter()
+            .find(|n| n.pubkey_hex == self.active_node_pubkey && n.network == kind)
+            .or_else(|| self.nodes.iter().find(|n| n.network == kind))?;
+        Some(ResolvedCoordinator {
+            pubkey_hex: node.pubkey_hex.clone(),
+            relays: self.relays_for(kind),
+        })
+    }
+
+    /// Drives the P2P network gate: is P2P trading actually usable on `net`?
+    ///
+    /// True only when (a) `net` is a test network, (b) a coordinator tagged
+    /// for test networks is configured, and (c) the network has a usable
+    /// Lightning rail for escrow. Mostro escrow is paid with HODL invoices
+    /// over Spark, which only runs on mainnet + Regtest, so among test
+    /// networks only Regtest can actually trade (COIN-370 §6 / Q1). Spark
+    /// availability is taken from [`crate::app::features::spark`] so the
+    /// rail dependency stays a single source of truth.
+    pub fn has_test_coordinator(&self, net: bitcoin::Network) -> bool {
+        NetworkKind::of(net) == NetworkKind::Test
+            && self.nodes.iter().any(|n| n.network == NetworkKind::Test)
+            && crate::app::features::spark(net).is_available()
+    }
+
+    /// Ensure the active selection suits `net`: if the active node isn't
+    /// tagged for this network kind, switch to the first node that is.
+    /// Never leaves a mainnet coordinator selected on a test network (or
+    /// vice-versa), per COIN-371 §3.4. No-op when a matching node is already
+    /// active, or when none exists for the network.
+    pub fn select_default_for(&mut self, net: bitcoin::Network) {
+        let kind = NetworkKind::of(net);
+        let active_matches = self
+            .nodes
+            .iter()
+            .any(|n| n.pubkey_hex == self.active_node_pubkey && n.network == kind);
+        if active_matches {
+            return;
+        }
+        if let Some(node) = self.nodes.iter().find(|n| n.network == kind) {
+            self.active_node_pubkey = node.pubkey_hex.clone();
+        }
+    }
+
+    /// Ensure there is always at least one node and one relay, and that the
+    /// active selection points at an existing node.
     pub fn ensure_defaults(&mut self) {
         if self.nodes.is_empty() {
             self.nodes = default_nodes();
+            self.nodes.extend(default_test_nodes());
         }
         if self.relays.is_empty() {
             self.relays = default_relays();
@@ -147,6 +316,11 @@ pub fn load_mostro_config() -> Result<MostroConfig, String> {
         .map_err(|e| format!("Failed to read mostro config at {}: {e}", path.display()))?;
     let mut config: MostroConfig = serde_json::from_slice(&data)
         .map_err(|e| format!("Failed to parse mostro config at {}: {e}", path.display()))?;
+    // Legacy files (version 0, nodes without a `network` tag) deserialize
+    // with every node defaulting to Mainnet — the correct migration, since
+    // the only pre-tagging coordinator was the mainnet official one. Stamp
+    // the current version so the next write-back is up to date.
+    config.version = CONFIG_VERSION;
     config.ensure_defaults();
     Ok(config)
 }
@@ -171,4 +345,146 @@ pub fn save_mostro_config(config: &MostroConfig) -> Result<(), String> {
     std::fs::rename(&tmp_path, &path)
         .map_err(|e| format!("Failed to rename temp config file: {e}"))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(name: &str, pubkey: &str, network: NetworkKind) -> MostroNode {
+        MostroNode {
+            name: name.to_string(),
+            pubkey_hex: pubkey.to_string(),
+            network,
+        }
+    }
+
+    /// A legacy `config.json` (no `version`, nodes without `network`) loads
+    /// with every node tagged Mainnet.
+    #[test]
+    fn legacy_config_loads_as_mainnet() {
+        let legacy = r#"{
+            "nodes": [{"name": "Mostro (Official)", "pubkey_hex": "abc123"}],
+            "active_node_pubkey": "abc123",
+            "relays": ["wss://relay.mostro.network"]
+        }"#;
+        let config: MostroConfig = serde_json::from_str(legacy).expect("parse legacy");
+        assert_eq!(config.version, 0, "legacy version defaults to 0");
+        assert_eq!(config.nodes.len(), 1);
+        assert_eq!(config.nodes[0].network, NetworkKind::Mainnet);
+        assert!(config.test_relays.is_empty());
+    }
+
+    #[test]
+    fn has_test_coordinator_requires_test_node_and_lightning_rail() {
+        let mut config = MostroConfig {
+            version: CONFIG_VERSION,
+            nodes: vec![node("Official", "main1", NetworkKind::Mainnet)],
+            active_node_pubkey: "main1".to_string(),
+            relays: vec!["wss://relay.mostro.network".to_string()],
+            test_relays: vec![],
+            blossom_url: None,
+        };
+
+        // No test node → never a test coordinator, on any network.
+        assert!(!config.has_test_coordinator(bitcoin::Network::Regtest));
+        assert!(!config.has_test_coordinator(bitcoin::Network::Testnet));
+
+        config
+            .nodes
+            .push(node("Local", "test1", NetworkKind::Test));
+
+        // Mainnet is never a "test coordinator" network.
+        assert!(!config.has_test_coordinator(bitcoin::Network::Bitcoin));
+        // Regtest has a Lightning rail (Spark) → enabled with a test node.
+        assert!(config.has_test_coordinator(bitcoin::Network::Regtest));
+        // Testnet/Signet/Testnet4 have no escrow rail → still gated even
+        // with a test coordinator configured.
+        assert!(!config.has_test_coordinator(bitcoin::Network::Testnet));
+        assert!(!config.has_test_coordinator(bitcoin::Network::Signet));
+        assert!(!config.has_test_coordinator(bitcoin::Network::Testnet4));
+    }
+
+    #[test]
+    fn active_for_resolves_per_network_kind() {
+        let config = MostroConfig {
+            version: CONFIG_VERSION,
+            nodes: vec![
+                node("Official", "main1", NetworkKind::Mainnet),
+                node("Local", "test1", NetworkKind::Test),
+            ],
+            active_node_pubkey: "main1".to_string(),
+            relays: vec!["wss://main.relay".to_string()],
+            test_relays: vec!["wss://test.relay".to_string()],
+            blossom_url: None,
+        };
+
+        // On mainnet: the active mainnet node + mainnet relays.
+        let m = config.active_for(bitcoin::Network::Bitcoin).expect("mainnet");
+        assert_eq!(m.pubkey_hex, "main1");
+        assert_eq!(m.relays, vec!["wss://main.relay".to_string()]);
+
+        // On a test network: falls through to the test node + test relays,
+        // never the mainnet coordinator.
+        let t = config.active_for(bitcoin::Network::Regtest).expect("test");
+        assert_eq!(t.pubkey_hex, "test1");
+        assert_eq!(t.relays, vec!["wss://test.relay".to_string()]);
+    }
+
+    #[test]
+    fn active_for_test_network_without_test_node_is_none() {
+        let config = MostroConfig {
+            version: CONFIG_VERSION,
+            nodes: vec![node("Official", "main1", NetworkKind::Mainnet)],
+            active_node_pubkey: "main1".to_string(),
+            relays: vec!["wss://main.relay".to_string()],
+            test_relays: vec![],
+            blossom_url: None,
+        };
+        assert!(config.active_for(bitcoin::Network::Regtest).is_none());
+    }
+
+    #[test]
+    fn select_default_for_avoids_cross_network_coordinator() {
+        let mut config = MostroConfig {
+            version: CONFIG_VERSION,
+            nodes: vec![
+                node("Official", "main1", NetworkKind::Mainnet),
+                node("Local", "test1", NetworkKind::Test),
+            ],
+            // Persisted selection is the mainnet coordinator.
+            active_node_pubkey: "main1".to_string(),
+            relays: vec!["wss://main.relay".to_string()],
+            test_relays: vec![],
+            blossom_url: None,
+        };
+
+        // On a test network it switches off the mainnet coordinator…
+        config.select_default_for(bitcoin::Network::Regtest);
+        assert_eq!(config.active_node_pubkey, "test1");
+
+        // …and back on mainnet it switches to a mainnet coordinator.
+        config.select_default_for(bitcoin::Network::Bitcoin);
+        assert_eq!(config.active_node_pubkey, "main1");
+
+        // No matching node for the network → selection left untouched.
+        config.nodes.retain(|n| n.network == NetworkKind::Mainnet);
+        config.active_node_pubkey = "main1".to_string();
+        config.select_default_for(bitcoin::Network::Regtest);
+        assert_eq!(config.active_node_pubkey, "main1");
+    }
+
+    #[test]
+    fn test_relays_fall_back_to_shared_when_empty() {
+        let config = MostroConfig {
+            version: CONFIG_VERSION,
+            nodes: vec![node("Local", "test1", NetworkKind::Test)],
+            active_node_pubkey: "test1".to_string(),
+            relays: vec!["wss://shared.relay".to_string()],
+            test_relays: vec![],
+            blossom_url: None,
+        };
+        let t = config.active_for(bitcoin::Network::Regtest).expect("test");
+        assert_eq!(t.relays, vec!["wss://shared.relay".to_string()]);
+    }
 }

--- a/coincube-gui/src/app/view/p2p/config.rs
+++ b/coincube-gui/src/app/view/p2p/config.rs
@@ -228,6 +228,26 @@ impl MostroConfig {
         }
     }
 
+    /// The relay set managed in Settings for `net`: the dedicated test set on
+    /// test networks, the shared set on mainnet. (Connections additionally
+    /// fall back to the shared set when the test set is empty — see
+    /// [`Self::relays_for`].) Paired with [`Self::settings_relays_mut`] so the
+    /// UI shows and edits exactly the set a given network uses.
+    pub fn settings_relays(&self, net: bitcoin::Network) -> &[String] {
+        match NetworkKind::of(net) {
+            NetworkKind::Mainnet => &self.relays,
+            NetworkKind::Test => &self.test_relays,
+        }
+    }
+
+    /// Mutable counterpart to [`Self::settings_relays`].
+    pub fn settings_relays_mut(&mut self, net: bitcoin::Network) -> &mut Vec<String> {
+        match NetworkKind::of(net) {
+            NetworkKind::Mainnet => &mut self.relays,
+            NetworkKind::Test => &mut self.test_relays,
+        }
+    }
+
     /// Resolve the coordinator + relays to use on `net`.
     ///
     /// Prefers the active node when it matches the network kind; otherwise
@@ -339,6 +359,20 @@ pub fn load_mostro_config() -> Result<MostroConfig, String> {
 
 pub fn save_mostro_config(config: &MostroConfig) -> Result<(), String> {
     let path = config_file_path()?;
+    // Never clobber a config written by a newer app version. This is the
+    // backstop for the load-time guard: if loading failed (too new) and the
+    // caller fell back to defaults, a later edit must not downgrade the
+    // on-disk file and drop fields this build doesn't understand.
+    if let Ok(existing) = std::fs::read(&path) {
+        if let Ok(on_disk) = serde_json::from_slice::<MostroConfig>(&existing) {
+            if on_disk.version > config.version {
+                return Err(format!(
+                    "Refusing to overwrite a newer Mostro config (v{} on disk, this app writes v{}).",
+                    on_disk.version, config.version
+                ));
+            }
+        }
+    }
     let dir = path
         .parent()
         .ok_or_else(|| "Config file has no parent directory".to_string())?;

--- a/coincube-gui/src/app/view/p2p/config.rs
+++ b/coincube-gui/src/app/view/p2p/config.rs
@@ -316,6 +316,18 @@ pub fn load_mostro_config() -> Result<MostroConfig, String> {
         .map_err(|e| format!("Failed to read mostro config at {}: {e}", path.display()))?;
     let mut config: MostroConfig = serde_json::from_slice(&data)
         .map_err(|e| format!("Failed to parse mostro config at {}: {e}", path.display()))?;
+    // Refuse a config written by a newer app version. Stamping it down to
+    // CONFIG_VERSION (and a later write-back) would silently drop fields this
+    // build doesn't understand, so fail loudly instead of downgrading.
+    if config.version > CONFIG_VERSION {
+        return Err(format!(
+            "Mostro config at {} is version {}, newer than this app supports ({}). \
+             Update the app to load it.",
+            path.display(),
+            config.version,
+            CONFIG_VERSION
+        ));
+    }
     // Legacy files (version 0, nodes without a `network` tag) deserialize
     // with every node defaulting to Mainnet — the correct migration, since
     // the only pre-tagging coordinator was the mainnet official one. Stamp

--- a/coincube-gui/src/app/view/p2p/config.rs
+++ b/coincube-gui/src/app/view/p2p/config.rs
@@ -390,9 +390,7 @@ mod tests {
         assert!(!config.has_test_coordinator(bitcoin::Network::Regtest));
         assert!(!config.has_test_coordinator(bitcoin::Network::Testnet));
 
-        config
-            .nodes
-            .push(node("Local", "test1", NetworkKind::Test));
+        config.nodes.push(node("Local", "test1", NetworkKind::Test));
 
         // Mainnet is never a "test coordinator" network.
         assert!(!config.has_test_coordinator(bitcoin::Network::Bitcoin));
@@ -420,7 +418,9 @@ mod tests {
         };
 
         // On mainnet: the active mainnet node + mainnet relays.
-        let m = config.active_for(bitcoin::Network::Bitcoin).expect("mainnet");
+        let m = config
+            .active_for(bitcoin::Network::Bitcoin)
+            .expect("mainnet");
         assert_eq!(m.pubkey_hex, "main1");
         assert_eq!(m.relays, vec!["wss://main.relay".to_string()]);
 

--- a/coincube-gui/src/app/view/p2p/panel.rs
+++ b/coincube-gui/src/app/view/p2p/panel.rs
@@ -31,7 +31,18 @@ use super::components::{
     trade_status_filter, BuySellFilter, OrderFilterState, OrderType, P2POrder, P2PTrade,
     PricingMode, TradeFilter, FIAT_CURRENCIES,
 };
-use super::config::{load_mostro_config, save_mostro_config, MostroConfig, MostroNode};
+use super::config::{
+    load_mostro_config, save_mostro_config, MostroConfig, MostroNode, NetworkKind,
+    ResolvedCoordinator,
+};
+use coincube_core::miniscript::bitcoin::Network;
+
+/// Shown (and returned from trade handlers) when the active Mostro
+/// coordinator's network doesn't match the wallet's. Trading is
+/// hard-blocked in that state (COIN-371 Q4).
+const COORDINATOR_MISMATCH_MSG: &str =
+    "Active Mostro coordinator doesn't match this wallet's network — select a matching \
+     coordinator in P2P → Settings.";
 
 /// Per-field validation warnings for the order creation form.
 /// Which chat view is currently active (mutually exclusive).
@@ -380,11 +391,18 @@ pub struct P2PPanel {
     // Dispute chat
     dispute_chat_input: form::Value<String>,
     pending_dispute_chat_message: Option<PendingChatMessage>,
+    // Bitcoin network this cube runs on. Drives network-aware coordinator
+    // selection (`MostroConfig::active_for`) — needed in `subscription`,
+    // which has no `Cache` access.
+    network: Network,
     // Mostro settings
     mostro_config: MostroConfig,
     new_relay_input: form::Value<String>,
     new_node_name_input: form::Value<String>,
     new_node_pubkey_input: form::Value<String>,
+    /// Whether the "Add Node" form will tag the new coordinator as a test
+    /// (vs. mainnet) coordinator.
+    new_node_is_test: bool,
     mostro_config_error: Option<&'static str>,
     /// Error surfaced from the subscription stream (relay failures, restore errors, etc.)
     pub stream_error: Option<String>,
@@ -406,6 +424,7 @@ impl P2PPanel {
         spark_backend: Option<Arc<SparkBackend>>,
         mnemonic: String,
         default_currency: Option<String>,
+        network: Network,
     ) -> Self {
         let default_currency = default_currency.unwrap_or_else(|| "USD".to_string());
         Self {
@@ -484,13 +503,21 @@ impl P2PPanel {
             chat_show_user_info: false,
             dispute_chat_input: Default::default(),
             pending_dispute_chat_message: None,
-            mostro_config: load_mostro_config().unwrap_or_else(|e| {
-                tracing::error!("Failed to load mostro config, using defaults: {e}");
-                MostroConfig::default()
-            }),
+            network,
+            mostro_config: {
+                let mut cfg = load_mostro_config().unwrap_or_else(|e| {
+                    tracing::error!("Failed to load mostro config, using defaults: {e}");
+                    MostroConfig::default()
+                });
+                // Never start with a cross-network coordinator selected
+                // (COIN-371 §3.4) — prefer a node tagged for this network.
+                cfg.select_default_for(network);
+                cfg
+            },
             new_relay_input: Default::default(),
             new_node_name_input: Default::default(),
             new_node_pubkey_input: Default::default(),
+            new_node_is_test: false,
             mostro_config_error: None,
             stream_error: None,
             cached_trade_messages: Vec::new(),
@@ -829,8 +856,8 @@ impl P2PPanel {
                 None
             },
             expiry_days: 1,
-            mostro_pubkey_hex: self.mostro_config.active_pubkey_hex().to_string(),
-            relay_urls: self.mostro_config.relays.clone(),
+            mostro_pubkey_hex: self.resolved_coordinator().pubkey_hex,
+            relay_urls: self.resolved_coordinator().relays,
         }
     }
 
@@ -1031,8 +1058,8 @@ impl P2PPanel {
                 cube_name: self.cube_name(),
                 mnemonic: self.mnemonic.clone(),
                 invoice,
-                mostro_pubkey_hex: self.mostro_config.active_pubkey_hex().to_string(),
-                relay_urls: self.mostro_config.relays.clone(),
+                mostro_pubkey_hex: self.resolved_coordinator().pubkey_hex,
+                relay_urls: self.resolved_coordinator().relays,
             };
             return Task::perform(action(data), |result| {
                 Message::View(view::Message::P2P(P2PMessage::TradeActionResult(result)))
@@ -3661,6 +3688,56 @@ impl P2PPanel {
         .into()
     }
 
+    /// Coordinator + relays to use on this cube's network, with a safe
+    /// fallback to the globally-active node/relays so mainnet keeps working
+    /// even if no network-tagged node resolves.
+    fn resolved_coordinator(&self) -> ResolvedCoordinator {
+        self.mostro_config
+            .active_for(self.network)
+            .unwrap_or_else(|| ResolvedCoordinator {
+                pubkey_hex: self.mostro_config.active_pubkey_hex().to_string(),
+                relays: self.mostro_config.relays.clone(),
+            })
+    }
+
+    /// Whether the selected coordinator's network kind matches the wallet's
+    /// network. A mismatch (e.g. a mainnet coordinator selected while on a
+    /// test network) hard-blocks trading — escrow would otherwise move
+    /// funds against the wrong network.
+    fn coordinator_network_matches(&self) -> bool {
+        self.mostro_config.active_node().network == NetworkKind::of(self.network)
+    }
+
+    /// Resolved P2P test-coordinator gate for this cube's network, mirrored
+    /// into [`Cache`] so the nav rail can grey the P2P item.
+    pub fn has_test_coordinator(&self) -> bool {
+        self.mostro_config.has_test_coordinator(self.network)
+    }
+
+    /// Warning banner shown when the active coordinator's network doesn't
+    /// match the wallet's — trading is hard-blocked until corrected.
+    fn network_mismatch_banner<'a>(&self) -> Option<Element<'a, view::Message>> {
+        if self.coordinator_network_matches() {
+            return None;
+        }
+        let active = self.mostro_config.active_node();
+        let msg = format!(
+            "The active Mostro coordinator \"{}\" is a {} coordinator, but this wallet is on {}. \
+             Trading is disabled — select a {} coordinator in P2P → Settings.",
+            active.name,
+            active.network.label(),
+            NetworkKind::of(self.network).label(),
+            NetworkKind::of(self.network).label(),
+        );
+        Some(
+            container(p2_regular(msg).style(theme::text::error))
+                .padding([10, 16])
+                .width(Length::Fill)
+                .style(theme::container::border_grey)
+                .into(),
+        )
+    }
+
     fn mostro_settings_view<'a>(&'a self) -> Element<'a, view::Message> {
         let p2p = |msg: P2PMessage| view::Message::P2P(msg);
 
@@ -3694,6 +3771,15 @@ impl P2PPanel {
                 let remove_btn = button::secondary_compact(Some(icon::trash_icon()), "")
                     .on_press(p2p(P2PMessage::MostroRemoveNode(node.pubkey_hex.clone())));
 
+                // Network tag so it's obvious which coordinator serves
+                // which network (a mainnet vs test footgun for escrow).
+                let net_badge = container(text(node.network.label()).size(10))
+                    .padding([2, 8])
+                    .style(match node.network {
+                        NetworkKind::Mainnet => theme::pill::info,
+                        NetworkKind::Test => theme::pill::warning,
+                    });
+
                 row![
                     column![
                         p2_bold(node.name.as_str()),
@@ -3701,6 +3787,7 @@ impl P2PPanel {
                     ]
                     .spacing(4)
                     .width(Length::Fill),
+                    net_badge,
                     select_btn,
                     remove_btn,
                 ]
@@ -3730,6 +3817,25 @@ impl P2PPanel {
                         |v| { view::Message::P2P(P2PMessage::MostroNodePubkeyInputEdited(v)) }
                     )
                     .padding(10),
+                    // Which network this coordinator serves. Mainnet vs Test
+                    // is escrow-critical, so it's an explicit choice.
+                    row![
+                        p2_regular("Network:").style(theme::text::secondary),
+                        if self.new_node_is_test {
+                            button::secondary(None, "Mainnet")
+                                .on_press(p2p(P2PMessage::MostroNodeNetworkToggled(false)))
+                        } else {
+                            button::primary(None, "Mainnet")
+                        },
+                        if self.new_node_is_test {
+                            button::primary(None, "Test")
+                        } else {
+                            button::secondary(None, "Test")
+                                .on_press(p2p(P2PMessage::MostroNodeNetworkToggled(true)))
+                        },
+                    ]
+                    .spacing(8)
+                    .align_y(iced::alignment::Vertical::Center),
                     if self.new_node_name_input.value.trim().is_empty()
                         || self.new_node_pubkey_input.value.trim().is_empty()
                     {
@@ -3794,9 +3900,11 @@ impl P2PPanel {
         )
         .width(Length::Fill);
 
-        let mut settings_col = column![nodes_card, relays_card]
-            .spacing(16)
-            .width(Length::Fill);
+        let mut settings_col = column![].spacing(16).width(Length::Fill);
+        if let Some(banner) = self.network_mismatch_banner() {
+            settings_col = settings_col.push(banner);
+        }
+        settings_col = settings_col.push(nodes_card).push(relays_card);
         if let Some(err) = self.mostro_config_error {
             settings_col = settings_col.push(p2_regular(err).style(theme::text::error));
         }
@@ -4041,6 +4149,8 @@ impl State for P2PPanel {
                                     &view::nav::NavContext {
                                         has_vault,
                                         has_p2p: cache.has_p2p,
+                                        network: cache.network,
+                                        p2p_test_coordinator: cache.p2p_test_coordinator,
                                         cube_name: &cache.cube_name,
                                         lightning_address: None,
                                         avatar: None,
@@ -4202,6 +4312,8 @@ impl State for P2PPanel {
                                         &view::nav::NavContext {
                                             has_vault,
                                             has_p2p: cache.has_p2p,
+                                            network: cache.network,
+                                            p2p_test_coordinator: cache.p2p_test_coordinator,
                                             cube_name: &cache.cube_name,
                                             lightning_address: None,
                                             avatar: None,
@@ -4259,6 +4371,8 @@ impl State for P2PPanel {
                                         &view::nav::NavContext {
                                             has_vault,
                                             has_p2p: cache.has_p2p,
+                                            network: cache.network,
+                                            p2p_test_coordinator: cache.p2p_test_coordinator,
                                             cube_name: &cache.cube_name,
                                             lightning_address: None,
                                             avatar: None,
@@ -4388,6 +4502,8 @@ impl State for P2PPanel {
                                         &view::nav::NavContext {
                                             has_vault,
                                             has_p2p: cache.has_p2p,
+                                            network: cache.network,
+                                            p2p_test_coordinator: cache.p2p_test_coordinator,
                                             cube_name: &cache.cube_name,
                                             lightning_address: None,
                                             avatar: None,
@@ -4442,6 +4558,8 @@ impl State for P2PPanel {
                                         &view::nav::NavContext {
                                             has_vault,
                                             has_p2p: cache.has_p2p,
+                                            network: cache.network,
+                                            p2p_test_coordinator: cache.p2p_test_coordinator,
                                             cube_name: &cache.cube_name,
                                             lightning_address: None,
                                             avatar: None,
@@ -4552,10 +4670,13 @@ impl State for P2PPanel {
     fn subscription(&self) -> Subscription<Message> {
         let cube_name = self.cube_name();
         let mnemonic = self.mnemonic.clone();
-        let active_pubkey = self.mostro_config.active_pubkey_hex().to_string();
-        let relays = self.mostro_config.relays.clone();
-        let mostro_sub =
-            super::mostro::mostro_subscription(cube_name, mnemonic, active_pubkey, relays);
+        let coordinator = self.resolved_coordinator();
+        let mostro_sub = super::mostro::mostro_subscription(
+            cube_name,
+            mnemonic,
+            coordinator.pubkey_hex,
+            coordinator.relays,
+        );
 
         // Tick every second when viewing a trade detail (for action countdown timer)
         let selected_is_active = self.selected_trade.as_ref().is_some_and(|id| {
@@ -4656,6 +4777,12 @@ impl State for P2PPanel {
             }
             P2PMessage::SubmitOrder => {
                 self.submit_attempted = true;
+                // Hard-block: never escrow against a coordinator whose
+                // network doesn't match the wallet's (COIN-371 Q4).
+                if !self.coordinator_network_matches() {
+                    self.order_submit_error = Some(COORDINATOR_MISMATCH_MSG.to_string());
+                    return Task::none();
+                }
                 // Double-check validation before showing confirmation
                 if self.validate_order_form().has_errors() {
                     return Task::none();
@@ -4667,6 +4794,13 @@ impl State for P2PPanel {
                 self.confirming_order = false;
             }
             P2PMessage::ConfirmOrder => {
+                // Hard-block chokepoint: refuse to escrow on a
+                // coordinator/network mismatch (COIN-371 Q4).
+                if !self.coordinator_network_matches() {
+                    self.confirming_order = false;
+                    self.order_submit_error = Some(COORDINATOR_MISMATCH_MSG.to_string());
+                    return Task::none();
+                }
                 // Final validation gate before sending to network
                 if self.validate_order_form().has_errors() {
                     self.confirming_order = false;
@@ -4945,6 +5079,9 @@ impl State for P2PPanel {
                 self.new_node_pubkey_input.warning = None;
                 self.new_node_pubkey_input.valid = true;
             }
+            P2PMessage::MostroNodeNetworkToggled(is_test) => {
+                self.new_node_is_test = is_test;
+            }
             P2PMessage::MostroAddNode => {
                 let name = self.new_node_name_input.value.trim().to_string();
                 let pubkey = self.new_node_pubkey_input.value.trim().to_string();
@@ -4968,12 +5105,18 @@ impl State for P2PPanel {
                     trial.nodes.push(MostroNode {
                         name,
                         pubkey_hex: pubkey,
+                        network: if self.new_node_is_test {
+                            NetworkKind::Test
+                        } else {
+                            NetworkKind::Mainnet
+                        },
                     });
                     match save_mostro_config(&trial) {
                         Ok(()) => {
                             self.mostro_config = trial;
                             self.new_node_name_input = Default::default();
                             self.new_node_pubkey_input = Default::default();
+                            self.new_node_is_test = false;
                             self.mostro_config_error = None;
                         }
                         Err(_) => {
@@ -5012,6 +5155,12 @@ impl State for P2PPanel {
             }
             // Take order flow
             P2PMessage::TakeOrder => {
+                // Hard-block: don't open the take flow when the active
+                // coordinator's network doesn't match the wallet (COIN-371 Q4).
+                if !self.coordinator_network_matches() {
+                    self.stream_error = Some(COORDINATOR_MISMATCH_MSG.to_string());
+                    return Task::none();
+                }
                 // Check if this order needs user input before confirming.
                 // Non-range orders where user is selling don't need any input,
                 // so skip straight to confirmation to avoid an invisible intermediate state.
@@ -5053,6 +5202,12 @@ impl State for P2PPanel {
                 self.take_order_submitting = false;
             }
             P2PMessage::ConfirmTakeOrder => {
+                // Hard-block chokepoint: refuse to escrow on a
+                // coordinator/network mismatch (COIN-371 Q4).
+                if !self.coordinator_network_matches() {
+                    self.stream_error = Some(COORDINATOR_MISMATCH_MSG.to_string());
+                    return Task::none();
+                }
                 if let Some(ref selected_id) = self.selected_order {
                     if let Some(order) = self.orders.iter().find(|o| o.id == *selected_id) {
                         let amount = if order.is_range_order() {

--- a/coincube-gui/src/app/view/p2p/panel.rs
+++ b/coincube-gui/src/app/view/p2p/panel.rs
@@ -4707,12 +4707,17 @@ impl State for P2PPanel {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        // When the active coordinator doesn't match the wallet's network,
-        // trading is hard-blocked and `resolved_coordinator` could fall back to
-        // a different coordinator than the one shown as active — so don't stream
-        // from it. The subscription resumes once a matching coordinator is
-        // selected (COIN-371 Q4).
-        let mostro_sub = if self.coordinator_network_matches() {
+        // Only stream from Mostro when P2P is actually usable, so the panel
+        // never holds a live relay subscription while the nav/content show P2P
+        // disabled. Two conditions, mirroring the rest of the gate:
+        //  - the feature is available on this network (test coordinator + a
+        //    connected Spark escrow backend — same as the nav gate), and
+        //  - the active coordinator matches the wallet's network (else
+        //    `resolved_coordinator` could stream from a different coordinator
+        //    than the one shown as active; COIN-371 Q4).
+        let p2p_available =
+            crate::app::features::p2p(self.network, self.has_test_coordinator()).is_available();
+        let mostro_sub = if p2p_available && self.coordinator_network_matches() {
             let cube_name = self.cube_name();
             let mnemonic = self.mnemonic.clone();
             let coordinator = self.resolved_coordinator();

--- a/coincube-gui/src/app/view/p2p/panel.rs
+++ b/coincube-gui/src/app/view/p2p/panel.rs
@@ -6022,6 +6022,13 @@ impl State for P2PPanel {
                 self.dispute_chat_input.value = v;
             }
             P2PMessage::SendDisputeChatMessage => {
+                // Hard-block: don't send to a coordinator whose network doesn't
+                // match the wallet (the subscription is also paused in that
+                // state, so replies wouldn't arrive). COIN-371 Q4.
+                if !self.coordinator_network_matches() {
+                    self.stream_error = Some(COORDINATOR_MISMATCH_MSG.to_string());
+                    return Task::none();
+                }
                 let text = self.dispute_chat_input.value.trim().to_string();
                 if text.is_empty() || self.pending_dispute_chat_message.is_some() {
                     return Task::none();
@@ -6085,6 +6092,13 @@ impl State for P2PPanel {
                 }
             }
             P2PMessage::SendChatMessage => {
+                // Hard-block: don't send to a coordinator whose network doesn't
+                // match the wallet (the subscription is also paused in that
+                // state, so replies wouldn't arrive). COIN-371 Q4.
+                if !self.coordinator_network_matches() {
+                    self.stream_error = Some(COORDINATOR_MISMATCH_MSG.to_string());
+                    return Task::none();
+                }
                 let text = self.chat_input.value.trim().to_string();
                 if text.is_empty() || self.pending_chat_message.is_some() {
                     return Task::none();
@@ -6391,6 +6405,13 @@ impl State for P2PPanel {
                 );
             }
             P2PMessage::FileSelected(path) => {
+                // Hard-block: don't send to a coordinator whose network doesn't
+                // match the wallet (the subscription is also paused in that
+                // state, so replies wouldn't arrive). COIN-371 Q4.
+                if !self.coordinator_network_matches() {
+                    self.stream_error = Some(COORDINATOR_MISMATCH_MSG.to_string());
+                    return Task::none();
+                }
                 if let Some(ref order_id) = self.active_order_id() {
                     let order_id = order_id.clone();
                     let oid_for_result = order_id.clone();

--- a/coincube-gui/src/app/view/p2p/panel.rs
+++ b/coincube-gui/src/app/view/p2p/panel.rs
@@ -1051,6 +1051,14 @@ impl P2PPanel {
             + Send
             + 'static,
     {
+        // Hard-block: every in-trade escrow action (submit invoice, confirm
+        // fiat, cancel, dispute) routes through here, so a single guard keeps
+        // them all off a coordinator whose network doesn't match the wallet
+        // (COIN-371 Q4) — matching the create/take entry points.
+        if !self.coordinator_network_matches() {
+            self.stream_error = Some(COORDINATOR_MISMATCH_MSG.to_string());
+            return Task::none();
+        }
         self.trade_action_loading = true;
         if let Some(ref order_id) = self.selected_trade {
             let data = super::mostro::TradeActionData {
@@ -4956,13 +4964,19 @@ impl State for P2PPanel {
                 return Task::done(Message::View(view::Message::Clipboard(id)));
             }
             P2PMessage::CancelOrder(order_id) => {
+                // Hard-block: cancel is a coordinator RPC too, so keep it off
+                // a wrong-network coordinator (COIN-371 Q4).
+                if !self.coordinator_network_matches() {
+                    self.stream_error = Some(COORDINATOR_MISMATCH_MSG.to_string());
+                    return Task::none();
+                }
                 let data = super::mostro::TradeActionData {
                     order_id,
                     cube_name: self.cube_name(),
                     mnemonic: self.mnemonic.clone(),
                     invoice: None,
-                    mostro_pubkey_hex: self.mostro_config.active_pubkey_hex().to_string(),
-                    relay_urls: self.mostro_config.relays.clone(),
+                    mostro_pubkey_hex: self.resolved_coordinator().pubkey_hex,
+                    relay_urls: self.resolved_coordinator().relays,
                 };
                 return Task::perform(super::mostro::cancel_trade(data), |result| {
                     Message::View(view::Message::P2P(P2PMessage::CancelOrderResult(
@@ -5243,8 +5257,8 @@ impl State for P2PPanel {
                             mnemonic: self.mnemonic.clone(),
                             amount,
                             lightning_invoice: invoice,
-                            mostro_pubkey_hex: self.mostro_config.active_pubkey_hex().to_string(),
-                            relay_urls: self.mostro_config.relays.clone(),
+                            mostro_pubkey_hex: self.resolved_coordinator().pubkey_hex,
+                            relay_urls: self.resolved_coordinator().relays,
                             fiat_code: Some(order.fiat_currency.clone()),
                             fiat_amount: Some(amount.unwrap_or(order.fiat_amount as i64)),
                             payment_method: Some(order.payment_methods.join(",")),
@@ -5624,6 +5638,12 @@ impl State for P2PPanel {
                 self.invoice_copied = false;
             }
             P2PMessage::CancelPaymentInvoice(order_id) => {
+                // Hard-block: keep this cancel RPC off a wrong-network
+                // coordinator (COIN-371 Q4).
+                if !self.coordinator_network_matches() {
+                    self.stream_error = Some(COORDINATOR_MISMATCH_MSG.to_string());
+                    return Task::none();
+                }
                 // Block cancel while a Spark RPC is in flight. If the
                 // prepare/send completes after we fire `cancel_trade`,
                 // Mostro and Spark disagree on the order state and the
@@ -5641,8 +5661,8 @@ impl State for P2PPanel {
                     cube_name: self.cube_name(),
                     mnemonic: self.mnemonic.clone(),
                     invoice: None,
-                    mostro_pubkey_hex: self.mostro_config.active_pubkey_hex().to_string(),
-                    relay_urls: self.mostro_config.relays.clone(),
+                    mostro_pubkey_hex: self.resolved_coordinator().pubkey_hex,
+                    relay_urls: self.resolved_coordinator().relays,
                 };
                 return Task::perform(super::mostro::cancel_trade(data), |result| {
                     Message::View(view::Message::P2P(P2PMessage::CancelOrderResult(
@@ -5808,8 +5828,8 @@ impl State for P2PPanel {
                     cube_name: self.cube_name(),
                     mnemonic: self.mnemonic.clone(),
                     invoice: None,
-                    mostro_pubkey_hex: self.mostro_config.active_pubkey_hex().to_string(),
-                    relay_urls: self.mostro_config.relays.clone(),
+                    mostro_pubkey_hex: self.resolved_coordinator().pubkey_hex,
+                    relay_urls: self.resolved_coordinator().relays,
                 };
                 return Task::perform(super::mostro::rate_counterparty(data, rating), |result| {
                     Message::View(view::Message::P2P(P2PMessage::TradeActionResult(result)))
@@ -5966,8 +5986,8 @@ impl State for P2PPanel {
                         cube_name,
                         mnemonic: self.mnemonic.clone(),
                         invoice: Some(text),
-                        mostro_pubkey_hex: self.mostro_config.active_pubkey_hex().to_string(),
-                        relay_urls: self.mostro_config.relays.clone(),
+                        mostro_pubkey_hex: self.resolved_coordinator().pubkey_hex,
+                        relay_urls: self.resolved_coordinator().relays,
                     };
                     return Task::perform(super::mostro::send_admin_chat_message(data), |result| {
                         Message::View(view::Message::P2P(P2PMessage::DisputeChatMessageSent(
@@ -6035,8 +6055,8 @@ impl State for P2PPanel {
                         cube_name,
                         mnemonic: self.mnemonic.clone(),
                         invoice: Some(text),
-                        mostro_pubkey_hex: self.mostro_config.active_pubkey_hex().to_string(),
-                        relay_urls: self.mostro_config.relays.clone(),
+                        mostro_pubkey_hex: self.resolved_coordinator().pubkey_hex,
+                        relay_urls: self.resolved_coordinator().relays,
                     };
                     return Task::perform(super::mostro::send_chat_message(data), |result| {
                         Message::View(view::Message::P2P(P2PMessage::ChatMessageSent(result)))
@@ -6317,8 +6337,9 @@ impl State for P2PPanel {
                     let oid_for_result = order_id.clone();
                     let cube_name = self.cube_name();
                     let mnemonic = self.mnemonic.clone();
-                    let mostro_pubkey_hex = self.mostro_config.active_pubkey_hex().to_string();
-                    let relay_urls = self.mostro_config.relays.clone();
+                    let coordinator = self.resolved_coordinator();
+                    let mostro_pubkey_hex = coordinator.pubkey_hex;
+                    let relay_urls = coordinator.relays;
 
                     self.attachment_sending = true;
                     return Task::perform(

--- a/coincube-gui/src/app/view/p2p/panel.rs
+++ b/coincube-gui/src/app/view/p2p/panel.rs
@@ -427,6 +427,29 @@ impl P2PPanel {
         network: Network,
     ) -> Self {
         let default_currency = default_currency.unwrap_or_else(|| "USD".to_string());
+        // Load the saved Mostro config. On failure (unreadable, corrupt, or
+        // written by a newer app version) fall back to defaults but surface
+        // the failure in Settings — and `save_mostro_config` refuses to
+        // overwrite a newer on-disk config, so the user's coordinators/relays
+        // aren't silently discarded.
+        let (mostro_config, mostro_config_error) = match load_mostro_config() {
+            Ok(mut cfg) => {
+                // Never start with a cross-network coordinator selected
+                // (COIN-371 §3.4) — prefer a node tagged for this network.
+                cfg.select_default_for(network);
+                (cfg, None)
+            }
+            Err(e) => {
+                tracing::error!("Failed to load mostro config, using defaults: {e}");
+                (
+                    MostroConfig::default(),
+                    Some(
+                        "Saved P2P config couldn't be loaded (it may be from a newer app \
+                         version); showing defaults. Changes won't overwrite it.",
+                    ),
+                )
+            }
+        };
         Self {
             wallet,
             spark_backend,
@@ -504,21 +527,12 @@ impl P2PPanel {
             dispute_chat_input: Default::default(),
             pending_dispute_chat_message: None,
             network,
-            mostro_config: {
-                let mut cfg = load_mostro_config().unwrap_or_else(|e| {
-                    tracing::error!("Failed to load mostro config, using defaults: {e}");
-                    MostroConfig::default()
-                });
-                // Never start with a cross-network coordinator selected
-                // (COIN-371 §3.4) — prefer a node tagged for this network.
-                cfg.select_default_for(network);
-                cfg
-            },
+            mostro_config,
             new_relay_input: Default::default(),
             new_node_name_input: Default::default(),
             new_node_pubkey_input: Default::default(),
             new_node_is_test: false,
-            mostro_config_error: None,
+            mostro_config_error,
             stream_error: None,
             cached_trade_messages: Vec::new(),
             cached_chat_identity: None,
@@ -3717,9 +3731,13 @@ impl P2PPanel {
     }
 
     /// Resolved P2P test-coordinator gate for this cube's network, mirrored
-    /// into [`Cache`] so the nav rail can grey the P2P item.
+    /// into [`Cache`] so the nav rail can grey the P2P item. Requires both a
+    /// test coordinator configured for the network (`MostroConfig`) *and* a
+    /// connected Spark backend — escrow is paid via HODL invoices over Spark,
+    /// so without an actual backend (e.g. the bridge failed to start on
+    /// regtest) P2P can't function and must stay gated.
     pub fn has_test_coordinator(&self) -> bool {
-        self.mostro_config.has_test_coordinator(self.network)
+        self.mostro_config.has_test_coordinator(self.network) && self.spark_backend.is_some()
     }
 
     /// Warning banner shown when the active coordinator's network doesn't
@@ -3860,9 +3878,14 @@ impl P2PPanel {
         .width(Length::Fill);
 
         // ── Relays card ──
+        // Edit the relay set the *current* network actually uses: the
+        // dedicated test relays on a test network, the shared set on mainnet.
+        // Otherwise test-network connections (which prefer `test_relays`)
+        // would be invisible and uneditable here.
+        let on_test_network = NetworkKind::of(self.network) == NetworkKind::Test;
         let relay_rows: Vec<Element<'a, view::Message>> = self
             .mostro_config
-            .relays
+            .settings_relays(self.network)
             .iter()
             .map(|relay| {
                 let remove_btn = button::secondary_compact(Some(icon::trash_icon()), "")
@@ -3879,10 +3902,18 @@ impl P2PPanel {
             })
             .collect();
 
+        let (relays_title, relays_subtitle) = if on_test_network {
+            (
+                "Test Relays",
+                "Relays for test-network Mostro connections (falls back to the shared relays when empty)",
+            )
+        } else {
+            ("Relays", "Relays used to connect to Mostro nodes")
+        };
         let relays_card = card::simple(
             column![
-                p1_bold("Relays"),
-                p2_regular("Relays used to connect to Mostro nodes").style(theme::text::secondary),
+                p1_bold(relays_title),
+                p2_regular(relays_subtitle).style(theme::text::secondary),
             ]
             .spacing(4)
             .push(column(relay_rows).spacing(12))
@@ -5050,12 +5081,16 @@ impl State for P2PPanel {
                 } else if !has_host {
                     self.new_relay_input.valid = false;
                     self.new_relay_input.warning = Some("Invalid relay URL — missing host");
-                } else if self.mostro_config.relays.contains(&url) {
+                } else if self
+                    .mostro_config
+                    .settings_relays(self.network)
+                    .contains(&url)
+                {
                     self.new_relay_input.valid = false;
                     self.new_relay_input.warning = Some("Relay already exists");
                 } else {
                     let mut trial = self.mostro_config.clone();
-                    trial.relays.push(url);
+                    trial.settings_relays_mut(self.network).push(url);
                     match save_mostro_config(&trial) {
                         Ok(()) => {
                             self.mostro_config = trial;
@@ -5071,7 +5106,9 @@ impl State for P2PPanel {
             }
             P2PMessage::MostroRemoveRelay(url) => {
                 let mut trial = self.mostro_config.clone();
-                trial.relays.retain(|r| r != &url);
+                trial
+                    .settings_relays_mut(self.network)
+                    .retain(|r| r != &url);
                 trial.ensure_defaults();
                 match save_mostro_config(&trial) {
                     Ok(()) => {
@@ -5815,6 +5852,13 @@ impl State for P2PPanel {
                 self.trade_rating = rating;
             }
             P2PMessage::SubmitRating => {
+                // Hard-block: rating is a coordinator RPC too, so keep it off a
+                // wrong-network coordinator like the other trade actions
+                // (COIN-371 Q4).
+                if !self.coordinator_network_matches() {
+                    self.stream_error = Some(COORDINATOR_MISMATCH_MSG.to_string());
+                    return Task::none();
+                }
                 let rating = self.trade_rating;
                 if rating == 0 {
                     return Task::none();

--- a/coincube-gui/src/app/view/p2p/panel.rs
+++ b/coincube-gui/src/app/view/p2p/panel.rs
@@ -432,13 +432,8 @@ impl P2PPanel {
         // the failure in Settings — and `save_mostro_config` refuses to
         // overwrite a newer on-disk config, so the user's coordinators/relays
         // aren't silently discarded.
-        let (mostro_config, mostro_config_error) = match load_mostro_config() {
-            Ok(mut cfg) => {
-                // Never start with a cross-network coordinator selected
-                // (COIN-371 §3.4) — prefer a node tagged for this network.
-                cfg.select_default_for(network);
-                (cfg, None)
-            }
+        let (mut mostro_config, mostro_config_error) = match load_mostro_config() {
+            Ok(cfg) => (cfg, None),
             Err(e) => {
                 tracing::error!("Failed to load mostro config, using defaults: {e}");
                 (
@@ -450,6 +445,11 @@ impl P2PPanel {
                 )
             }
         };
+        // Never start with a cross-network coordinator selected (COIN-371
+        // §3.4) — prefer a node tagged for this network. Applied to both the
+        // loaded and the default-fallback config so a test-network cube never
+        // starts on a mainnet coordinator.
+        mostro_config.select_default_for(network);
         Self {
             wallet,
             spark_backend,
@@ -4707,15 +4707,24 @@ impl State for P2PPanel {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        let cube_name = self.cube_name();
-        let mnemonic = self.mnemonic.clone();
-        let coordinator = self.resolved_coordinator();
-        let mostro_sub = super::mostro::mostro_subscription(
-            cube_name,
-            mnemonic,
-            coordinator.pubkey_hex,
-            coordinator.relays,
-        );
+        // When the active coordinator doesn't match the wallet's network,
+        // trading is hard-blocked and `resolved_coordinator` could fall back to
+        // a different coordinator than the one shown as active — so don't stream
+        // from it. The subscription resumes once a matching coordinator is
+        // selected (COIN-371 Q4).
+        let mostro_sub = if self.coordinator_network_matches() {
+            let cube_name = self.cube_name();
+            let mnemonic = self.mnemonic.clone();
+            let coordinator = self.resolved_coordinator();
+            super::mostro::mostro_subscription(
+                cube_name,
+                mnemonic,
+                coordinator.pubkey_hex,
+                coordinator.relays,
+            )
+        } else {
+            Subscription::none()
+        };
 
         // Tick every second when viewing a trade detail (for action countdown timer)
         let selected_is_active = self.selected_trade.as_ref().is_some_and(|id| {
@@ -5181,6 +5190,12 @@ impl State for P2PPanel {
                 let mut trial = self.mostro_config.clone();
                 trial.nodes.retain(|n| n.pubkey_hex != pubkey);
                 trial.ensure_defaults();
+                // `ensure_defaults` reselects `nodes[0]` network-blind (often
+                // the mainnet coordinator); re-pin to a node that matches this
+                // cube's network so removing the active test node doesn't leave
+                // a mainnet selection (mismatch hard-block) when another test
+                // node is still available.
+                trial.select_default_for(self.network);
                 match save_mostro_config(&trial) {
                     Ok(()) => {
                         self.mostro_config = trial;

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -1922,6 +1922,8 @@ pub fn create_app_with_remote_backend(
         Cache {
             network,
             datadir_path: coincube_dir.clone(),
+            // Recomputed from the P2P panel's Mostro config once panels are built.
+            p2p_test_coordinator: false,
             // We ignore last poll fields for remote backend.
             last_poll_at_startup: None,
             daemon_cache: DaemonCache {

--- a/coincube-gui/src/loader.rs
+++ b/coincube-gui/src/loader.rs
@@ -598,6 +598,8 @@ pub async fn load_application(
     let cache = Cache {
         datadir_path: config.datadir_path,
         network: config.info.network,
+        // Recomputed from the P2P panel's Mostro config once panels are built.
+        p2p_test_coordinator: false,
         last_poll_at_startup: config.info.last_poll_timestamp,
         daemon_cache: DaemonCache {
             blockheight: config.info.block_height,

--- a/coincube-ui/src/theme/button.rs
+++ b/coincube-ui/src/theme/button.rs
@@ -181,6 +181,21 @@ pub fn rail_active(theme: &Theme, _status: Status) -> Style {
     style
 }
 
+/// Disabled rail item — network-gated features that are greyed out with
+/// a hover popover instead of being hidden. Forces the disabled
+/// styling (muted text + icon) regardless of hover so the item reads as
+/// inert. Used by both the primary and secondary rails.
+pub fn rail_disabled(theme: &Theme, _status: Status) -> Style {
+    let mut style = button(&theme.colors.buttons.menu, Status::Disabled);
+    style.border.radius = 0.0.into();
+    style.border.width = 0.0;
+    // The default disabled alpha (0.2) is nearly invisible on the dark
+    // rail. Lift it so the greyed icon + label stay legible while still
+    // reading clearly as inert next to the full-strength active items.
+    style.text_color.a = 0.55;
+    style
+}
+
 pub fn tab_liquid(theme: &Theme, _status: Status) -> Style {
     tab(theme, Status::Pressed)
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches wallet loading, P2P escrow routing, and trading guards across many code paths; mistakes could block P2P on test networks or allow wrong-network coordinator use, though explicit hard-blocks and tests mitigate coordinator mismatch.
> 
> **Overview**
> Introduces **`app::features`** as the single source of truth for which capabilities (Spark, Liquid, Buy/Sell, P2P) work on each Bitcoin network. Navigation rails now **grey out** gated items with hover tooltips instead of hiding them; deep-linked or restored routes to unavailable features show a shared **“Not available on this network”** panel via `route_availability`.
> 
> **Liquid / Breez loading** is reworked: the master signer is loaded whenever possible, but the Liquid SDK only connects on mainnet (`features::liquid`). Elsewhere the app uses `BreezClient::disconnected_with_signer` so P2P can still derive Nostr identity from the mnemonic while Liquid stays gated. `BreezConfig::from_env` rejects unsupported networks and drops localhost Esplora fallbacks.
> 
> **P2P / Mostro** gains mainnet vs **test** coordinator tagging (`NetworkKind`), separate test relays, network-aware `active_for` / `select_default_for`, config versioning with forward-compat guards, and UI to add coordinators by network. Trading, chat, and subscriptions are **hard-blocked** when the active coordinator’s network doesn’t match the wallet; `Cache::p2p_test_coordinator` mirrors the panel so the sidebar can gate test-network P2P (test coordinator + Spark escrow on regtest).
> 
> Smaller UX: disabled rail button style (`rail_disabled`), avatar opens Cube → Avatar settings, Marketplace landing prefers enabled children (P2P Settings when trading is gated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2649dfe327a40d5a08dc9976f39dafbddf7bdeef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added network-aware feature availability (Spark, Liquid, Buy/Sell, P2P) with consistent "unavailable" reasons across the UI.
  * Disabled navigation items now appear inert with tooltips, and unavailable routes render a placeholder panel.
  * Added support for separating mainnet vs test-network Mostro coordinators for P2P, including network-aware routing.

* **Bug Fixes**
  * Prevented cross-network coordinator mismatches by blocking trading actions when coordinator network doesn't match the wallet network.
  * Improved Liquid network detection and explorer routing to avoid unsupported fallbacks.

* **Style**
  * Added dedicated disabled rail styling for navigation items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->