### PR TITLE
Expand amount formatting unit coverage

### DIFF
--- a/coincube-ui/src/component/amount.rs
+++ b/coincube-ui/src/component/amount.rs
@@ -166,7 +166,8 @@ pub fn format_u64_as_string(value: u64, sep: &str) -> String {
 //   1000 => 1 000
 //   100000 => 100 000
 fn format_amount_number_part(s: &str, sep: &str) -> String {
-    let mut part = s
+    let (sign, digits) = s.strip_prefix('-').map_or(("", s), |digits| ("-", digits));
+    let mut part = digits
         .chars()
         .collect::<Vec<_>>()
         .rchunks(3)
@@ -174,7 +175,7 @@ fn format_amount_number_part(s: &str, sep: &str) -> String {
         .collect::<Vec<_>>();
     part.reverse();
 
-    part.join(sep)
+    format!("{sign}{}", part.join(sep))
 }
 
 // Helper functions split a string at the first occurence of a non-zero integer (where
@@ -341,5 +342,42 @@ mod tests {
 
         assert_eq!(format_f64_as_string(0.0, ",", 0, false), "0");
         assert_eq!(format_f64_as_string(0.0, ",", 0, true), "0");
+    }
+
+    #[test]
+    fn format_u64_groups_boundaries_and_max_value() {
+        assert_eq!(format_u64_as_string(0, " "), "0");
+        assert_eq!(format_u64_as_string(999, " "), "999");
+        assert_eq!(format_u64_as_string(1_000, " "), "1 000");
+        assert_eq!(
+            format_u64_as_string(u64::MAX, ","),
+            "18,446,744,073,709,551,615"
+        );
+    }
+
+    #[test]
+    fn negative_values_keep_sign_attached_to_leading_digits() {
+        assert_eq!(format_f64_as_string(-123.5, " ", 2, false), "-123.50");
+        assert_eq!(
+            format_f64_as_string(-1_234_567.5, ",", 2, false),
+            "-1,234,567.50"
+        );
+    }
+
+    #[test]
+    fn display_unit_labels_and_amounts_are_stable() {
+        let amount = Amount::from_sat(123_456_789);
+
+        assert_eq!(BitcoinDisplayUnit::default(), BitcoinDisplayUnit::Sats);
+        assert_eq!(BitcoinDisplayUnit::BTC.to_string(), "BTC");
+        assert_eq!(BitcoinDisplayUnit::Sats.to_string(), "sats");
+        assert_eq!(
+            amount.to_formatted_string_with_unit(BitcoinDisplayUnit::BTC),
+            "1.23 456 789"
+        );
+        assert_eq!(
+            amount.to_formatted_string_with_unit(BitcoinDisplayUnit::Sats),
+            "123 456 789"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add boundary coverage for satoshi grouping and u64::MAX
- test display-unit labels and BTC/sats formatting
- preserve a leading minus sign when grouping negative formatted values

## Verification
- cargo test -p coincube-ui component::amount::tests
- 5 tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting in the UI layer with no auth or data-path changes; behavior is locked by new unit tests.
> 
> **Overview**
> **Negative amounts** now format correctly: `format_amount_number_part` strips a leading `-`, applies digit grouping, then re-attaches the sign so values like `-1,234,567.50` stay readable instead of breaking grouping.
> 
> **Test coverage** adds boundary checks for sat grouping (`0`, `999`, `1 000`, `u64::MAX`), negative `format_f64_as_string` cases, and stable `BitcoinDisplayUnit` labels plus BTC/sats strings from `Amount::to_formatted_string_with_unit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aae8b6a7932d09315d632c63348ff8d099f814a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->