### PR TITLE
Inheritance recovery

### DIFF
--- a/coincube-gui/src/feature_flags.rs
+++ b/coincube-gui/src/feature_flags.rs
@@ -31,6 +31,16 @@ pub const PASSKEY_ENABLED: bool = is_truthy(option_env!("COINCUBE_ENABLE_PASSKEY
 /// rest of the panel code still compiles but is unreachable via UI.
 pub const CUBE_MEMBERS_UI_ENABLED: bool = is_truthy(option_env!("COINCUBE_CUBE_MEMBERS_UI"));
 
+/// Whether the heir "Recover a Vault" discovery surface (COIN-377 / PR 1) is
+/// shown on the launcher.
+///
+/// Controlled by the `COINCUBE_ENABLE_RECOVER_VAULT` env var at build time.
+/// Defaults to `false`: the surface depends on the API's net-new
+/// `/connect/cubes/recoverable` endpoint and the COIN-376 recovery sweep, so it
+/// stays dark until both ship. When `false`, the "Recover a Vault" sidebar entry
+/// is hidden; the panel code still compiles but is unreachable via UI.
+pub const RECOVER_VAULT_ENABLED: bool = is_truthy(option_env!("COINCUBE_ENABLE_RECOVER_VAULT"));
+
 /// `const`-compatible truthy check: accepts `"1"`, `"true"`, `"yes"`
 /// (case-insensitive for the latter two). Anything else, including `None`,
 /// is `false`.

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -15,6 +15,7 @@ use tokio::runtime::Handle;
 
 use crate::feature_flags;
 use crate::pin_input;
+use crate::recover_vault::{self, RecoverVaultMessage, RecoverVaultPanel};
 use crate::services::coincube::{
     CoincubeClient, CubeLimitsResponse, CubeResponse, RegisterCubeRequest, UpdateCubeRequest,
 };
@@ -89,6 +90,9 @@ pub enum HomeSection {
     Cubes,
     /// Connect account-level sub-page
     Connect(app::menu::ConnectSubMenu),
+    /// Heir "Recover a Vault" discovery surface (COIN-377 / PR 1). Global —
+    /// reachable even when the heir owns no Vault of their own.
+    RecoverVault,
 }
 
 /// Context stashed for firing a remote cube update after local rename succeeds.
@@ -119,6 +123,8 @@ pub struct Home {
     account_tier: AccountTier,
     /// Account-level Connect panel (login, plan, security, etc.)
     pub connect_account: ConnectAccountPanel,
+    /// Heir "Recover a Vault" discovery surface state (COIN-377 / PR 1).
+    pub recover_vault: RecoverVaultPanel,
     /// Whether the Connect sidebar section is expanded
     pub connect_expanded: bool,
     /// Which section is currently displayed in the main content area
@@ -190,6 +196,7 @@ impl Home {
                     &datadir_path,
                 )),
                 connect_account: ConnectAccountPanel::new(),
+                recover_vault: RecoverVaultPanel::new(),
                 connect_expanded: false,
                 active_section: HomeSection::Cubes,
                 theme_mode: GlobalSettings::load_theme_mode(&GlobalSettings::path(&datadir_path)),
@@ -1415,7 +1422,28 @@ impl Home {
                         self.connect_account.reload_duress_state(),
                     ]));
                 }
+                // Load the recoverable-vault list on demand when opening the
+                // heir discovery surface (once per session — `is_loaded()`
+                // guards re-fetch on every reopen).
+                if matches!(self.active_section, HomeSection::RecoverVault)
+                    && !self.recover_vault.is_loaded()
+                {
+                    let client = self.connect_account.authenticated_client();
+                    return self
+                        .recover_vault
+                        .update(RecoverVaultMessage::Load, client)
+                        .map(|m| Message::View(ViewMessage::RecoverVault(m)));
+                }
                 Task::none()
+            }
+
+            Message::View(ViewMessage::RecoverVault(msg)) => {
+                // Forward to the discovery panel with the heir's authenticated
+                // Connect client; map the panel's task back into home messages.
+                let client = self.connect_account.authenticated_client();
+                self.recover_vault
+                    .update(msg, client)
+                    .map(|m| Message::View(ViewMessage::RecoverVault(m)))
             }
 
             Message::View(ViewMessage::RenameCube(index)) => {
@@ -1976,6 +2004,10 @@ impl Home {
             let connect_view: Element<ConnectAccountMessage> =
                 crate::app::view::connect::connect_account_panel(&self.connect_account);
             connect_view.map(|msg| Message::View(ViewMessage::ConnectAccount(msg)))
+        } else if matches!(self.active_section, HomeSection::RecoverVault) {
+            // Heir "Recover a Vault" discovery surface (COIN-377 / PR 1).
+            recover_vault::view(&self.recover_vault)
+                .map(|msg| Message::View(ViewMessage::RecoverVault(msg)))
         } else {
             content
         };
@@ -2234,6 +2266,27 @@ fn home_sidebar<'a>(home: &'a Home) -> Element<'a, Message> {
             };
             col = col.push(item);
         }
+    }
+
+    // Heir "Recover a Vault" — global discovery surface (COIN-377 / PR 1).
+    // Gated behind the capability flag (dark until the API's `recoverable`
+    // endpoint + COIN-376 sweep ship) and only shown to a signed-in account.
+    if is_authenticated && feature_flags::RECOVER_VAULT_ENABLED {
+        let is_active = matches!(home.active_section, HomeSection::RecoverVault);
+        let recover_button = if is_active {
+            Row::new()
+                .push(btn::menu_active(Some(ic::cube_icon()), "Recover a Vault").width(Length::Fill))
+                .width(Length::Fill)
+        } else {
+            Row::new()
+                .push(
+                    btn::menu(Some(ic::cube_icon()), "Recover a Vault")
+                        .on_press(msg(ViewMessage::GoToSection(HomeSection::RecoverVault)))
+                        .width(Length::Fill),
+                )
+                .width(Length::Fill)
+        };
+        col = col.push(recover_button);
     }
 
     // Bottom-pinned section: Sign In / email + theme toggle
@@ -2935,6 +2988,8 @@ pub enum ViewMessage {
     ToggleConnect,
     /// Account-level Connect messages (login, plan, security, etc.)
     ConnectAccount(ConnectAccountMessage),
+    /// Heir "Recover a Vault" discovery-surface messages (COIN-377 / PR 1).
+    RecoverVault(RecoverVaultMessage),
     /// Toggle light/dark theme
     ToggleTheme,
     /// Toggle passkey mode for Cube creation (no PIN when enabled).

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1429,9 +1429,10 @@ impl Home {
                     && !self.recover_vault.is_loaded()
                 {
                     let client = self.connect_account.authenticated_client();
+                    let gen = self.connect_account.session_generation();
                     return self
                         .recover_vault
-                        .update(RecoverVaultMessage::Load, client)
+                        .update(RecoverVaultMessage::Load, client, gen)
                         .map(|m| Message::View(ViewMessage::RecoverVault(m)));
                 }
                 Task::none()
@@ -1440,9 +1441,12 @@ impl Home {
             Message::View(ViewMessage::RecoverVault(msg)) => {
                 // Forward to the discovery panel with the heir's authenticated
                 // Connect client; map the panel's task back into home messages.
+                // The session generation lets the panel drop a list fetch that
+                // resolves after a logout / account switch.
                 let client = self.connect_account.authenticated_client();
+                let gen = self.connect_account.session_generation();
                 self.recover_vault
-                    .update(msg, client)
+                    .update(msg, client, gen)
                     .map(|m| Message::View(ViewMessage::RecoverVault(m)))
             }
 
@@ -1590,6 +1594,11 @@ impl Home {
                     if !now_authenticated {
                         self.server_cube_limit = None;
                         self.remote_cubes.clear();
+                        // Reset the heir discovery surface back to Idle so the
+                        // next sign-in re-fetches: otherwise its `Loaded` state
+                        // (and `is_loaded()` re-fetch guard) would persist and a
+                        // later account would see the prior account's vault rows.
+                        self.recover_vault = RecoverVaultPanel::new();
                     }
                 }
                 // Auto-expand Connect submenu and navigate to Cubes after login
@@ -2275,7 +2284,9 @@ fn home_sidebar<'a>(home: &'a Home) -> Element<'a, Message> {
         let is_active = matches!(home.active_section, HomeSection::RecoverVault);
         let recover_button = if is_active {
             Row::new()
-                .push(btn::menu_active(Some(ic::cube_icon()), "Recover a Vault").width(Length::Fill))
+                .push(
+                    btn::menu_active(Some(ic::cube_icon()), "Recover a Vault").width(Length::Fill),
+                )
                 .width(Length::Fill)
         } else {
             Row::new()

--- a/coincube-gui/src/lib.rs
+++ b/coincube-gui/src/lib.rs
@@ -18,6 +18,7 @@ pub mod node;
 pub mod phone_signer;
 pub mod pin_entry;
 pub mod pin_input;
+pub mod recover_vault;
 pub mod services;
 pub mod signer;
 pub mod utils;

--- a/coincube-gui/src/recover_vault.rs
+++ b/coincube-gui/src/recover_vault.rs
@@ -134,8 +134,10 @@ pub enum ListState {
     /// Not yet requested (e.g. before the section is opened).
     #[default]
     Idle,
-    /// Fetch in flight.
-    Loading,
+    /// Fetch in flight. Carries the Connect session generation it was fired in
+    /// so a stale `Loaded` only clears *its own* dead load, never a newer
+    /// in-flight one from a later session.
+    Loading(u64),
     /// Fetched rows (possibly empty).
     Loaded(Vec<RecoverableVault>),
     /// Fetch failed — message is display-safe.
@@ -162,8 +164,11 @@ pub enum RecoverVaultMessage {
     Loaded(Result<Vec<RecoverableVault>, String>, u64),
     /// Heir clicked "Recover" on the given cube — pull its descriptor.
     Recover(u64),
-    /// Descriptor fetch resolved (cube id, plaintext descriptor | display copy).
-    Fetched(u64, Result<String, String>),
+    /// Descriptor fetch resolved (cube id, plaintext descriptor | display copy,
+    /// session generation the fetch was fired in). The `u64` lets a fetch from a
+    /// prior session (account switch, same cube) be dropped instead of painting
+    /// its result onto the new session's row.
+    Fetched(u64, Result<String, String>, u64),
 }
 
 impl RecoverVaultPanel {
@@ -178,7 +183,7 @@ impl RecoverVaultPanel {
     /// `Error` (a transient failure) both return false so the next reopen
     /// retries instead of leaving the heir stuck on a stale error.
     pub fn is_loaded(&self) -> bool {
-        matches!(self.list, ListState::Loading | ListState::Loaded(_))
+        matches!(self.list, ListState::Loading(_) | ListState::Loaded(_))
     }
 
     /// Drives the surface. `client` is the heir's authenticated Connect client
@@ -200,7 +205,7 @@ impl RecoverVaultPanel {
                     self.list = ListState::Error(SIGNED_OUT_PROMPT.to_string());
                     return Task::none();
                 };
-                self.list = ListState::Loading;
+                self.list = ListState::Loading(session_generation);
                 Task::perform(
                     async move {
                         client
@@ -215,12 +220,14 @@ impl RecoverVaultPanel {
                 // Drop a list that resolved after the session changed (logout /
                 // account switch) so we never paint the prior account's vaults.
                 if gen != session_generation {
-                    // If that dead fetch was still showing `Loading`, fall back
-                    // to `Idle` so `is_loaded()` is false and reopening refetches
-                    // — otherwise the pane is stranded on "Loading…" with no
-                    // request in flight. Leave `Loaded`/`Error`/`Idle` as-is so
-                    // a current-session result or a live retry isn't clobbered.
-                    if matches!(self.list, ListState::Loading) {
+                    // If the pane is still showing the `Loading` for *this* dead
+                    // fetch, fall back to `Idle` so `is_loaded()` is false and
+                    // reopening refetches — otherwise it's stranded on "Loading…"
+                    // with no request in flight. Match on the stored generation
+                    // so a newer in-flight load (later session) keeps its
+                    // `Loading`; and leave `Loaded`/`Error`/`Idle` untouched so a
+                    // current result or a live retry isn't clobbered.
+                    if matches!(self.list, ListState::Loading(g) if g == gen) {
                         self.list = ListState::Idle;
                     }
                     return Task::none();
@@ -250,15 +257,20 @@ impl RecoverVaultPanel {
                             .map_err(|e| e.to_string());
                         (cube_id, res)
                     },
-                    |(cube_id, res)| RecoverVaultMessage::Fetched(cube_id, res),
+                    move |(cube_id, res)| {
+                        RecoverVaultMessage::Fetched(cube_id, res, session_generation)
+                    },
                 )
             }
-            RecoverVaultMessage::Fetched(cube_id, res) => {
-                // Drop a descriptor fetch the user has moved on from: starting
-                // recovery on another vault replaces `active` (and a logout
-                // clears it), so an older request must not paint its
-                // "Recovery ready"/error onto whatever row is now in flight.
-                if self.active.as_ref().map(|(id, _)| *id) != Some(cube_id) {
+            RecoverVaultMessage::Fetched(cube_id, res, gen) => {
+                // Drop a descriptor fetch the user (or session) has moved on
+                // from: a stale generation means a prior session fired it (an
+                // account switch — even the same cube id), and a non-matching
+                // `active` id means recovery started on another row. Either way
+                // its "Recovery ready"/error must not paint onto the live row.
+                if gen != session_generation
+                    || self.active.as_ref().map(|(id, _)| *id) != Some(cube_id)
+                {
                     return Task::none();
                 }
                 let status = match res {
@@ -304,7 +316,7 @@ pub fn view(panel: &RecoverVaultPanel) -> Element<'_, RecoverVaultMessage> {
                 .center_x(Length::Fill)
                 .into()
         }
-        ListState::Loading => {
+        ListState::Loading(_) => {
             Container::new(p1_regular("Loading recoverable vaults…").style(theme::text::secondary))
                 .padding(20)
                 .center_x(Length::Fill)
@@ -524,7 +536,7 @@ mod tests {
         panel.list = ListState::Error("boom".to_string());
         assert!(!panel.is_loaded());
         // Loading: in flight → don't duplicate the request.
-        panel.list = ListState::Loading;
+        panel.list = ListState::Loading(0);
         assert!(panel.is_loaded());
         // Loaded: already have the list → don't refetch on reopen.
         panel.list = ListState::Loaded(vec![]);
@@ -556,11 +568,12 @@ mod tests {
 
     #[test]
     fn stale_loaded_while_loading_falls_back_to_idle() {
-        // A stale-session list resolving while the pane still shows `Loading`
-        // must drop back to `Idle` — not strand it on "Loading…" forever (which
-        // `is_loaded()` would treat as loaded, blocking refetch on reopen).
+        // A stale-session list (gen 1) resolving while the pane still shows the
+        // `Loading` for *that same* dead fetch must drop back to `Idle` — not
+        // strand it on "Loading…" forever (which `is_loaded()` would treat as
+        // loaded, blocking refetch on reopen).
         let mut panel = RecoverVaultPanel::new();
-        panel.list = ListState::Loading;
+        panel.list = ListState::Loading(1);
         let rows = vec![vault(VaultMonitoringLevel::Full, "available", false)];
         let _ = panel.update(RecoverVaultMessage::Loaded(Ok(rows), 1), None, 2);
         assert!(
@@ -569,6 +582,22 @@ mod tests {
             panel.list
         );
         assert!(!panel.is_loaded());
+    }
+
+    #[test]
+    fn stale_loaded_does_not_clobber_a_newer_loading() {
+        // A newer in-flight load (gen 2 `Loading`) must survive a stale (gen 1)
+        // result resolving — the reset only clears the dead generation's own
+        // `Loading`, never a later session's request.
+        let mut panel = RecoverVaultPanel::new();
+        panel.list = ListState::Loading(2);
+        let rows = vec![vault(VaultMonitoringLevel::Full, "available", false)];
+        let _ = panel.update(RecoverVaultMessage::Loaded(Ok(rows), 1), None, 2);
+        assert!(
+            matches!(panel.list, ListState::Loading(2)),
+            "newer in-flight Loading must be preserved, got {:?}",
+            panel.list
+        );
     }
 
     #[test]
@@ -599,7 +628,11 @@ mod tests {
         // resolves, so the matching `Fetched` is applied to the active row.
         panel.active = Some((7, RecoverStatus::Fetching));
         let _ = panel.update(
-            RecoverVaultMessage::Fetched(7, Err("Recovery is unavailable right now.".to_string())),
+            RecoverVaultMessage::Fetched(
+                7,
+                Err("Recovery is unavailable right now.".to_string()),
+                0,
+            ),
             None,
             0,
         );
@@ -619,13 +652,33 @@ mod tests {
         let mut panel = RecoverVaultPanel::new();
         panel.active = Some((8, RecoverStatus::Fetching));
         let _ = panel.update(
-            RecoverVaultMessage::Fetched(7, Ok("wsh(...)".to_string())),
+            RecoverVaultMessage::Fetched(7, Ok("wsh(...)".to_string()), 0),
             None,
             0,
         );
         assert!(
             matches!(panel.active, Some((8, RecoverStatus::Fetching))),
             "stale cube-7 fetch must leave cube-8's row untouched, got {:?}",
+            panel.active
+        );
+    }
+
+    #[test]
+    fn stale_session_fetch_for_same_cube_is_dropped() {
+        // Account A's descriptor fetch for cube 7 (gen 1) resolving in account
+        // B's session (gen 2) — same cube id, since both are keyholders — must
+        // be dropped, not painted onto B's in-flight row. The cube-id-only guard
+        // would miss this; the generation check catches it.
+        let mut panel = RecoverVaultPanel::new();
+        panel.active = Some((7, RecoverStatus::Fetching));
+        let _ = panel.update(
+            RecoverVaultMessage::Fetched(7, Ok("wsh(...)".to_string()), 1),
+            None,
+            2,
+        );
+        assert!(
+            matches!(panel.active, Some((7, RecoverStatus::Fetching))),
+            "stale-session fetch must not overwrite the new session's row, got {:?}",
             panel.active
         );
     }

--- a/coincube-gui/src/recover_vault.rs
+++ b/coincube-gui/src/recover_vault.rs
@@ -1,0 +1,450 @@
+//! Heir "Recover a Vault" discovery surface (COIN-377, PR 1).
+//!
+//! A **global, pre-cube** surface on the launcher/home screen: it lists the
+//! Vaults the signed-in account is a keyholder/beneficiary of (but does not
+//! own) and, once a vault's recovery window is open on-chain, lets the heir
+//! start recovery. It is reachable even if the heir has no Vault of their own
+//! (master decision #6) and is gated behind [`crate::feature_flags`]'s
+//! `RECOVER_VAULT_ENABLED` (the surface stays dark until the API's
+//! `/connect/cubes/recoverable` endpoint and the COIN-376 sweep ship).
+//!
+//! This module owns the discovery state + view. It depends on the tested
+//! Connect-client foundation:
+//! [`CoincubeClient::list_recoverable_vaults`](crate::services::coincube::CoincubeClient::list_recoverable_vaults)
+//! for the list and
+//! [`fetch_recovery_descriptor`](crate::services::recovery::fetch_recovery_descriptor)
+//! for the keyholder release. The release returns a plaintext descriptor; the
+//! watch-only install + bridge into the recovery screen is PR 2 / PR 3 (see the
+//! `TODO(PR 2)` seam in [`RecoverVaultPanel::update`]).
+
+use iced::widget::{scrollable, Space};
+use iced::{Alignment, Length, Task};
+
+use coincube_ui::{
+    component::{button as btn, card, text::*},
+    theme,
+    widget::{Column, Container, Element, Row},
+};
+
+use crate::services::coincube::{
+    CoincubeClient, RecoverableVault, RecoveryState, VaultMonitoringLevel,
+};
+use crate::services::recovery::fetch_recovery_descriptor;
+
+/// How a discovery row should present, encoding invariants I1 (state gating)
+/// and I7 (tier honesty). Password-required (Heartbeat) rows take precedence:
+/// they are never actionable in v1 regardless of window state, and must show
+/// the deferred-path copy rather than a broken "Recover" button.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RowKind {
+    /// Window open **and** Full-tier (password-free) → the "Recover" button is
+    /// live.
+    Actionable,
+    /// Window not open yet (Full-tier) → visible but not actionable; show the
+    /// expected-open date and "we'll email you".
+    NotYetOpen,
+    /// Heartbeat tier (`requires_recovery_password`) → deferred to COIN-375;
+    /// show the "recovery password required — coming later" copy, never a
+    /// button. Takes precedence over the window state.
+    PasswordDeferred,
+}
+
+/// Classifies a recoverable-vault row. Pure — the unit tests below pin the
+/// invariants. Heartbeat/password-required is checked first so an open
+/// (`available`/`reminding`) Heartbeat vault still routes to the deferred copy.
+pub fn classify(v: &RecoverableVault) -> RowKind {
+    if v.requires_recovery_password {
+        RowKind::PasswordDeferred
+    } else if v.recovery_state().is_open() {
+        RowKind::Actionable
+    } else {
+        RowKind::NotYetOpen
+    }
+}
+
+/// The user-facing status line for a non-actionable row (invariant I7 copy).
+/// Returns `None` for an actionable row (it gets a button, not a status line).
+pub fn status_copy(v: &RecoverableVault) -> Option<String> {
+    match classify(v) {
+        RowKind::Actionable => None,
+        RowKind::PasswordDeferred => {
+            Some("Recovery password required — coming in a later update.".to_string())
+        }
+        RowKind::NotYetOpen => Some(match v.expected_open_at {
+            Some(at) => format!(
+                "Recovery isn't open yet — expected around {}. We'll email you.",
+                at.format("%-d %b %Y")
+            ),
+            None => "Recovery isn't open yet — we'll email you when it is.".to_string(),
+        }),
+    }
+}
+
+/// Short, display-only label for a vault's monitoring tier.
+fn tier_label(level: VaultMonitoringLevel) -> &'static str {
+    match level {
+        VaultMonitoringLevel::Full => "Full monitoring",
+        VaultMonitoringLevel::Heartbeat => "Alerts only",
+        VaultMonitoringLevel::Off => "Not monitored",
+    }
+}
+
+/// Short, display-only label for a vault's recovery-window state.
+fn state_label(state: RecoveryState) -> &'static str {
+    match state {
+        RecoveryState::Open => "Recovery open",
+        RecoveryState::Approaching => "Approaching",
+    }
+}
+
+/// In-flight status for the row the heir clicked "Recover" on.
+#[derive(Debug, Clone)]
+pub enum RecoverStatus {
+    /// Pulling the descriptor from the keyholder release endpoint.
+    Fetching,
+    /// Descriptor fetched. PR 2 picks up here (watch-only install).
+    Ready,
+    /// Gate/error copy (already neutralised by `KeyholderRecoveryError`'s
+    /// `Display`, so it is safe to show verbatim — never explains duress).
+    Failed(String),
+}
+
+/// Loading state for the discovery list.
+#[derive(Debug, Clone, Default)]
+pub enum ListState {
+    /// Not yet requested (e.g. before the section is opened).
+    #[default]
+    Idle,
+    /// Fetch in flight.
+    Loading,
+    /// Fetched rows (possibly empty).
+    Loaded(Vec<RecoverableVault>),
+    /// Fetch failed — message is display-safe.
+    Error(String),
+}
+
+/// State for the discovery surface.
+#[derive(Debug, Clone, Default)]
+pub struct RecoverVaultPanel {
+    list: ListState,
+    /// The cube currently being recovered, with its inline status.
+    active: Option<(u64, RecoverStatus)>,
+}
+
+/// Messages for the discovery surface. Home forwards these via
+/// `ViewMessage::RecoverVault(..)` and maps the returned task back.
+#[derive(Debug, Clone)]
+pub enum RecoverVaultMessage {
+    /// (Re)fetch the recoverable-vault list.
+    Load,
+    /// List fetch resolved.
+    Loaded(Result<Vec<RecoverableVault>, String>),
+    /// Heir clicked "Recover" on the given cube — pull its descriptor.
+    Recover(u64),
+    /// Descriptor fetch resolved (cube id, plaintext descriptor | display copy).
+    Fetched(u64, Result<String, String>),
+}
+
+impl RecoverVaultPanel {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// True once the list has been requested at least once — lets Home avoid
+    /// re-firing `Load` every time the section is reopened.
+    pub fn is_loaded(&self) -> bool {
+        !matches!(self.list, ListState::Idle)
+    }
+
+    /// Drives the surface. `client` is the heir's authenticated Connect client
+    /// (`None` when signed out — every action degrades to a sign-in prompt).
+    pub fn update(
+        &mut self,
+        message: RecoverVaultMessage,
+        client: Option<CoincubeClient>,
+    ) -> Task<RecoverVaultMessage> {
+        match message {
+            RecoverVaultMessage::Load => {
+                let Some(client) = client else {
+                    self.list = ListState::Error(
+                        "Sign in to your account to see vaults you can recover.".to_string(),
+                    );
+                    return Task::none();
+                };
+                self.list = ListState::Loading;
+                Task::perform(
+                    async move {
+                        client
+                            .list_recoverable_vaults()
+                            .await
+                            .map_err(|e| e.to_string())
+                    },
+                    RecoverVaultMessage::Loaded,
+                )
+            }
+            RecoverVaultMessage::Loaded(res) => {
+                self.list = match res {
+                    Ok(rows) => ListState::Loaded(rows),
+                    Err(e) => ListState::Error(e),
+                };
+                Task::none()
+            }
+            RecoverVaultMessage::Recover(cube_id) => {
+                let Some(client) = client else {
+                    self.active = Some((
+                        cube_id,
+                        RecoverStatus::Failed("Sign in to recover this vault.".to_string()),
+                    ));
+                    return Task::none();
+                };
+                self.active = Some((cube_id, RecoverStatus::Fetching));
+                Task::perform(
+                    async move {
+                        // The keyholder release returns the PLAINTEXT descriptor;
+                        // gate failures are already mapped to neutral, display-safe
+                        // copy by `KeyholderRecoveryError`'s `Display`.
+                        let res = fetch_recovery_descriptor(&client, cube_id)
+                            .await
+                            .map_err(|e| e.to_string());
+                        (cube_id, res)
+                    },
+                    |(cube_id, res)| RecoverVaultMessage::Fetched(cube_id, res),
+                )
+            }
+            RecoverVaultMessage::Fetched(cube_id, res) => {
+                let status = match res {
+                    Ok(_descriptor) => {
+                        // TODO(PR 2): hand the plaintext `_descriptor` to the
+                        // installer's `install_local_wallet()` path (a new
+                        // `UserFlow::RecoverKeyholderVault { cube_id }`) to create
+                        // the watch-only "Recovered Vault — [label]", then bridge
+                        // into `vault/recovery.rs` for the sweep (PR 3). For PR 1
+                        // we confirm the gated fetch succeeded.
+                        RecoverStatus::Ready
+                    }
+                    Err(copy) => RecoverStatus::Failed(copy),
+                };
+                self.active = Some((cube_id, status));
+                Task::none()
+            }
+        }
+    }
+}
+
+/// Renders the discovery surface for the launcher main-content area.
+pub fn view(panel: &RecoverVaultPanel) -> Element<'_, RecoverVaultMessage> {
+    let header = Column::new()
+        .spacing(6)
+        .push(h4_bold("Recover a Vault"))
+        .push(
+            p2_regular(
+                "Vaults you're a keyholder for appear here. When a vault's \
+                 recovery window opens, you can recover it — no password needed.",
+            )
+            .style(theme::text::secondary),
+        );
+
+    let body: Element<RecoverVaultMessage> = match &panel.list {
+        ListState::Idle | ListState::Loading => {
+            Container::new(p1_regular("Loading recoverable vaults…").style(theme::text::secondary))
+                .padding(20)
+                .center_x(Length::Fill)
+                .into()
+        }
+        ListState::Error(msg) => Container::new(
+            p1_regular(msg.clone()).style(theme::text::secondary),
+        )
+        .padding(20)
+        .center_x(Length::Fill)
+        .into(),
+        ListState::Loaded(rows) if rows.is_empty() => Container::new(
+            p1_regular("No vaults are available for you to recover right now.")
+                .style(theme::text::secondary),
+        )
+        .padding(20)
+        .center_x(Length::Fill)
+        .into(),
+        ListState::Loaded(rows) => {
+            let mut col = Column::new().spacing(12);
+            for row in rows {
+                col = col.push(vault_row(row, panel.active.as_ref()));
+            }
+            scrollable(col).into()
+        }
+    };
+
+    Column::new()
+        .spacing(20)
+        .width(Length::Fill)
+        .push(header)
+        .push(body)
+        .into()
+}
+
+/// One discovery row: title + tier/state meta + a CTA appropriate to its kind.
+fn vault_row<'a>(
+    v: &'a RecoverableVault,
+    active: Option<&'a (u64, RecoverStatus)>,
+) -> Element<'a, RecoverVaultMessage> {
+    let title = v
+        .owner_label
+        .clone()
+        .unwrap_or_else(|| format!("Vault #{}", v.cube_id));
+
+    let meta = format!(
+        "{} • {}",
+        tier_label(v.monitoring_level),
+        state_label(v.recovery_state())
+    );
+
+    let mut left = Column::new()
+        .spacing(4)
+        .push(p1_bold(title))
+        .push(caption(meta).style(theme::text::secondary));
+
+    // Non-actionable rows carry their status copy under the meta line.
+    if let Some(copy) = status_copy(v) {
+        left = left.push(p2_regular(copy).style(theme::text::secondary));
+    }
+
+    // The actionable CTA: either the live "Recover" button or, if this row is
+    // the one in flight, its inline status.
+    let cta: Element<RecoverVaultMessage> = if classify(v) == RowKind::Actionable {
+        match active {
+            Some((id, status)) if *id == v.cube_id => recover_status_view(status),
+            _ => btn::primary(None, "Recover")
+                .on_press(RecoverVaultMessage::Recover(v.cube_id))
+                .into(),
+        }
+    } else {
+        Space::new().width(Length::Fixed(0.0)).into()
+    };
+
+    card::simple(
+        Row::new()
+            .align_y(Alignment::Center)
+            .push(Container::new(left).width(Length::Fill))
+            .push(cta),
+    )
+    .padding(16)
+    .width(Length::Fill)
+    .into()
+}
+
+/// Inline status shown in place of the "Recover" button while a fetch is in
+/// flight or after it resolves.
+fn recover_status_view(status: &RecoverStatus) -> Element<'_, RecoverVaultMessage> {
+    match status {
+        RecoverStatus::Fetching => p2_regular("Preparing recovery…")
+            .style(theme::text::secondary)
+            .into(),
+        RecoverStatus::Ready => p2_bold("Recovery ready").into(),
+        RecoverStatus::Failed(copy) => p2_regular(copy.clone())
+            .style(theme::text::secondary)
+            .into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vault(level: VaultMonitoringLevel, state: &str, pw: bool) -> RecoverableVault {
+        RecoverableVault {
+            cube_id: 1,
+            owner_label: None,
+            monitoring_level: level,
+            state: state.to_string(),
+            requires_recovery_password: pw,
+            owner_last_active: None,
+            expected_open_at: None,
+            gap_limit: None,
+        }
+    }
+
+    #[test]
+    fn full_open_is_actionable() {
+        let v = vault(VaultMonitoringLevel::Full, "available", false);
+        assert_eq!(classify(&v), RowKind::Actionable);
+        assert!(status_copy(&v).is_none());
+    }
+
+    #[test]
+    fn full_reminding_is_actionable() {
+        // `reminding` is a later "still open" state — also actionable.
+        let v = vault(VaultMonitoringLevel::Full, "reminding", false);
+        assert_eq!(classify(&v), RowKind::Actionable);
+    }
+
+    #[test]
+    fn full_approaching_is_not_yet_open() {
+        let v = vault(VaultMonitoringLevel::Full, "approaching", false);
+        assert_eq!(classify(&v), RowKind::NotYetOpen);
+        assert!(status_copy(&v).unwrap().contains("isn't open yet"));
+    }
+
+    #[test]
+    fn full_none_is_not_yet_open() {
+        let v = vault(VaultMonitoringLevel::Full, "none", false);
+        assert_eq!(classify(&v), RowKind::NotYetOpen);
+    }
+
+    #[test]
+    fn heartbeat_requires_password_is_deferred_even_when_open() {
+        // Tier honesty (I7): an open Heartbeat vault is NOT a live button —
+        // it must show the deferred-path copy.
+        let v = vault(VaultMonitoringLevel::Heartbeat, "available", true);
+        assert_eq!(classify(&v), RowKind::PasswordDeferred);
+        assert_eq!(
+            status_copy(&v).unwrap(),
+            "Recovery password required — coming in a later update."
+        );
+    }
+
+    #[test]
+    fn password_required_takes_precedence_over_not_open() {
+        let v = vault(VaultMonitoringLevel::Heartbeat, "approaching", true);
+        assert_eq!(classify(&v), RowKind::PasswordDeferred);
+    }
+
+    #[test]
+    fn unknown_state_fails_closed_to_not_open() {
+        // An unrecognised wire state must never become a live Recover button.
+        let v = vault(VaultMonitoringLevel::Full, "weird-future-state", false);
+        assert_eq!(classify(&v), RowKind::NotYetOpen);
+    }
+
+    #[test]
+    fn load_without_client_surfaces_signin_prompt() {
+        let mut panel = RecoverVaultPanel::new();
+        let _ = panel.update(RecoverVaultMessage::Load, None);
+        match &panel.list {
+            ListState::Error(msg) => assert!(msg.contains("Sign in")),
+            other => panic!("expected sign-in error, got {:?}", other),
+        }
+        assert!(panel.is_loaded());
+    }
+
+    #[test]
+    fn loaded_stores_rows() {
+        let mut panel = RecoverVaultPanel::new();
+        let rows = vec![vault(VaultMonitoringLevel::Full, "available", false)];
+        let _ = panel.update(RecoverVaultMessage::Loaded(Ok(rows)), None);
+        assert!(matches!(panel.list, ListState::Loaded(ref r) if r.len() == 1));
+    }
+
+    #[test]
+    fn fetched_error_copy_is_shown_verbatim() {
+        let mut panel = RecoverVaultPanel::new();
+        let _ = panel.update(
+            RecoverVaultMessage::Fetched(7, Err("Recovery is unavailable right now.".to_string())),
+            None,
+        );
+        match panel.active {
+            Some((7, RecoverStatus::Failed(copy))) => {
+                assert_eq!(copy, "Recovery is unavailable right now.")
+            }
+            other => panic!("expected failed status, got {:?}", other),
+        }
+    }
+}

--- a/coincube-gui/src/recover_vault.rs
+++ b/coincube-gui/src/recover_vault.rs
@@ -37,9 +37,13 @@ use crate::services::recovery::fetch_recovery_descriptor;
 /// the deferred-path copy rather than a broken "Recover" button.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RowKind {
-    /// Window open **and** Full-tier (password-free) → the "Recover" button is
-    /// live.
+    /// Window open **and** Full-tier (password-free) **and** the caller is a
+    /// keyholder → the "Recover" button is live.
     Actionable,
+    /// Window open, but the caller is a beneficiary, not a keyholder → the
+    /// descriptor pull-down is keyholder-only (the release endpoint 403s
+    /// non-keyholders), so show "a keyholder completes this", never a button.
+    KeyholderOnly,
     /// Window not open yet (Full-tier) → visible but not actionable; show the
     /// expected-open date and "we'll email you".
     NotYetOpen,
@@ -51,12 +55,18 @@ pub enum RowKind {
 
 /// Classifies a recoverable-vault row. Pure — the unit tests below pin the
 /// invariants. Heartbeat/password-required is checked first so an open
-/// (`available`/`reminding`) Heartbeat vault still routes to the deferred copy.
+/// (`available`/`reminding`) Heartbeat vault still routes to the deferred copy;
+/// then the keyholder gate, so an open vault the caller can't pull down (they're
+/// a beneficiary) shows the keyholder-only copy rather than a 403'ing button.
 pub fn classify(v: &RecoverableVault) -> RowKind {
     if v.requires_recovery_password {
         RowKind::PasswordDeferred
     } else if v.recovery_state().is_open() {
-        RowKind::Actionable
+        if v.is_keyholder() {
+            RowKind::Actionable
+        } else {
+            RowKind::KeyholderOnly
+        }
     } else {
         RowKind::NotYetOpen
     }
@@ -67,6 +77,9 @@ pub fn classify(v: &RecoverableVault) -> RowKind {
 pub fn status_copy(v: &RecoverableVault) -> Option<String> {
     match classify(v) {
         RowKind::Actionable => None,
+        RowKind::KeyholderOnly => {
+            Some("Recovery is open — a keyholder of this vault can complete it.".to_string())
+        }
         RowKind::PasswordDeferred => {
             Some("Recovery password required — coming in a later update.".to_string())
         }
@@ -137,8 +150,10 @@ pub struct RecoverVaultPanel {
 pub enum RecoverVaultMessage {
     /// (Re)fetch the recoverable-vault list.
     Load,
-    /// List fetch resolved.
-    Loaded(Result<Vec<RecoverableVault>, String>),
+    /// List fetch resolved. The `u64` is the Connect session generation the
+    /// fetch was fired in — a stale value (logout / account switch landed
+    /// first) is dropped rather than painting the prior account's vaults.
+    Loaded(Result<Vec<RecoverableVault>, String>, u64),
     /// Heir clicked "Recover" on the given cube — pull its descriptor.
     Recover(u64),
     /// Descriptor fetch resolved (cube id, plaintext descriptor | display copy).
@@ -150,18 +165,28 @@ impl RecoverVaultPanel {
         Self::default()
     }
 
-    /// True once the list has been requested at least once — lets Home avoid
-    /// re-firing `Load` every time the section is reopened.
+    /// Whether Home should skip re-firing `Load` when the section is reopened.
+    /// True only while a fetch is in flight (`Loading`) or has succeeded
+    /// (`Loaded`) — so a successful list isn't re-fetched on every reopen, and
+    /// an in-flight fetch isn't duplicated. `Idle` (never requested) and
+    /// `Error` (a transient failure) both return false so the next reopen
+    /// retries instead of leaving the heir stuck on a stale error.
     pub fn is_loaded(&self) -> bool {
-        !matches!(self.list, ListState::Idle)
+        matches!(self.list, ListState::Loading | ListState::Loaded(_))
     }
 
     /// Drives the surface. `client` is the heir's authenticated Connect client
     /// (`None` when signed out — every action degrades to a sign-in prompt).
+    /// `session_generation` is the Connect account's current session counter
+    /// (bumped on login / logout / reset); it is stamped into the spawned list
+    /// fetch so a response that lands after the session changed is dropped
+    /// instead of painting a prior account's vaults — the same guard the
+    /// duress-contacts / recovery-alerts handlers use.
     pub fn update(
         &mut self,
         message: RecoverVaultMessage,
         client: Option<CoincubeClient>,
+        session_generation: u64,
     ) -> Task<RecoverVaultMessage> {
         match message {
             RecoverVaultMessage::Load => {
@@ -179,10 +204,15 @@ impl RecoverVaultPanel {
                             .await
                             .map_err(|e| e.to_string())
                     },
-                    RecoverVaultMessage::Loaded,
+                    move |res| RecoverVaultMessage::Loaded(res, session_generation),
                 )
             }
-            RecoverVaultMessage::Loaded(res) => {
+            RecoverVaultMessage::Loaded(res, gen) => {
+                // Drop a list that resolved after the session changed (logout /
+                // account switch) so we never paint the prior account's vaults.
+                if gen != session_generation {
+                    return Task::none();
+                }
                 self.list = match res {
                     Ok(rows) => ListState::Loaded(rows),
                     Err(e) => ListState::Error(e),
@@ -212,6 +242,13 @@ impl RecoverVaultPanel {
                 )
             }
             RecoverVaultMessage::Fetched(cube_id, res) => {
+                // Drop a descriptor fetch the user has moved on from: starting
+                // recovery on another vault replaces `active` (and a logout
+                // clears it), so an older request must not paint its
+                // "Recovery ready"/error onto whatever row is now in flight.
+                if self.active.as_ref().map(|(id, _)| *id) != Some(cube_id) {
+                    return Task::none();
+                }
                 let status = match res {
                     Ok(_descriptor) => {
                         // TODO(PR 2): hand the plaintext `_descriptor` to the
@@ -251,12 +288,12 @@ pub fn view(panel: &RecoverVaultPanel) -> Element<'_, RecoverVaultMessage> {
                 .center_x(Length::Fill)
                 .into()
         }
-        ListState::Error(msg) => Container::new(
-            p1_regular(msg.clone()).style(theme::text::secondary),
-        )
-        .padding(20)
-        .center_x(Length::Fill)
-        .into(),
+        ListState::Error(msg) => {
+            Container::new(p1_regular(msg.clone()).style(theme::text::secondary))
+                .padding(20)
+                .center_x(Length::Fill)
+                .into()
+        }
         ListState::Loaded(rows) if rows.is_empty() => Container::new(
             p1_regular("No vaults are available for you to recover right now.")
                 .style(theme::text::secondary),
@@ -349,12 +386,18 @@ fn recover_status_view(status: &RecoverStatus) -> Element<'_, RecoverVaultMessag
 mod tests {
     use super::*;
 
-    fn vault(level: VaultMonitoringLevel, state: &str, pw: bool) -> RecoverableVault {
+    fn vault_role(
+        level: VaultMonitoringLevel,
+        state: &str,
+        pw: bool,
+        role: &str,
+    ) -> RecoverableVault {
         RecoverableVault {
             cube_id: 1,
             owner_label: None,
             monitoring_level: level,
             state: state.to_string(),
+            role: role.to_string(),
             requires_recovery_password: pw,
             owner_last_active: None,
             expected_open_at: None,
@@ -362,11 +405,34 @@ mod tests {
         }
     }
 
+    /// The common case: the caller is a keyholder (the only role that can pull
+    /// the descriptor down). Beneficiary cases construct via `vault_role`.
+    fn vault(level: VaultMonitoringLevel, state: &str, pw: bool) -> RecoverableVault {
+        vault_role(level, state, pw, "keyholder")
+    }
+
     #[test]
     fn full_open_is_actionable() {
         let v = vault(VaultMonitoringLevel::Full, "available", false);
         assert_eq!(classify(&v), RowKind::Actionable);
         assert!(status_copy(&v).is_none());
+    }
+
+    #[test]
+    fn beneficiary_open_full_is_keyholder_only_not_actionable() {
+        // Same open + Full-tier state as `full_open_is_actionable`, but the
+        // caller is a beneficiary: the descriptor pull-down is keyholder-only
+        // (the release endpoint 403s non-keyholders), so this must NOT be a live
+        // button — it shows the keyholder-only copy instead.
+        let v = vault_role(
+            VaultMonitoringLevel::Full,
+            "available",
+            false,
+            "beneficiary",
+        );
+        assert_eq!(classify(&v), RowKind::KeyholderOnly);
+        assert!(!v.is_recoverable_now());
+        assert!(status_copy(&v).unwrap().contains("keyholder"));
     }
 
     #[test]
@@ -417,11 +483,29 @@ mod tests {
     #[test]
     fn load_without_client_surfaces_signin_prompt() {
         let mut panel = RecoverVaultPanel::new();
-        let _ = panel.update(RecoverVaultMessage::Load, None);
+        let _ = panel.update(RecoverVaultMessage::Load, None, 0);
         match &panel.list {
             ListState::Error(msg) => assert!(msg.contains("Sign in")),
             other => panic!("expected sign-in error, got {:?}", other),
         }
+        // An error is retryable: `is_loaded()` stays false so reopening the
+        // section (e.g. after the heir signs in) re-fires `Load`.
+        assert!(!panel.is_loaded());
+    }
+
+    #[test]
+    fn is_loaded_suppresses_refetch_only_for_loading_and_loaded() {
+        let mut panel = RecoverVaultPanel::new();
+        // Idle: never requested → fetch.
+        assert!(!panel.is_loaded());
+        // Error: transient failure → retry on reopen.
+        panel.list = ListState::Error("boom".to_string());
+        assert!(!panel.is_loaded());
+        // Loading: in flight → don't duplicate the request.
+        panel.list = ListState::Loading;
+        assert!(panel.is_loaded());
+        // Loaded: already have the list → don't refetch on reopen.
+        panel.list = ListState::Loaded(vec![]);
         assert!(panel.is_loaded());
     }
 
@@ -429,16 +513,45 @@ mod tests {
     fn loaded_stores_rows() {
         let mut panel = RecoverVaultPanel::new();
         let rows = vec![vault(VaultMonitoringLevel::Full, "available", false)];
-        let _ = panel.update(RecoverVaultMessage::Loaded(Ok(rows)), None);
+        let _ = panel.update(RecoverVaultMessage::Loaded(Ok(rows), 0), None, 0);
+        assert!(matches!(panel.list, ListState::Loaded(ref r) if r.len() == 1));
+    }
+
+    #[test]
+    fn loaded_from_a_stale_session_is_dropped() {
+        // A list fetch fired in generation 1 that lands after the session
+        // advanced (logout / account switch → generation 2) must not paint the
+        // prior account's vaults: the panel's `list` is left untouched.
+        let mut panel = RecoverVaultPanel::new();
+        let rows = vec![vault(VaultMonitoringLevel::Full, "available", false)];
+        let _ = panel.update(RecoverVaultMessage::Loaded(Ok(rows), 1), None, 2);
+        assert!(
+            matches!(panel.list, ListState::Idle),
+            "stale-session list must not be stored, got {:?}",
+            panel.list
+        );
+    }
+
+    #[test]
+    fn loaded_for_the_current_session_is_stored() {
+        // The matching-generation path still stores rows (regression guard for
+        // the stale-session check above).
+        let mut panel = RecoverVaultPanel::new();
+        let rows = vec![vault(VaultMonitoringLevel::Full, "available", false)];
+        let _ = panel.update(RecoverVaultMessage::Loaded(Ok(rows), 5), None, 5);
         assert!(matches!(panel.list, ListState::Loaded(ref r) if r.len() == 1));
     }
 
     #[test]
     fn fetched_error_copy_is_shown_verbatim() {
         let mut panel = RecoverVaultPanel::new();
+        // Simulate the in-flight recover `Recover` sets before the async fetch
+        // resolves, so the matching `Fetched` is applied to the active row.
+        panel.active = Some((7, RecoverStatus::Fetching));
         let _ = panel.update(
             RecoverVaultMessage::Fetched(7, Err("Recovery is unavailable right now.".to_string())),
             None,
+            0,
         );
         match panel.active {
             Some((7, RecoverStatus::Failed(copy))) => {
@@ -446,5 +559,24 @@ mod tests {
             }
             other => panic!("expected failed status, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn stale_fetch_does_not_overwrite_a_newer_active_row() {
+        // The heir starts recovery on cube 7, then on cube 8 (which replaces
+        // `active`). Cube 7's older descriptor fetch resolving afterwards must
+        // not paint its result onto cube 8's in-flight row.
+        let mut panel = RecoverVaultPanel::new();
+        panel.active = Some((8, RecoverStatus::Fetching));
+        let _ = panel.update(
+            RecoverVaultMessage::Fetched(7, Ok("wsh(...)".to_string())),
+            None,
+            0,
+        );
+        assert!(
+            matches!(panel.active, Some((8, RecoverStatus::Fetching))),
+            "stale cube-7 fetch must leave cube-8's row untouched, got {:?}",
+            panel.active
+        );
     }
 }

--- a/coincube-gui/src/recover_vault.rs
+++ b/coincube-gui/src/recover_vault.rs
@@ -31,6 +31,12 @@ use crate::services::coincube::{
 };
 use crate::services::recovery::fetch_recovery_descriptor;
 
+/// Shown when the heir isn't signed in: both for a `Load` attempted without a
+/// Connect client and for the reset (`Idle`) state the panel returns to after
+/// logout — Home may still be parked on this section, and `Idle` must read as a
+/// sign-in prompt rather than a perpetual "Loading…" with no request in flight.
+const SIGNED_OUT_PROMPT: &str = "Sign in to your account to see vaults you can recover.";
+
 /// How a discovery row should present, encoding invariants I1 (state gating)
 /// and I7 (tier honesty). Password-required (Heartbeat) rows take precedence:
 /// they are never actionable in v1 regardless of window state, and must show
@@ -191,9 +197,7 @@ impl RecoverVaultPanel {
         match message {
             RecoverVaultMessage::Load => {
                 let Some(client) = client else {
-                    self.list = ListState::Error(
-                        "Sign in to your account to see vaults you can recover.".to_string(),
-                    );
+                    self.list = ListState::Error(SIGNED_OUT_PROMPT.to_string());
                     return Task::none();
                 };
                 self.list = ListState::Loading;
@@ -211,6 +215,14 @@ impl RecoverVaultPanel {
                 // Drop a list that resolved after the session changed (logout /
                 // account switch) so we never paint the prior account's vaults.
                 if gen != session_generation {
+                    // If that dead fetch was still showing `Loading`, fall back
+                    // to `Idle` so `is_loaded()` is false and reopening refetches
+                    // — otherwise the pane is stranded on "Loading…" with no
+                    // request in flight. Leave `Loaded`/`Error`/`Idle` as-is so
+                    // a current-session result or a live retry isn't clobbered.
+                    if matches!(self.list, ListState::Loading) {
+                        self.list = ListState::Idle;
+                    }
                     return Task::none();
                 }
                 self.list = match res {
@@ -282,7 +294,17 @@ pub fn view(panel: &RecoverVaultPanel) -> Element<'_, RecoverVaultMessage> {
         );
 
     let body: Element<RecoverVaultMessage> = match &panel.list {
-        ListState::Idle | ListState::Loading => {
+        // Reset / never-requested. Opening the section while signed in fires
+        // `Load` immediately (→ `Loading`), so the pane only lands on `Idle`
+        // when Home is still parked here after a logout reset — show the
+        // sign-in prompt, not a "Loading…" that will never resolve.
+        ListState::Idle => {
+            Container::new(p1_regular(SIGNED_OUT_PROMPT).style(theme::text::secondary))
+                .padding(20)
+                .center_x(Length::Fill)
+                .into()
+        }
+        ListState::Loading => {
             Container::new(p1_regular("Loading recoverable vaults…").style(theme::text::secondary))
                 .padding(20)
                 .center_x(Length::Fill)
@@ -530,6 +552,34 @@ mod tests {
             "stale-session list must not be stored, got {:?}",
             panel.list
         );
+    }
+
+    #[test]
+    fn stale_loaded_while_loading_falls_back_to_idle() {
+        // A stale-session list resolving while the pane still shows `Loading`
+        // must drop back to `Idle` — not strand it on "Loading…" forever (which
+        // `is_loaded()` would treat as loaded, blocking refetch on reopen).
+        let mut panel = RecoverVaultPanel::new();
+        panel.list = ListState::Loading;
+        let rows = vec![vault(VaultMonitoringLevel::Full, "available", false)];
+        let _ = panel.update(RecoverVaultMessage::Loaded(Ok(rows), 1), None, 2);
+        assert!(
+            matches!(panel.list, ListState::Idle),
+            "stranded Loading must reset to Idle, got {:?}",
+            panel.list
+        );
+        assert!(!panel.is_loaded());
+    }
+
+    #[test]
+    fn stale_loaded_does_not_clobber_current_loaded_list() {
+        // A stale drop must leave an already-populated current-session list
+        // intact (don't reset a good `Loaded` back to `Idle`).
+        let mut panel = RecoverVaultPanel::new();
+        panel.list = ListState::Loaded(vec![vault(VaultMonitoringLevel::Full, "available", false)]);
+        let rows = vec![vault(VaultMonitoringLevel::Heartbeat, "approaching", true)];
+        let _ = panel.update(RecoverVaultMessage::Loaded(Ok(rows), 1), None, 2);
+        assert!(matches!(panel.list, ListState::Loaded(ref r) if r.len() == 1));
     }
 
     #[test]

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -1442,6 +1442,16 @@ impl CoincubeClient {
     ) -> Result<Vec<super::RecoverableVault>, CoincubeError> {
         let url = format!("{}/api/v1/connect/cubes/recoverable", self.base_url);
         let res = self.client.get(&url).send().await?;
+        // The endpoint is net-new and capability-gated: a `503` (recovery
+        // disabled via `ALERTS_RECOVERY_ENABLED=false`) or a `404` (not yet
+        // deployed) means the feature simply isn't there. Per the contract
+        // above, surface that as an empty list — the panel renders its
+        // "nothing to show" copy — rather than a generic error in the heir's
+        // face. Other non-success statuses (auth, 5xx) still flow to the panel
+        // as an error so genuine breakage stays visible.
+        if matches!(res.status().as_u16(), 404 | 503) {
+            return Ok(Vec::new());
+        }
         let res = res.check_success().await?;
         let resp: ApiResponse<Vec<super::RecoverableVault>> = res.json().await?;
         Ok(resp.data)

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -1420,6 +1420,58 @@ impl CoincubeClient {
 }
 
 // =============================================================================
+// Inheritance recovery — heir/keyholder (COIN-377)
+// =============================================================================
+//
+// The discovery list (PR 1) and the keyholder descriptor release (PR 2). See
+// the DTO block in `mod.rs` for the wire shapes and the
+// `services/recovery/keyholder.rs` helper for the typed gate-error mapping.
+
+impl CoincubeClient {
+    /// `GET /api/v1/connect/cubes/recoverable` (authenticated). Lists the
+    /// vaults the signed-in account is a keyholder/beneficiary of and may be
+    /// able to recover (PR 1 discovery surface).
+    ///
+    /// **Net-new endpoint** — owned by the API counterpart plan; not live yet.
+    /// The desktop drives the surface off this behind the capability flag, and
+    /// the UI should treat a non-success response (incl. `503` when
+    /// `ALERTS_RECOVERY_ENABLED=false`) as "feature unavailable / nothing to
+    /// show" rather than an error to the heir.
+    pub async fn list_recoverable_vaults(
+        &self,
+    ) -> Result<Vec<super::RecoverableVault>, CoincubeError> {
+        let url = format!("{}/api/v1/connect/cubes/recoverable", self.base_url);
+        let res = self.client.get(&url).send().await?;
+        let res = res.check_success().await?;
+        let resp: ApiResponse<Vec<super::RecoverableVault>> = res.json().await?;
+        Ok(resp.data)
+    }
+
+    /// `GET /api/v1/connect/cubes/{cubeId}/vault/recovery-descriptor`
+    /// (authenticated, keyholder-gated). Returns the **plaintext** descriptor
+    /// the server decrypts from escrow under its KEK — the keyholder path has
+    /// no password and does no client-side decryption.
+    ///
+    /// `404` (`RECOVERY_NOT_MONITORED`) → `NotFound` and `429` →
+    /// `RateLimited` short-circuit via `parse_recovery_response`. The gate
+    /// failures `403` (`RECOVERY_ACCESS_DENIED` / `RECOVERY_NOT_AVAILABLE`),
+    /// `423` (`DURESS_LOCKED`), and `503` come back as
+    /// `Unsuccessful { status_code, text }` with the body preserved, so
+    /// `services::recovery::keyholder::KeyholderRecoveryError::from` can map
+    /// `error.code` to the right UI state. A side effect of a 200 is a
+    /// server-side owner notification (invariant I4).
+    pub async fn get_recovery_descriptor(&self, cube_id: u64) -> Result<String, CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/vault/recovery-descriptor",
+            self.base_url, cube_id
+        );
+        let res = self.client.get(&url).send().await?;
+        let resp: super::RecoveryDescriptorResponse = Self::parse_recovery_response(res).await?;
+        Ok(resp.descriptor)
+    }
+}
+
+// =============================================================================
 // Duress alert contacts (Estate Notifications — PR 1)
 // =============================================================================
 //

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -2046,6 +2046,119 @@ pub struct VaultHeartbeatRequest {
     pub computed_at: chrono::DateTime<chrono::Utc>,
 }
 
+// =============================================================================
+// Inheritance recovery — heir/keyholder discovery + descriptor release (COIN-377)
+// =============================================================================
+//
+// The heir signs in to their OWN account and discovers Vaults they are a
+// keyholder/beneficiary of (but do not own); once the recovery window is open
+// on-chain they pull the owner's descriptor — server-decrypted, NO password —
+// to drive the existing recovery-sweep screen as a watch-only vault. Two
+// endpoints back this:
+//
+//   GET /api/v1/connect/cubes/recoverable                         (PR 1 list; NET-NEW)
+//   GET /api/v1/connect/cubes/{cubeId}/vault/recovery-descriptor  (PR 2 fetch; built)
+//
+// The second endpoint already exists and is gated server-side
+// (`coincube-api/services/connect/vault/monitoring/handler.go::GetRecoveryDescriptor`);
+// the first is net-new on both sides and owned by the API counterpart plan.
+
+/// Heir-facing recovery-window state for a vault. Collapses the API's
+/// `RecoveryMonitoringState` machine (`none`/`approaching`/`available`/
+/// `reminding`) to the two states the discovery UI acts on. Any unknown wire
+/// value maps to `Approaching` — fail-closed, so we never render a "Recover"
+/// button for a state this client doesn't understand.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryState {
+    /// `none`/`approaching` (and unknown) — visible but not actionable; show
+    /// the expected-open date and "we'll email you", no descriptor access.
+    Approaching,
+    /// `available`/`reminding` — the recovery path is open on-chain; the
+    /// descriptor can be released. The heir gets a "Recover" button.
+    Open,
+}
+
+impl RecoveryState {
+    /// Maps a raw server `state` / `last_notified_state` string to the
+    /// heir-facing state. `available`/`reminding` → `Open`; everything else
+    /// (`none`, `approaching`, unknown, empty) → `Approaching` (fail-closed).
+    pub fn from_wire(s: &str) -> Self {
+        match s {
+            "available" | "reminding" => Self::Open,
+            _ => Self::Approaching,
+        }
+    }
+
+    pub fn is_open(self) -> bool {
+        matches!(self, Self::Open)
+    }
+}
+
+/// One row from `GET /api/v1/connect/cubes/recoverable` — a vault the
+/// signed-in account is a keyholder/beneficiary of (but does not own) and may
+/// be able to recover. **Net-new endpoint** (COIN-377 / API counterpart plan);
+/// until it ships the desktop drives PR 1 off this documented shape behind the
+/// capability flag, with fixtures for tests. Tolerant `#[serde(default)]` on
+/// the optional/forward-compat fields so a slightly older/newer server shape
+/// still deserialises.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecoverableVault {
+    /// The owner's numeric cube id — the path segment for the descriptor fetch.
+    pub cube_id: u64,
+    /// Owner-chosen label for the vault (display only).
+    #[serde(default)]
+    pub owner_label: Option<String>,
+    /// Owner's monitoring tier. `Full` → password-free recovery (v1);
+    /// `Heartbeat` → recovery password required (deferred to COIN-375).
+    #[serde(default)]
+    pub monitoring_level: VaultMonitoringLevel,
+    /// Raw server recovery-window state (`none`/`approaching`/`available`/
+    /// `reminding`). Use [`RecoverableVault::recovery_state`] for the
+    /// heir-facing collapse.
+    #[serde(default)]
+    pub state: String,
+    /// True when recovering this vault needs the owner's recovery password
+    /// (Heartbeat tier). v1 shows the deferred-path copy for these rows; the
+    /// Alerts-only heir path is COIN-375.
+    #[serde(default)]
+    pub requires_recovery_password: bool,
+    /// "Owner last active" hint, when the server exposes it (display only).
+    #[serde(default)]
+    pub owner_last_active: Option<chrono::DateTime<chrono::Utc>>,
+    /// Expected/known date the recovery window opens, for `approaching` rows.
+    #[serde(default)]
+    pub expected_open_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Optional address gap-limit hint for the recovered watch-only sync. The
+    /// descriptor-release endpoint returns no gap hint (it's owner-only), so if
+    /// the API surfaces one it rides on this list row; otherwise the recovered
+    /// vault syncs with a generous default gap.
+    #[serde(default)]
+    pub gap_limit: Option<u32>,
+}
+
+impl RecoverableVault {
+    /// Collapses the raw wire `state` into the heir-facing two-state view.
+    pub fn recovery_state(&self) -> RecoveryState {
+        RecoveryState::from_wire(&self.state)
+    }
+
+    /// Whether the heir can act on this row now: the window is open AND it
+    /// isn't a password-required (Heartbeat) row deferred to COIN-375.
+    pub fn is_recoverable_now(&self) -> bool {
+        self.recovery_state().is_open() && !self.requires_recovery_password
+    }
+}
+
+/// Body of `GET /api/v1/connect/cubes/{cubeId}/vault/recovery-descriptor` on
+/// 200 — the **plaintext** descriptor. The server decrypts the escrowed copy
+/// under its KEK and returns it directly; the keyholder path carries no
+/// password and does no client-side decryption.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RecoveryDescriptorResponse {
+    pub descriptor: String,
+}
+
 #[cfg(test)]
 mod vault_monitoring_tests {
     use super::*;

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -2113,6 +2113,13 @@ pub struct RecoverableVault {
     /// `Heartbeat` → recovery password required (deferred to COIN-375).
     #[serde(default)]
     pub monitoring_level: VaultMonitoringLevel,
+    /// The caller's own membership role on this vault (`keyholder` /
+    /// `beneficiary`). Only keyholders can perform the password-free pull-down —
+    /// the descriptor-release endpoint 403s everyone else — so a non-keyholder
+    /// row is never a live "Recover" button. Defaults to non-keyholder (fails
+    /// closed) if an older server omits it.
+    #[serde(default)]
+    pub role: String,
     /// Raw server recovery-window state (`none`/`approaching`/`available`/
     /// `reminding`). Use [`RecoverableVault::recovery_state`] for the
     /// heir-facing collapse.
@@ -2120,8 +2127,10 @@ pub struct RecoverableVault {
     pub state: String,
     /// True when recovering this vault needs the owner's recovery password
     /// (Heartbeat tier). v1 shows the deferred-path copy for these rows; the
-    /// Alerts-only heir path is COIN-375.
-    #[serde(default)]
+    /// Alerts-only heir path is COIN-375. Defaults to `true` (fails closed) if
+    /// an older/partial server omits it: an absent field must never downgrade a
+    /// password-required row into a live, password-free "Recover" button.
+    #[serde(default = "default_requires_recovery_password")]
     pub requires_recovery_password: bool,
     /// "Owner last active" hint, when the server exposes it (display only).
     #[serde(default)]
@@ -2143,11 +2152,25 @@ impl RecoverableVault {
         RecoveryState::from_wire(&self.state)
     }
 
-    /// Whether the heir can act on this row now: the window is open AND it
-    /// isn't a password-required (Heartbeat) row deferred to COIN-375.
-    pub fn is_recoverable_now(&self) -> bool {
-        self.recovery_state().is_open() && !self.requires_recovery_password
+    /// Whether the caller is a keyholder (the only role that may pull the
+    /// descriptor down — beneficiaries are 403'd by the release endpoint).
+    pub fn is_keyholder(&self) -> bool {
+        self.role == "keyholder"
     }
+
+    /// Whether the heir can act on this row now: the caller is a keyholder AND
+    /// the window is open AND it isn't a password-required (Heartbeat) row
+    /// deferred to COIN-375.
+    pub fn is_recoverable_now(&self) -> bool {
+        self.is_keyholder() && self.recovery_state().is_open() && !self.requires_recovery_password
+    }
+}
+
+/// Serde default for [`RecoverableVault::requires_recovery_password`]: a missing
+/// field fails closed (assume a recovery password is required) so an
+/// older/partial payload never makes a Heartbeat row look password-free.
+fn default_requires_recovery_password() -> bool {
+    true
 }
 
 /// Body of `GET /api/v1/connect/cubes/{cubeId}/vault/recovery-descriptor` on
@@ -2195,6 +2218,21 @@ mod vault_monitoring_tests {
             KeyholderDownloadPolicy::default(),
             KeyholderDownloadPolicy::AtApproaching
         );
+    }
+
+    #[test]
+    fn recoverable_vault_requires_password_fails_closed_when_absent() {
+        // A payload that omits `requiresRecoveryPassword` must default to `true`
+        // (fail closed) so the row is never treated as a password-free, live
+        // "Recover" button. Even open + keyholder, it stays non-actionable.
+        let v = serde_json::json!({
+            "cubeId": 7,
+            "role": "keyholder",
+            "state": "available"
+        });
+        let row: RecoverableVault = serde_json::from_value(v).unwrap();
+        assert!(row.requires_recovery_password);
+        assert!(!row.is_recoverable_now());
     }
 
     #[test]

--- a/coincube-gui/src/services/recovery/keyholder.rs
+++ b/coincube-gui/src/services/recovery/keyholder.rs
@@ -50,30 +50,22 @@ pub enum KeyholderRecoveryError {
 impl std::fmt::Display for KeyholderRecoveryError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::NotKeyholder => write!(
-                f,
-                "You don't have permission to recover this vault."
-            ),
-            Self::NotOpen => write!(
-                f,
-                "This vault's recovery window isn't open yet."
-            ),
+            Self::NotKeyholder => write!(f, "You don't have permission to recover this vault."),
+            Self::NotOpen => write!(f, "This vault's recovery window isn't open yet."),
             // Neutral, duress-safe copy — matches the recovery-kit download
             // flow's wording so the two paths are indistinguishable.
             Self::Unavailable { .. } => write!(
                 f,
                 "Recovery is unavailable right now. Please try again later."
             ),
-            Self::NotMonitored => write!(
-                f,
-                "This vault isn't set up for assisted recovery."
-            ),
-            Self::Unsupported => write!(
-                f,
-                "Assisted recovery isn't available on this server."
-            ),
+            Self::NotMonitored => write!(f, "This vault isn't set up for assisted recovery."),
+            Self::Unsupported => write!(f, "Assisted recovery isn't available on this server."),
             Self::RateLimited { retry_after } => {
-                write!(f, "Too many attempts — try again in {}s.", retry_after.as_secs())
+                write!(
+                    f,
+                    "Too many attempts — try again in {}s.",
+                    retry_after.as_secs()
+                )
             }
             Self::Api(msg) => write!(f, "Recovery error: {}", msg),
         }
@@ -168,7 +160,10 @@ mod unit_tests {
     }
 
     fn err_body(code: &str) -> String {
-        format!(r#"{{"success":false,"error":{{"code":"{}","message":"x"}}}}"#, code)
+        format!(
+            r#"{{"success":false,"error":{{"code":"{}","message":"x"}}}}"#,
+            code
+        )
     }
 
     #[test]
@@ -199,10 +194,7 @@ mod unit_tests {
         let err: KeyholderRecoveryError = unsuccessful(423, body).into();
         match err {
             KeyholderRecoveryError::Unavailable { retry_at } => {
-                assert_eq!(
-                    retry_at.unwrap().to_rfc3339(),
-                    "2026-07-01T00:00:00+00:00"
-                );
+                assert_eq!(retry_at.unwrap().to_rfc3339(), "2026-07-01T00:00:00+00:00");
             }
             other => panic!("expected Unavailable, got {:?}", other),
         }
@@ -380,6 +372,7 @@ mod integration_tests {
                         {
                             "cubeId": 7,
                             "ownerLabel": "Dad's Vault",
+                            "role": "keyholder",
                             "monitoringLevel": "full",
                             "state": "available",
                             "requiresRecoveryPassword": false
@@ -387,6 +380,7 @@ mod integration_tests {
                         {
                             "cubeId": 8,
                             "ownerLabel": "Mum's Vault",
+                            "role": "keyholder",
                             "monitoringLevel": "heartbeat",
                             "state": "approaching",
                             "requiresRecoveryPassword": true
@@ -394,9 +388,18 @@ mod integration_tests {
                         {
                             "cubeId": 9,
                             "ownerLabel": "Open but pw-gated",
+                            "role": "keyholder",
                             "monitoringLevel": "heartbeat",
                             "state": "reminding",
                             "requiresRecoveryPassword": true
+                        },
+                        {
+                            "cubeId": 10,
+                            "ownerLabel": "Open but beneficiary",
+                            "role": "beneficiary",
+                            "monitoringLevel": "full",
+                            "state": "available",
+                            "requiresRecoveryPassword": false
                         }
                     ],
                     "error": null
@@ -409,12 +412,13 @@ mod integration_tests {
             .await
             .expect("list should parse");
         mock.assert();
-        assert_eq!(rows.len(), 3);
+        assert_eq!(rows.len(), 4);
 
-        // Row 0: Full + available → open + actionable now.
+        // Row 0: Full + available + keyholder → open + actionable now.
         assert_eq!(rows[0].cube_id, 7);
         assert_eq!(rows[0].monitoring_level, VaultMonitoringLevel::Full);
         assert_eq!(rows[0].recovery_state(), RecoveryState::Open);
+        assert!(rows[0].is_keyholder());
         assert!(rows[0].is_recoverable_now());
 
         // Row 1: Heartbeat + approaching → not open, not actionable.
@@ -426,5 +430,76 @@ mod integration_tests {
         // v1 (deferred to COIN-375), even though the window is open.
         assert_eq!(rows[2].recovery_state(), RecoveryState::Open);
         assert!(!rows[2].is_recoverable_now());
+
+        // Row 3: Full + available but the caller is a beneficiary → open, yet
+        // NOT actionable: the descriptor pull-down is keyholder-only (the
+        // release endpoint 403s non-keyholders).
+        assert_eq!(rows[3].recovery_state(), RecoveryState::Open);
+        assert!(!rows[3].is_keyholder());
+        assert!(!rows[3].is_recoverable_now());
+    }
+
+    #[tokio::test]
+    async fn list_recoverable_503_disabled_reads_as_empty() {
+        // Recovery disabled server-side (`ALERTS_RECOVERY_ENABLED=false`) →
+        // 503. The heir must see the "nothing to show" empty state, not a
+        // generic error, so this maps to an empty list rather than `Err`.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/recoverable");
+            then.status(503);
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let rows = client
+            .list_recoverable_vaults()
+            .await
+            .expect("503 should read as an empty list, not an error");
+        mock.assert();
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_recoverable_404_not_deployed_reads_as_empty() {
+        // The endpoint is net-new; an older server that hasn't deployed it
+        // returns 404. Treat that as "feature unavailable / nothing to show".
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/recoverable");
+            then.status(404);
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let rows = client
+            .list_recoverable_vaults()
+            .await
+            .expect("404 should read as an empty list, not an error");
+        mock.assert();
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_recoverable_500_still_surfaces_error() {
+        // Genuine server breakage must NOT be swallowed into an empty state —
+        // only the feature-unavailable statuses (404/503) soft-fail.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/recoverable");
+            then.status(500);
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .list_recoverable_vaults()
+            .await
+            .expect_err("500 should surface as an error, not an empty list");
+        mock.assert();
+        assert!(matches!(
+            err,
+            CoincubeError::Unsuccessful(info) if info.status_code == 500
+        ));
     }
 }

--- a/coincube-gui/src/services/recovery/keyholder.rs
+++ b/coincube-gui/src/services/recovery/keyholder.rs
@@ -1,0 +1,430 @@
+//! Heir/keyholder descriptor release (COIN-377, PR 2).
+//!
+//! Unlike the owner restore path in [`super::restore`], this path carries **no
+//! password** and does **no client-side decryption**: the server decrypts the
+//! escrowed descriptor under its KEK and returns plaintext to an authorised
+//! keyholder (`coincube-api .../monitoring/handler.go::GetRecoveryDescriptor`).
+//! So this module is just the fetch plus a typed mapping of the server's gate
+//! matrix into UI-actionable variants.
+//!
+//! The duress case (`423`) is deliberately collapsed to a neutral
+//! "unavailable, try later" — the heir UI must never explain *why* (invariant
+//! I3); the owner being under duress is not disclosed.
+
+use crate::services::coincube::{ApiErrorResponse, CoincubeClient, CoincubeError};
+
+/// Typed outcome of a keyholder descriptor fetch. Each variant maps a server
+/// gate response to a distinct UI state; see
+/// [`CoincubeClient::get_recovery_descriptor`](crate::services::coincube::CoincubeClient::get_recovery_descriptor)
+/// for which status/body produces which.
+///
+/// `Clone` + `Debug` mirror [`super::RestoreError`] (Iced clones messages
+/// between update/task/view); no variant carries secrets.
+#[derive(Debug, Clone)]
+pub enum KeyholderRecoveryError {
+    /// `403 RECOVERY_ACCESS_DENIED` — the signed-in account is not a keyholder
+    /// of this vault. Also the fail-closed default for any unrecognised `403`.
+    NotKeyholder,
+    /// `403 RECOVERY_NOT_AVAILABLE` — the recovery path is not open on-chain
+    /// yet. A race from an `open` discovery row; shouldn't normally occur.
+    NotOpen,
+    /// `423 DURESS_LOCKED` — the **owner's** account is under a duress lock.
+    /// Render the same neutral copy the duress flow uses; never explain duress.
+    /// `retry_at` is the optional `data.duress_unlock_at` hint, surfaced only
+    /// as a soft "try again later", never labelled as duress.
+    Unavailable {
+        retry_at: Option<chrono::DateTime<chrono::Utc>>,
+    },
+    /// `404 RECOVERY_NOT_MONITORED` — the vault has no monitoring/escrow record
+    /// (the owner never opted into Full monitoring).
+    NotMonitored,
+    /// `503` — the recovery surface is off (`ALERTS_RECOVERY_ENABLED=false`) or
+    /// descriptor escrow isn't configured server-side.
+    Unsupported,
+    /// `429` — rate limited (the route caps at ~10/min per IP).
+    RateLimited { retry_after: std::time::Duration },
+    /// Anything else — auth, network, 5xx, parse.
+    Api(String),
+}
+
+impl std::fmt::Display for KeyholderRecoveryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotKeyholder => write!(
+                f,
+                "You don't have permission to recover this vault."
+            ),
+            Self::NotOpen => write!(
+                f,
+                "This vault's recovery window isn't open yet."
+            ),
+            // Neutral, duress-safe copy — matches the recovery-kit download
+            // flow's wording so the two paths are indistinguishable.
+            Self::Unavailable { .. } => write!(
+                f,
+                "Recovery is unavailable right now. Please try again later."
+            ),
+            Self::NotMonitored => write!(
+                f,
+                "This vault isn't set up for assisted recovery."
+            ),
+            Self::Unsupported => write!(
+                f,
+                "Assisted recovery isn't available on this server."
+            ),
+            Self::RateLimited { retry_after } => {
+                write!(f, "Too many attempts — try again in {}s.", retry_after.as_secs())
+            }
+            Self::Api(msg) => write!(f, "Recovery error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for KeyholderRecoveryError {}
+
+impl From<CoincubeError> for KeyholderRecoveryError {
+    fn from(e: CoincubeError) -> Self {
+        match e {
+            // The client maps 404 → NotFound (RECOVERY_NOT_MONITORED) and
+            // 429 → RateLimited before we ever see them.
+            CoincubeError::NotFound => Self::NotMonitored,
+            CoincubeError::RateLimited { retry_after } => Self::RateLimited { retry_after },
+            CoincubeError::Unsuccessful(ref info) => match info.status_code {
+                403 => match error_code(&info.text).as_deref() {
+                    Some("RECOVERY_NOT_AVAILABLE") => Self::NotOpen,
+                    // RECOVERY_ACCESS_DENIED or any unrecognised 403 fails
+                    // closed to "you can't recover this".
+                    _ => Self::NotKeyholder,
+                },
+                423 => Self::Unavailable {
+                    retry_at: duress_unlock_at(&info.text),
+                },
+                503 => Self::Unsupported,
+                _ => Self::Api(e.to_string()),
+            },
+            other => Self::Api(other.to_string()),
+        }
+    }
+}
+
+/// Extracts `error.code` from a JSON error envelope, if present.
+fn error_code(body: &str) -> Option<String> {
+    serde_json::from_str::<ApiErrorResponse>(body)
+        .ok()
+        .map(|r| r.error.code)
+}
+
+/// Body of a `423 DURESS_LOCKED` response. The handler attaches the optional
+/// unlock hint via `ErrorWithData`, so the timestamp rides on `data`
+/// (snake-case `duress_unlock_at`) alongside the `error` envelope — a
+/// different shape from the recovery-kit download's `423` body, so we parse it
+/// here rather than reusing `DownloadError::from_locked_body`.
+#[derive(serde::Deserialize)]
+struct DuressLockEnvelope {
+    #[serde(default)]
+    data: Option<DuressLockData>,
+}
+
+#[derive(serde::Deserialize)]
+struct DuressLockData {
+    #[serde(default)]
+    duress_unlock_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Parses the optional `data.duress_unlock_at` hint from a `423` body. Returns
+/// `None` for an opaque/unparseable body — the variant is the same either way;
+/// we just lose the soft retry hint.
+fn duress_unlock_at(body: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    serde_json::from_str::<DuressLockEnvelope>(body)
+        .ok()
+        .and_then(|env| env.data)
+        .and_then(|d| d.duress_unlock_at)
+}
+
+/// Fetches the plaintext recovery descriptor for a vault the caller is a
+/// keyholder of, mapping the server's gate matrix to [`KeyholderRecoveryError`].
+/// No password, no decryption — the returned string is a ready-to-import
+/// watch-only descriptor.
+pub async fn fetch_recovery_descriptor(
+    client: &CoincubeClient,
+    cube_id: u64,
+) -> Result<String, KeyholderRecoveryError> {
+    client
+        .get_recovery_descriptor(cube_id)
+        .await
+        .map_err(KeyholderRecoveryError::from)
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use crate::services::http::NotSuccessResponseInfo;
+
+    fn unsuccessful(status: u16, text: &str) -> CoincubeError {
+        CoincubeError::Unsuccessful(NotSuccessResponseInfo {
+            status_code: status,
+            text: text.to_string(),
+        })
+    }
+
+    fn err_body(code: &str) -> String {
+        format!(r#"{{"success":false,"error":{{"code":"{}","message":"x"}}}}"#, code)
+    }
+
+    #[test]
+    fn forbidden_not_keyholder_maps_to_not_keyholder() {
+        let err: KeyholderRecoveryError =
+            unsuccessful(403, &err_body("RECOVERY_ACCESS_DENIED")).into();
+        assert!(matches!(err, KeyholderRecoveryError::NotKeyholder));
+    }
+
+    #[test]
+    fn forbidden_not_available_maps_to_not_open() {
+        let err: KeyholderRecoveryError =
+            unsuccessful(403, &err_body("RECOVERY_NOT_AVAILABLE")).into();
+        assert!(matches!(err, KeyholderRecoveryError::NotOpen));
+    }
+
+    #[test]
+    fn unknown_403_fails_closed_to_not_keyholder() {
+        // An unrecognised (or unparseable) 403 must NOT leak as "open" or a
+        // generic error — it stays a hard deny.
+        let err: KeyholderRecoveryError = unsuccessful(403, "garbage").into();
+        assert!(matches!(err, KeyholderRecoveryError::NotKeyholder));
+    }
+
+    #[test]
+    fn locked_with_unlock_hint_maps_to_unavailable_with_retry() {
+        let body = r#"{"success":false,"data":{"duress_unlock_at":"2026-07-01T00:00:00Z"},"error":{"code":"DURESS_LOCKED","message":"x"}}"#;
+        let err: KeyholderRecoveryError = unsuccessful(423, body).into();
+        match err {
+            KeyholderRecoveryError::Unavailable { retry_at } => {
+                assert_eq!(
+                    retry_at.unwrap().to_rfc3339(),
+                    "2026-07-01T00:00:00+00:00"
+                );
+            }
+            other => panic!("expected Unavailable, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn opaque_423_maps_to_unavailable_without_hint() {
+        let err: KeyholderRecoveryError = unsuccessful(423, "nope").into();
+        assert!(matches!(
+            err,
+            KeyholderRecoveryError::Unavailable { retry_at: None }
+        ));
+    }
+
+    #[test]
+    fn not_found_maps_to_not_monitored() {
+        let err: KeyholderRecoveryError = CoincubeError::NotFound.into();
+        assert!(matches!(err, KeyholderRecoveryError::NotMonitored));
+    }
+
+    #[test]
+    fn service_unavailable_maps_to_unsupported() {
+        let err: KeyholderRecoveryError =
+            unsuccessful(503, &err_body("ESCROW_NOT_CONFIGURED")).into();
+        assert!(matches!(err, KeyholderRecoveryError::Unsupported));
+    }
+
+    #[test]
+    fn rate_limited_preserves_retry_after() {
+        let err: KeyholderRecoveryError = CoincubeError::RateLimited {
+            retry_after: std::time::Duration::from_secs(31),
+        }
+        .into();
+        match err {
+            KeyholderRecoveryError::RateLimited { retry_after } => {
+                assert_eq!(retry_after, std::time::Duration::from_secs(31));
+            }
+            other => panic!("expected RateLimited, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn server_5xx_stays_api_error() {
+        let err: KeyholderRecoveryError = unsuccessful(500, "boom").into();
+        assert!(matches!(err, KeyholderRecoveryError::Api(_)));
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    //! End-to-end against a mocked Connect API, exercising the client's URL +
+    //! status handling together with this module's gate mapping.
+    use super::*;
+    use crate::services::coincube::{RecoveryState, VaultMonitoringLevel};
+    use httpmock::{Method as MockMethod, MockServer};
+    use serde_json::json;
+
+    const DESC_PATH: &str = "/api/v1/connect/cubes/42/vault/recovery-descriptor";
+
+    #[tokio::test]
+    async fn fetch_descriptor_200_returns_plaintext() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET).path(DESC_PATH);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": { "descriptor": "wsh(multi(2,xpubA,xpubB))" },
+                    "error": null
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let desc = fetch_recovery_descriptor(&client, 42)
+            .await
+            .expect("200 should yield a descriptor");
+        mock.assert();
+        assert_eq!(desc, "wsh(multi(2,xpubA,xpubB))");
+    }
+
+    #[tokio::test]
+    async fn fetch_descriptor_403_not_available_maps_to_not_open() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET).path(DESC_PATH);
+            then.status(403).json_body(json!({
+                "success": false,
+                "error": { "code": "RECOVERY_NOT_AVAILABLE", "message": "not open" }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = fetch_recovery_descriptor(&client, 42)
+            .await
+            .expect_err("expected NotOpen");
+        mock.assert();
+        assert!(matches!(err, KeyholderRecoveryError::NotOpen));
+    }
+
+    #[tokio::test]
+    async fn fetch_descriptor_403_access_denied_maps_to_not_keyholder() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET).path(DESC_PATH);
+            then.status(403).json_body(json!({
+                "success": false,
+                "error": { "code": "RECOVERY_ACCESS_DENIED", "message": "nope" }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = fetch_recovery_descriptor(&client, 42)
+            .await
+            .expect_err("expected NotKeyholder");
+        mock.assert();
+        assert!(matches!(err, KeyholderRecoveryError::NotKeyholder));
+    }
+
+    #[tokio::test]
+    async fn fetch_descriptor_423_maps_to_neutral_unavailable() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET).path(DESC_PATH);
+            then.status(423).json_body(json!({
+                "success": false,
+                "data": { "duress_unlock_at": "2026-07-01T00:00:00Z" },
+                "error": { "code": "DURESS_LOCKED", "message": "locked" }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = fetch_recovery_descriptor(&client, 42)
+            .await
+            .expect_err("expected Unavailable");
+        mock.assert();
+        // The duress reason must never reach the heir — only the neutral copy.
+        assert_eq!(
+            err.to_string(),
+            "Recovery is unavailable right now. Please try again later."
+        );
+        assert!(matches!(
+            err,
+            KeyholderRecoveryError::Unavailable { retry_at: Some(_) }
+        ));
+    }
+
+    #[tokio::test]
+    async fn fetch_descriptor_404_maps_to_not_monitored() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET).path(DESC_PATH);
+            then.status(404);
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = fetch_recovery_descriptor(&client, 42)
+            .await
+            .expect_err("expected NotMonitored");
+        mock.assert();
+        assert!(matches!(err, KeyholderRecoveryError::NotMonitored));
+    }
+
+    #[tokio::test]
+    async fn list_recoverable_parses_rows_and_actionability() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/recoverable");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": [
+                        {
+                            "cubeId": 7,
+                            "ownerLabel": "Dad's Vault",
+                            "monitoringLevel": "full",
+                            "state": "available",
+                            "requiresRecoveryPassword": false
+                        },
+                        {
+                            "cubeId": 8,
+                            "ownerLabel": "Mum's Vault",
+                            "monitoringLevel": "heartbeat",
+                            "state": "approaching",
+                            "requiresRecoveryPassword": true
+                        },
+                        {
+                            "cubeId": 9,
+                            "ownerLabel": "Open but pw-gated",
+                            "monitoringLevel": "heartbeat",
+                            "state": "reminding",
+                            "requiresRecoveryPassword": true
+                        }
+                    ],
+                    "error": null
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let rows = client
+            .list_recoverable_vaults()
+            .await
+            .expect("list should parse");
+        mock.assert();
+        assert_eq!(rows.len(), 3);
+
+        // Row 0: Full + available → open + actionable now.
+        assert_eq!(rows[0].cube_id, 7);
+        assert_eq!(rows[0].monitoring_level, VaultMonitoringLevel::Full);
+        assert_eq!(rows[0].recovery_state(), RecoveryState::Open);
+        assert!(rows[0].is_recoverable_now());
+
+        // Row 1: Heartbeat + approaching → not open, not actionable.
+        assert_eq!(rows[1].recovery_state(), RecoveryState::Approaching);
+        assert!(!rows[1].is_recoverable_now());
+        assert!(rows[1].requires_recovery_password);
+
+        // Row 2: open (`reminding`) but password-required → NOT actionable in
+        // v1 (deferred to COIN-375), even though the window is open.
+        assert_eq!(rows[2].recovery_state(), RecoveryState::Open);
+        assert!(!rows[2].is_recoverable_now());
+    }
+}

--- a/coincube-gui/src/services/recovery/mod.rs
+++ b/coincube-gui/src/services/recovery/mod.rs
@@ -11,12 +11,14 @@
 
 pub mod envelope;
 pub mod error;
+pub mod keyholder;
 pub mod password;
 pub mod plaintext;
 pub mod restore;
 
 pub use envelope::{decrypt, encrypt, KdfParams, ENVELOPE_VERSION, KDF_ID_ARGON2ID_V1};
 pub use error::RecoveryError;
+pub use keyholder::{fetch_recovery_descriptor, KeyholderRecoveryError};
 pub use password::{score as score_password, PasswordStrength, MIN_PASSWORD_LEN};
 pub use plaintext::{
     DescriptorBlob, DescriptorBlobCube, DescriptorBlobSigner, DescriptorBlobVault, SeedBlob,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches inheritance recovery and server-decrypted descriptors with session-stale guards, but the UI stays off by default and PR1 stops before installing wallets or sweeping funds.
> 
> **Overview**
> Adds a **build-time-gated** “Recover a Vault” launcher flow for signed-in heirs: a new home section and sidebar entry (via `COINCUBE_ENABLE_RECOVER_VAULT`) that lists vaults from `GET /connect/cubes/recoverable` and lets eligible keyholders start recovery by fetching a plaintext descriptor through the existing release endpoint.
> 
> The new `recover_vault` panel classifies each row (actionable vs beneficiary-only, not-yet-open, password-deferred) with fail-closed defaults, loads the list once per session, and guards async list/descriptor completions with Connect **session generation** plus logout resets so another account never sees stale vaults. Successful descriptor fetch only shows “Recovery ready” for now (`TODO(PR 2)` for watch-only install).
> 
> Connect client/DTO work adds `RecoverableVault`, `RecoveryState`, `list_recoverable_vaults` (404/503 → empty list), `get_recovery_descriptor`, and `services/recovery/keyholder` maps gate errors—including neutral copy for duress `423`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 604546bbd40812c0a2589a091d6de533595a65d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Recover a Vault” section in the home launcher sidebar (shown only when enabled).
  * Introduced a new recover-vault panel that lists eligible vaults, shows eligibility/status details, and lets eligible users start recovery.

* **Bug Fixes / Improvements**
  * Resets the recover-vault panel when users log in or out to avoid stale results.
  * Prevents recovery actions when required password and recovery window conditions aren’t satisfied, with clearer non-actionable status messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->