### PR TITLE
Test Spark overview payment mapping

### DIFF
--- a/coincube-gui/src/app/state/spark/overview.rs
+++ b/coincube-gui/src/app/state/spark/overview.rs
@@ -360,12 +360,7 @@ fn parse_method(raw: &str) -> SparkPaymentMethod {
 mod tests {
     use super::*;
 
-    fn payment(
-        direction: &str,
-        status: &str,
-        method: &str,
-        amount_sat: i64,
-    ) -> PaymentSummary {
+    fn payment(direction: &str, status: &str, method: &str, amount_sat: i64) -> PaymentSummary {
         PaymentSummary {
             id: "payment-1".to_string(),
             amount_sat,
@@ -383,8 +378,10 @@ mod tests {
 
     #[test]
     fn lightning_receive_maps_direction_status_amount_and_default_description() {
-        let row =
-            payment_summary_to_recent_tx(&payment("receive", "completed", "lightning", 42_000), None);
+        let row = payment_summary_to_recent_tx(
+            &payment("receive", "completed", "lightning", 42_000),
+            None,
+        );
 
         assert_eq!(row.id, "payment-1");
         assert!(row.is_incoming);

--- a/coincube-gui/src/app/state/spark/overview.rs
+++ b/coincube-gui/src/app/state/spark/overview.rs
@@ -355,3 +355,87 @@ fn parse_method(raw: &str) -> SparkPaymentMethod {
         _ => SparkPaymentMethod::Spark,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payment(
+        direction: &str,
+        status: &str,
+        method: &str,
+        amount_sat: i64,
+    ) -> PaymentSummary {
+        PaymentSummary {
+            id: "payment-1".to_string(),
+            amount_sat,
+            fees_sat: 12,
+            token_amount: None,
+            token_decimals: None,
+            token_ticker: None,
+            timestamp: 1_700_000_000,
+            status: status.to_string(),
+            direction: direction.to_string(),
+            method: method.to_string(),
+            description: None,
+        }
+    }
+
+    #[test]
+    fn lightning_receive_maps_direction_status_amount_and_default_description() {
+        let row =
+            payment_summary_to_recent_tx(&payment("receive", "completed", "lightning", 42_000), None);
+
+        assert_eq!(row.id, "payment-1");
+        assert!(row.is_incoming);
+        assert_eq!(row.status, DomainPaymentStatus::Complete);
+        assert_eq!(row.method, SparkPaymentMethod::Lightning);
+        assert_eq!(row.amount.to_sat(), 42_000);
+        assert_eq!(row.fees_sat.to_sat(), 12);
+        assert_eq!(row.description, "Lightning payment");
+        assert_eq!(row.token_display, None);
+    }
+
+    #[test]
+    fn onchain_withdraw_uses_outgoing_description_and_failed_status() {
+        let row =
+            payment_summary_to_recent_tx(&payment("Send", "Failed", "withdraw", -25_000), None);
+
+        assert!(!row.is_incoming);
+        assert_eq!(row.status, DomainPaymentStatus::Failed);
+        assert_eq!(row.method, SparkPaymentMethod::OnChainBitcoin);
+        assert_eq!(row.amount.to_sat(), 25_000);
+        assert_eq!(row.description, "On-chain withdrawal");
+    }
+
+    #[test]
+    fn unknown_wire_values_degrade_to_pending_spark_transfer() {
+        let row =
+            payment_summary_to_recent_tx(&payment("outbound", "future", "future", 1_000), None);
+
+        assert!(!row.is_incoming);
+        assert_eq!(row.status, DomainPaymentStatus::Pending);
+        assert_eq!(row.method, SparkPaymentMethod::Spark);
+        assert_eq!(row.description, "Spark transfer");
+    }
+
+    #[test]
+    fn token_payment_uses_token_units_instead_of_satoshis() {
+        let mut summary = payment("Receive", "Complete", "token", 999_999);
+        summary.fees_sat = 500;
+        summary.token_amount = Some(1_580_000);
+        summary.token_decimals = Some(6);
+        summary.token_ticker = Some("USDB".to_string());
+
+        let row = payment_summary_to_recent_tx(&summary, None);
+
+        assert!(row.is_incoming);
+        assert_eq!(row.status, DomainPaymentStatus::Complete);
+        assert_eq!(row.method, SparkPaymentMethod::StableBalance);
+        assert_eq!(row.amount, Amount::ZERO);
+        assert_eq!(row.fees_sat, Amount::ZERO);
+        assert_eq!(row.description, "Stable Balance");
+        assert_eq!(row.token_display.as_deref(), Some("1.58 USDB"));
+        assert!(row.fiat_amount.is_some());
+    }
+}


### PR DESCRIPTION
## Summary
- test Lightning receive mapping into overview rows
- test failed on-chain withdrawal mapping
- verify safe fallback behavior for unknown wire values
- verify Stable Balance token payments use token units instead of satoshis

## Verification
- cargo test -p coincube-gui app::state::spark::overview::tests
- 4 tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no modifications to production mapping logic.
> 
> **Overview**
> Adds a **`#[cfg(test)]`** module in `overview.rs` with four unit tests around **`payment_summary_to_recent_tx`**, locking in how bridge **`PaymentSummary`** values become overview transaction rows.
> 
> Coverage includes Lightning receives (direction, status, sats, default description), failed on-chain withdrawals, safe fallbacks when direction/status/method are unknown (pending + Spark transfer), and token/stable-balance payments (zero sats/fees, **`1.58 USDB`** display, fiat secondary line). **No production code changes**—behavior is documented and guarded by tests only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77c76f9a850de65380cabe301278122a86e4e9bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->