### PR TITLE
Add Rust coverage tooling and CI workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,46 @@
+name: Coverage
+
+on:
+  pull_request:
+    paths:
+      - "**/*.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "contrib/coverage.sh"
+      - ".github/workflows/coverage.yml"
+  workflow_dispatch:
+
+jobs:
+  rust-coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      BREEZ_API_KEY: DUMMY_BREEZ_API_KEY
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
+          components: llvm-tools-preview
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libudev-dev libfontconfig1-dev pkg-config libdbus-1-dev protobuf-compiler libwebkit2gtk-4.1-dev
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate coverage
+        run: ./contrib/coverage.sh
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: |
+            target/coverage/lcov.info
+            target/coverage/summary.json

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,13 +16,15 @@ jobs:
     timeout-minutes: 45
     env:
       BREEZ_API_KEY: DUMMY_BREEZ_API_KEY
+      CARGO_TOOLCHAIN: nightly-2026-06-17
+      COVERAGE_DOCTESTS: 1
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: 1.92.0
+          toolchain: nightly-2026-06-17
           components: llvm-tools-preview
 
       - name: Install system dependencies

--- a/contrib/coverage.sh
+++ b/contrib/coverage.sh
@@ -1,21 +1,101 @@
-# Assumes you have functional tests dependencies installed (likely you are in a venv)
+#!/usr/bin/env bash
+set -euo pipefail
 
-set -ex
+# Rust coverage for the main workspace. This intentionally excludes fuzz
+# targets: libFuzzer binaries do not behave like normal test binaries under
+# `-- --list` or coverage collection.
+#
+# Common local usage:
+#   ./contrib/coverage.sh
+#   HTML=1 ./contrib/coverage.sh
+#   FAIL_UNDER_LINES=45 ./contrib/coverage.sh
 
-if [ -z "$JOBS" ]; then JOBS=1; fi
+OUTPUT_DIR="${OUTPUT_DIR:-target/coverage}"
+LCOV_PATH="${LCOV_PATH:-${OUTPUT_DIR}/lcov.info}"
+SUMMARY_PATH="${SUMMARY_PATH:-${OUTPUT_DIR}/summary.json}"
+HTML="${HTML:-0}"
+COVERAGE_CLEAN="${COVERAGE_CLEAN:-1}"
 
-if ! command -v grcov &>/dev/null; then
-    cargo install grcov
+# The GUI embeds this value at compile time. Unit and integration tests do not
+# contact Breez unless explicitly configured, so mirror CI's harmless default.
+export BREEZ_API_KEY="${BREEZ_API_KEY:-DUMMY_BREEZ_API_KEY}"
+
+if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+error: cargo-llvm-cov is required.
+
+Install it with:
+  cargo install cargo-llvm-cov
+EOF
+  exit 1
 fi
 
-cargo clean
+mkdir -p "${OUTPUT_DIR}"
 
-rm -f "coincubed_coverage_*.profraw"
-LLVM_PROFILE_FILE="coincubed_coverage_%m.profraw" RUSTFLAGS="-Zinstrument-coverage" RUSTDOCFLAGS="$RUSTFLAGS -Z unstable-options --persist-doctests target/debug/doctestbins" cargo +nightly build --all-features
-LLVM_PROFILE_FILE="coincubed_coverage_%m.profraw" RUSTFLAGS="-Zinstrument-coverage" RUSTDOCFLAGS="$RUSTFLAGS -Z unstable-options --persist-doctests target/debug/doctestbins" cargo +nightly test --all-features
-pytest -n $JOBS
+coverage_args=(
+  --workspace
+  --exclude coincube-fuzz
+  --lib
+  --bins
+  --tests
+  --ignore-filename-regex '/(target|fuzz)/'
+)
 
-grcov . --source-dir ./src/ --binary-path ./target/debug/ -t html --branch --ignore-not-existing --llvm -o ./target/grcov/
-firefox target/grcov/index.html
+coverage_command=(
+  cargo llvm-cov
+  "${coverage_args[@]}"
+)
 
-set +ex
+if [[ "${COVERAGE_CLEAN}" != "1" ]]; then
+  coverage_command+=(--no-clean)
+fi
+
+if [[ -n "${FAIL_UNDER_LINES:-}" ]]; then
+  coverage_command+=(--fail-under-lines "${FAIL_UNDER_LINES}")
+fi
+if [[ -n "${FAIL_UNDER_FUNCTIONS:-}" ]]; then
+  coverage_command+=(--fail-under-functions "${FAIL_UNDER_FUNCTIONS}")
+fi
+if [[ -n "${FAIL_UNDER_REGIONS:-}" ]]; then
+  coverage_command+=(--fail-under-regions "${FAIL_UNDER_REGIONS}")
+fi
+
+if [[ "${COVERAGE_CLEAN}" == "1" ]]; then
+  cargo llvm-cov clean --workspace
+fi
+coverage_command+=(
+  --lcov
+  --output-path "${LCOV_PATH}"
+)
+set +e
+"${coverage_command[@]}" "$@"
+run_status=$?
+set -e
+
+cargo llvm-cov report \
+  --ignore-filename-regex '/(target|fuzz)/' \
+  --summary-only \
+  --json \
+  --output-path "${SUMMARY_PATH}"
+
+if [[ "${HTML}" == "1" ]]; then
+  cargo llvm-cov report \
+    --ignore-filename-regex '/(target|fuzz)/' \
+    --html \
+    --output-dir "${OUTPUT_DIR}/html"
+fi
+
+cat <<EOF
+Coverage artifacts written:
+  LCOV:    ${LCOV_PATH}
+  Summary: ${SUMMARY_PATH}
+EOF
+
+if [[ "${HTML}" == "1" ]]; then
+  echo "  HTML:    ${OUTPUT_DIR}/html/index.html"
+fi
+
+if [[ "${run_status}" -ne 0 ]]; then
+  echo "Coverage test run failed with exit status ${run_status}." >&2
+fi
+exit "${run_status}"

--- a/contrib/coverage.sh
+++ b/contrib/coverage.sh
@@ -9,12 +9,15 @@ set -euo pipefail
 #   ./contrib/coverage.sh
 #   HTML=1 ./contrib/coverage.sh
 #   FAIL_UNDER_LINES=45 ./contrib/coverage.sh
+#   CARGO_TOOLCHAIN=nightly COVERAGE_DOCTESTS=1 ./contrib/coverage.sh
 
 OUTPUT_DIR="${OUTPUT_DIR:-target/coverage}"
 LCOV_PATH="${LCOV_PATH:-${OUTPUT_DIR}/lcov.info}"
 SUMMARY_PATH="${SUMMARY_PATH:-${OUTPUT_DIR}/summary.json}"
 HTML="${HTML:-0}"
 COVERAGE_CLEAN="${COVERAGE_CLEAN:-1}"
+CARGO_TOOLCHAIN="${CARGO_TOOLCHAIN:-}"
+COVERAGE_DOCTESTS="${COVERAGE_DOCTESTS:-0}"
 
 # The GUI embeds this value at compile time. Unit and integration tests do not
 # contact Breez unless explicitly configured, so mirror CI's harmless default.
@@ -32,6 +35,12 @@ fi
 
 mkdir -p "${OUTPUT_DIR}"
 
+cargo_llvm_cov=(cargo)
+if [[ -n "${CARGO_TOOLCHAIN}" ]]; then
+  cargo_llvm_cov+=("+${CARGO_TOOLCHAIN}")
+fi
+cargo_llvm_cov+=(llvm-cov)
+
 coverage_args=(
   --workspace
   --exclude coincube-fuzz
@@ -41,8 +50,17 @@ coverage_args=(
   --ignore-filename-regex '/(target|fuzz)/'
 )
 
+report_args=(
+  --ignore-filename-regex '/(target|fuzz)/'
+)
+
+if [[ "${COVERAGE_DOCTESTS}" == "1" ]]; then
+  coverage_args+=(--doctests)
+  report_args+=(--doctests)
+fi
+
 coverage_command=(
-  cargo llvm-cov
+  "${cargo_llvm_cov[@]}"
   "${coverage_args[@]}"
 )
 
@@ -61,7 +79,7 @@ if [[ -n "${FAIL_UNDER_REGIONS:-}" ]]; then
 fi
 
 if [[ "${COVERAGE_CLEAN}" == "1" ]]; then
-  cargo llvm-cov clean --workspace
+  "${cargo_llvm_cov[@]}" clean --workspace
 fi
 coverage_command+=(
   --lcov
@@ -70,20 +88,23 @@ coverage_command+=(
 set +e
 "${coverage_command[@]}" "$@"
 run_status=$?
-set -e
 
-cargo llvm-cov report \
-  --ignore-filename-regex '/(target|fuzz)/' \
+"${cargo_llvm_cov[@]}" report \
+  "${report_args[@]}" \
   --summary-only \
   --json \
   --output-path "${SUMMARY_PATH}"
+summary_status=$?
 
+html_status=0
 if [[ "${HTML}" == "1" ]]; then
-  cargo llvm-cov report \
-    --ignore-filename-regex '/(target|fuzz)/' \
+  "${cargo_llvm_cov[@]}" report \
+    "${report_args[@]}" \
     --html \
     --output-dir "${OUTPUT_DIR}/html"
+  html_status=$?
 fi
+set -e
 
 cat <<EOF
 Coverage artifacts written:
@@ -97,5 +118,13 @@ fi
 
 if [[ "${run_status}" -ne 0 ]]; then
   echo "Coverage test run failed with exit status ${run_status}." >&2
+  exit "${run_status}"
 fi
-exit "${run_status}"
+if [[ "${summary_status}" -ne 0 ]]; then
+  echo "Coverage summary generation failed with exit status ${summary_status}." >&2
+  exit "${summary_status}"
+fi
+if [[ "${html_status}" -ne 0 ]]; then
+  echo "Coverage HTML generation failed with exit status ${html_status}." >&2
+  exit "${html_status}"
+fi

--- a/contrib/coverage.sh
+++ b/contrib/coverage.sh
@@ -41,13 +41,13 @@ if [[ -n "${CARGO_TOOLCHAIN}" ]]; then
 fi
 cargo_llvm_cov+=(llvm-cov)
 
-coverage_args=(
+test_args=(
   --workspace
   --exclude coincube-fuzz
   --lib
   --bins
   --tests
-  --ignore-filename-regex '/(target|fuzz)/'
+  --no-report
 )
 
 report_args=(
@@ -55,39 +55,47 @@ report_args=(
 )
 
 if [[ "${COVERAGE_DOCTESTS}" == "1" ]]; then
-  coverage_args+=(--doctests)
   report_args+=(--doctests)
 fi
 
-coverage_command=(
+test_command=(
   "${cargo_llvm_cov[@]}"
-  "${coverage_args[@]}"
+  "${test_args[@]}"
 )
 
-if [[ "${COVERAGE_CLEAN}" != "1" ]]; then
-  coverage_command+=(--no-clean)
-fi
-
 if [[ -n "${FAIL_UNDER_LINES:-}" ]]; then
-  coverage_command+=(--fail-under-lines "${FAIL_UNDER_LINES}")
+  report_args+=(--fail-under-lines "${FAIL_UNDER_LINES}")
 fi
 if [[ -n "${FAIL_UNDER_FUNCTIONS:-}" ]]; then
-  coverage_command+=(--fail-under-functions "${FAIL_UNDER_FUNCTIONS}")
+  report_args+=(--fail-under-functions "${FAIL_UNDER_FUNCTIONS}")
 fi
 if [[ -n "${FAIL_UNDER_REGIONS:-}" ]]; then
-  coverage_command+=(--fail-under-regions "${FAIL_UNDER_REGIONS}")
+  report_args+=(--fail-under-regions "${FAIL_UNDER_REGIONS}")
 fi
 
 if [[ "${COVERAGE_CLEAN}" == "1" ]]; then
   "${cargo_llvm_cov[@]}" clean --workspace
 fi
-coverage_command+=(
-  --lcov
-  --output-path "${LCOV_PATH}"
-)
+
 set +e
-"${coverage_command[@]}" "$@"
+"${test_command[@]}" "$@"
 run_status=$?
+
+doctest_status=0
+if [[ "${COVERAGE_DOCTESTS}" == "1" ]]; then
+  "${cargo_llvm_cov[@]}" \
+    --workspace \
+    --exclude coincube-fuzz \
+    --doc \
+    --no-report
+  doctest_status=$?
+fi
+
+"${cargo_llvm_cov[@]}" report \
+  "${report_args[@]}" \
+  --lcov \
+  --output-path "${LCOV_PATH}"
+lcov_status=$?
 
 "${cargo_llvm_cov[@]}" report \
   "${report_args[@]}" \
@@ -119,6 +127,14 @@ fi
 if [[ "${run_status}" -ne 0 ]]; then
   echo "Coverage test run failed with exit status ${run_status}." >&2
   exit "${run_status}"
+fi
+if [[ "${doctest_status}" -ne 0 ]]; then
+  echo "Coverage doctest run failed with exit status ${doctest_status}." >&2
+  exit "${doctest_status}"
+fi
+if [[ "${lcov_status}" -ne 0 ]]; then
+  echo "LCOV generation failed with exit status ${lcov_status}." >&2
+  exit "${lcov_status}"
 fi
 if [[ "${summary_status}" -ne 0 ]]; then
   echo "Coverage summary generation failed with exit status ${summary_status}." >&2

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests


### PR DESCRIPTION
## Summary
- replace the nightly/grcov coverage script with cargo-llvm-cov
- exclude fuzz targets and support LCOV, JSON, optional HTML, and coverage thresholds
- preserve reports when tests fail while returning the original test status
- add a GitHub Actions coverage workflow and artifact upload
- restrict pytest discovery to the application tests directory

## Verification
- bash -n contrib/coverage.sh
- git diff --check
- full instrumented workspace run produced LCOV and JSON reports
- pytest collection finds 44 application tests

## Current suite findings
- the instrumented run exposed timing sensitivity in local_signer_handshake_timeout
- coincubed::tests::daemon_startup failed after a 120-second startup stall

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and developer tooling only; no runtime product logic changes, though the coverage job may surface existing flaky or slow Rust tests.
> 
> **Overview**
> **Replaces** the old nightly `grcov` + Python pytest coverage flow with **`cargo-llvm-cov`** for the Rust workspace. Coverage now runs lib/bin/integration tests (and optional doctests), **excludes** `coincube-fuzz`, and writes **LCOV** and **JSON** summaries under `target/coverage`, with optional HTML and `FAIL_UNDER_*` thresholds. The script still **generates reports even when tests fail**, then exits with the test run’s status.
> 
> Adds a **GitHub Actions** `Coverage` job on relevant PRs (and `workflow_dispatch`): nightly toolchain, `llvm-tools`, GUI build deps, `cargo-llvm-cov`, artifact upload of `lcov.info` and `summary.json`.
> 
> Adds **`pytest.ini`** with `testpaths = tests` so bare `pytest` only collects application tests (Rust coverage no longer invokes pytest).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc226b78a95a94aa1c58a7cedbefaafc2cd40d15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->