### PR TITLE
ECIES flow

### DIFF
--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -3947,6 +3947,7 @@ impl App {
                 let entitled = self.panels.connect.account.is_recovery_alerts_entitled();
                 let members = self.panels.connect.cube.members.members.clone();
                 let session_generation = self.panels.connect.account.session_generation();
+                let local_cube_id = self.cube_settings.id.clone();
                 return crate::app::state::settings::recovery_alerts::update(
                     &mut self.panels.global_settings.recovery_alerts,
                     msg,
@@ -3956,6 +3957,8 @@ impl App {
                     entitled,
                     &members,
                     session_generation,
+                    &self.cache,
+                    &local_cube_id,
                 );
             }
 

--- a/coincube-gui/src/app/state/settings/recovery_alerts.rs
+++ b/coincube-gui/src/app/state/settings/recovery_alerts.rs
@@ -17,13 +17,16 @@
 use std::sync::Arc;
 
 use iced::Task;
+use zeroize::Zeroizing;
 
 use crate::{
-    app::{message::Message, view, wallet::Wallet},
+    app::{cache::Cache, message::Message, settings, view, wallet::Wallet},
     services::coincube::{
-        CoincubeClient, CubeMember, KeyholderDownloadPolicy, SetVaultMonitoringRequest,
-        VaultMonitoringLevel, VaultMonitoringStatus,
+        CoincubeClient, CubeMember, KeyholderDownloadPolicy, VaultMonitoringLevel,
+        VaultMonitoringStatus,
     },
+    services::inheritance::{disable_escrow, enroll_escrow, EscrowTier},
+    services::recovery::{SeedBlob, SeedBlobCube, SeedBlobMnemonic, BLOB_VERSION},
 };
 
 use view::{RecoveryAlertsMessage, SettingsMessage};
@@ -50,6 +53,19 @@ pub struct RecoveryAlerts {
     /// True once at least one load has been attempted — lets the card pick
     /// the right loading vs. empty copy.
     pub loaded_once: bool,
+    /// The escrow tier currently applied (best-effort: the monitoring status
+    /// reports on/off, not which tier, so this tracks the last applied/loaded
+    /// tier). `Off` when escrow is off.
+    pub tier: EscrowTier,
+    /// True while the card is collecting the owner's PIN to unlock the seed for
+    /// a Full-Cube enrolment (the only tier that escrows the seed).
+    pub awaiting_pin: bool,
+    /// PIN digits being entered for a Full-Cube enrolment. Cleared as soon as
+    /// it's consumed (or the flow is cancelled).
+    pub pin: String,
+    /// The tier a change is in flight for, applied to `tier` only once the
+    /// server confirms (so a failed change doesn't mislabel the selector).
+    pub pending_tier: Option<EscrowTier>,
 }
 
 impl Default for RecoveryAlerts {
@@ -70,6 +86,21 @@ impl RecoveryAlerts {
             entitled: false,
             no_vault: false,
             loaded_once: false,
+            tier: EscrowTier::Off,
+            awaiting_pin: false,
+            pin: String::new(),
+            pending_tier: None,
+        }
+    }
+
+    /// Best-effort current tier for the view. `Off` when monitoring is off;
+    /// otherwise the last tier we applied/loaded (escrow status doesn't report
+    /// which tier, so a freshly-loaded "on" vault shows the tracked tier).
+    pub fn tier(&self) -> EscrowTier {
+        if matches!(self.level(), VaultMonitoringLevel::Off) {
+            EscrowTier::Off
+        } else {
+            self.tier
         }
     }
 
@@ -114,6 +145,8 @@ pub fn update(
     entitled: bool,
     members: &[CubeMember],
     session_generation: u64,
+    cache: &Cache,
+    local_cube_id: &str,
 ) -> Task<Message> {
     ra.entitled = entitled;
     match msg {
@@ -182,10 +215,21 @@ pub fn update(
             ra.loaded_once = true;
             match res {
                 Ok((vid, status)) => {
+                    let level_off = matches!(status.level, VaultMonitoringLevel::Off);
                     ra.vault_id = Some(vid);
                     ra.status = Some(status);
                     ra.no_vault = false;
                     ra.error = None;
+                    // The monitoring status reports on/off, not which escrow
+                    // tier. Reconcile our tracked tier: Off when monitoring is
+                    // off; otherwise keep the tracked tier, defaulting an
+                    // unknown "on" vault to Vault-only (the safe minimum — we
+                    // never imply the seed is escrowed unless we set it).
+                    if level_off {
+                        ra.tier = EscrowTier::Off;
+                    } else if ra.tier == EscrowTier::Off {
+                        ra.tier = EscrowTier::VaultOnly;
+                    }
                 }
                 Err(e) => {
                     // A missing Connect vault (the cube has no vault yet, or a
@@ -208,50 +252,32 @@ pub fn update(
             }
             Task::none()
         }
-        RecoveryAlertsMessage::SelectLevel(level) => {
+        RecoveryAlertsMessage::SelectTier(tier) => {
+            ra.awaiting_pin = false;
+            ra.pin.clear();
             if !entitled {
                 ra.error = Some("Recovery alerts require an Estate plan.".to_string());
                 return Task::none();
             }
-            if ra.level() == level {
+            if ra.tier() == tier {
                 return Task::none();
             }
-            let (Some(client), Some(vault_id)) = (client, ra.vault_id) else {
+            let (Some(client), Some(vault_id), Some(server_cube_id)) =
+                (client, ra.vault_id, server_cube_id)
+            else {
                 ra.error = Some(
                     "Couldn't find this Vault on Connect yet — try again in a moment.".to_string(),
                 );
                 return Task::none();
             };
-            let current_policy = ra.status.as_ref().map(|s| s.crk_keyholder_download);
-            ra.submitting = true;
-            ra.error = None;
-            match level {
-                VaultMonitoringLevel::Off => Task::perform(
-                    async move {
-                        client
-                            .delete_vault_monitoring(vault_id)
-                            .await
-                            .map(|_| VaultMonitoringStatus {
-                                level: VaultMonitoringLevel::Off,
-                                crk_keyholder_download: current_policy.unwrap_or_default(),
-                                last_notified_state: None,
-                                updated_at: None,
-                            })
-                            .map_err(|e| e.to_string())
-                    },
-                    move |res| ra_msg(RecoveryAlertsMessage::ChangeResult(res, session_generation)),
-                ),
-                VaultMonitoringLevel::Heartbeat => {
-                    let req = SetVaultMonitoringRequest {
-                        level,
-                        descriptor: None,
-                        gap_limit: None,
-                        crk_keyholder_download: current_policy,
-                    };
+            match tier {
+                EscrowTier::Off => {
+                    ra.submitting = true;
+                    ra.error = None;
+                    ra.pending_tier = Some(EscrowTier::Off);
                     Task::perform(
                         async move {
-                            client
-                                .set_vault_monitoring(vault_id, req)
+                            disable_escrow(&client, server_cube_id, vault_id)
                                 .await
                                 .map_err(|e| e.to_string())
                         },
@@ -260,29 +286,25 @@ pub fn update(
                         },
                     )
                 }
-                VaultMonitoringLevel::Full => {
-                    // Full needs the descriptor to escrow. It only exists on
-                    // a device holding the live wallet.
-                    let Some(descriptor) = wallet.as_ref().map(|w| w.main_descriptor.to_string())
+                EscrowTier::VaultOnly => {
+                    // Descriptor-only escrow needs no seed (no PIN). Build the
+                    // descriptor blob from the live wallet and enrol.
+                    let Some(descriptor_json) =
+                        descriptor_blob_json(wallet.as_deref(), local_cube_id, cache.network)
                     else {
-                        ra.submitting = false;
                         ra.error = Some(
-                            "This Vault's descriptor isn't available on this device, so full \
-                             monitoring can't be enabled here."
+                            "This Vault's descriptor isn't available on this device, so recovery \
+                             escrow can't be set up here."
                                 .to_string(),
                         );
                         return Task::none();
                     };
-                    let req = SetVaultMonitoringRequest {
-                        level,
-                        descriptor: Some(descriptor),
-                        gap_limit: None,
-                        crk_keyholder_download: current_policy,
-                    };
+                    ra.submitting = true;
+                    ra.error = None;
+                    ra.pending_tier = Some(EscrowTier::VaultOnly);
                     Task::perform(
                         async move {
-                            client
-                                .set_vault_monitoring(vault_id, req)
+                            enroll_escrow(&client, server_cube_id, vault_id, descriptor_json, None)
                                 .await
                                 .map_err(|e| e.to_string())
                         },
@@ -291,7 +313,91 @@ pub fn update(
                         },
                     )
                 }
+                EscrowTier::FullCube => {
+                    // Full-Cube escrows the seed too — re-confirm the PIN before
+                    // exporting it. Collect the PIN; `ConfirmFullCube` enrols.
+                    if wallet.is_none() {
+                        ra.error = Some(
+                            "This Vault isn't available on this device, so full-Cube escrow can't \
+                             be set up here."
+                                .to_string(),
+                        );
+                        return Task::none();
+                    }
+                    ra.error = None;
+                    ra.awaiting_pin = true;
+                    ra.pin.clear();
+                    Task::none()
+                }
             }
+        }
+        RecoveryAlertsMessage::EscrowPinChanged(pin) => {
+            ra.pin = pin;
+            Task::none()
+        }
+        RecoveryAlertsMessage::CancelFullCube => {
+            ra.awaiting_pin = false;
+            ra.pin.clear();
+            ra.error = None;
+            Task::none()
+        }
+        RecoveryAlertsMessage::ConfirmFullCube => {
+            if !entitled || !ra.awaiting_pin {
+                return Task::none();
+            }
+            let (Some(client), Some(vault_id), Some(server_cube_id)) =
+                (client, ra.vault_id, server_cube_id)
+            else {
+                ra.error = Some(
+                    "Couldn't find this Vault on Connect yet — try again in a moment.".to_string(),
+                );
+                return Task::none();
+            };
+            let Some(descriptor_json) =
+                descriptor_blob_json(wallet.as_deref(), local_cube_id, cache.network)
+            else {
+                ra.error =
+                    Some("This Vault's descriptor isn't available on this device.".to_string());
+                return Task::none();
+            };
+            // Unlock the seed with the entered PIN, build the seed blob, then
+            // enrol descriptor + seed. The mnemonic is wrapped in `Zeroizing`
+            // at the async boundary and never rides a message.
+            let pin = Zeroizing::new(std::mem::take(&mut ra.pin));
+            let seed_cube = match seed_blob_cube(cache, local_cube_id) {
+                Ok(c) => c,
+                Err(e) => {
+                    ra.error = Some(e);
+                    return Task::none();
+                }
+            };
+            let network_dir = cache.datadir_path.network_directory(cache.network);
+            let datadir = cache.datadir_path.path().to_path_buf();
+            let network = cache.network;
+            let local_cube_id = local_cube_id.to_string();
+            ra.submitting = true;
+            ra.awaiting_pin = false;
+            ra.error = None;
+            ra.pending_tier = Some(EscrowTier::FullCube);
+            Task::perform(
+                async move {
+                    let seed_json = tokio::task::spawn_blocking(move || {
+                        build_seed_blob_json(&network_dir, &datadir, network, &local_cube_id, &pin, seed_cube)
+                    })
+                    .await
+                    .map_err(|e| format!("PIN task failed: {}", e))??;
+                    enroll_escrow(
+                        &client,
+                        server_cube_id,
+                        vault_id,
+                        descriptor_json,
+                        Some(seed_json),
+                    )
+                    .await
+                    .map_err(|e| e.to_string())
+                },
+                move |res| ra_msg(RecoveryAlertsMessage::ChangeResult(res, session_generation)),
+            )
         }
         RecoveryAlertsMessage::SetDownloadPolicy(policy) => {
             if !entitled {
@@ -327,12 +433,96 @@ pub fn update(
             ra.submitting = false;
             match res {
                 Ok(status) => {
+                    // Apply the tier we just enrolled/disabled (tracked in
+                    // `pending_tier`) now that the server confirmed it.
+                    if let Some(t) = ra.pending_tier.take() {
+                        ra.tier = t;
+                    }
                     ra.status = Some(status);
                     ra.error = None;
                 }
-                Err(e) => ra.error = Some(e),
+                Err(e) => {
+                    ra.pending_tier = None;
+                    ra.error = Some(e);
+                }
             }
             Task::none()
         }
     }
+}
+
+/// Serialises the descriptor blob JSON for escrow from the live wallet (the
+/// same `DescriptorBlob` the Cube Recovery Kit uses, so the heir restore reuses
+/// its parsing). `None` when no wallet is loaded on this device.
+fn descriptor_blob_json(
+    wallet: Option<&Wallet>,
+    cube_uuid: &str,
+    network: coincube_core::miniscript::bitcoin::Network,
+) -> Option<Vec<u8>> {
+    let wallet = wallet?;
+    let net = settings::network_to_api_string(network);
+    let blob = super::recovery_kit::descriptor_blob_from_wallet(wallet, cube_uuid, &net);
+    serde_json::to_vec(&blob).ok()
+}
+
+/// Builds the cube-metadata half of the seed blob from on-disk settings + the
+/// live cache. Read on the main thread before the PIN task so a settings/cube
+/// lookup failure surfaces synchronously.
+fn seed_blob_cube(cache: &Cache, local_cube_id: &str) -> Result<SeedBlobCube, String> {
+    let network_dir = cache.datadir_path.network_directory(cache.network);
+    let s = settings::Settings::from_file(&network_dir)
+        .map_err(|_| "Failed to read settings file.".to_string())?;
+    let cube = s
+        .cubes
+        .iter()
+        .find(|c| c.id == local_cube_id)
+        .ok_or_else(|| "Cube not found in settings.".to_string())?;
+    let created_at = chrono::DateTime::<chrono::Utc>::from_timestamp(cube.created_at, 0)
+        .map(|t| t.to_rfc3339())
+        .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string());
+    Ok(SeedBlobCube {
+        uuid: local_cube_id.to_string(),
+        name: cube.name.clone(),
+        network: settings::network_to_api_string(cache.network),
+        created_at,
+        lightning_address: cache.lightning_address.clone(),
+    })
+}
+
+/// Verifies the PIN, unlocks the mnemonic, and serialises the full seed blob
+/// JSON for Full-Cube escrow. Runs on a blocking thread (Argon2 PIN verify +
+/// disk read). The mnemonic is wiped (`Zeroizing`) as soon as the phrase string
+/// is built.
+fn build_seed_blob_json(
+    network_dir: &crate::dir::NetworkDirectory,
+    datadir: &std::path::Path,
+    network: coincube_core::miniscript::bitcoin::Network,
+    local_cube_id: &str,
+    pin: &str,
+    cube: SeedBlobCube,
+) -> Result<Vec<u8>, String> {
+    let s =
+        settings::Settings::from_file(network_dir).map_err(|_| "Failed to read settings file.")?;
+    let cube_settings = s
+        .cubes
+        .iter()
+        .find(|c| c.id == local_cube_id)
+        .ok_or("Cube not found in settings.")?;
+    if !cube_settings.verify_pin(pin) {
+        return Err("Incorrect PIN. Please try again.".to_string());
+    }
+    let fingerprint = cube_settings
+        .master_signer_fingerprint
+        .ok_or("This Cube has no master signer.")?;
+    let words = super::general::load_mnemonic_words(datadir, network, fingerprint, pin)?;
+    let phrase = Zeroizing::new(words.join(" "));
+    let blob = SeedBlob {
+        version: BLOB_VERSION,
+        cube,
+        mnemonic: SeedBlobMnemonic {
+            phrase: phrase.to_string(),
+            language: "en".to_string(),
+        },
+    };
+    serde_json::to_vec(&blob).map_err(|e| format!("seed blob: {}", e))
 }

--- a/coincube-gui/src/app/state/settings/recovery_alerts.rs
+++ b/coincube-gui/src/app/state/settings/recovery_alerts.rs
@@ -29,7 +29,7 @@ use crate::{
     services::recovery::{SeedBlob, SeedBlobCube, SeedBlobMnemonic, BLOB_VERSION},
 };
 
-use view::{RecoveryAlertsMessage, SettingsMessage};
+use view::{EscrowPin, RecoveryAlertsMessage, SettingsMessage};
 
 /// Settings-card state for Vault Recovery Alerts. Held on `SettingsState`.
 #[derive(Debug)]
@@ -53,19 +53,21 @@ pub struct RecoveryAlerts {
     /// True once at least one load has been attempted — lets the card pick
     /// the right loading vs. empty copy.
     pub loaded_once: bool,
-    /// The escrow tier currently applied (best-effort: the monitoring status
-    /// reports on/off, not which tier, so this tracks the last applied/loaded
-    /// tier). `Off` when escrow is off.
+    /// The escrow tier this session tracked from an enrol/disable we performed.
+    /// The owner monitoring status reports on/off, not which tier, so this is
+    /// the only tier signal we have — and it resets to `Off` on restart. `Off`
+    /// therefore means *either* escrow is off *or* it's on but untracked on this
+    /// device; use [`Self::tier`] (the method), which combines this with
+    /// [`Self::level`], to disambiguate (it returns `None` for the latter).
     pub tier: EscrowTier,
     /// True while the card is collecting the owner's PIN to unlock the seed for
     /// a Full-Cube enrolment (the only tier that escrows the seed).
     pub awaiting_pin: bool,
-    /// PIN digits being entered for a Full-Cube enrolment. Cleared as soon as
-    /// it's consumed (or the flow is cancelled).
-    pub pin: String,
-    /// The tier a change is in flight for, applied to `tier` only once the
-    /// server confirms (so a failed change doesn't mislabel the selector).
-    pub pending_tier: Option<EscrowTier>,
+    /// PIN digits being entered for a Full-Cube enrolment. Held in a redacting,
+    /// zeroizing [`EscrowPin`] so it never prints via the struct's `Debug` and
+    /// each keystroke's previous buffer is wiped. Cleared as soon as it's
+    /// consumed (or the flow is cancelled).
+    pub pin: EscrowPin,
 }
 
 impl Default for RecoveryAlerts {
@@ -88,19 +90,25 @@ impl RecoveryAlerts {
             loaded_once: false,
             tier: EscrowTier::Off,
             awaiting_pin: false,
-            pin: String::new(),
-            pending_tier: None,
+            pin: EscrowPin::default(),
         }
     }
 
-    /// Best-effort current tier for the view. `Off` when monitoring is off;
-    /// otherwise the last tier we applied/loaded (escrow status doesn't report
-    /// which tier, so a freshly-loaded "on" vault shows the tracked tier).
-    pub fn tier(&self) -> EscrowTier {
+    /// Current tier for the view and the no-op guards:
+    /// - `Some(Off)` when monitoring is off;
+    /// - `Some(tier)` when this session tracked the enrolled tier;
+    /// - `None` when escrow is on but this device doesn't know which tier —
+    ///   e.g. after a restart, since the owner monitoring status doesn't report
+    ///   it. We surface "on, tier unknown" rather than guess: guessing
+    ///   Vault-only for a Full-Cube vault would print a false claim (its copy
+    ///   says "the seed is never escrowed") for a seed that *is* escrowed.
+    pub fn tier(&self) -> Option<EscrowTier> {
         if matches!(self.level(), VaultMonitoringLevel::Off) {
-            EscrowTier::Off
+            Some(EscrowTier::Off)
+        } else if self.tier == EscrowTier::Off {
+            None
         } else {
-            self.tier
+            Some(self.tier)
         }
     }
 
@@ -221,14 +229,14 @@ pub fn update(
                     ra.no_vault = false;
                     ra.error = None;
                     // The monitoring status reports on/off, not which escrow
-                    // tier. Reconcile our tracked tier: Off when monitoring is
-                    // off; otherwise keep the tracked tier, defaulting an
-                    // unknown "on" vault to Vault-only (the safe minimum — we
-                    // never imply the seed is escrowed unless we set it).
+                    // tier. Reconcile our tracked tier: clear it to Off when
+                    // monitoring is off; otherwise leave it untouched. We do NOT
+                    // guess a tier for an "on" vault we didn't enrol this
+                    // session — `tier()` reports that as `None` ("on, tier
+                    // unknown") so the card never asserts a tier (and false
+                    // seed-escrow copy) it can't actually confirm.
                     if level_off {
                         ra.tier = EscrowTier::Off;
-                    } else if ra.tier == EscrowTier::Off {
-                        ra.tier = EscrowTier::VaultOnly;
                     }
                 }
                 Err(e) => {
@@ -259,7 +267,10 @@ pub fn update(
                 ra.error = Some("Recovery alerts require an Estate plan.".to_string());
                 return Task::none();
             }
-            if ra.tier() == tier {
+            // Skip a no-op re-select of the *known* current tier. When the tier
+            // is unknown on this device (`None`), any selection proceeds so the
+            // owner can confirm/change it.
+            if ra.tier() == Some(tier) {
                 return Task::none();
             }
             let (Some(client), Some(vault_id), Some(server_cube_id)) =
@@ -274,7 +285,6 @@ pub fn update(
                 EscrowTier::Off => {
                     ra.submitting = true;
                     ra.error = None;
-                    ra.pending_tier = Some(EscrowTier::Off);
                     Task::perform(
                         async move {
                             disable_escrow(&client, server_cube_id, vault_id)
@@ -282,7 +292,11 @@ pub fn update(
                                 .map_err(|e| e.to_string())
                         },
                         move |res| {
-                            ra_msg(RecoveryAlertsMessage::ChangeResult(res, session_generation))
+                            ra_msg(RecoveryAlertsMessage::ChangeResult(
+                                res,
+                                session_generation,
+                                Some(EscrowTier::Off),
+                            ))
                         },
                     )
                 }
@@ -301,15 +315,18 @@ pub fn update(
                     };
                     ra.submitting = true;
                     ra.error = None;
-                    ra.pending_tier = Some(EscrowTier::VaultOnly);
                     Task::perform(
                         async move {
-                            enroll_escrow(&client, server_cube_id, vault_id, descriptor_json, None)
+                            enroll_escrow(&client, server_cube_id, descriptor_json, None)
                                 .await
                                 .map_err(|e| e.to_string())
                         },
                         move |res| {
-                            ra_msg(RecoveryAlertsMessage::ChangeResult(res, session_generation))
+                            ra_msg(RecoveryAlertsMessage::ChangeResult(
+                                res,
+                                session_generation,
+                                Some(EscrowTier::VaultOnly),
+                            ))
                         },
                     )
                 }
@@ -345,7 +362,10 @@ pub fn update(
             if !entitled || !ra.awaiting_pin {
                 return Task::none();
             }
-            let (Some(client), Some(vault_id), Some(server_cube_id)) =
+            // We still require a resolved vault as a fast precondition, but
+            // `enroll_escrow` re-fetches and uses that vault's id, so we don't
+            // thread a (possibly stale) cached id through.
+            let (Some(client), Some(_), Some(server_cube_id)) =
                 (client, ra.vault_id, server_cube_id)
             else {
                 ra.error = Some(
@@ -363,7 +383,10 @@ pub fn update(
             // Unlock the seed with the entered PIN, build the seed blob, then
             // enrol descriptor + seed. The mnemonic is wrapped in `Zeroizing`
             // at the async boundary and never rides a message.
-            let pin = Zeroizing::new(std::mem::take(&mut ra.pin));
+            // `EscrowPin` is already zeroizing-backed; take it out (leaving an
+            // empty buffer) and let it drop inside the blocking task, wiping the
+            // PIN once the seed blob is built.
+            let pin = std::mem::take(&mut ra.pin);
             let seed_cube = match seed_blob_cube(cache, local_cube_id) {
                 Ok(c) => c,
                 Err(e) => {
@@ -378,25 +401,31 @@ pub fn update(
             ra.submitting = true;
             ra.awaiting_pin = false;
             ra.error = None;
-            ra.pending_tier = Some(EscrowTier::FullCube);
             Task::perform(
                 async move {
                     let seed_json = tokio::task::spawn_blocking(move || {
-                        build_seed_blob_json(&network_dir, &datadir, network, &local_cube_id, &pin, seed_cube)
+                        build_seed_blob_json(
+                            &network_dir,
+                            &datadir,
+                            network,
+                            &local_cube_id,
+                            pin.as_str(),
+                            seed_cube,
+                        )
                     })
                     .await
                     .map_err(|e| format!("PIN task failed: {}", e))??;
-                    enroll_escrow(
-                        &client,
-                        server_cube_id,
-                        vault_id,
-                        descriptor_json,
-                        Some(seed_json),
-                    )
-                    .await
-                    .map_err(|e| e.to_string())
+                    enroll_escrow(&client, server_cube_id, descriptor_json, Some(seed_json))
+                        .await
+                        .map_err(|e| e.to_string())
                 },
-                move |res| ra_msg(RecoveryAlertsMessage::ChangeResult(res, session_generation)),
+                move |res| {
+                    ra_msg(RecoveryAlertsMessage::ChangeResult(
+                        res,
+                        session_generation,
+                        Some(EscrowTier::FullCube),
+                    ))
+                },
             )
         }
         RecoveryAlertsMessage::SetDownloadPolicy(policy) => {
@@ -421,10 +450,19 @@ pub fn update(
                         .await
                         .map_err(|e| e.to_string())
                 },
-                move |res| ra_msg(RecoveryAlertsMessage::ChangeResult(res, session_generation)),
+                // A policy save carries no tier change (`None`) so its result
+                // never touches the tracked escrow tier — even if it resolves
+                // while a tier change is still in flight.
+                move |res| {
+                    ra_msg(RecoveryAlertsMessage::ChangeResult(
+                        res,
+                        session_generation,
+                        None,
+                    ))
+                },
             )
         }
-        RecoveryAlertsMessage::ChangeResult(res, gen) => {
+        RecoveryAlertsMessage::ChangeResult(res, gen, tier_change) => {
             // Drop a change that resolved after the session changed so a stale
             // result can't clobber a newer session's state.
             if gen != session_generation {
@@ -433,16 +471,16 @@ pub fn update(
             ra.submitting = false;
             match res {
                 Ok(status) => {
-                    // Apply the tier we just enrolled/disabled (tracked in
-                    // `pending_tier`) now that the server confirmed it.
-                    if let Some(t) = ra.pending_tier.take() {
+                    // Apply the tier this operation enrolled/disabled now that
+                    // the server confirmed it. `None` for a policy save, which
+                    // must never relabel the tier selector.
+                    if let Some(t) = tier_change {
                         ra.tier = t;
                     }
                     ra.status = Some(status);
                     ra.error = None;
                 }
                 Err(e) => {
-                    ra.pending_tier = None;
                     ra.error = Some(e);
                 }
             }
@@ -492,7 +530,9 @@ fn seed_blob_cube(cache: &Cache, local_cube_id: &str) -> Result<SeedBlobCube, St
 /// Verifies the PIN, unlocks the mnemonic, and serialises the full seed blob
 /// JSON for Full-Cube escrow. Runs on a blocking thread (Argon2 PIN verify +
 /// disk read). The mnemonic is wiped (`Zeroizing`) as soon as the phrase string
-/// is built.
+/// is built, and the serialised JSON — which itself contains the plaintext seed
+/// — is returned in a `Zeroizing` buffer so it's wiped once escrow sealing is
+/// done rather than lingering on the heap.
 fn build_seed_blob_json(
     network_dir: &crate::dir::NetworkDirectory,
     datadir: &std::path::Path,
@@ -500,7 +540,7 @@ fn build_seed_blob_json(
     local_cube_id: &str,
     pin: &str,
     cube: SeedBlobCube,
-) -> Result<Vec<u8>, String> {
+) -> Result<Zeroizing<Vec<u8>>, String> {
     let s =
         settings::Settings::from_file(network_dir).map_err(|_| "Failed to read settings file.")?;
     let cube_settings = s
@@ -524,5 +564,67 @@ fn build_seed_blob_json(
             language: "en".to_string(),
         },
     };
-    serde_json::to_vec(&blob).map_err(|e| format!("seed blob: {}", e))
+    serde_json::to_vec(&blob)
+        .map(Zeroizing::new)
+        .map_err(|e| format!("seed blob: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn monitoring_on() -> VaultMonitoringStatus {
+        VaultMonitoringStatus {
+            level: VaultMonitoringLevel::Heartbeat,
+            ..VaultMonitoringStatus::default()
+        }
+    }
+
+    #[test]
+    fn tier_is_off_when_monitoring_off() {
+        // No status loaded yet → level Off → tier is a confirmed Off.
+        assert_eq!(RecoveryAlerts::new().tier(), Some(EscrowTier::Off));
+    }
+
+    #[test]
+    fn tier_is_unknown_when_on_but_untracked() {
+        // Monitoring on but `tier` still at its default (e.g. fresh after a
+        // restart): we must report `None` ("on, tier unknown"), NOT guess
+        // Vault-only — guessing would render the false "the seed is never
+        // escrowed" copy for a vault that may be Full-Cube.
+        let mut ra = RecoveryAlerts::new();
+        ra.status = Some(monitoring_on());
+        assert_eq!(ra.tier(), None);
+    }
+
+    #[test]
+    fn tier_is_reported_when_on_and_tracked() {
+        // A tier we applied this session is reported as-is while monitoring is on.
+        let mut ra = RecoveryAlerts::new();
+        ra.status = Some(monitoring_on());
+        ra.tier = EscrowTier::FullCube;
+        assert_eq!(ra.tier(), Some(EscrowTier::FullCube));
+    }
+
+    #[test]
+    fn pin_is_redacted_in_debug_output() {
+        // Canary PIN unlikely to collide with any other field's Debug.
+        let mut ra = RecoveryAlerts::new();
+        ra.pin = EscrowPin::from("9173".to_string());
+
+        // The wrapper redacts itself...
+        assert_eq!(format!("{:?}", ra.pin), "EscrowPin(<redacted>)");
+        // ...so the struct's derived Debug can't leak the PIN.
+        let dump = format!("{:?}", ra);
+        assert!(!dump.contains("9173"), "PIN leaked in Debug: {}", dump);
+        assert!(dump.contains("<redacted>"));
+    }
+
+    #[test]
+    fn pin_clear_empties_the_buffer() {
+        let mut pin = EscrowPin::from("1234".to_string());
+        assert_eq!(pin.as_str(), "1234");
+        pin.clear();
+        assert_eq!(pin.as_str(), "");
+    }
 }

--- a/coincube-gui/src/app/state/settings/recovery_alerts.rs
+++ b/coincube-gui/src/app/state/settings/recovery_alerts.rs
@@ -128,6 +128,49 @@ impl RecoveryAlerts {
             .map(|s| s.crk_keyholder_download)
             .unwrap_or_default()
     }
+
+    /// Fold a change result into state.
+    ///
+    /// **Ok:** apply the confirmed `tier_change` (if any) and cache `status`. On
+    /// a **disable** (`Some(Off)`), `status` is the synthetic Off status
+    /// [`disable_escrow`](crate::services::inheritance::disable_escrow) returns,
+    /// which carries the *default* download policy — so we carry the owner's
+    /// prior keyholder download choice forward instead, keeping it for a later
+    /// re-enrol (the policy is an independent vault setting, not reset by turning
+    /// escrow off).
+    ///
+    /// **Err:** surface the (display-safe) error. A failed **Full-Cube** enrol
+    /// also restores `awaiting_pin`: `ConfirmFullCube` clears it before the
+    /// blocking verify, so a wrong PIN would otherwise hide the PIN entry and
+    /// force the owner to re-pick Full Cube. Restoring it re-shows the (now
+    /// empty — the buffer was taken) PIN field alongside the error for an inline
+    /// retry.
+    fn apply_change(
+        &mut self,
+        res: Result<VaultMonitoringStatus, String>,
+        tier_change: Option<EscrowTier>,
+    ) {
+        match res {
+            Ok(mut status) => {
+                if let Some(t) = tier_change {
+                    self.tier = t;
+                }
+                if matches!(tier_change, Some(EscrowTier::Off)) {
+                    if let Some(prev) = self.status.as_ref() {
+                        status.crk_keyholder_download = prev.crk_keyholder_download;
+                    }
+                }
+                self.status = Some(status);
+                self.error = None;
+            }
+            Err(e) => {
+                self.error = Some(e);
+                if matches!(tier_change, Some(EscrowTier::FullCube)) {
+                    self.awaiting_pin = true;
+                }
+            }
+        }
+    }
 }
 
 /// Wrap a [`RecoveryAlertsMessage`] in the settings-message envelope.
@@ -487,21 +530,10 @@ pub fn update(
                 return Task::none();
             }
             ra.submitting = false;
-            match res {
-                Ok(status) => {
-                    // Apply the tier this operation enrolled/disabled now that
-                    // the server confirmed it. `None` for a policy save, which
-                    // must never relabel the tier selector.
-                    if let Some(t) = tier_change {
-                        ra.tier = t;
-                    }
-                    ra.status = Some(status);
-                    ra.error = None;
-                }
-                Err(e) => {
-                    ra.error = Some(e);
-                }
-            }
+            // Fold the result into state: caches the status (preserving the
+            // download policy across a disable) on success, or surfaces the
+            // error and re-shows the PIN entry on a failed Full-Cube enrol.
+            ra.apply_change(res, tier_change);
             Task::none()
         }
     }
@@ -644,5 +676,82 @@ mod tests {
         assert_eq!(pin.as_str(), "1234");
         pin.clear();
         assert_eq!(pin.as_str(), "");
+    }
+
+    #[test]
+    fn disable_preserves_prior_download_policy() {
+        // Owner had escrow on with a non-default (Anytime) download policy.
+        let mut ra = RecoveryAlerts::new();
+        ra.status = Some(VaultMonitoringStatus {
+            level: VaultMonitoringLevel::Heartbeat,
+            crk_keyholder_download: KeyholderDownloadPolicy::Anytime,
+            ..VaultMonitoringStatus::default()
+        });
+        ra.tier = EscrowTier::VaultOnly;
+
+        // disable_escrow returns a synthetic Off status carrying the *default*
+        // (AtApproaching) policy.
+        let synthetic_off = VaultMonitoringStatus {
+            level: VaultMonitoringLevel::Off,
+            ..VaultMonitoringStatus::default()
+        };
+        ra.apply_change(Ok(synthetic_off), Some(EscrowTier::Off));
+
+        // Tier goes Off, but the owner's Anytime choice must survive so a later
+        // re-enrol forwards it — not silently revert to the default.
+        assert_eq!(ra.tier, EscrowTier::Off);
+        assert_eq!(ra.download_policy(), KeyholderDownloadPolicy::Anytime);
+    }
+
+    #[test]
+    fn enroll_caches_returned_download_policy_verbatim() {
+        // A (re-)enrol returns the real monitoring status; it is cached as-is
+        // (no disable-preservation override for non-Off changes).
+        let mut ra = RecoveryAlerts::new();
+        ra.status = Some(VaultMonitoringStatus {
+            level: VaultMonitoringLevel::Heartbeat,
+            crk_keyholder_download: KeyholderDownloadPolicy::Anytime,
+            ..VaultMonitoringStatus::default()
+        });
+        let returned = VaultMonitoringStatus {
+            level: VaultMonitoringLevel::Heartbeat,
+            crk_keyholder_download: KeyholderDownloadPolicy::AtApproaching,
+            ..VaultMonitoringStatus::default()
+        };
+        ra.apply_change(Ok(returned), Some(EscrowTier::FullCube));
+        assert_eq!(ra.tier, EscrowTier::FullCube);
+        assert_eq!(ra.download_policy(), KeyholderDownloadPolicy::AtApproaching);
+    }
+
+    #[test]
+    fn failed_full_cube_enrol_reshows_pin_entry() {
+        // ConfirmFullCube clears `awaiting_pin` before the blocking PIN verify;
+        // a wrong PIN surfaces as an Err here and must re-show the PIN entry for
+        // an inline retry (not force the owner to re-pick Full Cube).
+        let mut ra = RecoveryAlerts::new();
+        ra.awaiting_pin = false;
+        ra.apply_change(
+            Err("Incorrect PIN. Please try again.".to_string()),
+            Some(EscrowTier::FullCube),
+        );
+        assert!(
+            ra.awaiting_pin,
+            "a failed Full-Cube enrol must re-show the PIN entry"
+        );
+        assert_eq!(
+            ra.error.as_deref(),
+            Some("Incorrect PIN. Please try again.")
+        );
+    }
+
+    #[test]
+    fn failed_non_full_cube_change_leaves_pin_hidden() {
+        // Off / Vault-only have no PIN entry, so a failure must not flip
+        // `awaiting_pin` on.
+        let mut ra = RecoveryAlerts::new();
+        ra.awaiting_pin = false;
+        ra.apply_change(Err("network".to_string()), Some(EscrowTier::VaultOnly));
+        assert!(!ra.awaiting_pin);
+        assert_eq!(ra.error.as_deref(), Some("network"));
     }
 }

--- a/coincube-gui/src/app/state/settings/recovery_alerts.rs
+++ b/coincube-gui/src/app/state/settings/recovery_alerts.rs
@@ -171,6 +171,23 @@ impl RecoveryAlerts {
             }
         }
     }
+
+    /// Fold a successful `LoadStatus` into state.
+    ///
+    /// The monitoring status reports on/off (`level`) — **not** which escrow
+    /// tier. So we reset our session-tracked tier on every (re)load: the status
+    /// can't confirm it, and another device may have changed it (e.g. upgraded
+    /// Vault-only → Full-Cube) while monitoring stayed on. [`Self::tier`] then
+    /// reports an on vault as `None` ("on, tier unknown") until *this* device
+    /// performs an enrol/disable, so the card never re-asserts a stale tier (and
+    /// its false seed-escrow copy) it can't actually confirm.
+    fn apply_status_loaded(&mut self, vault_id: u64, status: VaultMonitoringStatus) {
+        self.vault_id = Some(vault_id);
+        self.status = Some(status);
+        self.no_vault = false;
+        self.error = None;
+        self.tier = EscrowTier::Off;
+    }
 }
 
 /// Wrap a [`RecoveryAlertsMessage`] in the settings-message envelope.
@@ -266,21 +283,10 @@ pub fn update(
             ra.loaded_once = true;
             match res {
                 Ok((vid, status)) => {
-                    let level_off = matches!(status.level, VaultMonitoringLevel::Off);
-                    ra.vault_id = Some(vid);
-                    ra.status = Some(status);
-                    ra.no_vault = false;
-                    ra.error = None;
-                    // The monitoring status reports on/off, not which escrow
-                    // tier. Reconcile our tracked tier: clear it to Off when
-                    // monitoring is off; otherwise leave it untouched. We do NOT
-                    // guess a tier for an "on" vault we didn't enrol this
-                    // session — `tier()` reports that as `None` ("on, tier
-                    // unknown") so the card never asserts a tier (and false
-                    // seed-escrow copy) it can't actually confirm.
-                    if level_off {
-                        ra.tier = EscrowTier::Off;
-                    }
+                    // Cache the freshly-loaded status and reset our tracked tier
+                    // (the status confirms on/off only, not the tier — so we
+                    // never re-assert a tier we can't confirm). See the method.
+                    ra.apply_status_loaded(vid, status);
                 }
                 Err(e) => {
                     // A missing Connect vault (the cube has no vault yet, or a
@@ -753,5 +759,40 @@ mod tests {
         ra.apply_change(Err("network".to_string()), Some(EscrowTier::VaultOnly));
         assert!(!ra.awaiting_pin);
         assert_eq!(ra.error.as_deref(), Some("network"));
+    }
+
+    #[test]
+    fn reload_clears_stale_session_tier_for_on_vault() {
+        // This device thinks it's Full-Cube from an earlier enrol...
+        let mut ra = RecoveryAlerts::new();
+        ra.tier = EscrowTier::FullCube;
+        // ...but a reload only confirms monitoring is *on* (level), not the tier
+        // — another device may have changed it. The card must NOT keep asserting
+        // Full-Cube ("seed is escrowed"); it must report "on, tier unknown".
+        ra.apply_status_loaded(
+            7,
+            VaultMonitoringStatus {
+                level: VaultMonitoringLevel::Heartbeat,
+                ..VaultMonitoringStatus::default()
+            },
+        );
+        assert_eq!(ra.tier(), None);
+        assert_eq!(ra.vault_id, Some(7));
+        assert!(!ra.no_vault);
+    }
+
+    #[test]
+    fn reload_reports_off_when_monitoring_off() {
+        // A stale tracked tier must collapse to Off when the load says off.
+        let mut ra = RecoveryAlerts::new();
+        ra.tier = EscrowTier::FullCube;
+        ra.apply_status_loaded(
+            7,
+            VaultMonitoringStatus {
+                level: VaultMonitoringLevel::Off,
+                ..VaultMonitoringStatus::default()
+            },
+        );
+        assert_eq!(ra.tier(), Some(EscrowTier::Off));
     }
 }

--- a/coincube-gui/src/app/state/settings/recovery_alerts.rs
+++ b/coincube-gui/src/app/state/settings/recovery_alerts.rs
@@ -315,11 +315,20 @@ pub fn update(
                     };
                     ra.submitting = true;
                     ra.error = None;
+                    // Preserve the vault's current download policy across the
+                    // enrol (omitting it would reset to the server default).
+                    let download_policy = ra.download_policy();
                     Task::perform(
                         async move {
-                            enroll_escrow(&client, server_cube_id, descriptor_json, None)
-                                .await
-                                .map_err(|e| e.to_string())
+                            enroll_escrow(
+                                &client,
+                                server_cube_id,
+                                descriptor_json,
+                                None,
+                                download_policy,
+                            )
+                            .await
+                            .map_err(|e| e.to_string())
                         },
                         move |res| {
                             ra_msg(RecoveryAlertsMessage::ChangeResult(
@@ -401,6 +410,9 @@ pub fn update(
             ra.submitting = true;
             ra.awaiting_pin = false;
             ra.error = None;
+            // Preserve the vault's current download policy across the enrol
+            // (omitting it would reset to the server default).
+            let download_policy = ra.download_policy();
             Task::perform(
                 async move {
                     let seed_json = tokio::task::spawn_blocking(move || {
@@ -415,9 +427,15 @@ pub fn update(
                     })
                     .await
                     .map_err(|e| format!("PIN task failed: {}", e))??;
-                    enroll_escrow(&client, server_cube_id, descriptor_json, Some(seed_json))
-                        .await
-                        .map_err(|e| e.to_string())
+                    enroll_escrow(
+                        &client,
+                        server_cube_id,
+                        descriptor_json,
+                        Some(seed_json),
+                        download_policy,
+                    )
+                    .await
+                    .map_err(|e| e.to_string())
                 },
                 move |res| {
                     ra_msg(RecoveryAlertsMessage::ChangeResult(

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -826,7 +826,11 @@ fn should_nudge_for_status(status: Option<&RecoveryKitStatus>) -> bool {
         .unwrap_or(true)
 }
 
-fn descriptor_blob_from_wallet(wallet: &Wallet, cube_uuid: &str, network: &str) -> DescriptorBlob {
+pub(crate) fn descriptor_blob_from_wallet(
+    wallet: &Wallet,
+    cube_uuid: &str,
+    network: &str,
+) -> DescriptorBlob {
     // The descriptor string embeds the full signer xpubs inline, so
     // restore is self-contained from `vault.descriptor` alone. The
     // separate `signers` array is metadata the UI can show pre-restore

--- a/coincube-gui/src/app/state/vault/keychain_sign.rs
+++ b/coincube-gui/src/app/state/vault/keychain_sign.rs
@@ -754,6 +754,8 @@ impl KeychainSignModal {
                     nanos: 0,
                 }),
                 require_user_presence: false,
+                // Owner-branch signing; the heir recovery sweep sets this true.
+                is_recovery_spend: false,
             };
             let tokens = tokens.clone();
             let grpc_url = grpc_url.clone();
@@ -1330,6 +1332,8 @@ impl KeychainSignModal {
                         nanos: 0,
                     }),
                     require_user_presence: false,
+                    // Owner-branch signing; the heir recovery sweep sets this true.
+                    is_recovery_spend: false,
                 };
                 client
                     .create_signing_session(req)

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -383,8 +383,16 @@ pub enum RecoveryAlertsMessage {
         Result<(u64, crate::services::coincube::VaultMonitoringStatus), String>,
         u64,
     ),
-    /// User picked a monitoring level (Off / Alerts-only / Full).
-    SelectLevel(crate::services::coincube::VaultMonitoringLevel),
+    /// User picked an inheritance escrow tier (Off / Vault-only / Full-Cube).
+    /// Vault-only and Off apply immediately; Full-Cube first collects the PIN
+    /// (to unlock the seed) and applies on `ConfirmFullCube`.
+    SelectTier(crate::services::inheritance::EscrowTier),
+    /// PIN digit input while enrolling the Full-Cube tier (escrows the seed).
+    EscrowPinChanged(String),
+    /// Confirm Full-Cube enrolment with the entered PIN (unlock seed + escrow).
+    ConfirmFullCube,
+    /// Abandon the in-progress Full-Cube PIN entry.
+    CancelFullCube,
     /// User changed the keyholder recovery-kit download policy.
     SetDownloadPolicy(crate::services::coincube::KeyholderDownloadPolicy),
     /// Async result of a level / policy change — the updated status. The

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -47,6 +47,41 @@ impl std::fmt::Debug for ConnectJwt {
     }
 }
 
+/// Wrapper around the PIN entered to unlock the seed for Full-Cube inheritance
+/// escrow. Redacts its contents from `Debug` and zeroes the heap allocation on
+/// drop, so the PIN never leaks — neither through `{:?}` on a parent message
+/// ([`RecoveryAlertsMessage`] derives `Debug` and tracing/panic dumps format
+/// messages transitively) nor through the `RecoveryAlerts` settings state it's
+/// stored in. Mirrors [`ConnectJwt`] and the `Zeroizing` secret pattern used
+/// across the app.
+#[derive(Clone, Default)]
+pub struct EscrowPin(Zeroizing<String>);
+
+impl EscrowPin {
+    /// Borrow the PIN digits (e.g. to verify against the cube settings).
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Wipe the entered PIN. Replaces the buffer so the previous bytes are
+    /// zeroed on drop — a plain `String::clear` would only reset the length.
+    pub fn clear(&mut self) {
+        self.0 = Zeroizing::default();
+    }
+}
+
+impl From<String> for EscrowPin {
+    fn from(pin: String) -> Self {
+        Self(Zeroizing::new(pin))
+    }
+}
+
+impl std::fmt::Debug for EscrowPin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("EscrowPin(<redacted>)")
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum FeeratePriority {
     Low,
@@ -388,7 +423,9 @@ pub enum RecoveryAlertsMessage {
     /// (to unlock the seed) and applies on `ConfirmFullCube`.
     SelectTier(crate::services::inheritance::EscrowTier),
     /// PIN digit input while enrolling the Full-Cube tier (escrows the seed).
-    EscrowPinChanged(String),
+    /// Carried in a redacting, zeroizing [`EscrowPin`] so the PIN never lands
+    /// in a `{:?}` dump or lingers un-wiped in a dropped message.
+    EscrowPinChanged(EscrowPin),
     /// Confirm Full-Cube enrolment with the entered PIN (unlock seed + escrow).
     ConfirmFullCube,
     /// Abandon the in-progress Full-Cube PIN entry.
@@ -396,12 +433,17 @@ pub enum RecoveryAlertsMessage {
     /// User changed the keyholder recovery-kit download policy.
     SetDownloadPolicy(crate::services::coincube::KeyholderDownloadPolicy),
     /// Async result of a level / policy change — the updated status. The
-    /// trailing `u64` is the spawn-time `session_generation` (see
-    /// `StatusLoaded`); a stale result is dropped rather than clobbering a
-    /// newer session's state.
+    /// `u64` is the spawn-time `session_generation` (see `StatusLoaded`); a
+    /// stale result is dropped rather than clobbering a newer session's state.
+    /// The trailing `Option<EscrowTier>` is the tier this operation enrolled /
+    /// disabled (`None` for a download-policy save): on success the handler
+    /// applies it to the tracked tier. Carrying it in the result — rather than
+    /// in shared state — keeps a policy save that resolves while a tier change
+    /// is in flight from applying the other operation's tier.
     ChangeResult(
         Result<crate::services::coincube::VaultMonitoringStatus, String>,
         u64,
+        Option<crate::services::inheritance::EscrowTier>,
     ),
 }
 

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -15,8 +15,9 @@ use crate::app::state::settings::recovery_alerts::RecoveryAlerts;
 use crate::app::state::settings::recovery_kit::RecoveryKit;
 use crate::app::view::dashboard;
 use crate::app::view::message::*;
-use crate::services::coincube::{KeyholderDownloadPolicy, RecoveryKitStatus, VaultMonitoringLevel};
+use crate::services::coincube::{KeyholderDownloadPolicy, RecoveryKitStatus};
 use crate::services::fiat::{Currency, ALL_PRICE_SOURCES};
+use crate::services::inheritance::EscrowTier;
 
 #[allow(clippy::too_many_arguments)]
 pub fn general_section<'a>(
@@ -140,32 +141,77 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
         return card::simple(body).width(Length::Fill).into();
     }
 
-    let level = ra.level();
+    let tier = ra.tier();
     let busy = ra.submitting;
 
-    // Three-tier selector row.
-    let level_row = Row::new()
+    // Inheritance escrow tier selector (ECIES pivot). Picking a tier turns the
+    // server-blind heartbeat gate on and uploads the per-keyholder ciphertext;
+    // Off tears the escrow down. The old plaintext-descriptor "Full" tier is
+    // gone — COINCUBE never sees the descriptor or seed.
+    let tier_row = Row::new()
         .spacing(8)
-        .push(level_button("Off", VaultMonitoringLevel::Off, level, busy))
-        .push(level_button(
-            "Alerts only",
-            VaultMonitoringLevel::Heartbeat,
-            level,
+        .push(tier_button("Off", EscrowTier::Off, tier, busy, ra.awaiting_pin))
+        .push(tier_button(
+            "Vault only",
+            EscrowTier::VaultOnly,
+            tier,
             busy,
+            ra.awaiting_pin,
         ))
-        .push(level_button(
-            "Full",
-            VaultMonitoringLevel::Full,
-            level,
+        .push(tier_button(
+            "Full Cube",
+            EscrowTier::FullCube,
+            tier,
             busy,
+            ra.awaiting_pin,
         ));
-    body = body.push(level_row);
+    body = body.push(tier_row);
 
     // The honest trade-off copy for the selected tier.
-    body = body.push(text(level_copy(level)).size(13));
+    body = body.push(text(tier_copy(tier)).size(13));
 
-    // Keyholder list + download policy only make sense when monitoring is on.
-    if !matches!(level, VaultMonitoringLevel::Off) {
+    // Full-Cube re-confirms the PIN before exporting the seed into escrow.
+    if ra.awaiting_pin {
+        body = body.push(Space::new().height(Length::Fixed(6.0)));
+        body = body.push(
+            text("Enter your PIN to include this Cube's seed in the encrypted escrow.").size(13),
+        );
+        body = body.push(
+            iced::widget::text_input("PIN", &ra.pin)
+                .secure(true)
+                .padding(8)
+                .on_input(|s| {
+                    SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::EscrowPinChanged(s))
+                        .into()
+                })
+                .on_submit(
+                    SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::ConfirmFullCube).into(),
+                ),
+        );
+        body = body.push(
+            Row::new()
+                .spacing(8)
+                .push(
+                    button::primary(None, "Confirm").padding([8, 14]).on_press_maybe(
+                        (!busy).then_some(
+                            SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::ConfirmFullCube)
+                                .into(),
+                        ),
+                    ),
+                )
+                .push(
+                    button::secondary(None, "Cancel")
+                        .padding([8, 14])
+                        .on_press_maybe(Some(
+                            SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::CancelFullCube)
+                                .into(),
+                        )),
+                ),
+        );
+    }
+
+    // Keyholder list + download policy only make sense when escrow is on.
+    if tier.is_on() {
         // Who would be notified.
         body = body.push(Space::new().height(Length::Fixed(4.0)));
         body = body.push(text("Keyholders who'd be notified").bold().size(14));
@@ -216,18 +262,21 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
     card::simple(body).width(Length::Fill).into()
 }
 
-/// A monitoring-level option button. Highlighted (primary) when it's the
-/// active level; disabled while a change is in flight.
-fn level_button<'a>(
+/// An escrow-tier option button. Highlighted (primary) when it's the active
+/// tier (or while collecting the PIN for a Full-Cube enrolment); disabled while
+/// a change is in flight.
+fn tier_button<'a>(
     label: &'static str,
-    this: VaultMonitoringLevel,
-    active: VaultMonitoringLevel,
+    this: EscrowTier,
+    active: EscrowTier,
     busy: bool,
+    awaiting_pin: bool,
 ) -> Element<'a, Message> {
-    let on_press = (!busy && this != active).then_some(
-        SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::SelectLevel(this)).into(),
+    let is_active = this == active || (awaiting_pin && this == EscrowTier::FullCube);
+    let on_press = (!busy && !is_active).then_some(
+        SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::SelectTier(this)).into(),
     );
-    if this == active {
+    if is_active {
         button::primary(None, label)
             .padding([8, 14])
             .on_press_maybe(None)
@@ -263,25 +312,27 @@ fn policy_button<'a>(
     }
 }
 
-/// Plain-language trade-off for each monitoring tier (no euphemisms — the
-/// self-custody trust model demands it; see `PLAN-estate-notifications.md`).
-fn level_copy(level: VaultMonitoringLevel) -> &'static str {
-    match level {
-        VaultMonitoringLevel::Off => {
-            "Off: COINCUBE doesn't watch this Vault. No keyholder alerts, and no copy of your \
-             descriptor is kept."
+/// Plain-language trade-off for each escrow tier (no euphemisms — the
+/// self-custody trust model demands it; see the ECIES decision record).
+/// Everything is encrypted to the keyholders' own keys: COINCUBE can read
+/// neither the descriptor nor the seed.
+fn tier_copy(tier: EscrowTier) -> &'static str {
+    match tier {
+        EscrowTier::Off => {
+            "Off: heirs can't recover this Vault. No encrypted copy is kept and COINCUBE watches \
+             nothing."
         }
-        VaultMonitoringLevel::Heartbeat => {
-            "Alerts only: your device tells COINCUBE just the date this Vault's recovery window \
-             opens — never its addresses or balances. Keyholders get an email when that date \
-             nears, and will still need the recovery password you shared with them."
+        EscrowTier::VaultOnly => {
+            "Vault only: an encrypted copy of this Vault's descriptor is sealed to each \
+             keyholder's own key — only they can open it, never COINCUBE. When the recovery \
+             window opens, a keyholder recovers the watch-only Vault and sweeps the funds. The \
+             seed is never escrowed."
         }
-        VaultMonitoringLevel::Full => {
-            "Full: COINCUBE keeps an encrypted copy of this Vault's descriptor to watch the chain \
-             for you — it can see this Vault's addresses and balances, never spend. Keyholders \
-             get an email when a recovery path opens and can recover this Vault WITHOUT your \
-             password. Your Cube master-seed backup still needs your recovery password — that's \
-             the one to share carefully."
+        EscrowTier::FullCube => {
+            "Full Cube: seals this Cube's seed AND descriptor to each keyholder's own key. A \
+             keyholder can restore the entire Cube — Liquid, Spark and Vault. COINCUBE can never \
+             read either; only the keyholder's key can. You'll re-confirm your PIN to include the \
+             seed."
         }
     }
 }

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -141,7 +141,10 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
         return card::simple(body).width(Length::Fill).into();
     }
 
+    // `None` = escrow is on but this device doesn't know which tier (e.g. after
+    // a restart). Escrow is "on" for anything that isn't a confirmed Off.
     let tier = ra.tier();
+    let is_on = !matches!(tier, Some(EscrowTier::Off));
     let busy = ra.submitting;
 
     // Inheritance escrow tier selector (ECIES pivot). Picking a tier turns the
@@ -150,7 +153,13 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
     // gone — COINCUBE never sees the descriptor or seed.
     let tier_row = Row::new()
         .spacing(8)
-        .push(tier_button("Off", EscrowTier::Off, tier, busy, ra.awaiting_pin))
+        .push(tier_button(
+            "Off",
+            EscrowTier::Off,
+            tier,
+            busy,
+            ra.awaiting_pin,
+        ))
         .push(tier_button(
             "Vault only",
             EscrowTier::VaultOnly,
@@ -167,8 +176,17 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
         ));
     body = body.push(tier_row);
 
-    // The honest trade-off copy for the selected tier.
-    body = body.push(text(tier_copy(tier)).size(13));
+    // The honest trade-off copy for the selected tier. While the PIN is being
+    // collected for a Full-Cube enrolment, `ra.tier()` still reports the prior
+    // tier (it only advances on a confirmed change) but the Full Cube button is
+    // already highlighted — show its copy to match (same condition the button
+    // uses for its highlight).
+    let display_tier = if ra.awaiting_pin {
+        Some(EscrowTier::FullCube)
+    } else {
+        tier
+    };
+    body = body.push(text(tier_copy(display_tier)).size(13));
 
     // Full-Cube re-confirms the PIN before exporting the seed into escrow.
     if ra.awaiting_pin {
@@ -177,12 +195,14 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
             text("Enter your PIN to include this Cube's seed in the encrypted escrow.").size(13),
         );
         body = body.push(
-            iced::widget::text_input("PIN", &ra.pin)
+            iced::widget::text_input("PIN", ra.pin.as_str())
                 .secure(true)
                 .padding(8)
                 .on_input(|s| {
-                    SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::EscrowPinChanged(s))
-                        .into()
+                    SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::EscrowPinChanged(
+                        s.into(),
+                    ))
+                    .into()
                 })
                 .on_submit(
                     SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::ConfirmFullCube).into(),
@@ -192,12 +212,16 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
             Row::new()
                 .spacing(8)
                 .push(
-                    button::primary(None, "Confirm").padding([8, 14]).on_press_maybe(
-                        (!busy).then_some(
-                            SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::ConfirmFullCube)
+                    button::primary(None, "Confirm")
+                        .padding([8, 14])
+                        .on_press_maybe(
+                            (!busy).then_some(
+                                SettingsMessage::RecoveryAlerts(
+                                    RecoveryAlertsMessage::ConfirmFullCube,
+                                )
                                 .into(),
+                            ),
                         ),
-                    ),
                 )
                 .push(
                     button::secondary(None, "Cancel")
@@ -211,7 +235,7 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
     }
 
     // Keyholder list + download policy only make sense when escrow is on.
-    if tier.is_on() {
+    if is_on {
         // Who would be notified.
         body = body.push(Space::new().height(Length::Fixed(4.0)));
         body = body.push(text("Keyholders who'd be notified").bold().size(14));
@@ -268,14 +292,15 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
 fn tier_button<'a>(
     label: &'static str,
     this: EscrowTier,
-    active: EscrowTier,
+    active: Option<EscrowTier>,
     busy: bool,
     awaiting_pin: bool,
 ) -> Element<'a, Message> {
-    let is_active = this == active || (awaiting_pin && this == EscrowTier::FullCube);
-    let on_press = (!busy && !is_active).then_some(
-        SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::SelectTier(this)).into(),
-    );
+    // `active == None` (tier on but unknown on this device) highlights nothing,
+    // leaving every tier pressable so the owner can confirm/change it.
+    let is_active = active == Some(this) || (awaiting_pin && this == EscrowTier::FullCube);
+    let on_press = (!busy && !is_active)
+        .then_some(SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::SelectTier(this)).into());
     if is_active {
         button::primary(None, label)
             .padding([8, 14])
@@ -316,19 +341,28 @@ fn policy_button<'a>(
 /// self-custody trust model demands it; see the ECIES decision record).
 /// Everything is encrypted to the keyholders' own keys: COINCUBE can read
 /// neither the descriptor nor the seed.
-fn tier_copy(tier: EscrowTier) -> &'static str {
+fn tier_copy(tier: Option<EscrowTier>) -> &'static str {
     match tier {
-        EscrowTier::Off => {
+        // Escrow is on, but this device didn't enrol it this session and the
+        // owner monitoring status doesn't report the tier — so we state that
+        // honestly rather than assert (and possibly mis-state) descriptor-only
+        // vs seed escrow.
+        None => {
+            "Recovery escrow is on, but this device can't tell which tier is active (it isn't \
+             reported after a restart). Reselect Vault only or Full Cube to confirm or change it, \
+             or Off to turn recovery off."
+        }
+        Some(EscrowTier::Off) => {
             "Off: heirs can't recover this Vault. No encrypted copy is kept and COINCUBE watches \
              nothing."
         }
-        EscrowTier::VaultOnly => {
+        Some(EscrowTier::VaultOnly) => {
             "Vault only: an encrypted copy of this Vault's descriptor is sealed to each \
              keyholder's own key — only they can open it, never COINCUBE. When the recovery \
              window opens, a keyholder recovers the watch-only Vault and sweeps the funds. The \
              seed is never escrowed."
         }
-        EscrowTier::FullCube => {
+        Some(EscrowTier::FullCube) => {
             "Full Cube: seals this Cube's seed AND descriptor to each keyholder's own key. A \
              keyholder can restore the entire Cube — Liquid, Spark and Vault. COINCUBE can never \
              read either; only the keyholder's key can. You'll re-confirm your PIN to include the \

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1438,6 +1438,31 @@ impl Home {
                 Task::none()
             }
 
+            // Heir clicked "Recover" on an actionable row: launch the installer's
+            // inheritance-recovery flow (COIN-377 PR 3). Intercepted here (not
+            // forwarded to the panel) because launching the installer is a
+            // home-level action — the heir's authenticated Connect client is
+            // threaded into the installer Context so the decrypt step can fetch
+            // the envelopes + build the gRPC relay client.
+            Message::View(ViewMessage::RecoverVault(RecoverVaultMessage::Launch {
+                cube_id,
+                full_cube,
+            })) => {
+                let datadir_path = self.datadir_path.clone();
+                let network = self.network;
+                let client = self.connect_account.authenticated_client();
+                Task::perform(
+                    async move { (datadir_path, network, client) },
+                    move |(d, n, c)| {
+                        Message::Install(
+                            d,
+                            n,
+                            UserFlow::RecoverInheritedVault { cube_id, full_cube },
+                            c,
+                        )
+                    },
+                )
+            }
             Message::View(ViewMessage::RecoverVault(msg)) => {
                 // Forward to the discovery panel with the heir's authenticated
                 // Connect client; map the panel's task back into home messages.

--- a/coincube-gui/src/installer/message.rs
+++ b/coincube-gui/src/installer/message.rs
@@ -122,6 +122,8 @@ pub enum Message {
     RestorePinSetup(RestorePinSetupMsg),
     /// Cube Recovery Kit restore step (W13 / W14 / W15).
     RecoveryKitRestore(RecoveryKitRestoreMsg),
+    /// Heir inheritance-recovery decrypt step (ECIES pivot, COIN-377 PR 3).
+    InheritanceRestore(InheritanceRestoreMsg),
     BorderWalletWizard(
         super::step::descriptor::editor::border_wallet_wizard::BorderWalletWizardMessage,
     ),
@@ -326,6 +328,39 @@ impl std::fmt::Debug for RecoveryKitRestoreMsg {
                 .finish(),
             Self::RetryFromStart => write!(f, "RetryFromStart"),
             Self::Skip => write!(f, "Skip"),
+        }
+    }
+}
+
+/// Message driving the heir inheritance-recovery decrypt step (ECIES pivot).
+/// Manual `Debug` redacts the decrypt result: its `Ok` arm carries the
+/// decrypted `SeedBlob`/`DescriptorBlob` (the seed half is the master secret),
+/// so a tracing dump of a parent message must never render it. The blobs are
+/// `ZeroizeOnDrop`; the redaction keeps them off the heap-dump surface too.
+#[derive(Clone)]
+pub enum InheritanceRestoreMsg {
+    /// Async result of the fetch + Keychain relay decrypt + AEAD open: the
+    /// opened blobs, or a display-safe error string (gate failures already
+    /// neutralised — the duress 423 never explains why).
+    DecryptResult(
+        Result<
+            (
+                Option<crate::services::recovery::SeedBlob>,
+                Option<crate::services::recovery::DescriptorBlob>,
+            ),
+            String,
+        >,
+    ),
+}
+
+impl std::fmt::Debug for InheritanceRestoreMsg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DecryptResult(Ok(_)) => write!(f, "DecryptResult(Ok(<redacted>))"),
+            Self::DecryptResult(Err(e)) => f
+                .debug_tuple("DecryptResult")
+                .field(&Err::<(), _>(e))
+                .finish(),
         }
     }
 }

--- a/coincube-gui/src/installer/mod.rs
+++ b/coincube-gui/src/installer/mod.rs
@@ -107,9 +107,9 @@ pub use message::Message;
 use step::{
     BackupDescriptor, BackupMnemonic, ChooseBackend, ChooseDescriptorTemplate, CoincubeConnectStep,
     DefineDescriptor, DefineNode, DescriptorTemplateDescription, Final, ImportDescriptor,
-    ImportRemoteWallet, InternalBitcoindStep, RecoverMnemonic, RecoveryKitRestoreStep,
-    RegisterDescriptor, RemoteBackendLogin, RestorePinSetupStep, RestoreScope,
-    SelectBitcoindTypeStep, Step, WalletAlias,
+    ImportRemoteWallet, InheritanceRestoreStep, InternalBitcoindStep, RecoverMnemonic,
+    RecoveryKitRestoreStep, RegisterDescriptor, RemoteBackendLogin, RestorePinSetupStep,
+    RestoreScope, SelectBitcoindTypeStep, Step, WalletAlias,
 };
 
 #[derive(Debug, Clone)]
@@ -128,6 +128,16 @@ pub enum UserFlow {
     /// just needs to rehydrate the vault). Launched from the
     /// running app's "Create Vault" menu.
     RestoreVaultFromRecoveryKit,
+    /// Heir inheritance recovery (ECIES pivot, COIN-377 PR 3). Launched from
+    /// the pre-Cube "Recover a Vault" surface. `InheritanceRestoreStep`
+    /// fetches + relay-decrypts the heir's escrowed envelope(s) and stages the
+    /// seed/descriptor; the rest reuses the existing restore machinery.
+    /// `full_cube` picks the scope: Full (seed + descriptor → a real Cube, with
+    /// a PIN-setup step) vs descriptor-only (watch-only Vault recovery).
+    RecoverInheritedVault {
+        cube_id: u64,
+        full_cube: bool,
+    },
 }
 
 pub struct Installer {
@@ -245,7 +255,8 @@ impl Installer {
                         // `Undefined` and the `Message::Install` match panics
                         // with `unreachable!("Must be defined at this point")`.
                         (UserFlow::RestoreFromRecoveryKit, _)
-                        | (UserFlow::RestoreVaultFromRecoveryKit, _) => RemoteBackend::None,
+                        | (UserFlow::RestoreVaultFromRecoveryKit, _)
+                        | (UserFlow::RecoverInheritedVault { .. }, _) => RemoteBackend::None,
                         // AddWallet still has ChooseBackend which transitions away from Undefined.
                         (_, Network::Bitcoin | Network::Signet) => RemoteBackend::Undefined,
                         // Non-mainnet/signet AddWallet skips backend choice.
@@ -357,6 +368,41 @@ impl Installer {
                         WalletAlias::default().into(),
                         Final::new().into(),
                     ],
+                    // Heir inheritance recovery (COIN-377 PR 3). Same shape as
+                    // the owner restore flows, but `InheritanceRestoreStep`
+                    // (ECIES relay) is the decrypt source instead of the
+                    // owner-password Recovery-Kit step.
+                    UserFlow::RecoverInheritedVault { cube_id, full_cube } => {
+                        if full_cube {
+                            // Full-Cube: seed + descriptor → a real Cube. Mirror
+                            // RestoreFromRecoveryKit (incl. PIN setup for the
+                            // restored seed).
+                            vec![
+                                InheritanceRestoreStep::new(RestoreScope::Full, cube_id).into(),
+                                RestorePinSetupStep::new().into(),
+                                CoincubeConnectStep::new().into(),
+                                SelectBitcoindTypeStep::new().into(),
+                                InternalBitcoindStep::new(&context.coincube_directory).into(),
+                                DefineNode::new(crate::node::NodeType::Esplora).into(),
+                                WalletAlias::default().into(),
+                                Final::new().into(),
+                            ]
+                        } else {
+                            // Vault-only: descriptor → watch-only Vault. Mirror
+                            // RestoreVaultFromRecoveryKit (descriptor import, no
+                            // seed on disk).
+                            vec![
+                                InheritanceRestoreStep::new(RestoreScope::DescriptorOnly, cube_id)
+                                    .into(),
+                                RegisterDescriptor::new_import_wallet().into(),
+                                SelectBitcoindTypeStep::new().into(),
+                                InternalBitcoindStep::new(&context.coincube_directory).into(),
+                                DefineNode::default().into(),
+                                WalletAlias::default().into(),
+                                Final::new().into(),
+                            ]
+                        }
+                    }
                 }
             },
             context,

--- a/coincube-gui/src/installer/step/inheritance_restore.rs
+++ b/coincube-gui/src/installer/step/inheritance_restore.rs
@@ -1,0 +1,248 @@
+//! Installer step: heir inheritance recovery (ECIES pivot, COIN-377 PR 3).
+//!
+//! The heir picks a recoverable Vault on the pre-Cube "Recover a Vault" surface
+//! ([`crate::recover_vault`]); that launches the installer with
+//! [`UserFlow::RecoverInheritedVault`](crate::installer::UserFlow). This step is
+//! the **decrypt source** — it fetches the caller's ciphertext envelope(s) from
+//! the gated release endpoint, brokers the per-envelope key through the heir's
+//! Keychain over the Connect gRPC relay, AES-256-GCM-opens the envelopes
+//! locally, and stages the seed/descriptor into the installer `Context`. From
+//! there the **existing** restore machinery runs unchanged (the same
+//! [`stage_restore`] seam the owner Cube Recovery Kit restore uses → PIN setup →
+//! node → `install_local_wallet`).
+//!
+//! Crypto: `SPEC-ecies-v1.md` §4 (open) + §4b (key unwrap). The seed exists only
+//! transiently here, on the heir's desktop, for the restore — Keychain never
+//! returns it, and it never rides a top-level message (the decrypt result stays
+//! on this step's redacting [`InheritanceRestoreMsg`]).
+
+use std::sync::Arc;
+
+use coincube_ui::widget::Element;
+use iced::Task;
+use zeroize::Zeroizing;
+
+use crate::{
+    hw::HardwareWallets,
+    installer::{
+        context::Context,
+        message::{InheritanceRestoreMsg, Message},
+        step::{
+            recovery_kit_restore::{stage_restore, RestoreScope},
+            Step,
+        },
+        view,
+    },
+    services::{
+        coincube::CoincubeClient,
+        connect::{
+            client::resolve_connect_grpc_url,
+            grpc::{create_channel, interceptor::AuthInterceptor, session::GrpcSessionClient},
+        },
+        inheritance::heir::decrypt_envelopes,
+        recovery::{DescriptorBlob, KeyholderRecoveryError, SeedBlob},
+    },
+};
+
+#[derive(Debug)]
+enum Phase {
+    /// Fetching the envelope set + brokering the Keychain decrypt relay.
+    Decrypting,
+    /// Decrypted cleanly; `apply` stages these into `Context` and the flow
+    /// auto-advances. Holds the seed only transiently (ZeroizeOnDrop blobs).
+    Ready {
+        seed: Option<SeedBlob>,
+        descriptor: Option<DescriptorBlob>,
+    },
+    /// Terminal, display-safe copy (gate failures already neutralised; the
+    /// duress 423 never explains why — invariant I3).
+    Error { message: String },
+}
+
+/// Heir inheritance-recovery decrypt step. Self-contained: it reuses the
+/// authenticated Connect client threaded into `Context` (the heir is already
+/// signed in on the discovery surface) and builds a short-lived
+/// [`GrpcSessionClient`] for the decrypt relay.
+pub struct InheritanceRestoreStep {
+    scope: RestoreScope,
+    /// Connect (server) cube id of the Vault being recovered.
+    cube_id: u64,
+    /// Authenticated Connect REST client, pulled from `Context` on first load.
+    client: Option<CoincubeClient>,
+    phase: Phase,
+}
+
+impl InheritanceRestoreStep {
+    pub fn new(scope: RestoreScope, cube_id: u64) -> Self {
+        Self {
+            scope,
+            cube_id,
+            client: None,
+            phase: Phase::Decrypting,
+        }
+    }
+
+    /// The async decrypt: fetch the gated ciphertext, relay-decrypt each
+    /// envelope via the heir's Keychain, return the opened blobs. All errors
+    /// are mapped to display-safe strings (gate failures via
+    /// [`KeyholderRecoveryError`], which neutralises the duress 423).
+    fn decrypt_task(client: CoincubeClient, cube_id: u64) -> Task<Message> {
+        Task::perform(
+            async move {
+                let wires = client
+                    .get_recovery_envelope(cube_id)
+                    .await
+                    .map_err(|e| KeyholderRecoveryError::from(e).to_string())?;
+                if wires.is_empty() {
+                    return Err("There's nothing escrowed for you to recover here.".to_string());
+                }
+                let token = client
+                    .token()
+                    .ok_or_else(|| "Sign in to your account to recover this Vault.".to_string())?
+                    .to_string();
+                let grpc_url = resolve_connect_grpc_url().await.ok_or_else(|| {
+                    "Recovery is unavailable right now. Try again later.".to_string()
+                })?;
+                let channel = create_channel(&grpc_url)
+                    .await
+                    .map_err(|e| format!("Couldn't reach Connect: {}", e))?;
+                let mut grpc = GrpcSessionClient::new(channel, AuthInterceptor::new(&token));
+                let kit = decrypt_envelopes(&mut grpc, cube_id, &wires)
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok::<_, String>((kit.seed, kit.descriptor))
+            },
+            |res| Message::InheritanceRestore(InheritanceRestoreMsg::DecryptResult(res)),
+        )
+    }
+}
+
+impl From<InheritanceRestoreStep> for Box<dyn Step> {
+    fn from(s: InheritanceRestoreStep) -> Box<dyn Step> {
+        Box::new(s)
+    }
+}
+
+impl Step for InheritanceRestoreStep {
+    /// Pick up the heir's already-authenticated Connect client from `Context`
+    /// (forwarded by the launcher from the discovery surface).
+    fn load_context(&mut self, ctx: &Context) {
+        if self.client.is_none() {
+            self.client.clone_from(&ctx.coincube_client);
+        }
+    }
+
+    /// Kick off the decrypt as soon as the step becomes active.
+    fn load(&self) -> Task<Message> {
+        if !matches!(self.phase, Phase::Decrypting) {
+            return Task::none();
+        }
+        match &self.client {
+            Some(client) => Self::decrypt_task(client.clone(), self.cube_id),
+            None => Task::done(Message::InheritanceRestore(
+                InheritanceRestoreMsg::DecryptResult(Err(
+                    "Sign in to your account to recover this Vault.".to_string(),
+                )),
+            )),
+        }
+    }
+
+    fn update(&mut self, _hws: &mut HardwareWallets, message: Message) -> Task<Message> {
+        let Message::InheritanceRestore(InheritanceRestoreMsg::DecryptResult(res)) = message else {
+            return Task::none();
+        };
+        match res {
+            Ok((seed, descriptor)) => {
+                // Verify we actually got the half this scope needs before we
+                // advance (Full needs the seed; DescriptorOnly the descriptor).
+                let missing_half = match self.scope {
+                    RestoreScope::Full => seed.is_none(),
+                    RestoreScope::DescriptorOnly => descriptor.is_none(),
+                };
+                if missing_half {
+                    self.phase = Phase::Error {
+                        message: "This Vault isn't set up for the kind of recovery you started."
+                            .to_string(),
+                    };
+                    return Task::none();
+                }
+                self.phase = Phase::Ready { seed, descriptor };
+                // Auto-advance — the decrypt succeeded; no extra click needed.
+                Task::done(Message::Next)
+            }
+            Err(message) => {
+                self.phase = Phase::Error { message };
+                Task::none()
+            }
+        }
+    }
+
+    fn apply(&mut self, ctx: &mut Context) -> bool {
+        let Phase::Ready { seed, descriptor } = &self.phase else {
+            return false;
+        };
+        // Reuse the shared seam: parse descriptor + derive the seed signer
+        // (Full only), all-or-nothing. Borrows of `seed`/`descriptor` end with
+        // this call, so the error arm can re-borrow `self` mutably.
+        let staged = match stage_restore(
+            ctx.bitcoin_config.network,
+            self.scope,
+            seed.as_ref(),
+            descriptor.as_ref(),
+        ) {
+            Ok(staged) => staged,
+            Err(message) => {
+                self.phase = Phase::Error { message };
+                return false;
+            }
+        };
+        if let Some(d) = staged.descriptor {
+            ctx.descriptor = Some(d);
+        }
+        if let Some(s) = staged.signer {
+            ctx.recovered_signer = Some(Arc::new(s));
+        }
+        // Thread the heir's Connect session into the context so the downstream
+        // `CoincubeConnectStep` skips a redundant re-auth and `Final` registers
+        // the recovered Cube under the heir's account — mirrors the owner CRK
+        // restore's JWT hand-off.
+        if let Some(token) = self.client.as_ref().and_then(|c| c.token()) {
+            ctx.connect_jwt = Some(Zeroizing::new(token.to_string()));
+            ctx.use_coincube_connect = true;
+        }
+        true
+    }
+
+    fn revert(&self, ctx: &mut Context) {
+        if matches!(self.scope, RestoreScope::Full) {
+            ctx.recovered_signer = None;
+        }
+        ctx.descriptor = None;
+        ctx.connect_jwt = None;
+        ctx.use_coincube_connect = false;
+    }
+
+    fn view<'a>(
+        &'a self,
+        _hws: &'a HardwareWallets,
+        progress: (usize, usize),
+        email: Option<&'a str>,
+    ) -> Element<'a, Message> {
+        match &self.phase {
+            Phase::Decrypting | Phase::Ready { .. } => view::install(
+                progress,
+                email,
+                true,
+                false,
+                None,
+                Some(
+                    "Recovering this Vault — approve the decryption on your Keychain when prompted…"
+                        .to_string(),
+                ),
+            ),
+            Phase::Error { message } => {
+                view::install(progress, email, false, false, Some(message), None)
+            }
+        }
+    }
+}

--- a/coincube-gui/src/installer/step/mod.rs
+++ b/coincube-gui/src/installer/step/mod.rs
@@ -3,6 +3,7 @@ pub mod import_descriptor;
 
 mod backend;
 mod coincube_connect;
+pub mod inheritance_restore;
 mod mnemonic;
 pub(crate) mod node;
 pub mod recovery_kit_restore;
@@ -24,6 +25,7 @@ pub use descriptor::{
 
 pub use backend::{ChooseBackend, ImportRemoteWallet, RemoteBackendLogin};
 pub use coincube_connect::CoincubeConnectStep;
+pub use inheritance_restore::InheritanceRestoreStep;
 pub use mnemonic::{BackupMnemonic, RecoverMnemonic};
 pub use recovery_kit_restore::{RecoveryKitRestoreStep, RestoreScope};
 pub use restore_pin_setup::RestorePinSetupStep;

--- a/coincube-gui/src/installer/step/recovery_kit_restore.rs
+++ b/coincube-gui/src/installer/step/recovery_kit_restore.rs
@@ -22,7 +22,9 @@
 
 use std::sync::Arc;
 
-use coincube_core::{descriptors::CoincubeDescriptor, signer::MasterSigner};
+use coincube_core::{
+    descriptors::CoincubeDescriptor, miniscript::bitcoin::Network, signer::MasterSigner,
+};
 use coincube_ui::{component::form, widget::Element};
 use iced::Task;
 use zeroize::Zeroizing;
@@ -323,6 +325,59 @@ fn validate_blobs_match_selected(
         }
     }
     Ok(())
+}
+
+/// The installer-context material derived from a decrypted kit: the parsed
+/// descriptor (any scope) and, for `Full`, the seed signer. Shared by the owner
+/// Recovery-Kit restore and the heir inheritance restore (`InheritanceRestoreStep`)
+/// so the descriptor-parse + seed-derive path is audited in one place.
+pub(crate) struct StagedRestore {
+    pub descriptor: Option<CoincubeDescriptor>,
+    pub signer: Option<Signer>,
+}
+
+/// Convert decrypted kit halves into [`StagedRestore`], applying the scope's
+/// all-or-nothing discipline (Full needs the seed; DescriptorOnly ignores any
+/// seed half). Returns a user-visible error string on descriptor-parse or
+/// signer-derive failure; the caller surfaces it and leaves its context
+/// untouched. Pure (no context mutation) so it's unit-testable in isolation and
+/// reusable across both restore sources.
+pub(crate) fn stage_restore(
+    network: Network,
+    scope: RestoreScope,
+    seed: Option<&SeedBlob>,
+    descriptor: Option<&DescriptorBlob>,
+) -> Result<StagedRestore, String> {
+    // Parse the descriptor into an owned value first; an error here aborts
+    // before we touch any seed, so a partial result is never committed.
+    let descriptor = match descriptor {
+        Some(desc_blob) => Some(
+            desc_blob
+                .vault
+                .descriptor
+                .parse::<CoincubeDescriptor>()
+                .map_err(|e| {
+                    format!(
+                        "Recovery Kit descriptor failed to parse: {}. Kit may be from a newer \
+                         client version.",
+                        e
+                    )
+                })?,
+        ),
+        None => None,
+    };
+
+    // Derive the seed signer (Full only). DescriptorOnly ignores any seed half.
+    let signer = if matches!(scope, RestoreScope::Full) {
+        let seed_blob = seed.ok_or_else(|| "Seed blob missing from decrypted kit.".to_string())?;
+        let master = MasterSigner::from_str(network, &seed_blob.mnemonic.phrase)
+            .map_err(|e| format!("Restored mnemonic failed to derive a signer: {}", e))?;
+        Some(Signer::new(master))
+    } else {
+        None
+    };
+
+    Ok(StagedRestore { descriptor, signer })
 }
 
 /// Does `c` carry the specific encrypted half this restore flow
@@ -714,66 +769,32 @@ impl Step for RecoveryKitRestoreStep {
             return false;
         };
 
-        // Stage 1 — parse the descriptor into a local. If this fails
-        // we transition to `Phase::Error` and bail without touching
-        // `ctx`. Keeping the parse result in a local instead of
-        // writing it straight through to `ctx.descriptor` means a
-        // subsequent seed-derivation failure won't leave a partially-
-        // applied context behind, which would survive until the user
-        // re-enters the step and could be picked up by a downstream
-        // step that wasn't expecting a populated `ctx.descriptor`.
-        let staged_descriptor: Option<CoincubeDescriptor> = match descriptor {
-            Some(desc_blob) => match desc_blob.vault.descriptor.parse::<CoincubeDescriptor>() {
-                Ok(parsed) => Some(parsed),
-                Err(e) => {
-                    self.set_phase(Phase::Error {
-                        message: format!(
-                            "Recovery Kit descriptor failed to parse: {}. Kit may be from a \
-                             newer client version.",
-                            e
-                        ),
-                    });
-                    return false;
-                }
-            },
-            None => None,
-        };
-
-        // Stage 2 — derive the seed signer into a local (W13 only).
-        // Same all-or-nothing discipline as stage 1.
-        let staged_signer: Option<Signer> = if matches!(self.scope, RestoreScope::Full) {
-            let Some(seed_blob) = seed else {
-                // `Ready` phase should have had the seed already —
-                // defensive check in case the phase was populated
-                // with a DescriptorOnly kit.
-                self.set_phase(Phase::Error {
-                    message: "Seed blob missing from decrypted kit.".to_string(),
-                });
+        // Stage 1+2 — parse the descriptor and derive the seed signer (Full
+        // only) into locals via the shared [`stage_restore`] seam. All-or-
+        // nothing: any failure transitions to `Phase::Error` and bails without
+        // touching `ctx`, so a partial result never survives into a later step.
+        let staged = match stage_restore(
+            ctx.bitcoin_config.network,
+            self.scope,
+            seed.as_ref(),
+            descriptor.as_ref(),
+        ) {
+            Ok(staged) => staged,
+            Err(message) => {
+                self.set_phase(Phase::Error { message });
                 return false;
-            };
-            match MasterSigner::from_str(ctx.bitcoin_config.network, &seed_blob.mnemonic.phrase) {
-                Ok(master) => Some(Signer::new(master)),
-                Err(e) => {
-                    self.set_phase(Phase::Error {
-                        message: format!("Restored mnemonic failed to derive a signer: {}", e),
-                    });
-                    return false;
-                }
             }
-        } else {
-            None
         };
 
-        // Stage 3 — commit both results atomically. We only reach
-        // here after every fallible step above succeeded, so `ctx`
-        // transitions from "nothing applied" to "fully applied" in
-        // one go. `Arc::new` happens here rather than at staging so
-        // we don't allocate the refcounted handle for a signer that
-        // ultimately gets dropped on the error path.
-        if let Some(d) = staged_descriptor {
+        // Stage 3 — commit both results atomically. We only reach here after
+        // every fallible step above succeeded, so `ctx` transitions from
+        // "nothing applied" to "fully applied" in one go. `Arc::new` happens
+        // here rather than at staging so we don't allocate the refcounted handle
+        // for a signer that ultimately gets dropped on the error path.
+        if let Some(d) = staged.descriptor {
             ctx.descriptor = Some(d);
         }
-        if let Some(s) = staged_signer {
+        if let Some(s) = staged.signer {
             ctx.recovered_signer = Some(Arc::new(s));
         }
 
@@ -1180,5 +1201,91 @@ mod tests {
             Phase::CubePicker { cubes, .. } => assert!(cubes.is_empty()),
             other => panic!("expected CubePicker, got {:?}", other),
         }
+    }
+
+    // ── stage_restore: the shared DecryptedKit → installer-context seam ──
+    // Reused by both the owner CRK restore (apply, above) and the heir
+    // inheritance restore. These pin the scope discipline + error mapping
+    // without standing up a full installer Context.
+
+    /// A SeedBlob carrying a specific (valid) BIP39 phrase.
+    fn seed_blob_with(phrase: &str) -> SeedBlob {
+        use crate::services::recovery::{SeedBlobCube, SeedBlobMnemonic};
+        SeedBlob {
+            version: crate::services::recovery::plaintext::BLOB_VERSION,
+            cube: SeedBlobCube {
+                uuid: "uuid".to_string(),
+                name: "n".to_string(),
+                network: "bitcoin".to_string(),
+                created_at: "2026-04-23T00:00:00Z".to_string(),
+                lightning_address: None,
+            },
+            mnemonic: SeedBlobMnemonic {
+                phrase: phrase.to_string(),
+                language: "en".to_string(),
+            },
+        }
+    }
+
+    const VALID_MNEMONIC: &str =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    #[test]
+    fn stage_restore_descriptor_only_with_nothing_is_empty() {
+        let staged =
+            stage_restore(Network::Bitcoin, RestoreScope::DescriptorOnly, None, None).unwrap();
+        assert!(staged.descriptor.is_none());
+        assert!(staged.signer.is_none());
+    }
+
+    #[test]
+    fn stage_restore_full_without_seed_errors() {
+        // `StagedRestore` holds a `Signer` (no `Debug`), so match instead of
+        // `unwrap_err`.
+        let Err(err) = stage_restore(Network::Bitcoin, RestoreScope::Full, None, None) else {
+            panic!("expected an error");
+        };
+        assert!(err.contains("Seed blob missing"), "got: {}", err);
+    }
+
+    #[test]
+    fn stage_restore_unparseable_descriptor_errors() {
+        // `descriptor_blob_for` uses the placeholder descriptor "d", which is
+        // not a valid CoincubeDescriptor → parse failure.
+        let d = descriptor_blob_for("uuid", "bitcoin");
+        let Err(err) = stage_restore(
+            Network::Bitcoin,
+            RestoreScope::DescriptorOnly,
+            None,
+            Some(&d),
+        ) else {
+            panic!("expected an error");
+        };
+        assert!(err.contains("descriptor failed to parse"), "got: {}", err);
+    }
+
+    #[test]
+    fn stage_restore_full_derives_signer_from_valid_mnemonic() {
+        let seed = seed_blob_with(VALID_MNEMONIC);
+        let staged =
+            stage_restore(Network::Bitcoin, RestoreScope::Full, Some(&seed), None).unwrap();
+        assert!(staged.signer.is_some(), "Full scope must derive a signer");
+        assert!(staged.descriptor.is_none());
+    }
+
+    #[test]
+    fn stage_restore_descriptor_only_ignores_present_seed() {
+        let seed = seed_blob_with(VALID_MNEMONIC);
+        let staged = stage_restore(
+            Network::Bitcoin,
+            RestoreScope::DescriptorOnly,
+            Some(&seed),
+            None,
+        )
+        .unwrap();
+        assert!(
+            staged.signer.is_none(),
+            "DescriptorOnly must ignore the seed half"
+        );
     }
 }

--- a/coincube-gui/src/phone_signer/mod.rs
+++ b/coincube-gui/src/phone_signer/mod.rs
@@ -184,6 +184,7 @@ impl HWI for PhoneSigner {
             created_by_device_id: String::new(),
             note: String::new(),
             submitted_signatures: Vec::new(),
+            is_recovery_spend: false,
         };
 
         let envelope = present_session_envelope(session);

--- a/coincube-gui/src/recover_vault.rs
+++ b/coincube-gui/src/recover_vault.rs
@@ -185,6 +185,12 @@ pub enum RecoverVaultMessage {
     /// a fetch from a prior session (account switch, same cube) be dropped
     /// instead of painting its result onto the new session's row.
     Fetched(u64, Result<usize, String>, u64),
+    /// Heir clicked "Recover" on an actionable row — launch the installer's
+    /// inheritance-recovery flow (COIN-377 PR 3). `full_cube` selects the scope
+    /// (Full-Cube vs Vault-only). **Home intercepts this** and emits
+    /// `home::Message::Install(UserFlow::RecoverInheritedVault { .. })`; it is a
+    /// no-op inside this panel (the installer owns the decrypt + restore).
+    Launch { cube_id: u64, full_cube: bool },
 }
 
 impl RecoverVaultPanel {
@@ -307,6 +313,9 @@ impl RecoverVaultPanel {
                 self.active = Some((cube_id, status));
                 Task::none()
             }
+            // Home intercepts `Launch` before delegating here (it launches the
+            // installer flow), so reaching this arm is a no-op backstop.
+            RecoverVaultMessage::Launch { .. } => Task::none(),
         }
     }
 }
@@ -406,7 +415,10 @@ fn vault_row<'a>(
         match active {
             Some((id, status)) if *id == v.cube_id => recover_status_view(status),
             _ => btn::primary(None, recover_button_label(v))
-                .on_press(RecoverVaultMessage::Recover(v.cube_id))
+                .on_press(RecoverVaultMessage::Launch {
+                    cube_id: v.cube_id,
+                    full_cube: v.is_full_cube(),
+                })
                 .into(),
         }
     } else {
@@ -674,11 +686,7 @@ mod tests {
         // not paint its result onto cube 8's in-flight row.
         let mut panel = RecoverVaultPanel::new();
         panel.active = Some((8, RecoverStatus::Fetching));
-        let _ = panel.update(
-            RecoverVaultMessage::Fetched(7, Ok(1), 0),
-            None,
-            0,
-        );
+        let _ = panel.update(RecoverVaultMessage::Fetched(7, Ok(1), 0), None, 0);
         assert!(
             matches!(panel.active, Some((8, RecoverStatus::Fetching))),
             "stale cube-7 fetch must leave cube-8's row untouched, got {:?}",
@@ -694,11 +702,7 @@ mod tests {
         // would miss this; the generation check catches it.
         let mut panel = RecoverVaultPanel::new();
         panel.active = Some((7, RecoverStatus::Fetching));
-        let _ = panel.update(
-            RecoverVaultMessage::Fetched(7, Ok(1), 1),
-            None,
-            2,
-        );
+        let _ = panel.update(RecoverVaultMessage::Fetched(7, Ok(1), 1), None, 2);
         assert!(
             matches!(panel.active, Some((7, RecoverStatus::Fetching))),
             "stale-session fetch must not overwrite the new session's row, got {:?}",

--- a/coincube-gui/src/recover_vault.rs
+++ b/coincube-gui/src/recover_vault.rs
@@ -12,24 +12,25 @@
 //! Connect-client foundation:
 //! [`CoincubeClient::list_recoverable_vaults`](crate::services::coincube::CoincubeClient::list_recoverable_vaults)
 //! for the list and
-//! [`fetch_recovery_descriptor`](crate::services::recovery::fetch_recovery_descriptor)
-//! for the keyholder release. The release returns a plaintext descriptor; the
-//! watch-only install + bridge into the recovery screen is PR 2 / PR 3 (see the
-//! `TODO(PR 2)` seam in [`RecoverVaultPanel::update`]).
+//! [`CoincubeClient::get_recovery_envelope`](crate::services::coincube::CoincubeClient::get_recovery_envelope)
+//! for the gated ECIES release. Under the ECIES pivot the release returns the
+//! caller's **ciphertext** envelope(s); the heir's Keychain does the ECDH and
+//! the desktop opens + restores via the tested heir core
+//! ([`crate::services::inheritance::heir::decrypt_envelopes`] → `DecryptedKit`
+//! → the existing Recovery-Kit restore). Rows are labelled by escrow tier and
+//! marked **Beta**.
 
 use iced::widget::{scrollable, Space};
 use iced::{Alignment, Length, Task};
 
 use coincube_ui::{
-    component::{button as btn, card, text::*},
+    component::{badge, button as btn, card, text::*},
     theme,
     widget::{Column, Container, Element, Row},
 };
 
-use crate::services::coincube::{
-    CoincubeClient, RecoverableVault, RecoveryState, VaultMonitoringLevel,
-};
-use crate::services::recovery::fetch_recovery_descriptor;
+use crate::services::coincube::{CoincubeClient, RecoverableVault, RecoveryState};
+use crate::services::recovery::KeyholderRecoveryError;
 
 /// Shown when the heir isn't signed in: both for a `Load` attempted without a
 /// Connect client and for the reset (`Idle`) state the panel returns to after
@@ -38,43 +39,41 @@ use crate::services::recovery::fetch_recovery_descriptor;
 const SIGNED_OUT_PROMPT: &str = "Sign in to your account to see vaults you can recover.";
 
 /// How a discovery row should present, encoding invariants I1 (state gating)
-/// and I7 (tier honesty). Password-required (Heartbeat) rows take precedence:
-/// they are never actionable in v1 regardless of window state, and must show
-/// the deferred-path copy rather than a broken "Recover" button.
+/// and I7 (tier honesty). Under the ECIES pivot there is no recovery-password
+/// path: a row is actionable iff the window is open on-chain, the caller is a
+/// keyholder, and the owner escrowed material to their key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RowKind {
-    /// Window open **and** Full-tier (password-free) **and** the caller is a
-    /// keyholder → the "Recover" button is live.
+    /// Window open **and** the caller is a keyholder **and** something is
+    /// escrowed for them → the "Recover" button is live. The button label
+    /// reflects the tier (full Cube vs Vault).
     Actionable,
     /// Window open, but the caller is a beneficiary, not a keyholder → the
-    /// descriptor pull-down is keyholder-only (the release endpoint 403s
-    /// non-keyholders), so show "a keyholder completes this", never a button.
+    /// release endpoint serves envelopes only to keyholders (403s everyone
+    /// else), so show "a keyholder completes this", never a button.
     KeyholderOnly,
-    /// Window not open yet (Full-tier) → visible but not actionable; show the
-    /// expected-open date and "we'll email you".
+    /// Window open and the caller is a keyholder, but the owner escrowed
+    /// nothing to their key → there is nothing this heir can decrypt. Show a
+    /// neutral "not set up for you" line, never a button.
+    NotEscrowed,
+    /// Window not open yet → visible but not actionable; show the expected-open
+    /// date and "we'll email you".
     NotYetOpen,
-    /// Heartbeat tier (`requires_recovery_password`) → deferred to COIN-375;
-    /// show the "recovery password required — coming later" copy, never a
-    /// button. Takes precedence over the window state.
-    PasswordDeferred,
 }
 
 /// Classifies a recoverable-vault row. Pure — the unit tests below pin the
-/// invariants. Heartbeat/password-required is checked first so an open
-/// (`available`/`reminding`) Heartbeat vault still routes to the deferred copy;
-/// then the keyholder gate, so an open vault the caller can't pull down (they're
-/// a beneficiary) shows the keyholder-only copy rather than a 403'ing button.
+/// invariants. Window state first (a closed window is never actionable); then
+/// the keyholder gate (a beneficiary can't decrypt); then whether anything is
+/// escrowed for this caller.
 pub fn classify(v: &RecoverableVault) -> RowKind {
-    if v.requires_recovery_password {
-        RowKind::PasswordDeferred
-    } else if v.recovery_state().is_open() {
-        if v.is_keyholder() {
-            RowKind::Actionable
-        } else {
-            RowKind::KeyholderOnly
-        }
-    } else {
+    if !v.recovery_state().is_open() {
         RowKind::NotYetOpen
+    } else if !v.is_keyholder() {
+        RowKind::KeyholderOnly
+    } else if v.has_descriptor_tier() {
+        RowKind::Actionable
+    } else {
+        RowKind::NotEscrowed
     }
 }
 
@@ -86,8 +85,8 @@ pub fn status_copy(v: &RecoverableVault) -> Option<String> {
         RowKind::KeyholderOnly => {
             Some("Recovery is open — a keyholder of this vault can complete it.".to_string())
         }
-        RowKind::PasswordDeferred => {
-            Some("Recovery password required — coming in a later update.".to_string())
+        RowKind::NotEscrowed => {
+            Some("Recovery is open, but this vault isn't set up for you to recover.".to_string())
         }
         RowKind::NotYetOpen => Some(match v.expected_open_at {
             Some(at) => format!(
@@ -99,12 +98,27 @@ pub fn status_copy(v: &RecoverableVault) -> Option<String> {
     }
 }
 
-/// Short, display-only label for a vault's monitoring tier.
-fn tier_label(level: VaultMonitoringLevel) -> &'static str {
-    match level {
-        VaultMonitoringLevel::Full => "Full monitoring",
-        VaultMonitoringLevel::Heartbeat => "Alerts only",
-        VaultMonitoringLevel::Off => "Not monitored",
+/// Short, display-only label for what this heir can recover (invariant I7).
+/// Keys off the escrowed tiers, not the owner's monitoring level: Full-Cube
+/// (seed escrowed) restores the whole Cube; Vault-only (descriptor) recovers
+/// the watch-only Vault. When nothing is escrowed for the caller (beneficiary
+/// or not-escrowed), fall back to a neutral label.
+fn tier_label(v: &RecoverableVault) -> &'static str {
+    if v.is_full_cube() {
+        "Full Cube"
+    } else if v.has_descriptor_tier() {
+        "Vault only"
+    } else {
+        "Assisted recovery"
+    }
+}
+
+/// The "Recover" button label for an actionable row — honest about scope.
+fn recover_button_label(v: &RecoverableVault) -> &'static str {
+    if v.is_full_cube() {
+        "Recover full Cube"
+    } else {
+        "Recover Vault"
     }
 }
 
@@ -119,9 +133,10 @@ fn state_label(state: RecoveryState) -> &'static str {
 /// In-flight status for the row the heir clicked "Recover" on.
 #[derive(Debug, Clone)]
 pub enum RecoverStatus {
-    /// Pulling the descriptor from the keyholder release endpoint.
+    /// Downloading the caller's ECIES envelope(s) from the gated release.
     Fetching,
-    /// Descriptor fetched. PR 2 picks up here (watch-only install).
+    /// Ciphertext received. The Keychain ECDH-decrypt + restore handoff
+    /// (`heir::decrypt_envelopes` → existing Recovery-Kit restore) picks up here.
     Ready,
     /// Gate/error copy (already neutralised by `KeyholderRecoveryError`'s
     /// `Display`, so it is safe to show verbatim — never explains duress).
@@ -162,13 +177,14 @@ pub enum RecoverVaultMessage {
     /// fetch was fired in — a stale value (logout / account switch landed
     /// first) is dropped rather than painting the prior account's vaults.
     Loaded(Result<Vec<RecoverableVault>, String>, u64),
-    /// Heir clicked "Recover" on the given cube — pull its descriptor.
+    /// Heir clicked "Recover" on the given cube — pull its ECIES envelope set
+    /// from the gated release endpoint.
     Recover(u64),
-    /// Descriptor fetch resolved (cube id, plaintext descriptor | display copy,
-    /// session generation the fetch was fired in). The `u64` lets a fetch from a
-    /// prior session (account switch, same cube) be dropped instead of painting
-    /// its result onto the new session's row.
-    Fetched(u64, Result<String, String>, u64),
+    /// Envelope fetch resolved (cube id, number of envelopes received | neutral
+    /// display copy, session generation the fetch was fired in). The `u64` lets
+    /// a fetch from a prior session (account switch, same cube) be dropped
+    /// instead of painting its result onto the new session's row.
+    Fetched(u64, Result<usize, String>, u64),
 }
 
 impl RecoverVaultPanel {
@@ -249,12 +265,15 @@ impl RecoverVaultPanel {
                 self.active = Some((cube_id, RecoverStatus::Fetching));
                 Task::perform(
                     async move {
-                        // The keyholder release returns the PLAINTEXT descriptor;
-                        // gate failures are already mapped to neutral, display-safe
-                        // copy by `KeyholderRecoveryError`'s `Display`.
-                        let res = fetch_recovery_descriptor(&client, cube_id)
+                        // The ECIES release returns the caller's ciphertext
+                        // envelope(s); gate failures (403/423/404/503) are mapped
+                        // to neutral, display-safe copy by `KeyholderRecoveryError`
+                        // (the duress 423 never explains why — invariant I3).
+                        let res = client
+                            .get_recovery_envelope(cube_id)
                             .await
-                            .map_err(|e| e.to_string());
+                            .map(|envelopes| envelopes.len())
+                            .map_err(|e| KeyholderRecoveryError::from(e).to_string());
                         (cube_id, res)
                     },
                     move |(cube_id, res)| {
@@ -263,7 +282,7 @@ impl RecoverVaultPanel {
                 )
             }
             RecoverVaultMessage::Fetched(cube_id, res, gen) => {
-                // Drop a descriptor fetch the user (or session) has moved on
+                // Drop an envelope fetch the user (or session) has moved on
                 // from: a stale generation means a prior session fired it (an
                 // account switch — even the same cube id), and a non-matching
                 // `active` id means recovery started on another row. Either way
@@ -274,15 +293,15 @@ impl RecoverVaultPanel {
                     return Task::none();
                 }
                 let status = match res {
-                    Ok(_descriptor) => {
-                        // TODO(PR 2): hand the plaintext `_descriptor` to the
-                        // installer's `install_local_wallet()` path (a new
-                        // `UserFlow::RecoverKeyholderVault { cube_id }`) to create
-                        // the watch-only "Recovered Vault — [label]", then bridge
-                        // into `vault/recovery.rs` for the sweep (PR 3). For PR 1
-                        // we confirm the gated fetch succeeded.
-                        RecoverStatus::Ready
-                    }
+                    // The gated ciphertext is in hand. The Keychain ECDH-decrypt
+                    // + existing Recovery-Kit restore is the app-level handoff
+                    // (`services::inheritance::heir::decrypt_envelopes` →
+                    // `DecryptedKit` → `RestoreScope::Full`/`DescriptorOnly`),
+                    // which needs the heir's Keychain online (regtest E2E gate).
+                    Ok(0) => RecoverStatus::Failed(
+                        "There's nothing escrowed for you to recover here.".to_string(),
+                    ),
+                    Ok(_n) => RecoverStatus::Ready,
                     Err(copy) => RecoverStatus::Failed(copy),
                 };
                 self.active = Some((cube_id, status));
@@ -296,11 +315,18 @@ impl RecoverVaultPanel {
 pub fn view(panel: &RecoverVaultPanel) -> Element<'_, RecoverVaultMessage> {
     let header = Column::new()
         .spacing(6)
-        .push(h4_bold("Recover a Vault"))
+        .push(
+            Row::new()
+                .spacing(10)
+                .align_y(Alignment::Center)
+                .push(h4_bold("Recover a Vault"))
+                .push(badge::beta()),
+        )
         .push(
             p2_regular(
                 "Vaults you're a keyholder for appear here. When a vault's \
-                 recovery window opens, you can recover it — no password needed.",
+                 recovery window opens, you can recover it with your Keychain — \
+                 no password needed.",
             )
             .style(theme::text::secondary),
         );
@@ -362,11 +388,7 @@ fn vault_row<'a>(
         .clone()
         .unwrap_or_else(|| format!("Vault #{}", v.cube_id));
 
-    let meta = format!(
-        "{} • {}",
-        tier_label(v.monitoring_level),
-        state_label(v.recovery_state())
-    );
+    let meta = format!("{} • {}", tier_label(v), state_label(v.recovery_state()));
 
     let mut left = Column::new()
         .spacing(4)
@@ -383,7 +405,7 @@ fn vault_row<'a>(
     let cta: Element<RecoverVaultMessage> = if classify(v) == RowKind::Actionable {
         match active {
             Some((id, status)) if *id == v.cube_id => recover_status_view(status),
-            _ => btn::primary(None, "Recover")
+            _ => btn::primary(None, recover_button_label(v))
                 .on_press(RecoverVaultMessage::Recover(v.cube_id))
                 .into(),
         }
@@ -409,7 +431,7 @@ fn recover_status_view(status: &RecoverStatus) -> Element<'_, RecoverVaultMessag
         RecoverStatus::Fetching => p2_regular("Preparing recovery…")
             .style(theme::text::secondary)
             .into(),
-        RecoverStatus::Ready => p2_bold("Recovery ready").into(),
+        RecoverStatus::Ready => p2_bold("Recovery data received — approve on your Keychain").into(),
         RecoverStatus::Failed(copy) => p2_regular(copy.clone())
             .style(theme::text::secondary)
             .into(),
@@ -419,98 +441,99 @@ fn recover_status_view(status: &RecoverStatus) -> Element<'_, RecoverVaultMessag
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::services::coincube::VaultMonitoringLevel;
 
-    fn vault_role(
-        level: VaultMonitoringLevel,
-        state: &str,
-        pw: bool,
-        role: &str,
-    ) -> RecoverableVault {
+    fn vault_role(state: &str, tiers: &[&str], role: &str) -> RecoverableVault {
         RecoverableVault {
             cube_id: 1,
             owner_label: None,
-            monitoring_level: level,
+            // Display-only post-pivot; the heartbeat gate drives availability.
+            monitoring_level: VaultMonitoringLevel::Heartbeat,
             state: state.to_string(),
             role: role.to_string(),
-            requires_recovery_password: pw,
+            // Deprecated under ECIES; never consulted by `classify`.
+            requires_recovery_password: false,
             owner_last_active: None,
             expected_open_at: None,
             gap_limit: None,
+            available_tiers: tiers.iter().map(|t| t.to_string()).collect(),
         }
     }
 
-    /// The common case: the caller is a keyholder (the only role that can pull
-    /// the descriptor down). Beneficiary cases construct via `vault_role`.
-    fn vault(level: VaultMonitoringLevel, state: &str, pw: bool) -> RecoverableVault {
-        vault_role(level, state, pw, "keyholder")
+    /// The common case: the caller is a keyholder. Beneficiary cases construct
+    /// via `vault_role`. `tiers` are the artifact kinds escrowed for the caller.
+    fn vault(state: &str, tiers: &[&str]) -> RecoverableVault {
+        vault_role(state, tiers, "keyholder")
     }
 
     #[test]
-    fn full_open_is_actionable() {
-        let v = vault(VaultMonitoringLevel::Full, "available", false);
+    fn full_cube_open_is_actionable_with_full_cube_button() {
+        let v = vault("available", &["descriptor", "seed"]);
         assert_eq!(classify(&v), RowKind::Actionable);
+        assert!(v.is_recoverable_now());
+        assert!(v.is_full_cube());
+        assert_eq!(recover_button_label(&v), "Recover full Cube");
+        assert_eq!(tier_label(&v), "Full Cube");
         assert!(status_copy(&v).is_none());
     }
 
     #[test]
-    fn beneficiary_open_full_is_keyholder_only_not_actionable() {
-        // Same open + Full-tier state as `full_open_is_actionable`, but the
-        // caller is a beneficiary: the descriptor pull-down is keyholder-only
-        // (the release endpoint 403s non-keyholders), so this must NOT be a live
-        // button — it shows the keyholder-only copy instead.
-        let v = vault_role(
-            VaultMonitoringLevel::Full,
-            "available",
-            false,
-            "beneficiary",
-        );
+    fn vault_only_open_is_actionable_with_vault_button() {
+        // Descriptor escrowed but no seed → Vault-only tier (watch-only sweep).
+        let v = vault("available", &["descriptor"]);
+        assert_eq!(classify(&v), RowKind::Actionable);
+        assert!(v.is_recoverable_now());
+        assert!(!v.is_full_cube());
+        assert_eq!(recover_button_label(&v), "Recover Vault");
+        assert_eq!(tier_label(&v), "Vault only");
+    }
+
+    #[test]
+    fn beneficiary_open_is_keyholder_only_not_actionable() {
+        // Open window, but the caller is a beneficiary: the release endpoint
+        // serves envelopes only to keyholders (403s everyone else), so this must
+        // NOT be a live button — it shows the keyholder-only copy instead.
+        let v = vault_role("available", &[], "beneficiary");
         assert_eq!(classify(&v), RowKind::KeyholderOnly);
         assert!(!v.is_recoverable_now());
         assert!(status_copy(&v).unwrap().contains("keyholder"));
     }
 
     #[test]
-    fn full_reminding_is_actionable() {
+    fn keyholder_open_but_nothing_escrowed_is_not_escrowed() {
+        // Tier honesty (I7): an open window where the owner escrowed nothing to
+        // this keyholder's key is NOT a live button — there is nothing to decrypt.
+        let v = vault("available", &[]);
+        assert_eq!(classify(&v), RowKind::NotEscrowed);
+        assert!(!v.is_recoverable_now());
+        assert!(status_copy(&v).unwrap().contains("isn't set up for you"));
+    }
+
+    #[test]
+    fn reminding_is_actionable() {
         // `reminding` is a later "still open" state — also actionable.
-        let v = vault(VaultMonitoringLevel::Full, "reminding", false);
+        let v = vault("reminding", &["descriptor"]);
         assert_eq!(classify(&v), RowKind::Actionable);
     }
 
     #[test]
-    fn full_approaching_is_not_yet_open() {
-        let v = vault(VaultMonitoringLevel::Full, "approaching", false);
+    fn approaching_is_not_yet_open() {
+        let v = vault("approaching", &["descriptor", "seed"]);
         assert_eq!(classify(&v), RowKind::NotYetOpen);
         assert!(status_copy(&v).unwrap().contains("isn't open yet"));
     }
 
     #[test]
-    fn full_none_is_not_yet_open() {
-        let v = vault(VaultMonitoringLevel::Full, "none", false);
+    fn none_is_not_yet_open() {
+        let v = vault("none", &["descriptor"]);
         assert_eq!(classify(&v), RowKind::NotYetOpen);
     }
 
     #[test]
-    fn heartbeat_requires_password_is_deferred_even_when_open() {
-        // Tier honesty (I7): an open Heartbeat vault is NOT a live button —
-        // it must show the deferred-path copy.
-        let v = vault(VaultMonitoringLevel::Heartbeat, "available", true);
-        assert_eq!(classify(&v), RowKind::PasswordDeferred);
-        assert_eq!(
-            status_copy(&v).unwrap(),
-            "Recovery password required — coming in a later update."
-        );
-    }
-
-    #[test]
-    fn password_required_takes_precedence_over_not_open() {
-        let v = vault(VaultMonitoringLevel::Heartbeat, "approaching", true);
-        assert_eq!(classify(&v), RowKind::PasswordDeferred);
-    }
-
-    #[test]
     fn unknown_state_fails_closed_to_not_open() {
-        // An unrecognised wire state must never become a live Recover button.
-        let v = vault(VaultMonitoringLevel::Full, "weird-future-state", false);
+        // An unrecognised wire state must never become a live Recover button,
+        // even with material escrowed.
+        let v = vault("weird-future-state", &["descriptor", "seed"]);
         assert_eq!(classify(&v), RowKind::NotYetOpen);
     }
 
@@ -546,7 +569,7 @@ mod tests {
     #[test]
     fn loaded_stores_rows() {
         let mut panel = RecoverVaultPanel::new();
-        let rows = vec![vault(VaultMonitoringLevel::Full, "available", false)];
+        let rows = vec![vault("available", &["descriptor"])];
         let _ = panel.update(RecoverVaultMessage::Loaded(Ok(rows), 0), None, 0);
         assert!(matches!(panel.list, ListState::Loaded(ref r) if r.len() == 1));
     }
@@ -557,7 +580,7 @@ mod tests {
         // advanced (logout / account switch → generation 2) must not paint the
         // prior account's vaults: the panel's `list` is left untouched.
         let mut panel = RecoverVaultPanel::new();
-        let rows = vec![vault(VaultMonitoringLevel::Full, "available", false)];
+        let rows = vec![vault("available", &["descriptor"])];
         let _ = panel.update(RecoverVaultMessage::Loaded(Ok(rows), 1), None, 2);
         assert!(
             matches!(panel.list, ListState::Idle),
@@ -574,7 +597,7 @@ mod tests {
         // loaded, blocking refetch on reopen).
         let mut panel = RecoverVaultPanel::new();
         panel.list = ListState::Loading(1);
-        let rows = vec![vault(VaultMonitoringLevel::Full, "available", false)];
+        let rows = vec![vault("available", &["descriptor"])];
         let _ = panel.update(RecoverVaultMessage::Loaded(Ok(rows), 1), None, 2);
         assert!(
             matches!(panel.list, ListState::Idle),
@@ -591,7 +614,7 @@ mod tests {
         // `Loading`, never a later session's request.
         let mut panel = RecoverVaultPanel::new();
         panel.list = ListState::Loading(2);
-        let rows = vec![vault(VaultMonitoringLevel::Full, "available", false)];
+        let rows = vec![vault("available", &["descriptor"])];
         let _ = panel.update(RecoverVaultMessage::Loaded(Ok(rows), 1), None, 2);
         assert!(
             matches!(panel.list, ListState::Loading(2)),
@@ -605,8 +628,8 @@ mod tests {
         // A stale drop must leave an already-populated current-session list
         // intact (don't reset a good `Loaded` back to `Idle`).
         let mut panel = RecoverVaultPanel::new();
-        panel.list = ListState::Loaded(vec![vault(VaultMonitoringLevel::Full, "available", false)]);
-        let rows = vec![vault(VaultMonitoringLevel::Heartbeat, "approaching", true)];
+        panel.list = ListState::Loaded(vec![vault("available", &["descriptor"])]);
+        let rows = vec![vault("approaching", &[])];
         let _ = panel.update(RecoverVaultMessage::Loaded(Ok(rows), 1), None, 2);
         assert!(matches!(panel.list, ListState::Loaded(ref r) if r.len() == 1));
     }
@@ -616,7 +639,7 @@ mod tests {
         // The matching-generation path still stores rows (regression guard for
         // the stale-session check above).
         let mut panel = RecoverVaultPanel::new();
-        let rows = vec![vault(VaultMonitoringLevel::Full, "available", false)];
+        let rows = vec![vault("available", &["descriptor"])];
         let _ = panel.update(RecoverVaultMessage::Loaded(Ok(rows), 5), None, 5);
         assert!(matches!(panel.list, ListState::Loaded(ref r) if r.len() == 1));
     }
@@ -652,7 +675,7 @@ mod tests {
         let mut panel = RecoverVaultPanel::new();
         panel.active = Some((8, RecoverStatus::Fetching));
         let _ = panel.update(
-            RecoverVaultMessage::Fetched(7, Ok("wsh(...)".to_string()), 0),
+            RecoverVaultMessage::Fetched(7, Ok(1), 0),
             None,
             0,
         );
@@ -672,7 +695,7 @@ mod tests {
         let mut panel = RecoverVaultPanel::new();
         panel.active = Some((7, RecoverStatus::Fetching));
         let _ = panel.update(
-            RecoverVaultMessage::Fetched(7, Ok("wsh(...)".to_string()), 1),
+            RecoverVaultMessage::Fetched(7, Ok(1), 1),
             None,
             2,
         );

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -1479,6 +1479,66 @@ impl CoincubeClient {
         let resp: super::RecoveryDescriptorResponse = Self::parse_recovery_response(res).await?;
         Ok(resp.descriptor)
     }
+
+    /// `PUT /api/v1/connect/cubes/{cubeId}/vault/escrow` (authenticated,
+    /// **owner-only**). Uploads the full ECIES envelope set for the cube's
+    /// current keyholders (ECIES pivot PR 2). The server idempotently replaces
+    /// the stored set and stores the bytes opaquely — it never decrypts. Re-run
+    /// on any keyholder add/remove/key-rotate.
+    pub async fn put_vault_escrow(
+        &self,
+        cube_id: u64,
+        envelopes: Vec<super::InheritanceEnvelopeWire>,
+    ) -> Result<(), CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/vault/escrow",
+            self.base_url, cube_id
+        );
+        let req = super::PutVaultEscrowRequest { envelopes };
+        let res = self.client.put(&url).json(&req).send().await?;
+        res.check_success().await?;
+        Ok(())
+    }
+
+    /// `DELETE /api/v1/connect/cubes/{cubeId}/vault/escrow` (authenticated,
+    /// owner-only). True-delete of the cube's escrow set when the owner turns
+    /// inheritance escrow off. Idempotent: a `404` (nothing stored) is success.
+    pub async fn delete_vault_escrow(&self, cube_id: u64) -> Result<(), CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/vault/escrow",
+            self.base_url, cube_id
+        );
+        let res = self.client.delete(&url).send().await?;
+        if res.status().as_u16() == 404 {
+            return Ok(());
+        }
+        res.check_success().await?;
+        Ok(())
+    }
+
+    /// `GET /api/v1/connect/cubes/{cubeId}/vault/recovery-envelope`
+    /// (authenticated; the caller is the heir keyholder). Returns **only the
+    /// caller's own** ECIES envelopes as ciphertext (ECIES pivot PR 3); the
+    /// server is blind and decrypts nothing. The heir's Keychain does the ECDH;
+    /// the desktop opens the AES-GCM ciphertext.
+    ///
+    /// Same gate matrix and error plumbing as [`Self::get_recovery_descriptor`]:
+    /// `404`/`429` short-circuit via `parse_recovery_response`; the gate
+    /// failures `403` (`RECOVERY_ACCESS_DENIED` / `RECOVERY_NOT_AVAILABLE`),
+    /// `423` (`DURESS_LOCKED`), and `503` arrive as `Unsuccessful` with the body
+    /// preserved, so `KeyholderRecoveryError::from` maps them. A 200 triggers a
+    /// server-side owner notification (invariant I4).
+    pub async fn get_recovery_envelope(
+        &self,
+        cube_id: u64,
+    ) -> Result<Vec<super::InheritanceEnvelopeWire>, CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/vault/recovery-envelope",
+            self.base_url, cube_id
+        );
+        let res = self.client.get(&url).send().await?;
+        Self::parse_recovery_response(res).await
+    }
 }
 
 // =============================================================================

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -2215,7 +2215,7 @@ pub struct RecoveryDescriptorResponse {
 }
 
 /// One ECIES heir-escrow envelope on the wire (camelCase JSON; byte fields
-/// base64). The desktop **defines** this contract; `coincube-api` stores the
+/// lowercase hex, SPEC §5). The desktop **defines** this contract; `coincube-api` stores the
 /// bytes opaquely (it never parses or decrypts them) and `keychain-app`
 /// decrypts. Shared by owner upload (`PUT …/vault/escrow`) and gated heir
 /// release (`GET …/vault/recovery-envelope`, which returns only the caller's
@@ -2240,13 +2240,14 @@ pub struct InheritanceEnvelopeWire {
     pub keyholder_key_id: Option<u64>,
     /// `"descriptor"` | `"seed"`.
     pub artifact_kind: String,
-    /// ECIES scheme tag, e.g. `"ecies-secp256k1-hkdf-aes256gcm-v1"`.
+    /// ECIES scheme tag, e.g. `"ecies-secp256k1-hkdf-sha256-aes256gcm-v1"`.
     pub scheme: String,
-    /// base64 of the 33-byte compressed ephemeral secp256k1 public key.
+    /// Lowercase hex (SPEC §5) of the 33-byte compressed ephemeral secp256k1
+    /// public key.
     pub ephemeral_pubkey: String,
-    /// base64 of `ciphertext || GCM tag`.
+    /// Lowercase hex (SPEC §5) of `ciphertext || GCM tag`.
     pub ciphertext: String,
-    /// base64 of the 12-byte GCM nonce.
+    /// Lowercase hex (SPEC §5) of the 12-byte GCM nonce.
     pub nonce: String,
     /// The non-hardened encryption child path (relative to the keyholder xpub).
     pub derivation: String,

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -2125,11 +2125,11 @@ pub struct RecoverableVault {
     /// heir-facing collapse.
     #[serde(default)]
     pub state: String,
-    /// True when recovering this vault needs the owner's recovery password
-    /// (Heartbeat tier). v1 shows the deferred-path copy for these rows; the
-    /// Alerts-only heir path is COIN-375. Defaults to `true` (fails closed) if
-    /// an older/partial server omits it: an absent field must never downgrade a
-    /// password-required row into a live, password-free "Recover" button.
+    /// **Deprecated under the ECIES pivot (rev 3).** The old KEK model had a
+    /// "recovery password" path; ECIES heir-escrow has none — the heir's
+    /// Keychain decrypts. Retained only so a pre-pivot server payload still
+    /// deserialises; actionability now keys off [`Self::available_tiers`], not
+    /// this field. Defaults `true` (fails closed) when absent.
     #[serde(default = "default_requires_recovery_password")]
     pub requires_recovery_password: bool,
     /// "Owner last active" hint, when the server exposes it (display only).
@@ -2139,11 +2139,18 @@ pub struct RecoverableVault {
     #[serde(default)]
     pub expected_open_at: Option<chrono::DateTime<chrono::Utc>>,
     /// Optional address gap-limit hint for the recovered watch-only sync. The
-    /// descriptor-release endpoint returns no gap hint (it's owner-only), so if
-    /// the API surfaces one it rides on this list row; otherwise the recovered
-    /// vault syncs with a generous default gap.
+    /// release endpoint returns no gap hint (it's owner-only), so if the API
+    /// surfaces one it rides on this list row; otherwise the recovered vault
+    /// syncs with a generous default gap.
     #[serde(default)]
     pub gap_limit: Option<u32>,
+    /// Which ECIES artifact kinds are escrowed **for this caller** (PR C):
+    /// `["descriptor"]` → Vault-only (heir recovers the watch-only Vault and
+    /// sweeps); `["descriptor","seed"]` → Full-Cube (heir restores the whole
+    /// Cube). Empty/absent → nothing escrowed for me, so not recoverable.
+    /// Drives the row label ("Recover Vault" vs "Recover full Cube").
+    #[serde(default)]
+    pub available_tiers: Vec<String>,
 }
 
 impl RecoverableVault {
@@ -2152,17 +2159,37 @@ impl RecoverableVault {
         RecoveryState::from_wire(&self.state)
     }
 
-    /// Whether the caller is a keyholder (the only role that may pull the
-    /// descriptor down — beneficiaries are 403'd by the release endpoint).
+    /// Whether the caller is a keyholder (the only role the release endpoint
+    /// serves envelopes to — beneficiaries are 403'd).
     pub fn is_keyholder(&self) -> bool {
         self.role == "keyholder"
     }
 
+    /// Whether a descriptor envelope is escrowed for this caller. Every
+    /// escrowed tier carries the descriptor, so this is the "anything to
+    /// recover" check.
+    pub fn has_descriptor_tier(&self) -> bool {
+        self.available_tiers.iter().any(|t| t == "descriptor")
+    }
+
+    /// Whether the master seed is escrowed for this caller — the Full-Cube
+    /// tier, which restores the entire Cube (Liquid + Spark + Vault) rather
+    /// than just the watch-only Vault.
+    pub fn has_seed_tier(&self) -> bool {
+        self.available_tiers.iter().any(|t| t == "seed")
+    }
+
+    /// Full-Cube (seed escrowed) vs Vault-only (descriptor only). Drives the
+    /// row label and which restore scope the heir flow uses.
+    pub fn is_full_cube(&self) -> bool {
+        self.has_seed_tier()
+    }
+
     /// Whether the heir can act on this row now: the caller is a keyholder AND
-    /// the window is open AND it isn't a password-required (Heartbeat) row
-    /// deferred to COIN-375.
+    /// the window is open on-chain AND something is escrowed for them. Under
+    /// ECIES there is no password gate — the heir's Keychain decrypts.
     pub fn is_recoverable_now(&self) -> bool {
-        self.is_keyholder() && self.recovery_state().is_open() && !self.requires_recovery_password
+        self.is_keyholder() && self.recovery_state().is_open() && self.has_descriptor_tier()
     }
 }
 
@@ -2177,9 +2204,70 @@ fn default_requires_recovery_password() -> bool {
 /// 200 — the **plaintext** descriptor. The server decrypts the escrowed copy
 /// under its KEK and returns it directly; the keyholder path carries no
 /// password and does no client-side decryption.
+///
+/// **Superseded by the ECIES pivot (rev 3):** the server is now blind and
+/// returns *ciphertext* envelopes via the recovery-envelope endpoint
+/// ([`InheritanceEnvelopeWire`]); the heir's Keychain decrypts. Retained while
+/// the pre-pivot endpoint is still deployed.
 #[derive(Debug, Clone, Deserialize)]
 pub struct RecoveryDescriptorResponse {
     pub descriptor: String,
+}
+
+/// One ECIES heir-escrow envelope on the wire (camelCase JSON; byte fields
+/// base64). The desktop **defines** this contract; `coincube-api` stores the
+/// bytes opaquely (it never parses or decrypts them) and `keychain-app`
+/// decrypts. Shared by owner upload (`PUT …/vault/escrow`, with
+/// `keyholderKeyId`) and gated heir release (`GET …/vault/recovery-envelope`,
+/// where the server returns only the caller's own envelopes, no
+/// `keyholderKeyId`).
+///
+/// `Debug` is manual: `ciphertext` is encrypted, but we still avoid dumping
+/// the blob; the other fields are non-secret (public key, path, scheme).
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InheritanceEnvelopeWire {
+    /// Which keyholder's xpub this is sealed to (`models.Key` id). Present on
+    /// upload; omitted on release (the caller's own envelopes only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keyholder_key_id: Option<u64>,
+    /// `"descriptor"` | `"seed"`.
+    pub artifact_kind: String,
+    /// ECIES scheme tag, e.g. `"ecies-secp256k1-hkdf-aes256gcm-v1"`.
+    pub scheme: String,
+    /// base64 of the 33-byte compressed ephemeral secp256k1 public key.
+    pub ephemeral_pubkey: String,
+    /// base64 of `ciphertext || GCM tag`.
+    pub ciphertext: String,
+    /// base64 of the 12-byte GCM nonce.
+    pub nonce: String,
+    /// The non-hardened encryption child path (relative to the keyholder xpub).
+    pub derivation: String,
+}
+
+impl std::fmt::Debug for InheritanceEnvelopeWire {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InheritanceEnvelopeWire")
+            .field("keyholder_key_id", &self.keyholder_key_id)
+            .field("artifact_kind", &self.artifact_kind)
+            .field("scheme", &self.scheme)
+            .field("ephemeral_pubkey", &self.ephemeral_pubkey)
+            .field("derivation", &self.derivation)
+            .field("ciphertext", &"<redacted>")
+            .field("nonce", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Body of `PUT /api/v1/connect/cubes/{cubeId}/vault/escrow` — the owner
+/// uploads the **whole** envelope set for the cube's current keyholders. The
+/// server idempotently replaces the stored set (handles keyholder
+/// add/remove/key-rotate), validating structure + that each `keyholderKeyId`
+/// is a current member; it never decrypts.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PutVaultEscrowRequest {
+    pub envelopes: Vec<InheritanceEnvelopeWire>,
 }
 
 #[cfg(test)]
@@ -2221,18 +2309,66 @@ mod vault_monitoring_tests {
     }
 
     #[test]
-    fn recoverable_vault_requires_password_fails_closed_when_absent() {
-        // A payload that omits `requiresRecoveryPassword` must default to `true`
-        // (fail closed) so the row is never treated as a password-free, live
-        // "Recover" button. Even open + keyholder, it stays non-actionable.
+    fn recoverable_vault_without_escrowed_tiers_is_not_recoverable() {
+        // Under the ECIES pivot, actionability keys off `availableTiers` (what's
+        // escrowed for the caller), not a recovery password. A payload that omits
+        // it (older server, or nothing escrowed for this keyholder) must never
+        // present a live "Recover" button — even open + keyholder.
         let v = serde_json::json!({
             "cubeId": 7,
             "role": "keyholder",
             "state": "available"
         });
         let row: RecoverableVault = serde_json::from_value(v).unwrap();
-        assert!(row.requires_recovery_password);
+        assert!(row.available_tiers.is_empty());
+        assert!(!row.has_descriptor_tier());
         assert!(!row.is_recoverable_now());
+    }
+
+    #[test]
+    fn recoverable_vault_tier_flags_drive_actionability() {
+        // Vault-only: descriptor escrowed → recoverable, not full-cube.
+        let vault_only: RecoverableVault = serde_json::from_value(serde_json::json!({
+            "cubeId": 7,
+            "role": "keyholder",
+            "state": "reminding",
+            "availableTiers": ["descriptor"]
+        }))
+        .unwrap();
+        assert!(vault_only.is_recoverable_now());
+        assert!(vault_only.has_descriptor_tier());
+        assert!(!vault_only.is_full_cube());
+
+        // Full-Cube: seed escrowed too → recoverable and full-cube.
+        let full_cube: RecoverableVault = serde_json::from_value(serde_json::json!({
+            "cubeId": 8,
+            "role": "keyholder",
+            "state": "available",
+            "availableTiers": ["descriptor", "seed"]
+        }))
+        .unwrap();
+        assert!(full_cube.is_recoverable_now());
+        assert!(full_cube.is_full_cube());
+
+        // Escrowed but window not open → not recoverable yet.
+        let not_open: RecoverableVault = serde_json::from_value(serde_json::json!({
+            "cubeId": 9,
+            "role": "keyholder",
+            "state": "approaching",
+            "availableTiers": ["descriptor", "seed"]
+        }))
+        .unwrap();
+        assert!(!not_open.is_recoverable_now());
+
+        // Escrowed + open, but caller is a beneficiary → not recoverable.
+        let beneficiary: RecoverableVault = serde_json::from_value(serde_json::json!({
+            "cubeId": 10,
+            "role": "beneficiary",
+            "state": "available",
+            "availableTiers": ["descriptor"]
+        }))
+        .unwrap();
+        assert!(!beneficiary.is_recoverable_now());
     }
 
     #[test]

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -2217,18 +2217,25 @@ pub struct RecoveryDescriptorResponse {
 /// One ECIES heir-escrow envelope on the wire (camelCase JSON; byte fields
 /// base64). The desktop **defines** this contract; `coincube-api` stores the
 /// bytes opaquely (it never parses or decrypts them) and `keychain-app`
-/// decrypts. Shared by owner upload (`PUT …/vault/escrow`, with
-/// `keyholderKeyId`) and gated heir release (`GET …/vault/recovery-envelope`,
-/// where the server returns only the caller's own envelopes, no
-/// `keyholderKeyId`).
+/// decrypts. Shared by owner upload (`PUT …/vault/escrow`) and gated heir
+/// release (`GET …/vault/recovery-envelope`, which returns only the caller's
+/// own envelopes). `keyholderKeyId` is bound into the ECIES AAD at seal time
+/// (SPEC §1), so it MUST be present in **both** directions — the heir needs it
+/// to rebuild the AAD and open the envelope (see the field doc).
 ///
 /// `Debug` is manual: `ciphertext` is encrypted, but we still avoid dumping
 /// the blob; the other fields are non-secret (public key, path, scheme).
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InheritanceEnvelopeWire {
-    /// Which keyholder's xpub this is sealed to (`models.Key` id). Present on
-    /// upload; omitted on release (the caller's own envelopes only).
+    /// Which keyholder's xpub this is sealed to (`models.Key` id). Bound into
+    /// the ECIES AAD at seal time (SPEC §1), so the heir **requires** it on the
+    /// gated release to rebuild the AAD and open the envelope — `coincube-api`
+    /// MUST include it on `GET …/vault/recovery-envelope` (the caller's own key
+    /// id), not just echo it on upload. `Option` because the wire field can be
+    /// absent (e.g. an older server); [`crate::services::inheritance`]'s
+    /// `heir::open_blob` then fails closed with a clear error rather than
+    /// silently producing a wrong AAD.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub keyholder_key_id: Option<u64>,
     /// `"descriptor"` | `"seed"`.

--- a/coincube-gui/src/services/connect/grpc/session.rs
+++ b/coincube-gui/src/services/connect/grpc/session.rs
@@ -1,17 +1,30 @@
+use std::convert::TryFrom;
+
 use tonic::transport::Channel;
 
 use super::connect_v1::{
     session_service_client::SessionServiceClient, CancelSigningSessionRequest,
-    CreateSigningSessionRequest, DecryptInheritanceEnvelopeRequest, GetSigningSessionRequest,
-    GetSigningSessionResponse, ListPendingSessionsResponse, ResolveSignersRequest,
-    ResolveSignersResponse, SigningSession,
+    CreateDecryptRequestRequest, CreateSigningSessionRequest, DecryptRequestStatus,
+    GetDecryptResultRequest, GetSigningSessionRequest, GetSigningSessionResponse,
+    ListPendingSessionsResponse, ResolveSignersRequest, ResolveSignersResponse, SigningSession,
 };
 use super::interceptor::AuthInterceptor;
 
-/// secp256k1 ECDH + HKDF-SHA256 yield a 32-byte symmetric key; the desktop
-/// rejects anything else from the relayed Keychain response (a malformed key
-/// would otherwise surface as an opaque AES-GCM open failure).
-const INHERITANCE_SHARED_KEY_LEN: usize = 32;
+/// Terminal-or-pending outcome of an inheritance decrypt-relay request,
+/// translated from the proto `DecryptRequestStatus` so callers don't depend on
+/// generated types. `Completed` carries the opaque `wrapped_shared_key` to
+/// unwrap (SPEC-ecies-v1 §4b).
+#[derive(Debug, Clone)]
+pub enum DecryptOutcome {
+    /// Still awaiting the heir's Keychain approval — poll again.
+    Pending,
+    /// Keychain approved; carries the ECIES-wrapped key to unwrap locally.
+    Completed(Vec<u8>),
+    /// Keychain declined (approval denied or the heir is under duress).
+    Rejected,
+    /// The request TTL elapsed without a Keychain answer.
+    Expired,
+}
 
 type InterceptedSessionClient =
     SessionServiceClient<tonic::service::interceptor::InterceptedService<Channel, AuthInterceptor>>;
@@ -95,37 +108,47 @@ impl GrpcSessionClient {
             .map(|r| r.into_inner())
     }
 
-    /// Heir-side inheritance recovery: ask the heir's Keychain (via the API
-    /// relay) to ECDH-decrypt one ECIES envelope and return the derived
-    /// symmetric key `K`. Keychain approves with biometric/PIN and never
-    /// returns the recovery private key or the seed/descriptor plaintext — the
-    /// desktop completes the AES-256-GCM open with `K`. `purpose` pins the
-    /// scheme so a Keychain that doesn't implement it can refuse.
-    ///
-    /// `ephemeral_pubkey` is the 33-byte compressed point and `derivation` the
-    /// non-hardened child path, both taken verbatim from the envelope.
-    pub async fn decrypt_inheritance_envelope(
+    /// Heir desktop — inheritance decrypt relay, step 1. Brokers a decrypt of
+    /// the envelope addressed to us for (`cube_id`, `artifact_kind`); the server
+    /// applies the recovery gate and notifies the heir's Keychain, which (after
+    /// biometric/PIN approval) ECIES-**wraps** the derived key to
+    /// `transport_pubkey` (compressed SEC1) — the server never sees the key.
+    /// Idempotent on `request_id`.
+    pub async fn create_decrypt_request(
         &mut self,
+        request_id: String,
         cube_id: String,
-        ephemeral_pubkey: Vec<u8>,
-        derivation: String,
-    ) -> Result<Vec<u8>, tonic::Status> {
-        let request = DecryptInheritanceEnvelopeRequest {
+        artifact_kind: String,
+        transport_pubkey: Vec<u8>,
+    ) -> Result<(), tonic::Status> {
+        let request = CreateDecryptRequestRequest {
+            request_id,
             cube_id,
-            ephemeral_pubkey,
-            derivation,
-            purpose: crate::services::inheritance::SCHEME.to_string(),
+            artifact_kind,
+            desktop_transport_pubkey: transport_pubkey,
         };
-        let resp = self
-            .inner
-            .decrypt_inheritance_envelope(request)
-            .await?
-            .into_inner();
-        if resp.shared_key.len() != INHERITANCE_SHARED_KEY_LEN {
-            return Err(tonic::Status::internal(
-                "DecryptInheritanceEnvelope returned a shared key of the wrong length",
-            ));
-        }
-        Ok(resp.shared_key)
+        self.inner.create_decrypt_request(request).await.map(|_| ())
+    }
+
+    /// Heir desktop — inheritance decrypt relay, step 4 (poll). Fetches the
+    /// current [`DecryptOutcome`] of a request; the companion to the best-effort
+    /// `decrypt_result` stream push. On `Completed`, the wrapped key is unwrapped
+    /// locally with the per-recovery transport private key (SPEC §4b).
+    pub async fn get_decrypt_result(
+        &mut self,
+        request_id: String,
+    ) -> Result<DecryptOutcome, tonic::Status> {
+        let request = GetDecryptResultRequest { request_id };
+        let resp = self.inner.get_decrypt_result(request).await?.into_inner();
+        let status = DecryptRequestStatus::try_from(resp.status)
+            .map_err(|_| tonic::Status::internal("GetDecryptResult returned an unknown status"))?;
+        Ok(match status {
+            DecryptRequestStatus::Completed => DecryptOutcome::Completed(resp.wrapped_shared_key),
+            DecryptRequestStatus::Rejected => DecryptOutcome::Rejected,
+            DecryptRequestStatus::Expired => DecryptOutcome::Expired,
+            DecryptRequestStatus::Pending | DecryptRequestStatus::Unspecified => {
+                DecryptOutcome::Pending
+            }
+        })
     }
 }

--- a/coincube-gui/src/services/connect/grpc/session.rs
+++ b/coincube-gui/src/services/connect/grpc/session.rs
@@ -2,10 +2,16 @@ use tonic::transport::Channel;
 
 use super::connect_v1::{
     session_service_client::SessionServiceClient, CancelSigningSessionRequest,
-    CreateSigningSessionRequest, GetSigningSessionRequest, GetSigningSessionResponse,
-    ListPendingSessionsResponse, ResolveSignersRequest, ResolveSignersResponse, SigningSession,
+    CreateSigningSessionRequest, DecryptInheritanceEnvelopeRequest, GetSigningSessionRequest,
+    GetSigningSessionResponse, ListPendingSessionsResponse, ResolveSignersRequest,
+    ResolveSignersResponse, SigningSession,
 };
 use super::interceptor::AuthInterceptor;
+
+/// secp256k1 ECDH + HKDF-SHA256 yield a 32-byte symmetric key; the desktop
+/// rejects anything else from the relayed Keychain response (a malformed key
+/// would otherwise surface as an opaque AES-GCM open failure).
+const INHERITANCE_SHARED_KEY_LEN: usize = 32;
 
 type InterceptedSessionClient =
     SessionServiceClient<tonic::service::interceptor::InterceptedService<Channel, AuthInterceptor>>;
@@ -87,5 +93,39 @@ impl GrpcSessionClient {
             .resolve_signers(request)
             .await
             .map(|r| r.into_inner())
+    }
+
+    /// Heir-side inheritance recovery: ask the heir's Keychain (via the API
+    /// relay) to ECDH-decrypt one ECIES envelope and return the derived
+    /// symmetric key `K`. Keychain approves with biometric/PIN and never
+    /// returns the recovery private key or the seed/descriptor plaintext — the
+    /// desktop completes the AES-256-GCM open with `K`. `purpose` pins the
+    /// scheme so a Keychain that doesn't implement it can refuse.
+    ///
+    /// `ephemeral_pubkey` is the 33-byte compressed point and `derivation` the
+    /// non-hardened child path, both taken verbatim from the envelope.
+    pub async fn decrypt_inheritance_envelope(
+        &mut self,
+        cube_id: String,
+        ephemeral_pubkey: Vec<u8>,
+        derivation: String,
+    ) -> Result<Vec<u8>, tonic::Status> {
+        let request = DecryptInheritanceEnvelopeRequest {
+            cube_id,
+            ephemeral_pubkey,
+            derivation,
+            purpose: crate::services::inheritance::SCHEME.to_string(),
+        };
+        let resp = self
+            .inner
+            .decrypt_inheritance_envelope(request)
+            .await?
+            .into_inner();
+        if resp.shared_key.len() != INHERITANCE_SHARED_KEY_LEN {
+            return Err(tonic::Status::internal(
+                "DecryptInheritanceEnvelope returned a shared key of the wrong length",
+            ));
+        }
+        Ok(resp.shared_key)
     }
 }

--- a/coincube-gui/src/services/inheritance/ecies.rs
+++ b/coincube-gui/src/services/inheritance/ecies.rs
@@ -9,64 +9,81 @@
 //! ECDH with the matching recovery private child key and returns the derived
 //! symmetric key `K`; the desktop completes the AES-256-GCM open here.
 //!
-//! ## Canonical wire contract (`ecies-secp256k1-hkdf-aes256gcm-v1`)
+//! ## Canonical wire contract — `SPEC-ecies-v1.md` (§1, §3, §4, §7)
 //!
-//! The desktop **defines** this contract; `coincube-api` (blob store) and
-//! `keychain-app` (ECDH-decrypt) must match it byte-for-byte. The
-//! known-answer tests at the bottom of this file are the cross-repo vectors.
+//! This module MUST match `SPEC-ecies-v1.md` byte-for-byte; `coincube-api`
+//! (blob store) and `keychain-app` (ECDH-decrypt) match the same spec. The
+//! `kat_spec_v1_*` tests at the bottom replay the §7 known-answer vector.
 //!
 //! ```text
-//! recipient_child_pub = derive_pub(recipient_xpub, derivation)   // I5: a
-//!                                                                // dedicated
-//!                                                                // non-hardened
-//!                                                                // child, never
-//!                                                                // the signing key
-//! (eph_sk, eph_pk)    = fresh ephemeral secp256k1 keypair (per envelope)
-//! S  = SHA256( compressed( eph_sk · recipient_child_pub ) )      // secp256k1
-//!                                                                // ecdh::SharedSecret
-//! K  = HKDF-SHA256( salt = "", ikm = S,
-//!                   info = "coincube-inheritance-ecies-v1", L = 32 )
-//! AAD = "ecies-secp256k1-hkdf-aes256gcm-v1" || 0x00 ||
-//!        kind_byte || derivation_utf8 || eph_pk_compressed(33)
-//! ct||tag = AES-256-GCM-Seal( key = K, nonce = random 12B, aad = AAD, pt )
+//! P  = CKDpub(recipient_account_xpub, 7000)        // dedicated enc child (I5)
+//! (e, E) = fresh ephemeral secp256k1 keypair (per envelope)
+//! ikm = compressed_SEC1( e · P )                   // 33B — the RAW point, NOT
+//!                                                  // SHA256'd (no hashed ECDH)
+//! K  = HKDF-SHA256( salt = 0x00*32, ikm,
+//!                   info = "coincube-inheritance-ecies-v1\x00" ‖ E ‖ P, L=32 )
+//! AAD = "coincube-inheritance-ecies-v1\x00" ‖ kind_byte(1) ‖
+//!        cube_id(u64 BE) ‖ keyholder_key_id(u64 BE)
+//! ct‖tag = AES-256-GCM-Seal( key = K, nonce = random 12B, aad = AAD, pt )
 //! ```
 //!
-//! The heir reconstructs the *same* `S` as
-//! `SHA256(compressed(recovery_child_sk · eph_pk))` (ECDH symmetry), so
-//! Keychain returns `K = HKDF-SHA256(S, …)` and the desktop opens with it.
-//! Every public envelope field is bound into the GCM AAD, so a tampered
-//! `derivation`, `artifact_kind`, or `ephemeral_pubkey` fails the tag.
+//! The heir reconstructs the same `ikm` as `compressed(d · E)` (ECDH symmetry,
+//! `d · E == e · P`); Keychain returns `K = HKDF(ikm, …)` and the desktop opens
+//! with it. `cube_id` + `keyholder_key_id` are bound into the AAD (not the
+//! envelope body), so the server cannot silently re-target an envelope.
 
 use aes_gcm::aead::{Aead, Payload};
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
-use coincube_core::miniscript::bitcoin::bip32::{DerivationPath, Xpub};
+use coincube_core::miniscript::bitcoin::bip32::{ChildNumber, Xpub};
 use coincube_core::miniscript::bitcoin::secp256k1::{
-    ecdh::SharedSecret, PublicKey, Secp256k1, SecretKey,
+    ecdh::shared_secret_point, PublicKey, Secp256k1, SecretKey,
 };
 use rand::RngCore;
 use zeroize::Zeroizing;
 
 use super::error::EciesError;
 
-/// Wire identifier for this scheme. A new value here is a wire-format break
-/// requiring matching changes in `coincube-api` and `keychain-app`.
-pub const SCHEME: &str = "ecies-secp256k1-hkdf-aes256gcm-v1";
+/// Wire identifier for this scheme (SPEC-ecies-v1 §scheme id). A new value
+/// here is a wire-format break requiring matching changes in `coincube-api`
+/// and `keychain-app`.
+pub const SCHEME: &str = "ecies-secp256k1-hkdf-sha256-aes256gcm-v1";
 
-/// HKDF `info` string binding the derived key to this purpose. Keychain uses
-/// the identical bytes when it derives `K`.
-pub const HKDF_INFO: &[u8] = b"coincube-inheritance-ecies-v1";
+/// The label prefixing both the HKDF `info` and the AEAD `aad` (SPEC §1). The
+/// trailing `\x00` is part of the label — it separates the label from the
+/// binary that follows.
+const ECIES_LABEL: &[u8] = b"coincube-inheritance-ecies-v1\x00";
 
-/// The dedicated, non-hardened encryption child derived from the keyholder's
-/// registered xpub (invariant I5 — never the signing key, never chain 0/1
-/// which the wallet descriptor spends from). Stored in each envelope's
-/// `derivation` field so Keychain replays the exact path against its xpriv.
-pub const ENCRYPTION_CHILD_DERIVATION: &str = "9/0";
+/// HKDF salt: 32 explicit zero bytes (SPEC §1 — not empty/None).
+const HKDF_SALT: [u8; 32] = [0u8; 32];
+
+/// §4b key-wrap scheme id (the keychain→desktop wrap of `K`). The wire blob is a
+/// fixed binary layout (see [`unwrap_shared_key`]); this id is the SPEC
+/// identifier, not an on-wire field.
+pub const WRAP_SCHEME: &str = "ecies-secp256k1-hkdf-sha256-aes256gcm-wrap-v1";
+
+/// Domain label for the §4b key wrap's HKDF `info` and AEAD `aad` — distinct
+/// from [`ECIES_LABEL`] so a wrapped-key blob and an envelope can never be
+/// opened as one another. The trailing `\x00` separates label from binary.
+const WRAP_LABEL: &[u8] = b"coincube-inheritance-wrap-v1\x00";
+
+/// Version byte prefixing a `wrapped_shared_key` blob (§4b layout).
+const WRAP_VERSION: u8 = 0x01;
+
+/// Reserved non-hardened child index for inheritance encryption (invariant
+/// I5). A sibling of the wallet's `0`/`1` branch nodes but a different index,
+/// so it can never collide with a signing key or address. The owner derives
+/// `P = CKDpub(account_xpub, 7000)`; the envelope's `derivation` carries the
+/// full path from the seed root so Keychain derives the matching `d`.
+pub const ENCRYPTION_CHILD_INDEX: u32 = 7000;
 
 const KEY_LEN: usize = 32; // AES-256
 const NONCE_LEN: usize = 12; // GCM standard
 const TAG_LEN: usize = 16;
 /// Compressed secp256k1 point.
 const PUBKEY_LEN: usize = 33;
+/// Fixed length of a `wrapped_shared_key` (§4b): `version(1) ‖ E_w(33) ‖
+/// nonce(12) ‖ ct‖tag(48)` — the wrapped plaintext is always the 32-byte `K`.
+const WRAPPED_LEN: usize = 1 + PUBKEY_LEN + NONCE_LEN + KEY_LEN + TAG_LEN;
 
 /// Which recovery artifact an envelope carries. The byte form is bound into
 /// the AAD; the wire string matches the API's `artifactKind`.
@@ -87,8 +104,7 @@ impl ArtifactKind {
         }
     }
 
-    /// One-byte AAD discriminant. Distinct from `as_wire` so a future kind
-    /// can't silently collide on a shared prefix.
+    /// One-byte AAD discriminant (SPEC §1: descriptor=0x01, seed=0x02).
     fn aad_byte(self) -> u8 {
         match self {
             Self::Descriptor => 0x01,
@@ -111,9 +127,7 @@ impl ArtifactKind {
 /// to the gated heir. Field names mirror the API schema (PR A).
 ///
 /// `Debug` is manual: the `ciphertext` is encrypted, but we still avoid
-/// dumping the raw bytes to any `{:?}` site and never let the plaintext-
-/// adjacent fields read as innocuous. Public fields (scheme, derivation,
-/// kind, ephemeral pubkey) are non-secret and shown.
+/// dumping the raw bytes to any `{:?}` site.
 #[derive(Clone)]
 pub struct Envelope {
     pub artifact_kind: ArtifactKind,
@@ -124,7 +138,9 @@ pub struct Envelope {
     pub ciphertext: Vec<u8>,
     /// 12-byte GCM nonce.
     pub nonce: Vec<u8>,
-    /// The non-hardened child path used (relative to the keyholder xpub).
+    /// Full BIP32 path from the seed root to the dedicated encryption child
+    /// (e.g. `m/48h/1h/0h/2h/7000`) — Keychain derives `d` from it. Metadata
+    /// only: it is NOT part of the AAD (the AAD binds cube + keyholder id).
     pub derivation: String,
 }
 
@@ -141,6 +157,53 @@ impl std::fmt::Debug for Envelope {
     }
 }
 
+/// A fresh, in-memory secp256k1 transport keypair for the heir desktop's
+/// per-recovery wrap target. In the async decrypt relay the heir's Keychain
+/// ECIES-**wraps** `K` to this public key, so the server only ever relays an
+/// opaque blob; the desktop unwraps it locally with the private scalar. The
+/// secret is zeroized on drop and **never persisted**. [`unwrap_shared_key`]
+/// consumes it to recover `K` from the Keychain's `wrapped_shared_key` (§4b).
+pub struct TransportKeypair {
+    secret: Zeroizing<[u8; 32]>,
+    /// Compressed SEC1 (33-byte) public key — the `desktop_transport_pubkey`.
+    public: [u8; PUBKEY_LEN],
+}
+
+impl TransportKeypair {
+    /// The compressed-SEC1 public key to send as `desktop_transport_pubkey`.
+    pub fn public_key(&self) -> [u8; PUBKEY_LEN] {
+        self.public
+    }
+
+    /// The raw private scalar (32 bytes), for the wrap-open. Borrowed from the
+    /// zeroizing buffer so it isn't copied out un-wiped.
+    pub fn secret_bytes(&self) -> &[u8; 32] {
+        &self.secret
+    }
+}
+
+impl std::fmt::Debug for TransportKeypair {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TransportKeypair")
+            .field("public", &hex(&self.public))
+            .field("secret", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Generates a fresh transport keypair (see [`TransportKeypair`]).
+pub fn transport_keypair() -> TransportKeypair {
+    let secp = Secp256k1::new();
+    let sk = random_secret_key();
+    let pk = PublicKey::from_secret_key(&secp, &sk);
+    let mut secret = Zeroizing::new([0u8; 32]);
+    secret.copy_from_slice(&sk.secret_bytes());
+    TransportKeypair {
+        secret,
+        public: pk.serialize(),
+    }
+}
+
 fn hex(bytes: &[u8]) -> String {
     use std::fmt::Write;
     let mut s = String::with_capacity(bytes.len() * 2);
@@ -150,28 +213,47 @@ fn hex(bytes: &[u8]) -> String {
     s
 }
 
-/// The Additional Authenticated Data bound into the GCM tag. Reconstructed
-/// identically by the heir from public envelope fields, so any mutation of
-/// `scheme` / `kind` / `derivation` / `ephemeral_pubkey` breaks the tag.
-fn aad_bytes(kind: ArtifactKind, derivation: &str, ephemeral_pubkey: &[u8]) -> Vec<u8> {
-    let mut aad = Vec::with_capacity(SCHEME.len() + 2 + derivation.len() + ephemeral_pubkey.len());
-    aad.extend_from_slice(SCHEME.as_bytes());
-    aad.push(0x00); // domain separator between scheme and the rest
+/// The Additional Authenticated Data bound into the GCM tag (SPEC §1):
+/// `label ‖ kind_byte ‖ cube_id(u64 BE) ‖ keyholder_key_id(u64 BE)`. The heir
+/// rebuilds it from the envelope kind + the recovery context, so a server that
+/// re-targets an envelope to a different cube/keyholder breaks the tag.
+fn aad_bytes(kind: ArtifactKind, cube_id: u64, keyholder_key_id: u64) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(ECIES_LABEL.len() + 1 + 8 + 8);
+    aad.extend_from_slice(ECIES_LABEL);
     aad.push(kind.aad_byte());
-    aad.extend_from_slice(derivation.as_bytes());
-    aad.extend_from_slice(ephemeral_pubkey);
+    aad.extend_from_slice(&cube_id.to_be_bytes());
+    aad.extend_from_slice(&keyholder_key_id.to_be_bytes());
     aad
 }
 
-/// HKDF-SHA256 over `ring` (already in-tree; avoids the hmac/sha2 digest
-/// version split). Empty salt → RFC-5869 all-zero salt, matching a Go
-/// `hkdf.New(sha256, ikm, nil, info)` on the Keychain side.
-fn hkdf_sha256_key(ikm: &[u8]) -> Zeroizing<[u8; KEY_LEN]> {
-    let salt = ring::hkdf::Salt::new(ring::hkdf::HKDF_SHA256, &[]);
+/// The ECDH input keying material (SPEC §1): the **compressed SEC1 encoding of
+/// `scalar · point`** — the raw curve point, deliberately NOT the SHA256-hashed
+/// `ecdh::SharedSecret`. `shared_secret_point` returns the uncompressed `x‖y`;
+/// we compress it (prefix from the parity of `y`).
+fn ecdh_ikm(point: &PublicKey, scalar: &SecretKey) -> Zeroizing<[u8; PUBKEY_LEN]> {
+    let xy = shared_secret_point(point, scalar); // [u8; 64] = x(32) ‖ y(32), BE
+    let mut ikm = Zeroizing::new([0u8; PUBKEY_LEN]);
+    ikm[0] = 0x02 | (xy[63] & 0x01); // compressed prefix from y's least bit
+    ikm[1..].copy_from_slice(&xy[0..32]); // x
+    ikm
+}
+
+/// HKDF-SHA256 per SPEC §1 / §4b: `salt = 0x00*32`, `info = label ‖ E ‖ P`,
+/// 32-byte output. `label` is [`ECIES_LABEL`] for envelopes and [`WRAP_LABEL`]
+/// for the §4b key wrap; `eph_pub` is `E`, `recipient_pub` is `P` (compressed).
+fn hkdf_key(
+    label: &[u8],
+    ikm: &[u8],
+    eph_pub: &[u8],
+    recipient_pub: &[u8],
+) -> Zeroizing<[u8; KEY_LEN]> {
+    let salt = ring::hkdf::Salt::new(ring::hkdf::HKDF_SHA256, &HKDF_SALT);
     let prk = salt.extract(ikm);
-    // `HKDF_SHA256` as its own `KeyType` yields a 32-byte (SHA-256-len) OKM.
+    // Bound to a local: `Okm` borrows the info slice until `fill`, so it must
+    // outlive the `expand` call (the parts aren't all `'static`).
+    let info: [&[u8]; 3] = [label, eph_pub, recipient_pub];
     let okm = prk
-        .expand(&[HKDF_INFO], ring::hkdf::HKDF_SHA256)
+        .expand(&info, ring::hkdf::HKDF_SHA256)
         .expect("HKDF expand of one SHA-256 block never exceeds the length cap");
     let mut key = Zeroizing::new([0u8; KEY_LEN]);
     okm.fill(key.as_mut())
@@ -179,58 +261,100 @@ fn hkdf_sha256_key(ikm: &[u8]) -> Zeroizing<[u8; KEY_LEN]> {
     key
 }
 
-/// Derives the per-envelope symmetric key from a completed ECDH. This is the
-/// exact computation Keychain performs (ECDH on the recovery child private
-/// key, then HKDF) and returns to the desktop as `K`; kept here so the
-/// desktop can (a) seal owner-side and (b) round-trip in tests without a
-/// Keychain. **Never** call this with the owner's seed material at heir
-/// recovery time — `K` then comes from Keychain, not from a local key. It is
-/// `pub(crate)` only so the sibling escrow tests can exercise the full path.
-pub(crate) fn shared_key_from_ecdh(
-    point: &PublicKey,
-    scalar: &SecretKey,
+/// The **Keychain half** of the open (also used in tests to stand in for
+/// Keychain): given the recovery child private key `d` and the envelope's
+/// ephemeral pubkey `E`, returns `K = HKDF(ikm = d·E, info = label‖E‖P)` where
+/// `P = d·G`. Never exposes `d`, the seed, or the raw ECDH point. At real
+/// recovery `K` comes from Keychain, not from a local key; this is here so the
+/// desktop can seal owner-side and round-trip in tests without a Keychain. It
+/// is test-only (`#[cfg(test)]`) so the sibling escrow/heir tests can exercise
+/// the full path without a Keychain; production never derives `K` locally.
+#[cfg(test)]
+pub(crate) fn keychain_shared_key(
+    child_sk: &SecretKey,
+    eph_pub: &PublicKey,
 ) -> Zeroizing<[u8; KEY_LEN]> {
-    // `SharedSecret::new` = SHA256(compressed(scalar · point)) — the `S` of
-    // the wire contract. ECDH symmetry makes owner and heir agree on it.
-    let s = SharedSecret::new(point, scalar);
-    hkdf_sha256_key(&s.secret_bytes())
+    let secp = Secp256k1::new();
+    let recipient_pub = PublicKey::from_secret_key(&secp, child_sk);
+    let ikm = ecdh_ikm(eph_pub, child_sk);
+    hkdf_key(
+        ECIES_LABEL,
+        ikm.as_ref(),
+        &eph_pub.serialize(),
+        &recipient_pub.serialize(),
+    )
 }
 
-/// **Owner side.** Seals `plaintext` to a keyholder's `recipient_xpub` under
-/// the dedicated encryption child at `derivation`. Generates a fresh
-/// ephemeral keypair and nonce per call. Public-key encryption only — no
-/// secret of the recipient's is needed, so this runs on the owner's desktop
-/// with no Keychain involvement.
+/// **Owner side.** Seals `plaintext` to a keyholder's `recipient_xpub` (their
+/// registered account xpub) under the dedicated encryption child (index
+/// [`ENCRYPTION_CHILD_INDEX`], invariant I5). `full_derivation` is the full
+/// path from the seed root stored in the envelope so Keychain can derive `d`.
+/// `cube_id` + `keyholder_key_id` are bound into the AAD. Generates a fresh
+/// ephemeral keypair and nonce per call; public-key encryption only (no
+/// recipient secret), so it runs on the owner's desktop without Keychain.
 pub fn seal_to_xpub(
     recipient_xpub: &Xpub,
-    derivation: &DerivationPath,
+    full_derivation: &str,
     kind: ArtifactKind,
+    cube_id: u64,
+    keyholder_key_id: u64,
     plaintext: &[u8],
 ) -> Result<Envelope, EciesError> {
     let secp = Secp256k1::new();
-    // Derive the dedicated, non-hardened encryption child pubkey (I5). An
-    // xpub can only walk non-hardened steps; `derive_pub` errors otherwise.
+    // Derive the dedicated, non-hardened encryption child pubkey from the
+    // account xpub. An xpub can only walk non-hardened steps; `derive_pub`
+    // errors otherwise.
+    let child = ChildNumber::from_normal_idx(ENCRYPTION_CHILD_INDEX)
+        .map_err(|_| EciesError::MalformedEnvelope("encryption child index"))?;
     let recipient_child_pub = recipient_xpub
-        .derive_pub(&secp, derivation)
+        .derive_pub(&secp, &[child])
         .map_err(EciesError::Derivation)?
         .public_key;
 
     let eph_sk = random_secret_key();
-    let eph_pk = PublicKey::from_secret_key(&secp, &eph_sk);
-    let ephemeral_pubkey = eph_pk.serialize().to_vec(); // 33-byte compressed
+    let mut nonce = [0u8; NONCE_LEN];
+    rand::thread_rng().fill_bytes(&mut nonce);
 
-    let key = shared_key_from_ecdh(&recipient_child_pub, &eph_sk);
+    seal_with_ephemeral(
+        &recipient_child_pub,
+        &eph_sk,
+        &nonce,
+        kind,
+        cube_id,
+        keyholder_key_id,
+        full_derivation,
+        plaintext,
+    )
+}
 
-    let mut nonce_bytes = [0u8; NONCE_LEN];
-    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+/// The deterministic seal core (fixed ephemeral key + nonce). [`seal_to_xpub`]
+/// supplies random ones; the KAT test supplies the §7 fixtures.
+#[allow(clippy::too_many_arguments)]
+fn seal_with_ephemeral(
+    recipient_child_pub: &PublicKey,
+    eph_sk: &SecretKey,
+    nonce: &[u8; NONCE_LEN],
+    kind: ArtifactKind,
+    cube_id: u64,
+    keyholder_key_id: u64,
+    full_derivation: &str,
+    plaintext: &[u8],
+) -> Result<Envelope, EciesError> {
+    let secp = Secp256k1::new();
+    let eph_pk = PublicKey::from_secret_key(&secp, eph_sk);
+    let ikm = ecdh_ikm(recipient_child_pub, eph_sk);
+    let key = hkdf_key(
+        ECIES_LABEL,
+        ikm.as_ref(),
+        &eph_pk.serialize(),
+        &recipient_child_pub.serialize(),
+    );
 
-    let derivation_str = derivation.to_string();
-    let aad = aad_bytes(kind, &derivation_str, &ephemeral_pubkey);
-
+    let aad = aad_bytes(kind, cube_id, keyholder_key_id);
     let cipher = Aes256Gcm::new_from_slice(key.as_ref()).map_err(EciesError::Cipher)?;
     let ciphertext = cipher
         .encrypt(
-            Nonce::from_slice(&nonce_bytes),
+            Nonce::from_slice(nonce),
             Payload {
                 msg: plaintext,
                 aad: &aad,
@@ -241,21 +365,24 @@ pub fn seal_to_xpub(
     Ok(Envelope {
         artifact_kind: kind,
         scheme: SCHEME.to_string(),
-        ephemeral_pubkey,
+        ephemeral_pubkey: eph_pk.serialize().to_vec(),
         ciphertext,
-        nonce: nonce_bytes.to_vec(),
-        derivation: derivation_str,
+        nonce: nonce.to_vec(),
+        derivation: full_derivation.to_string(),
     })
 }
 
 /// **Heir side.** Opens an envelope with the symmetric key `K` returned by
-/// Keychain (which did the ECDH + HKDF on the recovery private key). The
-/// plaintext lands in a `Zeroizing<Vec<u8>>` wiped on drop. A wrong key,
-/// tampered ciphertext, or tampered AAD all surface as
-/// [`EciesError::BadKeyOrCorrupt`] — indistinguishable by design.
+/// Keychain (which did the ECDH + HKDF on the recovery private key). The AAD is
+/// rebuilt from the envelope kind + the recovery context's `cube_id` /
+/// `keyholder_key_id` (SPEC §1). The plaintext lands in a `Zeroizing<Vec<u8>>`
+/// wiped on drop. A wrong key, tampered ciphertext, or tampered AAD all surface
+/// as [`EciesError::BadKeyOrCorrupt`] — indistinguishable by design.
 pub fn open_with_shared_key(
     shared_key: &[u8; KEY_LEN],
     env: &Envelope,
+    cube_id: u64,
+    keyholder_key_id: u64,
 ) -> Result<Zeroizing<Vec<u8>>, EciesError> {
     if env.scheme != SCHEME {
         return Err(EciesError::UnsupportedScheme(env.scheme.clone()));
@@ -270,7 +397,7 @@ pub fn open_with_shared_key(
         return Err(EciesError::MalformedEnvelope("ciphertext shorter than tag"));
     }
 
-    let aad = aad_bytes(env.artifact_kind, &env.derivation, &env.ephemeral_pubkey);
+    let aad = aad_bytes(env.artifact_kind, cube_id, keyholder_key_id);
     let cipher = Aes256Gcm::new_from_slice(shared_key).map_err(EciesError::Cipher)?;
     let pt = cipher
         .decrypt(
@@ -282,6 +409,60 @@ pub fn open_with_shared_key(
         )
         .map_err(|_| EciesError::BadKeyOrCorrupt)?;
     Ok(Zeroizing::new(pt))
+}
+
+/// **Heir desktop, §4b.** Unwraps the `wrapped_shared_key` the Keychain returned
+/// (an ECIES wrap of `K` to our per-recovery transport key) into the 32-byte
+/// envelope key `K`. `request_id` is the `CreateDecryptRequest` id, bound into
+/// the wrap AAD. `wrapped` is the fixed [`WRAPPED_LEN`]-byte layout
+/// `version ‖ E_w(33) ‖ nonce(12) ‖ ct‖tag(48)`. A malformed blob, the wrong
+/// transport key, or a tampered AAD all fail closed as
+/// [`EciesError::BadKeyOrCorrupt`] / [`EciesError::MalformedEnvelope`].
+pub fn unwrap_shared_key(
+    transport: &TransportKeypair,
+    request_id: &str,
+    wrapped: &[u8],
+) -> Result<Zeroizing<[u8; KEY_LEN]>, EciesError> {
+    if wrapped.len() != WRAPPED_LEN {
+        return Err(EciesError::MalformedEnvelope("wrapped key length"));
+    }
+    if wrapped[0] != WRAP_VERSION {
+        return Err(EciesError::MalformedEnvelope("wrapped key version"));
+    }
+    let eph_pub_bytes = &wrapped[1..1 + PUBKEY_LEN];
+    let nonce = &wrapped[1 + PUBKEY_LEN..1 + PUBKEY_LEN + NONCE_LEN];
+    let ct = &wrapped[1 + PUBKEY_LEN + NONCE_LEN..];
+
+    let eph_pub = PublicKey::from_slice(eph_pub_bytes)
+        .map_err(|_| EciesError::MalformedEnvelope("wrapped key ephemeral pubkey"))?;
+    let t = SecretKey::from_slice(transport.secret_bytes())
+        .map_err(|_| EciesError::MalformedEnvelope("transport secret"))?;
+
+    // ikm = t · E_w (== e_w · T); HKDF over the WRAP domain, info = E_w ‖ T.
+    let ikm = ecdh_ikm(&eph_pub, &t);
+    let wrap_key = hkdf_key(
+        WRAP_LABEL,
+        ikm.as_ref(),
+        eph_pub_bytes,
+        &transport.public_key(),
+    );
+
+    let mut aad = Vec::with_capacity(WRAP_LABEL.len() + request_id.len());
+    aad.extend_from_slice(WRAP_LABEL);
+    aad.extend_from_slice(request_id.as_bytes());
+
+    let cipher = Aes256Gcm::new_from_slice(wrap_key.as_ref()).map_err(EciesError::Cipher)?;
+    let pt = Zeroizing::new(
+        cipher
+            .decrypt(Nonce::from_slice(nonce), Payload { msg: ct, aad: &aad })
+            .map_err(|_| EciesError::BadKeyOrCorrupt)?,
+    );
+    if pt.len() != KEY_LEN {
+        return Err(EciesError::MalformedEnvelope("unwrapped key length"));
+    }
+    let mut k = Zeroizing::new([0u8; KEY_LEN]);
+    k.copy_from_slice(&pt);
+    Ok(k)
 }
 
 /// Generates a uniformly random valid secp256k1 secret key. The reject loop
@@ -301,9 +482,16 @@ fn random_secret_key() -> SecretKey {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use coincube_core::miniscript::bitcoin::bip32::Xpriv;
+    use coincube_core::miniscript::bitcoin::bip32::{DerivationPath, Xpriv};
     use coincube_core::miniscript::bitcoin::Network;
     use std::str::FromStr;
+
+    fn unhex(s: &str) -> Vec<u8> {
+        (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+            .collect()
+    }
 
     /// A deterministic test keyholder: master xpriv → account xpub (what the
     /// owner sees as `models.Key.XPub`) plus the matching account xpriv (what
@@ -316,9 +504,6 @@ mod tests {
     fn keyholder_from_seed(seed: &[u8]) -> TestKeyholder {
         let secp = Secp256k1::new();
         let master = Xpriv::new_master(Network::Bitcoin, seed).unwrap();
-        // Pretend the registered key is an account-level xpub; the exact
-        // origin path is irrelevant to the ECIES contract (the `derivation`
-        // is relative to whatever xpub the owner holds).
         let account_path = DerivationPath::from_str("m/48'/0'/0'/2'").unwrap();
         let account_xpriv = master.derive_priv(&secp, &account_path).unwrap();
         let account_xpub = Xpub::from_priv(&secp, &account_xpriv);
@@ -328,37 +513,25 @@ mod tests {
         }
     }
 
-    /// Mirrors what Keychain does end-to-end: derive the recovery child
-    /// private key at `derivation`, ECDH against the envelope's ephemeral
-    /// pubkey, HKDF → `K`. Test-only: at recovery `K` comes from Keychain.
-    fn keychain_derive_shared_key(kh: &TestKeyholder, env: &Envelope) -> Zeroizing<[u8; KEY_LEN]> {
+    /// Stands in for Keychain: derive the recovery child (`/7000`) private key
+    /// from the account xpriv, then ECDH+HKDF against the envelope's ephemeral
+    /// pubkey → `K`.
+    fn keychain_k(kh: &TestKeyholder, env: &Envelope) -> Zeroizing<[u8; KEY_LEN]> {
         let secp = Secp256k1::new();
-        let path = DerivationPath::from_str(&env.derivation).unwrap();
+        let child = ChildNumber::from_normal_idx(ENCRYPTION_CHILD_INDEX).unwrap();
         let child_sk = kh
             .account_xpriv
-            .derive_priv(&secp, &path)
+            .derive_priv(&secp, &[child])
             .unwrap()
             .private_key;
-        let eph_pk = PublicKey::from_slice(&env.ephemeral_pubkey).unwrap();
-        shared_key_from_ecdh(&eph_pk, &child_sk)
+        let eph_pub = PublicKey::from_slice(&env.ephemeral_pubkey).unwrap();
+        keychain_shared_key(&child_sk, &eph_pub)
     }
 
-    fn derivation() -> DerivationPath {
-        DerivationPath::from_str(ENCRYPTION_CHILD_DERIVATION).unwrap()
-    }
-
-    #[test]
-    fn encryption_child_derivation_is_non_hardened_and_parses() {
-        // Must parse and be reachable from an xpub: every step non-hardened
-        // (no `'`/`h` marker). The roundtrip tests further prove `derive_pub`
-        // accepts it (which only succeeds for non-hardened paths).
-        let rendered = derivation().to_string();
-        assert!(
-            !rendered.contains('\'') && !rendered.contains('h'),
-            "encryption child path must be non-hardened, got {}",
-            rendered
-        );
-    }
+    // Test cube / keyholder ids bound into the AAD (arbitrary but fixed).
+    const CUBE: u64 = 1;
+    const KEY: u64 = 10;
+    const FULL_DERIV: &str = "m/48'/0'/0'/2'/7000";
 
     #[test]
     fn seal_then_keychain_ecdh_then_open_roundtrips_descriptor() {
@@ -367,86 +540,120 @@ mod tests {
 
         let env = seal_to_xpub(
             &kh.account_xpub,
-            &derivation(),
+            FULL_DERIV,
             ArtifactKind::Descriptor,
+            CUBE,
+            KEY,
             plaintext,
         )
         .unwrap();
 
         assert_eq!(env.scheme, SCHEME);
         assert_eq!(env.artifact_kind, ArtifactKind::Descriptor);
-        assert_eq!(env.derivation, ENCRYPTION_CHILD_DERIVATION);
+        assert_eq!(env.derivation, FULL_DERIV);
         assert_eq!(env.ephemeral_pubkey.len(), PUBKEY_LEN);
         assert_eq!(env.nonce.len(), NONCE_LEN);
 
-        // Heir path: Keychain derives K, desktop opens.
-        let k = keychain_derive_shared_key(&kh, &env);
-        let pt = open_with_shared_key(&k, &env).unwrap();
+        let k = keychain_k(&kh, &env);
+        let pt = open_with_shared_key(&k, &env, CUBE, KEY).unwrap();
         assert_eq!(pt.as_slice(), plaintext);
     }
 
     #[test]
     fn seal_then_open_roundtrips_seed() {
         let kh = keyholder_from_seed(b"keyholder-seed-seed-roundtrip-vector-000000");
-        // A representative SeedBlob-sized JSON payload.
         let plaintext = br#"{"version":1,"cube":{"uuid":"u"},"mnemonic":{"phrase":"abandon abandon ... about","language":"en"}}"#;
 
-        let env =
-            seal_to_xpub(&kh.account_xpub, &derivation(), ArtifactKind::Seed, plaintext).unwrap();
-        let k = keychain_derive_shared_key(&kh, &env);
-        let pt = open_with_shared_key(&k, &env).unwrap();
+        let env = seal_to_xpub(
+            &kh.account_xpub,
+            FULL_DERIV,
+            ArtifactKind::Seed,
+            CUBE,
+            KEY,
+            plaintext,
+        )
+        .unwrap();
+        let k = keychain_k(&kh, &env);
+        let pt = open_with_shared_key(&k, &env, CUBE, KEY).unwrap();
         assert_eq!(pt.as_slice(), plaintext.as_slice());
     }
 
     #[test]
     fn wrong_keyholder_key_fails_closed() {
-        let owner_target = keyholder_from_seed(b"the-real-heir-keyholder-seed-vector-0000000");
+        let target = keyholder_from_seed(b"the-real-heir-keyholder-seed-vector-0000000");
         let attacker = keyholder_from_seed(b"a-different-keyholder-who-should-not-decrypt");
 
         let env = seal_to_xpub(
-            &owner_target.account_xpub,
-            &derivation(),
+            &target.account_xpub,
+            FULL_DERIV,
             ArtifactKind::Descriptor,
+            CUBE,
+            KEY,
             b"secret descriptor",
         )
         .unwrap();
 
-        // The attacker's Keychain derives a different shared key.
-        let wrong_k = keychain_derive_shared_key(&attacker, &env);
-        let err = open_with_shared_key(&wrong_k, &env).unwrap_err();
+        let wrong_k = keychain_k(&attacker, &env);
+        let err = open_with_shared_key(&wrong_k, &env, CUBE, KEY).unwrap_err();
         assert!(matches!(err, EciesError::BadKeyOrCorrupt));
     }
 
     #[test]
     fn tampered_ciphertext_fails_tag() {
         let kh = keyholder_from_seed(b"tamper-ct-keyholder-seed-vector-00000000000");
-        let mut env =
-            seal_to_xpub(&kh.account_xpub, &derivation(), ArtifactKind::Descriptor, b"hello")
-                .unwrap();
+        let mut env = seal_to_xpub(
+            &kh.account_xpub,
+            FULL_DERIV,
+            ArtifactKind::Descriptor,
+            CUBE,
+            KEY,
+            b"hello",
+        )
+        .unwrap();
         env.ciphertext[0] ^= 0x01;
-        let k = keychain_derive_shared_key(&kh, &env);
+        let k = keychain_k(&kh, &env);
         assert!(matches!(
-            open_with_shared_key(&k, &env).unwrap_err(),
+            open_with_shared_key(&k, &env, CUBE, KEY).unwrap_err(),
             EciesError::BadKeyOrCorrupt
         ));
     }
 
     #[test]
-    fn tampered_derivation_in_aad_fails_tag() {
-        // The derivation rides in the AAD, not the ciphertext. Swapping it
-        // (e.g. a server trying to redirect the heir to a different child)
-        // must break the tag even though the key `K` would still be derived
-        // from the original child by an honest Keychain.
-        let kh = keyholder_from_seed(b"tamper-aad-keyholder-seed-vector-0000000000");
-        let env =
-            seal_to_xpub(&kh.account_xpub, &derivation(), ArtifactKind::Descriptor, b"hello")
-                .unwrap();
-        let k = keychain_derive_shared_key(&kh, &env);
-
-        let mut tampered = env.clone();
-        tampered.derivation = "9/1".to_string();
+    fn tampered_cube_id_in_aad_fails_tag() {
+        // cube_id rides in the AAD; opening against a different cube must break
+        // the tag (a server re-pointing the envelope at another cube).
+        let kh = keyholder_from_seed(b"tamper-cube-keyholder-seed-vector-000000000");
+        let env = seal_to_xpub(
+            &kh.account_xpub,
+            FULL_DERIV,
+            ArtifactKind::Descriptor,
+            CUBE,
+            KEY,
+            b"hello",
+        )
+        .unwrap();
+        let k = keychain_k(&kh, &env);
         assert!(matches!(
-            open_with_shared_key(&k, &tampered).unwrap_err(),
+            open_with_shared_key(&k, &env, CUBE + 1, KEY).unwrap_err(),
+            EciesError::BadKeyOrCorrupt
+        ));
+    }
+
+    #[test]
+    fn tampered_keyholder_id_in_aad_fails_tag() {
+        let kh = keyholder_from_seed(b"tamper-khid-keyholder-seed-vector-000000000");
+        let env = seal_to_xpub(
+            &kh.account_xpub,
+            FULL_DERIV,
+            ArtifactKind::Descriptor,
+            CUBE,
+            KEY,
+            b"hello",
+        )
+        .unwrap();
+        let k = keychain_k(&kh, &env);
+        assert!(matches!(
+            open_with_shared_key(&k, &env, CUBE, KEY + 1).unwrap_err(),
             EciesError::BadKeyOrCorrupt
         ));
     }
@@ -454,14 +661,21 @@ mod tests {
     #[test]
     fn tampered_artifact_kind_in_aad_fails_tag() {
         let kh = keyholder_from_seed(b"tamper-kind-keyholder-seed-vector-000000000");
-        let env = seal_to_xpub(&kh.account_xpub, &derivation(), ArtifactKind::Seed, b"hello")
-            .unwrap();
-        let k = keychain_derive_shared_key(&kh, &env);
+        let env = seal_to_xpub(
+            &kh.account_xpub,
+            FULL_DERIV,
+            ArtifactKind::Seed,
+            CUBE,
+            KEY,
+            b"hello",
+        )
+        .unwrap();
+        let k = keychain_k(&kh, &env);
 
         let mut tampered = env.clone();
         tampered.artifact_kind = ArtifactKind::Descriptor;
         assert!(matches!(
-            open_with_shared_key(&k, &tampered).unwrap_err(),
+            open_with_shared_key(&k, &tampered, CUBE, KEY).unwrap_err(),
             EciesError::BadKeyOrCorrupt
         ));
     }
@@ -469,83 +683,243 @@ mod tests {
     #[test]
     fn unsupported_scheme_rejected() {
         let kh = keyholder_from_seed(b"scheme-keyholder-seed-vector-00000000000000");
-        let mut env =
-            seal_to_xpub(&kh.account_xpub, &derivation(), ArtifactKind::Descriptor, b"x").unwrap();
+        let mut env = seal_to_xpub(
+            &kh.account_xpub,
+            FULL_DERIV,
+            ArtifactKind::Descriptor,
+            CUBE,
+            KEY,
+            b"x",
+        )
+        .unwrap();
         env.scheme = "ecies-v2-some-future-thing".to_string();
-        let k = keychain_derive_shared_key(&kh, &env);
+        let k = keychain_k(&kh, &env);
         assert!(matches!(
-            open_with_shared_key(&k, &env).unwrap_err(),
+            open_with_shared_key(&k, &env, CUBE, KEY).unwrap_err(),
             EciesError::UnsupportedScheme(_)
         ));
     }
 
     #[test]
-    fn distinct_ephemeral_keys_across_calls() {
-        // Two seals to the same recipient must use different ephemeral keys
-        // (and thus different ciphertext) — otherwise the RNG isn't feeding
-        // the ephemeral keypair.
-        let kh = keyholder_from_seed(b"distinct-eph-keyholder-seed-vector-00000000");
-        let a =
-            seal_to_xpub(&kh.account_xpub, &derivation(), ArtifactKind::Descriptor, b"same").unwrap();
-        let b =
-            seal_to_xpub(&kh.account_xpub, &derivation(), ArtifactKind::Descriptor, b"same").unwrap();
-        assert_ne!(a.ephemeral_pubkey, b.ephemeral_pubkey);
-        assert_ne!(a.ciphertext, b.ciphertext);
+    fn transport_keypair_is_fresh_and_compressed() {
+        let a = transport_keypair();
+        let b = transport_keypair();
+        // Compressed SEC1 pubkey, valid prefix, and parses as a point.
+        assert_eq!(a.public_key().len(), PUBKEY_LEN);
+        assert!(matches!(a.public_key()[0], 0x02 | 0x03));
+        assert!(PublicKey::from_slice(&a.public_key()).is_ok());
+        // Fresh each call (private and public differ).
+        assert_ne!(a.public_key(), b.public_key());
+        assert_ne!(a.secret_bytes(), b.secret_bytes());
     }
 
-    // ---- Cross-repo known-answer vectors --------------------------------
+    // ─── SPEC-ecies-v1 §7 known-answer vector ───────────────────────────────
     //
-    // These pin the HKDF and the full ECDH→HKDF→AES-GCM path against fixed
-    // inputs so `coincube-api` (storage) and `keychain-app` (ECDH-decrypt)
-    // can verify byte-compatibility. If a KAT changes, the wire contract
-    // changed — every escrowed envelope in the wild would need re-encryption.
+    // Every implementation (owner seal, Keychain ECDH, desktop open) MUST
+    // reproduce these exact bytes. Generated by `ecies_kat_reference.py`.
+
+    const KAT_ACCOUNT_XPUB: &str = "xpub6EuX7TBEwhFgifQY24vFeMRqeWHGyGCupztDxk7G2ECAqGQ22Fik8E811p8GrM2LfajQzLidXy4qECxhdcxChkjiKhnq2fiVMVjdfSoZQwg";
+    const KAT_P: &str = "02e25a19d7ceb9635790c029af449589048ebc99e370d0e54f6176ff5aae4cb857";
+    const KAT_D: &str = "db1b87125557540f11359013f0bd4040de82edabe99a134328e9dacf1795bca3";
+    const KAT_E: &str = "034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa";
+    const KAT_NONCE: &str = "0000000000000000deadbeef";
+    const KAT_AES_KEY: &str = "4ae180fd201c8401b63c475bf22ee59ef1c624f623affc54eb5e51625ff99ca8";
+    const KAT_CT: &str = "2e283e30ebac64ec0741b8f0281b3ae458196e5563bf95ac308414d1a457e261c15b99ed0606c4ccd7d44645c52ad3874cf6030efacb5891b7df4c98d426e7cda4ee173ecb5334bd8bae6dea9f2428a5d8920f5b4c8779db83baf40e8ad890ca7465a4964f6ed2d4fc";
+    const KAT_CUBE_ID: u64 = 42;
+    const KAT_KEYHOLDER_KEY_ID: u64 = 7;
+    const KAT_PLAINTEXT: &[u8] = b"wsh(or_d(pk([00000000/48h/1h/0h/2h]xpub.../0/*),and_v(v:pkh(...),older(65535))))#cccccccc";
+    const KAT_ENC_PATH: &str = "m/48h/1h/0h/2h/7000";
 
     #[test]
-    fn kat_hkdf_pins_derived_key() {
-        // Fixed 32-byte ECDH shared secret `S` → fixed `K`. Independent of
-        // any EC math, so a Go implementer can check HKDF alone.
-        let s = [0x42u8; 32];
-        let k = hkdf_sha256_key(&s);
-        // HKDF-SHA256(salt="", ikm=0x42*32, info="coincube-inheritance-ecies-v1", L=32)
-        assert_eq!(
-            hex(&k[..]),
-            "58c2505e26eb737e87d50f0175b806048024671511f3679e3a21ae1c909973cb"
-        );
+    fn kat_spec_v1_recipient_pubkey_from_account_xpub() {
+        // P = CKDpub(account_xpub, 7000) — owner derives it xpub-only.
+        let secp = Secp256k1::new();
+        let xpub = Xpub::from_str(KAT_ACCOUNT_XPUB).unwrap();
+        let child = ChildNumber::from_normal_idx(ENCRYPTION_CHILD_INDEX).unwrap();
+        let p = xpub.derive_pub(&secp, &[child]).unwrap().public_key;
+        assert_eq!(hex(&p.serialize()), KAT_P);
     }
 
     #[test]
-    fn kat_full_envelope_fixed_keys() {
-        // Fixed recipient + fixed ephemeral key → the heir recovers the
-        // exact plaintext. We can't pin the ciphertext bytes (the public
-        // `seal_to_xpub` draws a random ephemeral key + nonce), so this KAT
-        // drives the deterministic internals: derive the child pub, ECDH
-        // with a fixed ephemeral secret, and assert the round-trip key.
-        let kh = keyholder_from_seed(&[0x01u8; 32]);
+    fn kat_spec_v1_seal_matches_vector() {
+        let p = PublicKey::from_slice(&unhex(KAT_P)).unwrap();
+        // Fixed ephemeral scalar e = 0x11 * 32 (test only, per §7).
+        let eph_sk = SecretKey::from_slice(&[0x11u8; 32]).unwrap();
+        let mut nonce = [0u8; NONCE_LEN];
+        nonce.copy_from_slice(&unhex(KAT_NONCE));
+        let env = seal_with_ephemeral(
+            &p,
+            &eph_sk,
+            &nonce,
+            ArtifactKind::Descriptor,
+            KAT_CUBE_ID,
+            KAT_KEYHOLDER_KEY_ID,
+            KAT_ENC_PATH,
+            KAT_PLAINTEXT,
+        )
+        .unwrap();
+        assert_eq!(hex(&env.ephemeral_pubkey), KAT_E);
+        assert_eq!(hex(&env.ciphertext), KAT_CT);
+    }
+
+    #[test]
+    fn kat_spec_v1_keychain_key_and_open() {
+        // Keychain half: d + E → K must equal the vector aes_key.
+        let d = SecretKey::from_slice(&unhex(KAT_D)).unwrap();
+        let eph_pub = PublicKey::from_slice(&unhex(KAT_E)).unwrap();
+        let k = keychain_shared_key(&d, &eph_pub);
+        assert_eq!(hex(k.as_ref()), KAT_AES_KEY);
+
+        // Desktop half: open the vector ciphertext with the vector key.
+        let mut key = [0u8; KEY_LEN];
+        key.copy_from_slice(&unhex(KAT_AES_KEY));
+        let env = Envelope {
+            artifact_kind: ArtifactKind::Descriptor,
+            scheme: SCHEME.to_string(),
+            ephemeral_pubkey: unhex(KAT_E),
+            ciphertext: unhex(KAT_CT),
+            nonce: unhex(KAT_NONCE),
+            derivation: KAT_ENC_PATH.to_string(),
+        };
+        let pt = open_with_shared_key(&key, &env, KAT_CUBE_ID, KAT_KEYHOLDER_KEY_ID).unwrap();
+        assert_eq!(pt.as_slice(), KAT_PLAINTEXT);
+    }
+
+    // ─── SPEC-ecies-v1 §7.2 key-wrap known-answer vector (§4b) ───────────────
+    //
+    // Wraps the §7.1 `aes_key` (the two vectors chain). Locked cross-impl values
+    // from keychain-app + the reference generator.
+
+    const WRAP_P_DESKTOP: &str =
+        "02466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27";
+    const WRAP_E_WRAP: &str = "023c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1";
+    const WRAP_KEY: &str = "8e6d42b3d27bd0b024ffd39ab3337c3083c287badb4a61ff8af827b6af12a09b";
+    const WRAP_NONCE: &str = "0000000000000000feedface";
+    const WRAP_REQUEST_ID: &str = "rq-test-0001";
+
+    /// Construct a [`TransportKeypair`] from a fixed secret (test-only; the
+    /// child test module can touch the parent's private fields).
+    fn transport_from(sk: &SecretKey) -> TransportKeypair {
         let secp = Secp256k1::new();
-        let recipient_child_pub = kh
-            .account_xpub
-            .derive_pub(&secp, &derivation())
-            .unwrap()
-            .public_key;
-        let eph_sk = SecretKey::from_slice(&[0x07u8; 32]).unwrap();
+        let pk = PublicKey::from_secret_key(&secp, sk);
+        let mut secret = Zeroizing::new([0u8; 32]);
+        secret.copy_from_slice(&sk.secret_bytes());
+        TransportKeypair {
+            secret,
+            public: pk.serialize(),
+        }
+    }
 
-        // Owner computes K from (eph_sk, recipient_child_pub)...
-        let k_owner = shared_key_from_ecdh(&recipient_child_pub, &eph_sk);
-        // ...heir computes K from (recovery_child_sk, eph_pk); must match.
-        let eph_pk = PublicKey::from_secret_key(&secp, &eph_sk);
-        let child_sk = kh
-            .account_xpriv
-            .derive_priv(&secp, &derivation())
-            .unwrap()
-            .private_key;
-        let k_heir = shared_key_from_ecdh(&eph_pk, &child_sk);
-
-        assert_eq!(&k_owner[..], &k_heir[..], "ECDH symmetry broken");
-        // K = HKDF(SHA256(compressed(eph·child)),…) for seed=0x01*32,
-        // derivation "9/0", eph_sk=0x07*32.
-        assert_eq!(
-            hex(&k_owner[..]),
-            "9c713238b700cd88322be148353948e04022e9a163162fac958a44ece8e2c8c7"
+    /// Mirrors the Keychain §4b wrap: ECIES `K` to the transport pubkey under a
+    /// fixed ephemeral + nonce, returning the 94-byte `wrapped_shared_key`.
+    fn wrap_shared_key(
+        transport_pub: &PublicKey,
+        eph_sk: &SecretKey,
+        nonce: &[u8; NONCE_LEN],
+        request_id: &str,
+        k: &[u8; KEY_LEN],
+    ) -> Vec<u8> {
+        let secp = Secp256k1::new();
+        let eph_pub = PublicKey::from_secret_key(&secp, eph_sk);
+        let ikm = ecdh_ikm(transport_pub, eph_sk); // e_w · T
+        let wrap_key = hkdf_key(
+            WRAP_LABEL,
+            ikm.as_ref(),
+            &eph_pub.serialize(),
+            &transport_pub.serialize(),
         );
+        let mut aad = WRAP_LABEL.to_vec();
+        aad.extend_from_slice(request_id.as_bytes());
+        let cipher = Aes256Gcm::new_from_slice(wrap_key.as_ref()).unwrap();
+        let ct = cipher
+            .encrypt(Nonce::from_slice(nonce), Payload { msg: k, aad: &aad })
+            .unwrap();
+        let mut out = Vec::with_capacity(WRAPPED_LEN);
+        out.push(WRAP_VERSION);
+        out.extend_from_slice(&eph_pub.serialize());
+        out.extend_from_slice(nonce);
+        out.extend_from_slice(&ct);
+        out
+    }
+
+    #[test]
+    fn kat_spec_v1_wrap_matches_locked_values_and_unwraps() {
+        // Fixed inputs: t = 0x22*32, e_w = 0x33*32, K = §7.1 aes_key.
+        let t = SecretKey::from_slice(&[0x22u8; 32]).unwrap();
+        let ew = SecretKey::from_slice(&[0x33u8; 32]).unwrap();
+        let transport = transport_from(&t);
+
+        // (1) transport pubkey T == locked P_desktop.
+        assert_eq!(hex(&transport.public_key()), WRAP_P_DESKTOP);
+
+        // (2) wrap ephemeral pubkey E_w == locked E_wrap.
+        let secp = Secp256k1::new();
+        let ew_pub = PublicKey::from_secret_key(&secp, &ew);
+        assert_eq!(hex(&ew_pub.serialize()), WRAP_E_WRAP);
+
+        // (3) wrap_key from (t, E_wrap) over the WRAP label == locked wrap_key.
+        //     This is the byte-exact ECDH + HKDF + domain-label check.
+        let e_wrap_point = PublicKey::from_slice(&unhex(WRAP_E_WRAP)).unwrap();
+        let ikm = ecdh_ikm(&e_wrap_point, &t); // t · E_wrap == e_w · T
+        let wkey = hkdf_key(
+            WRAP_LABEL,
+            ikm.as_ref(),
+            &unhex(WRAP_E_WRAP),
+            &unhex(WRAP_P_DESKTOP),
+        );
+        assert_eq!(hex(wkey.as_ref()), WRAP_KEY);
+
+        // (4) Full §4b round-trip: wrap §7.1's K to T, then unwrap → exactly K.
+        //     (AES-GCM is deterministic, so this `wrapped` equals the locked
+        //     wrapped_shared_key byte-for-byte given the matching wrap_key.)
+        let mut nonce = [0u8; NONCE_LEN];
+        nonce.copy_from_slice(&unhex(WRAP_NONCE));
+        let mut k = [0u8; KEY_LEN];
+        k.copy_from_slice(&unhex(KAT_AES_KEY));
+        let t_pub = PublicKey::from_slice(&unhex(WRAP_P_DESKTOP)).unwrap();
+        let wrapped = wrap_shared_key(&t_pub, &ew, &nonce, WRAP_REQUEST_ID, &k);
+
+        assert_eq!(wrapped.len(), WRAPPED_LEN);
+        assert_eq!(wrapped[0], WRAP_VERSION);
+        assert_eq!(hex(&wrapped[1..1 + PUBKEY_LEN]), WRAP_E_WRAP);
+
+        let unwrapped = unwrap_shared_key(&transport, WRAP_REQUEST_ID, &wrapped).unwrap();
+        assert_eq!(hex(unwrapped.as_ref()), KAT_AES_KEY);
+    }
+
+    #[test]
+    fn unwrap_rejects_tampered_request_id() {
+        let t = SecretKey::from_slice(&[0x22u8; 32]).unwrap();
+        let ew = SecretKey::from_slice(&[0x33u8; 32]).unwrap();
+        let transport = transport_from(&t);
+        let t_pub = PublicKey::from_slice(&unhex(WRAP_P_DESKTOP)).unwrap();
+        let mut nonce = [0u8; NONCE_LEN];
+        nonce.copy_from_slice(&unhex(WRAP_NONCE));
+        let mut k = [0u8; KEY_LEN];
+        k.copy_from_slice(&unhex(KAT_AES_KEY));
+        let wrapped = wrap_shared_key(&t_pub, &ew, &nonce, WRAP_REQUEST_ID, &k);
+
+        // A different request_id (server replaying another request's wrap)
+        // breaks the AAD → fail closed.
+        assert!(matches!(
+            unwrap_shared_key(&transport, "rq-test-0002", &wrapped),
+            Err(EciesError::BadKeyOrCorrupt)
+        ));
+    }
+
+    #[test]
+    fn unwrap_rejects_malformed_blob() {
+        let t = SecretKey::from_slice(&[0x22u8; 32]).unwrap();
+        let transport = transport_from(&t);
+        // Wrong length.
+        assert!(matches!(
+            unwrap_shared_key(&transport, WRAP_REQUEST_ID, &[0x01u8; 10]),
+            Err(EciesError::MalformedEnvelope("wrapped key length"))
+        ));
+        // Right length, wrong version byte.
+        assert!(matches!(
+            unwrap_shared_key(&transport, WRAP_REQUEST_ID, &[0x02u8; WRAPPED_LEN]),
+            Err(EciesError::MalformedEnvelope("wrapped key version"))
+        ));
     }
 }

--- a/coincube-gui/src/services/inheritance/ecies.rs
+++ b/coincube-gui/src/services/inheritance/ecies.rs
@@ -1,0 +1,551 @@
+//! Client-side, per-keyholder ECIES for inheritance heir-escrow.
+//!
+//! At Vault-monitoring opt-in the **owner's desktop** seals the recovery
+//! material (the wallet descriptor always; the master seed too for the
+//! Full-Cube tier) to *each designated heir keyholder's* secp256k1 xpub.
+//! COINCUBE stores opaque ciphertext it cannot read and only gates its
+//! release (decision record `2026-06-22-inheritance-ecies-heir-escrow.md`,
+//! invariants I1/I5/I8). At recovery the heir's **Keychain** performs the
+//! ECDH with the matching recovery private child key and returns the derived
+//! symmetric key `K`; the desktop completes the AES-256-GCM open here.
+//!
+//! ## Canonical wire contract (`ecies-secp256k1-hkdf-aes256gcm-v1`)
+//!
+//! The desktop **defines** this contract; `coincube-api` (blob store) and
+//! `keychain-app` (ECDH-decrypt) must match it byte-for-byte. The
+//! known-answer tests at the bottom of this file are the cross-repo vectors.
+//!
+//! ```text
+//! recipient_child_pub = derive_pub(recipient_xpub, derivation)   // I5: a
+//!                                                                // dedicated
+//!                                                                // non-hardened
+//!                                                                // child, never
+//!                                                                // the signing key
+//! (eph_sk, eph_pk)    = fresh ephemeral secp256k1 keypair (per envelope)
+//! S  = SHA256( compressed( eph_sk · recipient_child_pub ) )      // secp256k1
+//!                                                                // ecdh::SharedSecret
+//! K  = HKDF-SHA256( salt = "", ikm = S,
+//!                   info = "coincube-inheritance-ecies-v1", L = 32 )
+//! AAD = "ecies-secp256k1-hkdf-aes256gcm-v1" || 0x00 ||
+//!        kind_byte || derivation_utf8 || eph_pk_compressed(33)
+//! ct||tag = AES-256-GCM-Seal( key = K, nonce = random 12B, aad = AAD, pt )
+//! ```
+//!
+//! The heir reconstructs the *same* `S` as
+//! `SHA256(compressed(recovery_child_sk · eph_pk))` (ECDH symmetry), so
+//! Keychain returns `K = HKDF-SHA256(S, …)` and the desktop opens with it.
+//! Every public envelope field is bound into the GCM AAD, so a tampered
+//! `derivation`, `artifact_kind`, or `ephemeral_pubkey` fails the tag.
+
+use aes_gcm::aead::{Aead, Payload};
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use coincube_core::miniscript::bitcoin::bip32::{DerivationPath, Xpub};
+use coincube_core::miniscript::bitcoin::secp256k1::{
+    ecdh::SharedSecret, PublicKey, Secp256k1, SecretKey,
+};
+use rand::RngCore;
+use zeroize::Zeroizing;
+
+use super::error::EciesError;
+
+/// Wire identifier for this scheme. A new value here is a wire-format break
+/// requiring matching changes in `coincube-api` and `keychain-app`.
+pub const SCHEME: &str = "ecies-secp256k1-hkdf-aes256gcm-v1";
+
+/// HKDF `info` string binding the derived key to this purpose. Keychain uses
+/// the identical bytes when it derives `K`.
+pub const HKDF_INFO: &[u8] = b"coincube-inheritance-ecies-v1";
+
+/// The dedicated, non-hardened encryption child derived from the keyholder's
+/// registered xpub (invariant I5 — never the signing key, never chain 0/1
+/// which the wallet descriptor spends from). Stored in each envelope's
+/// `derivation` field so Keychain replays the exact path against its xpriv.
+pub const ENCRYPTION_CHILD_DERIVATION: &str = "9/0";
+
+const KEY_LEN: usize = 32; // AES-256
+const NONCE_LEN: usize = 12; // GCM standard
+const TAG_LEN: usize = 16;
+/// Compressed secp256k1 point.
+const PUBKEY_LEN: usize = 33;
+
+/// Which recovery artifact an envelope carries. The byte form is bound into
+/// the AAD; the wire string matches the API's `artifactKind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactKind {
+    /// The wallet output descriptor (Vault-only and Full-Cube tiers).
+    Descriptor,
+    /// The master seed / mnemonic (Full-Cube tier only).
+    Seed,
+}
+
+impl ArtifactKind {
+    /// Lowercase wire token, matching `coincube-api`'s `artifactKind`.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            Self::Descriptor => "descriptor",
+            Self::Seed => "seed",
+        }
+    }
+
+    /// One-byte AAD discriminant. Distinct from `as_wire` so a future kind
+    /// can't silently collide on a shared prefix.
+    fn aad_byte(self) -> u8 {
+        match self {
+            Self::Descriptor => 0x01,
+            Self::Seed => 0x02,
+        }
+    }
+
+    /// Parses the API wire token. Unknown kinds are rejected (fail-closed)
+    /// rather than mapped to a default.
+    pub fn from_wire(s: &str) -> Option<Self> {
+        match s {
+            "descriptor" => Some(Self::Descriptor),
+            "seed" => Some(Self::Seed),
+            _ => None,
+        }
+    }
+}
+
+/// One sealed envelope: everything `coincube-api` stores opaquely and returns
+/// to the gated heir. Field names mirror the API schema (PR A).
+///
+/// `Debug` is manual: the `ciphertext` is encrypted, but we still avoid
+/// dumping the raw bytes to any `{:?}` site and never let the plaintext-
+/// adjacent fields read as innocuous. Public fields (scheme, derivation,
+/// kind, ephemeral pubkey) are non-secret and shown.
+#[derive(Clone)]
+pub struct Envelope {
+    pub artifact_kind: ArtifactKind,
+    pub scheme: String,
+    /// Compressed (33-byte) ephemeral public key.
+    pub ephemeral_pubkey: Vec<u8>,
+    /// `ciphertext || GCM tag`.
+    pub ciphertext: Vec<u8>,
+    /// 12-byte GCM nonce.
+    pub nonce: Vec<u8>,
+    /// The non-hardened child path used (relative to the keyholder xpub).
+    pub derivation: String,
+}
+
+impl std::fmt::Debug for Envelope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Envelope")
+            .field("artifact_kind", &self.artifact_kind)
+            .field("scheme", &self.scheme)
+            .field("derivation", &self.derivation)
+            .field("ephemeral_pubkey", &hex(&self.ephemeral_pubkey))
+            .field("ciphertext_len", &self.ciphertext.len())
+            .field("nonce_len", &self.nonce.len())
+            .finish()
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{:02x}", b);
+    }
+    s
+}
+
+/// The Additional Authenticated Data bound into the GCM tag. Reconstructed
+/// identically by the heir from public envelope fields, so any mutation of
+/// `scheme` / `kind` / `derivation` / `ephemeral_pubkey` breaks the tag.
+fn aad_bytes(kind: ArtifactKind, derivation: &str, ephemeral_pubkey: &[u8]) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(SCHEME.len() + 2 + derivation.len() + ephemeral_pubkey.len());
+    aad.extend_from_slice(SCHEME.as_bytes());
+    aad.push(0x00); // domain separator between scheme and the rest
+    aad.push(kind.aad_byte());
+    aad.extend_from_slice(derivation.as_bytes());
+    aad.extend_from_slice(ephemeral_pubkey);
+    aad
+}
+
+/// HKDF-SHA256 over `ring` (already in-tree; avoids the hmac/sha2 digest
+/// version split). Empty salt → RFC-5869 all-zero salt, matching a Go
+/// `hkdf.New(sha256, ikm, nil, info)` on the Keychain side.
+fn hkdf_sha256_key(ikm: &[u8]) -> Zeroizing<[u8; KEY_LEN]> {
+    let salt = ring::hkdf::Salt::new(ring::hkdf::HKDF_SHA256, &[]);
+    let prk = salt.extract(ikm);
+    // `HKDF_SHA256` as its own `KeyType` yields a 32-byte (SHA-256-len) OKM.
+    let okm = prk
+        .expand(&[HKDF_INFO], ring::hkdf::HKDF_SHA256)
+        .expect("HKDF expand of one SHA-256 block never exceeds the length cap");
+    let mut key = Zeroizing::new([0u8; KEY_LEN]);
+    okm.fill(key.as_mut())
+        .expect("OKM length matches the requested key length");
+    key
+}
+
+/// Derives the per-envelope symmetric key from a completed ECDH. This is the
+/// exact computation Keychain performs (ECDH on the recovery child private
+/// key, then HKDF) and returns to the desktop as `K`; kept here so the
+/// desktop can (a) seal owner-side and (b) round-trip in tests without a
+/// Keychain. **Never** call this with the owner's seed material at heir
+/// recovery time — `K` then comes from Keychain, not from a local key. It is
+/// `pub(crate)` only so the sibling escrow tests can exercise the full path.
+pub(crate) fn shared_key_from_ecdh(
+    point: &PublicKey,
+    scalar: &SecretKey,
+) -> Zeroizing<[u8; KEY_LEN]> {
+    // `SharedSecret::new` = SHA256(compressed(scalar · point)) — the `S` of
+    // the wire contract. ECDH symmetry makes owner and heir agree on it.
+    let s = SharedSecret::new(point, scalar);
+    hkdf_sha256_key(&s.secret_bytes())
+}
+
+/// **Owner side.** Seals `plaintext` to a keyholder's `recipient_xpub` under
+/// the dedicated encryption child at `derivation`. Generates a fresh
+/// ephemeral keypair and nonce per call. Public-key encryption only — no
+/// secret of the recipient's is needed, so this runs on the owner's desktop
+/// with no Keychain involvement.
+pub fn seal_to_xpub(
+    recipient_xpub: &Xpub,
+    derivation: &DerivationPath,
+    kind: ArtifactKind,
+    plaintext: &[u8],
+) -> Result<Envelope, EciesError> {
+    let secp = Secp256k1::new();
+    // Derive the dedicated, non-hardened encryption child pubkey (I5). An
+    // xpub can only walk non-hardened steps; `derive_pub` errors otherwise.
+    let recipient_child_pub = recipient_xpub
+        .derive_pub(&secp, derivation)
+        .map_err(EciesError::Derivation)?
+        .public_key;
+
+    let eph_sk = random_secret_key();
+    let eph_pk = PublicKey::from_secret_key(&secp, &eph_sk);
+    let ephemeral_pubkey = eph_pk.serialize().to_vec(); // 33-byte compressed
+
+    let key = shared_key_from_ecdh(&recipient_child_pub, &eph_sk);
+
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+
+    let derivation_str = derivation.to_string();
+    let aad = aad_bytes(kind, &derivation_str, &ephemeral_pubkey);
+
+    let cipher = Aes256Gcm::new_from_slice(key.as_ref()).map_err(EciesError::Cipher)?;
+    let ciphertext = cipher
+        .encrypt(
+            Nonce::from_slice(&nonce_bytes),
+            Payload {
+                msg: plaintext,
+                aad: &aad,
+            },
+        )
+        .map_err(|_| EciesError::Seal)?;
+
+    Ok(Envelope {
+        artifact_kind: kind,
+        scheme: SCHEME.to_string(),
+        ephemeral_pubkey,
+        ciphertext,
+        nonce: nonce_bytes.to_vec(),
+        derivation: derivation_str,
+    })
+}
+
+/// **Heir side.** Opens an envelope with the symmetric key `K` returned by
+/// Keychain (which did the ECDH + HKDF on the recovery private key). The
+/// plaintext lands in a `Zeroizing<Vec<u8>>` wiped on drop. A wrong key,
+/// tampered ciphertext, or tampered AAD all surface as
+/// [`EciesError::BadKeyOrCorrupt`] — indistinguishable by design.
+pub fn open_with_shared_key(
+    shared_key: &[u8; KEY_LEN],
+    env: &Envelope,
+) -> Result<Zeroizing<Vec<u8>>, EciesError> {
+    if env.scheme != SCHEME {
+        return Err(EciesError::UnsupportedScheme(env.scheme.clone()));
+    }
+    if env.nonce.len() != NONCE_LEN {
+        return Err(EciesError::MalformedEnvelope("nonce length"));
+    }
+    if env.ephemeral_pubkey.len() != PUBKEY_LEN {
+        return Err(EciesError::MalformedEnvelope("ephemeral pubkey length"));
+    }
+    if env.ciphertext.len() < TAG_LEN {
+        return Err(EciesError::MalformedEnvelope("ciphertext shorter than tag"));
+    }
+
+    let aad = aad_bytes(env.artifact_kind, &env.derivation, &env.ephemeral_pubkey);
+    let cipher = Aes256Gcm::new_from_slice(shared_key).map_err(EciesError::Cipher)?;
+    let pt = cipher
+        .decrypt(
+            Nonce::from_slice(&env.nonce),
+            Payload {
+                msg: &env.ciphertext,
+                aad: &aad,
+            },
+        )
+        .map_err(|_| EciesError::BadKeyOrCorrupt)?;
+    Ok(Zeroizing::new(pt))
+}
+
+/// Generates a uniformly random valid secp256k1 secret key. The reject loop
+/// only ever retries on the negligible chance of a zero / out-of-range
+/// scalar; in practice it succeeds on the first draw.
+fn random_secret_key() -> SecretKey {
+    let mut rng = rand::thread_rng();
+    loop {
+        let mut bytes = Zeroizing::new([0u8; 32]);
+        rng.fill_bytes(bytes.as_mut());
+        if let Ok(sk) = SecretKey::from_slice(bytes.as_ref()) {
+            return sk;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coincube_core::miniscript::bitcoin::bip32::Xpriv;
+    use coincube_core::miniscript::bitcoin::Network;
+    use std::str::FromStr;
+
+    /// A deterministic test keyholder: master xpriv → account xpub (what the
+    /// owner sees as `models.Key.XPub`) plus the matching account xpriv (what
+    /// Keychain holds to derive the recovery child).
+    struct TestKeyholder {
+        account_xpub: Xpub,
+        account_xpriv: Xpriv,
+    }
+
+    fn keyholder_from_seed(seed: &[u8]) -> TestKeyholder {
+        let secp = Secp256k1::new();
+        let master = Xpriv::new_master(Network::Bitcoin, seed).unwrap();
+        // Pretend the registered key is an account-level xpub; the exact
+        // origin path is irrelevant to the ECIES contract (the `derivation`
+        // is relative to whatever xpub the owner holds).
+        let account_path = DerivationPath::from_str("m/48'/0'/0'/2'").unwrap();
+        let account_xpriv = master.derive_priv(&secp, &account_path).unwrap();
+        let account_xpub = Xpub::from_priv(&secp, &account_xpriv);
+        TestKeyholder {
+            account_xpub,
+            account_xpriv,
+        }
+    }
+
+    /// Mirrors what Keychain does end-to-end: derive the recovery child
+    /// private key at `derivation`, ECDH against the envelope's ephemeral
+    /// pubkey, HKDF → `K`. Test-only: at recovery `K` comes from Keychain.
+    fn keychain_derive_shared_key(kh: &TestKeyholder, env: &Envelope) -> Zeroizing<[u8; KEY_LEN]> {
+        let secp = Secp256k1::new();
+        let path = DerivationPath::from_str(&env.derivation).unwrap();
+        let child_sk = kh
+            .account_xpriv
+            .derive_priv(&secp, &path)
+            .unwrap()
+            .private_key;
+        let eph_pk = PublicKey::from_slice(&env.ephemeral_pubkey).unwrap();
+        shared_key_from_ecdh(&eph_pk, &child_sk)
+    }
+
+    fn derivation() -> DerivationPath {
+        DerivationPath::from_str(ENCRYPTION_CHILD_DERIVATION).unwrap()
+    }
+
+    #[test]
+    fn encryption_child_derivation_is_non_hardened_and_parses() {
+        // Must parse and be reachable from an xpub: every step non-hardened
+        // (no `'`/`h` marker). The roundtrip tests further prove `derive_pub`
+        // accepts it (which only succeeds for non-hardened paths).
+        let rendered = derivation().to_string();
+        assert!(
+            !rendered.contains('\'') && !rendered.contains('h'),
+            "encryption child path must be non-hardened, got {}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn seal_then_keychain_ecdh_then_open_roundtrips_descriptor() {
+        let kh = keyholder_from_seed(b"keyholder-seed-descriptor-roundtrip-vector-0");
+        let plaintext = b"wsh(or_d(multi(2,xpubA,xpubB),and_v(...)))#abcdefgh";
+
+        let env = seal_to_xpub(
+            &kh.account_xpub,
+            &derivation(),
+            ArtifactKind::Descriptor,
+            plaintext,
+        )
+        .unwrap();
+
+        assert_eq!(env.scheme, SCHEME);
+        assert_eq!(env.artifact_kind, ArtifactKind::Descriptor);
+        assert_eq!(env.derivation, ENCRYPTION_CHILD_DERIVATION);
+        assert_eq!(env.ephemeral_pubkey.len(), PUBKEY_LEN);
+        assert_eq!(env.nonce.len(), NONCE_LEN);
+
+        // Heir path: Keychain derives K, desktop opens.
+        let k = keychain_derive_shared_key(&kh, &env);
+        let pt = open_with_shared_key(&k, &env).unwrap();
+        assert_eq!(pt.as_slice(), plaintext);
+    }
+
+    #[test]
+    fn seal_then_open_roundtrips_seed() {
+        let kh = keyholder_from_seed(b"keyholder-seed-seed-roundtrip-vector-000000");
+        // A representative SeedBlob-sized JSON payload.
+        let plaintext = br#"{"version":1,"cube":{"uuid":"u"},"mnemonic":{"phrase":"abandon abandon ... about","language":"en"}}"#;
+
+        let env =
+            seal_to_xpub(&kh.account_xpub, &derivation(), ArtifactKind::Seed, plaintext).unwrap();
+        let k = keychain_derive_shared_key(&kh, &env);
+        let pt = open_with_shared_key(&k, &env).unwrap();
+        assert_eq!(pt.as_slice(), plaintext.as_slice());
+    }
+
+    #[test]
+    fn wrong_keyholder_key_fails_closed() {
+        let owner_target = keyholder_from_seed(b"the-real-heir-keyholder-seed-vector-0000000");
+        let attacker = keyholder_from_seed(b"a-different-keyholder-who-should-not-decrypt");
+
+        let env = seal_to_xpub(
+            &owner_target.account_xpub,
+            &derivation(),
+            ArtifactKind::Descriptor,
+            b"secret descriptor",
+        )
+        .unwrap();
+
+        // The attacker's Keychain derives a different shared key.
+        let wrong_k = keychain_derive_shared_key(&attacker, &env);
+        let err = open_with_shared_key(&wrong_k, &env).unwrap_err();
+        assert!(matches!(err, EciesError::BadKeyOrCorrupt));
+    }
+
+    #[test]
+    fn tampered_ciphertext_fails_tag() {
+        let kh = keyholder_from_seed(b"tamper-ct-keyholder-seed-vector-00000000000");
+        let mut env =
+            seal_to_xpub(&kh.account_xpub, &derivation(), ArtifactKind::Descriptor, b"hello")
+                .unwrap();
+        env.ciphertext[0] ^= 0x01;
+        let k = keychain_derive_shared_key(&kh, &env);
+        assert!(matches!(
+            open_with_shared_key(&k, &env).unwrap_err(),
+            EciesError::BadKeyOrCorrupt
+        ));
+    }
+
+    #[test]
+    fn tampered_derivation_in_aad_fails_tag() {
+        // The derivation rides in the AAD, not the ciphertext. Swapping it
+        // (e.g. a server trying to redirect the heir to a different child)
+        // must break the tag even though the key `K` would still be derived
+        // from the original child by an honest Keychain.
+        let kh = keyholder_from_seed(b"tamper-aad-keyholder-seed-vector-0000000000");
+        let env =
+            seal_to_xpub(&kh.account_xpub, &derivation(), ArtifactKind::Descriptor, b"hello")
+                .unwrap();
+        let k = keychain_derive_shared_key(&kh, &env);
+
+        let mut tampered = env.clone();
+        tampered.derivation = "9/1".to_string();
+        assert!(matches!(
+            open_with_shared_key(&k, &tampered).unwrap_err(),
+            EciesError::BadKeyOrCorrupt
+        ));
+    }
+
+    #[test]
+    fn tampered_artifact_kind_in_aad_fails_tag() {
+        let kh = keyholder_from_seed(b"tamper-kind-keyholder-seed-vector-000000000");
+        let env = seal_to_xpub(&kh.account_xpub, &derivation(), ArtifactKind::Seed, b"hello")
+            .unwrap();
+        let k = keychain_derive_shared_key(&kh, &env);
+
+        let mut tampered = env.clone();
+        tampered.artifact_kind = ArtifactKind::Descriptor;
+        assert!(matches!(
+            open_with_shared_key(&k, &tampered).unwrap_err(),
+            EciesError::BadKeyOrCorrupt
+        ));
+    }
+
+    #[test]
+    fn unsupported_scheme_rejected() {
+        let kh = keyholder_from_seed(b"scheme-keyholder-seed-vector-00000000000000");
+        let mut env =
+            seal_to_xpub(&kh.account_xpub, &derivation(), ArtifactKind::Descriptor, b"x").unwrap();
+        env.scheme = "ecies-v2-some-future-thing".to_string();
+        let k = keychain_derive_shared_key(&kh, &env);
+        assert!(matches!(
+            open_with_shared_key(&k, &env).unwrap_err(),
+            EciesError::UnsupportedScheme(_)
+        ));
+    }
+
+    #[test]
+    fn distinct_ephemeral_keys_across_calls() {
+        // Two seals to the same recipient must use different ephemeral keys
+        // (and thus different ciphertext) — otherwise the RNG isn't feeding
+        // the ephemeral keypair.
+        let kh = keyholder_from_seed(b"distinct-eph-keyholder-seed-vector-00000000");
+        let a =
+            seal_to_xpub(&kh.account_xpub, &derivation(), ArtifactKind::Descriptor, b"same").unwrap();
+        let b =
+            seal_to_xpub(&kh.account_xpub, &derivation(), ArtifactKind::Descriptor, b"same").unwrap();
+        assert_ne!(a.ephemeral_pubkey, b.ephemeral_pubkey);
+        assert_ne!(a.ciphertext, b.ciphertext);
+    }
+
+    // ---- Cross-repo known-answer vectors --------------------------------
+    //
+    // These pin the HKDF and the full ECDH→HKDF→AES-GCM path against fixed
+    // inputs so `coincube-api` (storage) and `keychain-app` (ECDH-decrypt)
+    // can verify byte-compatibility. If a KAT changes, the wire contract
+    // changed — every escrowed envelope in the wild would need re-encryption.
+
+    #[test]
+    fn kat_hkdf_pins_derived_key() {
+        // Fixed 32-byte ECDH shared secret `S` → fixed `K`. Independent of
+        // any EC math, so a Go implementer can check HKDF alone.
+        let s = [0x42u8; 32];
+        let k = hkdf_sha256_key(&s);
+        // HKDF-SHA256(salt="", ikm=0x42*32, info="coincube-inheritance-ecies-v1", L=32)
+        assert_eq!(
+            hex(&k[..]),
+            "58c2505e26eb737e87d50f0175b806048024671511f3679e3a21ae1c909973cb"
+        );
+    }
+
+    #[test]
+    fn kat_full_envelope_fixed_keys() {
+        // Fixed recipient + fixed ephemeral key → the heir recovers the
+        // exact plaintext. We can't pin the ciphertext bytes (the public
+        // `seal_to_xpub` draws a random ephemeral key + nonce), so this KAT
+        // drives the deterministic internals: derive the child pub, ECDH
+        // with a fixed ephemeral secret, and assert the round-trip key.
+        let kh = keyholder_from_seed(&[0x01u8; 32]);
+        let secp = Secp256k1::new();
+        let recipient_child_pub = kh
+            .account_xpub
+            .derive_pub(&secp, &derivation())
+            .unwrap()
+            .public_key;
+        let eph_sk = SecretKey::from_slice(&[0x07u8; 32]).unwrap();
+
+        // Owner computes K from (eph_sk, recipient_child_pub)...
+        let k_owner = shared_key_from_ecdh(&recipient_child_pub, &eph_sk);
+        // ...heir computes K from (recovery_child_sk, eph_pk); must match.
+        let eph_pk = PublicKey::from_secret_key(&secp, &eph_sk);
+        let child_sk = kh
+            .account_xpriv
+            .derive_priv(&secp, &derivation())
+            .unwrap()
+            .private_key;
+        let k_heir = shared_key_from_ecdh(&eph_pk, &child_sk);
+
+        assert_eq!(&k_owner[..], &k_heir[..], "ECDH symmetry broken");
+        // K = HKDF(SHA256(compressed(eph·child)),…) for seed=0x01*32,
+        // derivation "9/0", eph_sk=0x07*32.
+        assert_eq!(
+            hex(&k_owner[..]),
+            "9c713238b700cd88322be148353948e04022e9a163162fac958a44ece8e2c8c7"
+        );
+    }
+}

--- a/coincube-gui/src/services/inheritance/error.rs
+++ b/coincube-gui/src/services/inheritance/error.rs
@@ -34,10 +34,17 @@ impl fmt::Display for EciesError {
             Self::Cipher(e) => write!(f, "AES-GCM key init failed: {}", e),
             Self::Seal => write!(f, "AES-GCM seal failed"),
             Self::BadKeyOrCorrupt => {
-                write!(f, "recovery envelope could not be decrypted (wrong key or corrupted)")
+                write!(
+                    f,
+                    "recovery envelope could not be decrypted (wrong key or corrupted)"
+                )
             }
             Self::UnsupportedScheme(s) => {
-                write!(f, "recovery envelope scheme '{}' is not supported by this client", s)
+                write!(
+                    f,
+                    "recovery envelope scheme '{}' is not supported by this client",
+                    s
+                )
             }
             Self::MalformedEnvelope(field) => {
                 write!(f, "recovery envelope is malformed: {}", field)

--- a/coincube-gui/src/services/inheritance/error.rs
+++ b/coincube-gui/src/services/inheritance/error.rs
@@ -1,0 +1,57 @@
+//! Errors for the inheritance ECIES codec.
+//!
+//! `BadKeyOrCorrupt` deliberately collapses "wrong key", "tampered
+//! ciphertext", and "tampered AAD" into one case — distinguishing them would
+//! hand an oracle to anyone probing the gated release endpoint. Mirrors the
+//! Cube Recovery Kit's `RecoveryError::BadPasswordOrCorrupt`.
+
+use std::fmt;
+
+#[derive(Debug)]
+pub enum EciesError {
+    /// Deriving the dedicated encryption child from the keyholder xpub failed
+    /// (e.g. a hardened step in the derivation, which an xpub cannot walk).
+    Derivation(coincube_core::miniscript::bitcoin::bip32::Error),
+    /// AES-GCM key init refused the key slice (never happens at 32 bytes).
+    Cipher(aes_gcm::aes::cipher::InvalidLength),
+    /// AES-GCM seal returned an opaque error.
+    Seal,
+    /// Open failed: wrong key, tampered ciphertext, or tampered AAD —
+    /// indistinguishable by design.
+    BadKeyOrCorrupt,
+    /// The envelope's `scheme` isn't one this client understands.
+    UnsupportedScheme(String),
+    /// A structural field (nonce / ephemeral pubkey / ciphertext length) is
+    /// the wrong size — a truncated or mis-encoded envelope. The `&str` names
+    /// the offending field for logs (non-sensitive).
+    MalformedEnvelope(&'static str),
+}
+
+impl fmt::Display for EciesError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Derivation(e) => write!(f, "encryption-child derivation failed: {}", e),
+            Self::Cipher(e) => write!(f, "AES-GCM key init failed: {}", e),
+            Self::Seal => write!(f, "AES-GCM seal failed"),
+            Self::BadKeyOrCorrupt => {
+                write!(f, "recovery envelope could not be decrypted (wrong key or corrupted)")
+            }
+            Self::UnsupportedScheme(s) => {
+                write!(f, "recovery envelope scheme '{}' is not supported by this client", s)
+            }
+            Self::MalformedEnvelope(field) => {
+                write!(f, "recovery envelope is malformed: {}", field)
+            }
+        }
+    }
+}
+
+impl std::error::Error for EciesError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Derivation(e) => Some(e),
+            Self::Cipher(e) => Some(e),
+            _ => None,
+        }
+    }
+}

--- a/coincube-gui/src/services/inheritance/escrow.rs
+++ b/coincube-gui/src/services/inheritance/escrow.rs
@@ -9,14 +9,12 @@
 
 use std::str::FromStr;
 
-use coincube_core::miniscript::bitcoin::bip32::{DerivationPath, Xpub};
+use coincube_core::miniscript::bitcoin::bip32::Xpub;
 
-use super::ecies::{seal_to_xpub, ArtifactKind, ENCRYPTION_CHILD_DERIVATION};
+use super::ecies::{seal_to_xpub, ArtifactKind, ENCRYPTION_CHILD_INDEX};
 use super::error::EciesError;
 use super::wire::envelope_to_wire;
-use crate::services::coincube::{
-    ConnectVaultResponse, InheritanceEnvelopeWire, VaultMemberRole,
-};
+use crate::services::coincube::{ConnectVaultResponse, InheritanceEnvelopeWire, VaultMemberRole};
 
 /// The owner's chosen escrow tier for a Vault (the single selector decided for
 /// the ECIES pivot). Heartbeat monitoring (the server-blind release gate) is on
@@ -50,6 +48,10 @@ impl EscrowTier {
 pub struct KeyholderXpub {
     pub key_id: u64,
     pub xpub: Xpub,
+    /// The keyholder's registered account derivation path (`models.Key
+    /// .DerivationPath`). The envelope's full enc-child path is this + `/7000`
+    /// (SPEC §2), so Keychain can derive the matching private child from root.
+    pub account_derivation: String,
 }
 
 /// Errors from building the escrow set.
@@ -115,6 +117,7 @@ pub fn keyholders_from_vault(
         out.push(KeyholderXpub {
             key_id: key.id,
             xpub,
+            account_derivation: key.derivation_path.clone(),
         });
     }
     if out.is_empty() {
@@ -131,23 +134,39 @@ pub fn keyholders_from_vault(
 ///
 /// `seed_json` must be `Some` iff `tier.includes_seed()`. Returns
 /// `2 * keyholders` envelopes for Full-Cube, `keyholders` for Vault-only.
+/// `cube_id` is the Connect vault's cube id, bound into each envelope's AAD
+/// (SPEC §1) so a relayed envelope can't be re-targeted at another cube.
 pub fn build_escrow_set(
     keyholders: &[KeyholderXpub],
+    cube_id: u64,
     descriptor_json: &[u8],
     seed_json: Option<&[u8]>,
 ) -> Result<Vec<InheritanceEnvelopeWire>, EscrowError> {
-    // The constant is a fixed non-hardened path; parse once.
-    let derivation = DerivationPath::from_str(ENCRYPTION_CHILD_DERIVATION)
-        .expect("ENCRYPTION_CHILD_DERIVATION is a valid non-hardened path");
-
-    let mut envelopes = Vec::with_capacity(keyholders.len() * if seed_json.is_some() { 2 } else { 1 });
+    let mut envelopes =
+        Vec::with_capacity(keyholders.len() * if seed_json.is_some() { 2 } else { 1 });
     for kh in keyholders {
-        let descriptor_env =
-            seal_to_xpub(&kh.xpub, &derivation, ArtifactKind::Descriptor, descriptor_json)?;
+        // Full path from the seed root to the dedicated enc child (SPEC §2),
+        // stored in the envelope so Keychain derives the matching `d`.
+        let full_derivation = format!("{}/{}", kh.account_derivation, ENCRYPTION_CHILD_INDEX);
+        let descriptor_env = seal_to_xpub(
+            &kh.xpub,
+            &full_derivation,
+            ArtifactKind::Descriptor,
+            cube_id,
+            kh.key_id,
+            descriptor_json,
+        )?;
         envelopes.push(envelope_to_wire(&descriptor_env, kh.key_id));
 
         if let Some(seed) = seed_json {
-            let seed_env = seal_to_xpub(&kh.xpub, &derivation, ArtifactKind::Seed, seed)?;
+            let seed_env = seal_to_xpub(
+                &kh.xpub,
+                &full_derivation,
+                ArtifactKind::Seed,
+                cube_id,
+                kh.key_id,
+                seed,
+            )?;
             envelopes.push(envelope_to_wire(&seed_env, kh.key_id));
         }
     }
@@ -158,12 +177,15 @@ pub fn build_escrow_set(
 mod tests {
     use super::*;
     use crate::services::coincube::{VaultMemberKeySummary, VaultMemberResponse, VaultStatus};
-    use crate::services::inheritance::ecies::shared_key_from_ecdh;
+    use crate::services::inheritance::ecies::keychain_shared_key;
     use crate::services::inheritance::{open_with_shared_key, wire_to_envelope};
-    use coincube_core::miniscript::bitcoin::bip32::Xpriv;
+    use coincube_core::miniscript::bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv};
     use coincube_core::miniscript::bitcoin::secp256k1::{PublicKey, Secp256k1};
     use coincube_core::miniscript::bitcoin::Network;
     use zeroize::Zeroizing;
+
+    // Connect cube id bound into the AAD; the open side must match the seal.
+    const CUBE: u64 = 1;
 
     /// A test keyholder: account xpub (registered) + account xpriv (Keychain).
     struct TestKeyholder {
@@ -184,17 +206,23 @@ mod tests {
     }
 
     /// Recompute `K` the way the heir's Keychain would, to open an envelope.
+    /// The test keyholder's xpriv is at the account level, so it derives the
+    /// dedicated enc child by the single relative step `/7000`.
     fn recover_key(kh: &TestKeyholder, wire: &InheritanceEnvelopeWire) -> Zeroizing<[u8; 32]> {
         let secp = Secp256k1::new();
-        let path = DerivationPath::from_str(&wire.derivation).unwrap();
-        let child_sk = kh.account_xpriv.derive_priv(&secp, &path).unwrap().private_key;
+        let child = ChildNumber::from_normal_idx(ENCRYPTION_CHILD_INDEX).unwrap();
+        let child_sk = kh
+            .account_xpriv
+            .derive_priv(&secp, &[child])
+            .unwrap()
+            .private_key;
         let eph_pk = PublicKey::from_slice(
             &base64::engine::general_purpose::STANDARD
                 .decode(&wire.ephemeral_pubkey)
                 .unwrap(),
         )
         .unwrap();
-        shared_key_from_ecdh(&eph_pk, &child_sk)
+        keychain_shared_key(&child_sk, &eph_pk)
     }
 
     fn member(role: VaultMemberRole, key: Option<VaultMemberKeySummary>) -> VaultMemberResponse {
@@ -239,11 +267,17 @@ mod tests {
         let alice = keyholder(b"alice-seed-vector-000000000000000000000000");
         let bob = keyholder(b"bob-seed-vector-00000000000000000000000000");
         let vault = vault_with(vec![
-            member(VaultMemberRole::Keyholder, Some(key_summary(10, &alice.account_xpub))),
+            member(
+                VaultMemberRole::Keyholder,
+                Some(key_summary(10, &alice.account_xpub)),
+            ),
             // A keyholder with no registered key yet (pending invite) — skipped.
             member(VaultMemberRole::Keyholder, None),
             // A beneficiary — not an inheritance keyholder.
-            member(VaultMemberRole::Beneficiary, Some(key_summary(11, &bob.account_xpub))),
+            member(
+                VaultMemberRole::Beneficiary,
+                Some(key_summary(11, &bob.account_xpub)),
+            ),
         ]);
         let khs = keyholders_from_vault(&vault).unwrap();
         assert_eq!(khs.len(), 1);
@@ -260,7 +294,10 @@ mod tests {
         };
         let vault = vault_with(vec![member(VaultMemberRole::Keyholder, Some(bad))]);
         let err = keyholders_from_vault(&vault).unwrap_err();
-        assert!(matches!(err, EscrowError::BadKeyholderXpub { key_id: 99, .. }));
+        assert!(matches!(
+            err,
+            EscrowError::BadKeyholderXpub { key_id: 99, .. }
+        ));
     }
 
     #[test]
@@ -277,45 +314,57 @@ mod tests {
         let alice = keyholder(b"vo-alice-seed-vector-0000000000000000000000");
         let bob = keyholder(b"vo-bob-seed-vector-000000000000000000000000");
         let khs = vec![
-            KeyholderXpub { key_id: 10, xpub: alice.account_xpub },
-            KeyholderXpub { key_id: 20, xpub: bob.account_xpub },
+            KeyholderXpub {
+                key_id: 10,
+                xpub: alice.account_xpub,
+                account_derivation: "m/48'/0'/0'/2'".to_string(),
+            },
+            KeyholderXpub {
+                key_id: 20,
+                xpub: bob.account_xpub,
+                account_derivation: "m/48'/0'/0'/2'".to_string(),
+            },
         ];
         let descriptor = b"wsh(or_d(multi(2,A,B),and_v(...)))#cksum";
 
-        let set = build_escrow_set(&khs, descriptor, None).unwrap();
+        let set = build_escrow_set(&khs, CUBE, descriptor, None).unwrap();
         // One descriptor envelope per keyholder, no seed envelopes.
         assert_eq!(set.len(), 2);
         assert!(set.iter().all(|e| e.artifact_kind == "descriptor"));
         assert_eq!(set[0].keyholder_key_id, Some(10));
         assert_eq!(set[1].keyholder_key_id, Some(20));
 
-        // Alice's Keychain opens her descriptor envelope.
+        // Alice's Keychain opens her descriptor envelope (AAD = CUBE + key 10).
         let alice_kh = keyholder(b"vo-alice-seed-vector-0000000000000000000000");
         let k = recover_key(&alice_kh, &set[0]);
         let env = wire_to_envelope(&set[0]).unwrap();
-        let pt = open_with_shared_key(&k, &env).unwrap();
+        let pt = open_with_shared_key(&k, &env, CUBE, 10).unwrap();
         assert_eq!(pt.as_slice(), descriptor.as_slice());
     }
 
     #[test]
     fn full_cube_builds_descriptor_and_seed_per_keyholder() {
         let alice = keyholder(b"fc-alice-seed-vector-0000000000000000000000");
-        let khs = vec![KeyholderXpub { key_id: 10, xpub: alice.account_xpub }];
+        let khs = vec![KeyholderXpub {
+            key_id: 10,
+            xpub: alice.account_xpub,
+            account_derivation: "m/48'/0'/0'/2'".to_string(),
+        }];
         let descriptor = b"wsh(...)#ck";
         let seed = br#"{"version":1,"mnemonic":{"phrase":"abandon ... about","language":"en"}}"#;
 
-        let set = build_escrow_set(&khs, descriptor, Some(seed)).unwrap();
+        let set = build_escrow_set(&khs, CUBE, descriptor, Some(seed)).unwrap();
         assert_eq!(set.len(), 2);
         let kinds: Vec<&str> = set.iter().map(|e| e.artifact_kind.as_str()).collect();
         assert!(kinds.contains(&"descriptor"));
         assert!(kinds.contains(&"seed"));
 
-        // The seed envelope round-trips to the exact seed JSON.
+        // The seed envelope round-trips to the exact seed JSON (AAD = CUBE + 10).
         let alice_kh = keyholder(b"fc-alice-seed-vector-0000000000000000000000");
         let seed_wire = set.iter().find(|e| e.artifact_kind == "seed").unwrap();
         let k = recover_key(&alice_kh, seed_wire);
         let env = wire_to_envelope(seed_wire).unwrap();
-        let pt = open_with_shared_key(&k, &env).unwrap();
+        let pt = open_with_shared_key(&k, &env, CUBE, 10).unwrap();
         assert_eq!(pt.as_slice(), seed.as_slice());
     }
 }

--- a/coincube-gui/src/services/inheritance/escrow.rs
+++ b/coincube-gui/src/services/inheritance/escrow.rs
@@ -1,0 +1,321 @@
+//! Owner-side escrow-set construction (ECIES pivot PR 2).
+//!
+//! When the owner turns on inheritance escrow for a Vault, the desktop seals
+//! the recovery material to **each designated keyholder's** registered xpub and
+//! uploads the whole set with `PUT …/vault/escrow`. This module is the pure
+//! core: extract the keyholder xpubs from the Connect vault, then build the
+//! [`InheritanceEnvelopeWire`] set for a chosen [`EscrowTier`]. It does no I/O —
+//! the recovery-alerts card supplies the descriptor/seed plaintext and uploads.
+
+use std::str::FromStr;
+
+use coincube_core::miniscript::bitcoin::bip32::{DerivationPath, Xpub};
+
+use super::ecies::{seal_to_xpub, ArtifactKind, ENCRYPTION_CHILD_DERIVATION};
+use super::error::EciesError;
+use super::wire::envelope_to_wire;
+use crate::services::coincube::{
+    ConnectVaultResponse, InheritanceEnvelopeWire, VaultMemberRole,
+};
+
+/// The owner's chosen escrow tier for a Vault (the single selector decided for
+/// the ECIES pivot). Heartbeat monitoring (the server-blind release gate) is on
+/// whenever the tier is on; `Off` tears the escrow down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EscrowTier {
+    /// No escrow — heirs cannot recover. Deletes any stored envelope set.
+    Off,
+    /// Encrypt the **descriptor** only. The heir recovers the watch-only Vault
+    /// and sweeps via the recovery branch; never receives the seed.
+    VaultOnly,
+    /// Encrypt **seed + descriptor**. The heir restores the entire Cube
+    /// (Liquid + Spark + Vault).
+    FullCube,
+}
+
+impl EscrowTier {
+    /// Whether this tier escrows the master seed (Full-Cube only).
+    pub fn includes_seed(self) -> bool {
+        matches!(self, Self::FullCube)
+    }
+
+    /// Whether escrow is enabled (anything to upload + heartbeat on).
+    pub fn is_on(self) -> bool {
+        !matches!(self, Self::Off)
+    }
+}
+
+/// One keyholder we'll seal to: their `models.Key` id and parsed xpub.
+#[derive(Debug, Clone)]
+pub struct KeyholderXpub {
+    pub key_id: u64,
+    pub xpub: Xpub,
+}
+
+/// Errors from building the escrow set.
+#[derive(Debug)]
+pub enum EscrowError {
+    /// A keyholder's registered xpub didn't parse — we refuse to upload a
+    /// partial set silently, because a dropped keyholder couldn't recover.
+    BadKeyholderXpub {
+        key_id: u64,
+        source: coincube_core::miniscript::bitcoin::bip32::Error,
+    },
+    /// No keyholder with a registered key was found — there is no one to
+    /// escrow to, so escrow would be a no-op the owner should be told about.
+    NoKeyholders,
+    /// Sealing failed (e.g. a hardened derivation). Wraps the ECIES error.
+    Ecies(EciesError),
+}
+
+impl std::fmt::Display for EscrowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadKeyholderXpub { key_id, source } => write!(
+                f,
+                "keyholder key #{} has an unreadable xpub ({}); can't set up recovery for them",
+                key_id, source
+            ),
+            Self::NoKeyholders => write!(
+                f,
+                "this Vault has no keyholders with a registered key to set up recovery for"
+            ),
+            Self::Ecies(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for EscrowError {}
+
+impl From<EciesError> for EscrowError {
+    fn from(e: EciesError) -> Self {
+        Self::Ecies(e)
+    }
+}
+
+/// Extracts the designated inheritance keyholders (role == Keyholder, with a
+/// registered key) and parses each xpub. A keyholder role without a registered
+/// key (e.g. a pending invite) is skipped; a present-but-unparseable xpub is a
+/// hard error (we never silently drop a keyholder from the set).
+pub fn keyholders_from_vault(
+    vault: &ConnectVaultResponse,
+) -> Result<Vec<KeyholderXpub>, EscrowError> {
+    let mut out = Vec::new();
+    for m in &vault.members {
+        if m.role != VaultMemberRole::Keyholder {
+            continue;
+        }
+        let Some(key) = m.key.as_ref() else {
+            continue; // keyholder without a registered key — nothing to seal to
+        };
+        let xpub = Xpub::from_str(&key.xpub).map_err(|source| EscrowError::BadKeyholderXpub {
+            key_id: key.id,
+            source,
+        })?;
+        out.push(KeyholderXpub {
+            key_id: key.id,
+            xpub,
+        });
+    }
+    if out.is_empty() {
+        return Err(EscrowError::NoKeyholders);
+    }
+    Ok(out)
+}
+
+/// Builds the full envelope set to upload: for each keyholder, one descriptor
+/// envelope (always) plus, for the Full-Cube tier, one seed envelope. The
+/// plaintext is the serialized `DescriptorBlob` / `SeedBlob` JSON (the same
+/// blobs the Cube Recovery Kit uses), so the heir restore reuses the existing
+/// blob parsing.
+///
+/// `seed_json` must be `Some` iff `tier.includes_seed()`. Returns
+/// `2 * keyholders` envelopes for Full-Cube, `keyholders` for Vault-only.
+pub fn build_escrow_set(
+    keyholders: &[KeyholderXpub],
+    descriptor_json: &[u8],
+    seed_json: Option<&[u8]>,
+) -> Result<Vec<InheritanceEnvelopeWire>, EscrowError> {
+    // The constant is a fixed non-hardened path; parse once.
+    let derivation = DerivationPath::from_str(ENCRYPTION_CHILD_DERIVATION)
+        .expect("ENCRYPTION_CHILD_DERIVATION is a valid non-hardened path");
+
+    let mut envelopes = Vec::with_capacity(keyholders.len() * if seed_json.is_some() { 2 } else { 1 });
+    for kh in keyholders {
+        let descriptor_env =
+            seal_to_xpub(&kh.xpub, &derivation, ArtifactKind::Descriptor, descriptor_json)?;
+        envelopes.push(envelope_to_wire(&descriptor_env, kh.key_id));
+
+        if let Some(seed) = seed_json {
+            let seed_env = seal_to_xpub(&kh.xpub, &derivation, ArtifactKind::Seed, seed)?;
+            envelopes.push(envelope_to_wire(&seed_env, kh.key_id));
+        }
+    }
+    Ok(envelopes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::coincube::{VaultMemberKeySummary, VaultMemberResponse, VaultStatus};
+    use crate::services::inheritance::ecies::shared_key_from_ecdh;
+    use crate::services::inheritance::{open_with_shared_key, wire_to_envelope};
+    use coincube_core::miniscript::bitcoin::bip32::Xpriv;
+    use coincube_core::miniscript::bitcoin::secp256k1::{PublicKey, Secp256k1};
+    use coincube_core::miniscript::bitcoin::Network;
+    use zeroize::Zeroizing;
+
+    /// A test keyholder: account xpub (registered) + account xpriv (Keychain).
+    struct TestKeyholder {
+        account_xpub: Xpub,
+        account_xpriv: Xpriv,
+    }
+
+    fn keyholder(seed: &[u8]) -> TestKeyholder {
+        let secp = Secp256k1::new();
+        let master = Xpriv::new_master(Network::Bitcoin, seed).unwrap();
+        let path = DerivationPath::from_str("m/48'/0'/0'/2'").unwrap();
+        let account_xpriv = master.derive_priv(&secp, &path).unwrap();
+        let account_xpub = Xpub::from_priv(&secp, &account_xpriv);
+        TestKeyholder {
+            account_xpub,
+            account_xpriv,
+        }
+    }
+
+    /// Recompute `K` the way the heir's Keychain would, to open an envelope.
+    fn recover_key(kh: &TestKeyholder, wire: &InheritanceEnvelopeWire) -> Zeroizing<[u8; 32]> {
+        let secp = Secp256k1::new();
+        let path = DerivationPath::from_str(&wire.derivation).unwrap();
+        let child_sk = kh.account_xpriv.derive_priv(&secp, &path).unwrap().private_key;
+        let eph_pk = PublicKey::from_slice(
+            &base64::engine::general_purpose::STANDARD
+                .decode(&wire.ephemeral_pubkey)
+                .unwrap(),
+        )
+        .unwrap();
+        shared_key_from_ecdh(&eph_pk, &child_sk)
+    }
+
+    fn member(role: VaultMemberRole, key: Option<VaultMemberKeySummary>) -> VaultMemberResponse {
+        VaultMemberResponse {
+            id: 1,
+            contact_id: None,
+            key_id: key.as_ref().map(|k| k.id),
+            role,
+            contact: None,
+            key,
+            created_at: "2026-06-22T00:00:00Z".into(),
+        }
+    }
+
+    fn key_summary(id: u64, xpub: &Xpub) -> VaultMemberKeySummary {
+        VaultMemberKeySummary {
+            id,
+            name: "Heir key".into(),
+            xpub: xpub.to_string(),
+            derivation_path: "m/48'/0'/0'/2'".into(),
+        }
+    }
+
+    fn vault_with(members: Vec<VaultMemberResponse>) -> ConnectVaultResponse {
+        ConnectVaultResponse {
+            id: 1,
+            cube_id: 1,
+            timelock_days: 365,
+            timelock_expires_at: "2027-06-22T00:00:00Z".into(),
+            last_reset_at: "2026-06-22T00:00:00Z".into(),
+            status: VaultStatus::Active,
+            members,
+            created_at: "2026-06-22T00:00:00Z".into(),
+            updated_at: "2026-06-22T00:00:00Z".into(),
+        }
+    }
+
+    use base64::Engine;
+
+    #[test]
+    fn keyholders_filters_role_and_skips_keyless() {
+        let alice = keyholder(b"alice-seed-vector-000000000000000000000000");
+        let bob = keyholder(b"bob-seed-vector-00000000000000000000000000");
+        let vault = vault_with(vec![
+            member(VaultMemberRole::Keyholder, Some(key_summary(10, &alice.account_xpub))),
+            // A keyholder with no registered key yet (pending invite) — skipped.
+            member(VaultMemberRole::Keyholder, None),
+            // A beneficiary — not an inheritance keyholder.
+            member(VaultMemberRole::Beneficiary, Some(key_summary(11, &bob.account_xpub))),
+        ]);
+        let khs = keyholders_from_vault(&vault).unwrap();
+        assert_eq!(khs.len(), 1);
+        assert_eq!(khs[0].key_id, 10);
+    }
+
+    #[test]
+    fn keyholders_errors_on_unparseable_xpub() {
+        let bad = VaultMemberKeySummary {
+            id: 99,
+            name: "Broken".into(),
+            xpub: "not-an-xpub".into(),
+            derivation_path: "m/0".into(),
+        };
+        let vault = vault_with(vec![member(VaultMemberRole::Keyholder, Some(bad))]);
+        let err = keyholders_from_vault(&vault).unwrap_err();
+        assert!(matches!(err, EscrowError::BadKeyholderXpub { key_id: 99, .. }));
+    }
+
+    #[test]
+    fn keyholders_errors_when_none() {
+        let vault = vault_with(vec![member(VaultMemberRole::Observer, None)]);
+        assert!(matches!(
+            keyholders_from_vault(&vault).unwrap_err(),
+            EscrowError::NoKeyholders
+        ));
+    }
+
+    #[test]
+    fn vault_only_builds_descriptor_envelopes_only_and_roundtrips() {
+        let alice = keyholder(b"vo-alice-seed-vector-0000000000000000000000");
+        let bob = keyholder(b"vo-bob-seed-vector-000000000000000000000000");
+        let khs = vec![
+            KeyholderXpub { key_id: 10, xpub: alice.account_xpub },
+            KeyholderXpub { key_id: 20, xpub: bob.account_xpub },
+        ];
+        let descriptor = b"wsh(or_d(multi(2,A,B),and_v(...)))#cksum";
+
+        let set = build_escrow_set(&khs, descriptor, None).unwrap();
+        // One descriptor envelope per keyholder, no seed envelopes.
+        assert_eq!(set.len(), 2);
+        assert!(set.iter().all(|e| e.artifact_kind == "descriptor"));
+        assert_eq!(set[0].keyholder_key_id, Some(10));
+        assert_eq!(set[1].keyholder_key_id, Some(20));
+
+        // Alice's Keychain opens her descriptor envelope.
+        let alice_kh = keyholder(b"vo-alice-seed-vector-0000000000000000000000");
+        let k = recover_key(&alice_kh, &set[0]);
+        let env = wire_to_envelope(&set[0]).unwrap();
+        let pt = open_with_shared_key(&k, &env).unwrap();
+        assert_eq!(pt.as_slice(), descriptor.as_slice());
+    }
+
+    #[test]
+    fn full_cube_builds_descriptor_and_seed_per_keyholder() {
+        let alice = keyholder(b"fc-alice-seed-vector-0000000000000000000000");
+        let khs = vec![KeyholderXpub { key_id: 10, xpub: alice.account_xpub }];
+        let descriptor = b"wsh(...)#ck";
+        let seed = br#"{"version":1,"mnemonic":{"phrase":"abandon ... about","language":"en"}}"#;
+
+        let set = build_escrow_set(&khs, descriptor, Some(seed)).unwrap();
+        assert_eq!(set.len(), 2);
+        let kinds: Vec<&str> = set.iter().map(|e| e.artifact_kind.as_str()).collect();
+        assert!(kinds.contains(&"descriptor"));
+        assert!(kinds.contains(&"seed"));
+
+        // The seed envelope round-trips to the exact seed JSON.
+        let alice_kh = keyholder(b"fc-alice-seed-vector-0000000000000000000000");
+        let seed_wire = set.iter().find(|e| e.artifact_kind == "seed").unwrap();
+        let k = recover_key(&alice_kh, seed_wire);
+        let env = wire_to_envelope(seed_wire).unwrap();
+        let pt = open_with_shared_key(&k, &env).unwrap();
+        assert_eq!(pt.as_slice(), seed.as_slice());
+    }
+}

--- a/coincube-gui/src/services/inheritance/escrow.rs
+++ b/coincube-gui/src/services/inheritance/escrow.rs
@@ -216,12 +216,9 @@ mod tests {
             .derive_priv(&secp, &[child])
             .unwrap()
             .private_key;
-        let eph_pk = PublicKey::from_slice(
-            &base64::engine::general_purpose::STANDARD
-                .decode(&wire.ephemeral_pubkey)
-                .unwrap(),
-        )
-        .unwrap();
+        // The wire encodes byte fields as lowercase hex (SPEC §5), matching
+        // production / `coincube-api` — decode the same way the heir does.
+        let eph_pk = PublicKey::from_slice(&hex::decode(&wire.ephemeral_pubkey).unwrap()).unwrap();
         keychain_shared_key(&child_sk, &eph_pk)
     }
 
@@ -259,8 +256,6 @@ mod tests {
             updated_at: "2026-06-22T00:00:00Z".into(),
         }
     }
-
-    use base64::Engine;
 
     #[test]
     fn keyholders_filters_role_and_skips_keyless() {

--- a/coincube-gui/src/services/inheritance/heir.rs
+++ b/coincube-gui/src/services/inheritance/heir.rs
@@ -228,7 +228,6 @@ mod tests {
     use crate::services::recovery::{
         DescriptorBlobCube, DescriptorBlobVault, SeedBlobCube, SeedBlobMnemonic,
     };
-    use base64::Engine;
     use coincube_core::miniscript::bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv, Xpub};
     use coincube_core::miniscript::bitcoin::secp256k1::{PublicKey, Secp256k1};
     use coincube_core::miniscript::bitcoin::Network;
@@ -258,12 +257,9 @@ mod tests {
         let secp = Secp256k1::new();
         let child = ChildNumber::from_normal_idx(ENCRYPTION_CHILD_INDEX).unwrap();
         let child_sk = k.xpriv.derive_priv(&secp, &[child]).unwrap().private_key;
-        let eph_pk = PublicKey::from_slice(
-            &base64::engine::general_purpose::STANDARD
-                .decode(&wire.ephemeral_pubkey)
-                .unwrap(),
-        )
-        .unwrap();
+        // The wire encodes byte fields as lowercase hex (SPEC §5), matching
+        // production / `coincube-api` — decode the same way `wire_to_envelope` does.
+        let eph_pk = PublicKey::from_slice(&hex::decode(&wire.ephemeral_pubkey).unwrap()).unwrap();
         keychain_shared_key(&child_sk, &eph_pk)
     }
 

--- a/coincube-gui/src/services/inheritance/heir.rs
+++ b/coincube-gui/src/services/inheritance/heir.rs
@@ -1,0 +1,336 @@
+//! Heir-side decrypt (ECIES pivot PR 3).
+//!
+//! Given the ciphertext envelope set the release endpoint returns, the heir's
+//! Keychain derives the per-envelope symmetric key `K` (ECDH + HKDF on the
+//! recovery private child), and the desktop opens the AES-256-GCM ciphertext
+//! here and parses it into the same [`SeedBlob`] / [`DescriptorBlob`] the Cube
+//! Recovery Kit uses — so the restore reuses the existing installer machinery.
+//!
+//! The seed (if any) is reconstructed only here, transiently, on the heir's
+//! desktop. Keychain never returns the seed or the recovery private key.
+
+use super::ecies::ArtifactKind;
+use super::error::EciesError;
+use super::wire::wire_to_envelope;
+use super::{open_with_shared_key, SCHEME};
+use crate::services::coincube::InheritanceEnvelopeWire;
+use crate::services::connect::grpc::session::GrpcSessionClient;
+use crate::services::recovery::{DecryptedKit, DescriptorBlob, SeedBlob, BLOB_VERSION};
+
+/// Length of the HKDF-derived symmetric key Keychain returns.
+const SHARED_KEY_LEN: usize = 32;
+
+/// Errors from the heir decrypt path. `Clone` so it can ride Iced messages;
+/// no variant carries secrets (only metadata / display copy).
+#[derive(Debug, Clone)]
+pub enum HeirDecryptError {
+    /// The Keychain decrypt call (relayed via the API) failed — declined,
+    /// offline, timed out, or returned a malformed key. Display-safe.
+    Keychain(String),
+    /// The envelope was malformed or used an unsupported scheme.
+    Envelope(String),
+    /// The ciphertext failed to open (wrong key / tampered) — fail-closed.
+    BadKeyOrCorrupt,
+    /// Decrypted cleanly but the plaintext JSON wasn't a blob we understand
+    /// (or a newer blob version this client must refuse).
+    BlobParse(String),
+    /// The release returned no envelopes at all, or none of the kind a given
+    /// restore needs (e.g. Full-Cube with no seed envelope).
+    MissingMaterial,
+}
+
+impl std::fmt::Display for HeirDecryptError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Keychain(m) => write!(f, "Keychain couldn't complete recovery: {}", m),
+            Self::Envelope(m) => write!(f, "The recovery data was malformed: {}", m),
+            Self::BadKeyOrCorrupt => {
+                write!(f, "The recovery data couldn't be decrypted on this device.")
+            }
+            Self::BlobParse(m) => write!(f, "The recovery data wasn't recognised: {}", m),
+            Self::MissingMaterial => write!(f, "There's nothing escrowed for you to recover here."),
+        }
+    }
+}
+
+impl std::error::Error for HeirDecryptError {}
+
+impl From<EciesError> for HeirDecryptError {
+    fn from(e: EciesError) -> Self {
+        match e {
+            EciesError::BadKeyOrCorrupt => Self::BadKeyOrCorrupt,
+            EciesError::UnsupportedScheme(s) => {
+                Self::Envelope(format!("unsupported scheme '{}'", s))
+            }
+            EciesError::MalformedEnvelope(field) => Self::Envelope(field.to_string()),
+            other => Self::Envelope(other.to_string()),
+        }
+    }
+}
+
+/// One decrypted, parsed artifact.
+#[derive(Debug)]
+pub enum OpenedArtifact {
+    Seed(SeedBlob),
+    Descriptor(DescriptorBlob),
+}
+
+fn check_blob_version(kind: &str, seen: u8) -> Result<(), HeirDecryptError> {
+    if seen == BLOB_VERSION {
+        return Ok(());
+    }
+    Err(HeirDecryptError::BlobParse(format!(
+        "{} version {} not supported by this client (expected {}). Update your Cube app.",
+        kind, seen, BLOB_VERSION
+    )))
+}
+
+/// Opens one envelope with the Keychain-derived key `K` and parses its blob.
+/// Pure (no I/O) — the [`super::decrypt_envelopes`] orchestration calls
+/// Keychain for `K` and then this.
+pub fn open_blob(
+    wire: &InheritanceEnvelopeWire,
+    shared_key: &[u8; SHARED_KEY_LEN],
+) -> Result<OpenedArtifact, HeirDecryptError> {
+    let env = wire_to_envelope(wire)?;
+    let pt = open_with_shared_key(shared_key, &env)?;
+    match env.artifact_kind {
+        ArtifactKind::Seed => {
+            let blob: SeedBlob = serde_json::from_slice(&pt)
+                .map_err(|e| HeirDecryptError::BlobParse(format!("seed blob: {}", e)))?;
+            check_blob_version("seed blob", blob.version)?;
+            Ok(OpenedArtifact::Seed(blob))
+        }
+        ArtifactKind::Descriptor => {
+            let blob: DescriptorBlob = serde_json::from_slice(&pt)
+                .map_err(|e| HeirDecryptError::BlobParse(format!("descriptor blob: {}", e)))?;
+            check_blob_version("descriptor blob", blob.version)?;
+            Ok(OpenedArtifact::Descriptor(blob))
+        }
+    }
+}
+
+/// Collapses the opened artifacts into the same [`DecryptedKit`] the Cube
+/// Recovery Kit restore consumes. The last of each kind wins (the set has at
+/// most one of each for the caller).
+pub fn assemble(artifacts: Vec<OpenedArtifact>) -> DecryptedKit {
+    let mut seed = None;
+    let mut descriptor = None;
+    for a in artifacts {
+        match a {
+            OpenedArtifact::Seed(b) => seed = Some(b),
+            OpenedArtifact::Descriptor(b) => descriptor = Some(b),
+        }
+    }
+    DecryptedKit { seed, descriptor }
+}
+
+/// Full heir decrypt: for each envelope, ask the heir's Keychain (via the API
+/// relay) for `K`, then open + parse locally. Returns the assembled
+/// [`DecryptedKit`] for the existing restore machinery. The `grpc` client is
+/// the authenticated Connect SessionService client; `cube_id` selects the
+/// recovery key on the heir's Keychain.
+pub async fn decrypt_envelopes(
+    grpc: &mut GrpcSessionClient,
+    cube_id: u64,
+    wires: &[InheritanceEnvelopeWire],
+) -> Result<DecryptedKit, HeirDecryptError> {
+    if wires.is_empty() {
+        return Err(HeirDecryptError::MissingMaterial);
+    }
+    let cube_id_str = cube_id.to_string();
+    let mut artifacts = Vec::with_capacity(wires.len());
+    for wire in wires {
+        // Refuse a scheme we can't open before round-tripping to Keychain.
+        if wire.scheme != SCHEME {
+            return Err(HeirDecryptError::Envelope(format!(
+                "unsupported scheme '{}'",
+                wire.scheme
+            )));
+        }
+        let env = wire_to_envelope(wire)?;
+        let shared = grpc
+            .decrypt_inheritance_envelope(
+                cube_id_str.clone(),
+                env.ephemeral_pubkey.clone(),
+                env.derivation.clone(),
+            )
+            .await
+            .map_err(|s| HeirDecryptError::Keychain(s.message().to_string()))?;
+        if shared.len() != SHARED_KEY_LEN {
+            return Err(HeirDecryptError::Keychain(
+                "Keychain returned a key of the wrong length".into(),
+            ));
+        }
+        let mut key = [0u8; SHARED_KEY_LEN];
+        key.copy_from_slice(&shared);
+        artifacts.push(open_blob(wire, &key)?);
+    }
+    Ok(assemble(artifacts))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::inheritance::ecies::shared_key_from_ecdh;
+    use crate::services::inheritance::{build_escrow_set, KeyholderXpub};
+    use crate::services::recovery::{
+        DescriptorBlobCube, DescriptorBlobVault, SeedBlobCube, SeedBlobMnemonic,
+    };
+    use base64::Engine;
+    use coincube_core::miniscript::bitcoin::bip32::{DerivationPath, Xpriv, Xpub};
+    use coincube_core::miniscript::bitcoin::secp256k1::{PublicKey, Secp256k1};
+    use coincube_core::miniscript::bitcoin::Network;
+    use std::str::FromStr;
+    use zeroize::Zeroizing;
+
+    struct Kh {
+        xpub: Xpub,
+        xpriv: Xpriv,
+    }
+
+    fn kh(seed: &[u8]) -> Kh {
+        let secp = Secp256k1::new();
+        let master = Xpriv::new_master(Network::Bitcoin, seed).unwrap();
+        let path = DerivationPath::from_str("m/48'/0'/0'/2'").unwrap();
+        let xpriv = master.derive_priv(&secp, &path).unwrap();
+        let xpub = Xpub::from_priv(&secp, &xpriv);
+        Kh { xpub, xpriv }
+    }
+
+    fn recover_key(k: &Kh, wire: &InheritanceEnvelopeWire) -> Zeroizing<[u8; 32]> {
+        let secp = Secp256k1::new();
+        let path = DerivationPath::from_str(&wire.derivation).unwrap();
+        let child_sk = k.xpriv.derive_priv(&secp, &path).unwrap().private_key;
+        let eph_pk = PublicKey::from_slice(
+            &base64::engine::general_purpose::STANDARD
+                .decode(&wire.ephemeral_pubkey)
+                .unwrap(),
+        )
+        .unwrap();
+        shared_key_from_ecdh(&eph_pk, &child_sk)
+    }
+
+    fn sample_seed_blob() -> SeedBlob {
+        SeedBlob {
+            version: BLOB_VERSION,
+            cube: SeedBlobCube {
+                uuid: "cube-uuid".into(),
+                name: "My Cube".into(),
+                network: "bitcoin".into(),
+                created_at: "2026-06-22T00:00:00Z".into(),
+                lightning_address: None,
+            },
+            mnemonic: SeedBlobMnemonic {
+                phrase: "abandon abandon abandon abandon abandon abandon abandon abandon \
+                         abandon abandon abandon about"
+                    .into(),
+                language: "en".into(),
+            },
+        }
+    }
+
+    fn sample_descriptor_blob() -> DescriptorBlob {
+        DescriptorBlob {
+            version: BLOB_VERSION,
+            cube: DescriptorBlobCube {
+                uuid: "cube-uuid".into(),
+                network: "bitcoin".into(),
+            },
+            vault: DescriptorBlobVault {
+                name: "My Vault".into(),
+                descriptor: "wsh(multi(2,xpubA,xpubB))#cksum".into(),
+                change_descriptor: None,
+                signers: vec![],
+            },
+        }
+    }
+
+    /// Full-Cube round-trip: owner seals seed+descriptor → heir opens both →
+    /// assembled DecryptedKit carries both, parsed correctly.
+    #[test]
+    fn full_cube_open_and_assemble() {
+        let heir = kh(b"heir-full-cube-seed-vector-0000000000000000");
+        let khs = vec![KeyholderXpub {
+            key_id: 5,
+            xpub: heir.xpub,
+        }];
+        let descriptor_json = serde_json::to_vec(&sample_descriptor_blob()).unwrap();
+        let seed_json = serde_json::to_vec(&sample_seed_blob()).unwrap();
+
+        let set = build_escrow_set(&khs, &descriptor_json, Some(&seed_json)).unwrap();
+
+        let opened: Vec<OpenedArtifact> = set
+            .iter()
+            .map(|w| {
+                let heir2 = kh(b"heir-full-cube-seed-vector-0000000000000000");
+                let k = recover_key(&heir2, w);
+                open_blob(w, &k).unwrap()
+            })
+            .collect();
+
+        let kit = assemble(opened);
+        assert!(kit.seed.is_some(), "seed half present");
+        assert!(kit.descriptor.is_some(), "descriptor half present");
+        assert_eq!(kit.seed.unwrap().mnemonic.language, "en");
+        assert_eq!(kit.descriptor.unwrap().vault.name, "My Vault");
+    }
+
+    /// Vault-only: a single descriptor envelope → descriptor present, no seed.
+    #[test]
+    fn vault_only_open_has_descriptor_no_seed() {
+        let heir = kh(b"heir-vault-only-seed-vector-000000000000000");
+        let khs = vec![KeyholderXpub {
+            key_id: 7,
+            xpub: heir.xpub,
+        }];
+        let descriptor_json = serde_json::to_vec(&sample_descriptor_blob()).unwrap();
+        let set = build_escrow_set(&khs, &descriptor_json, None).unwrap();
+
+        let heir2 = kh(b"heir-vault-only-seed-vector-000000000000000");
+        let k = recover_key(&heir2, &set[0]);
+        let kit = assemble(vec![open_blob(&set[0], &k).unwrap()]);
+        assert!(kit.descriptor.is_some());
+        assert!(kit.seed.is_none());
+    }
+
+    /// A wrong key fails closed as BadKeyOrCorrupt, never a parse error.
+    #[test]
+    fn wrong_key_fails_closed() {
+        let owner_heir = kh(b"correct-heir-seed-vector-00000000000000000");
+        let attacker = kh(b"attacker-heir-seed-vector-0000000000000000");
+        let khs = vec![KeyholderXpub {
+            key_id: 1,
+            xpub: owner_heir.xpub,
+        }];
+        let descriptor_json = serde_json::to_vec(&sample_descriptor_blob()).unwrap();
+        let set = build_escrow_set(&khs, &descriptor_json, None).unwrap();
+
+        let wrong = recover_key(&attacker, &set[0]);
+        assert!(matches!(
+            open_blob(&set[0], &wrong),
+            Err(HeirDecryptError::BadKeyOrCorrupt)
+        ));
+    }
+
+    /// A newer blob version is refused rather than mis-parsed into v1 shape.
+    #[test]
+    fn newer_blob_version_refused() {
+        let heir = kh(b"version-heir-seed-vector-00000000000000000");
+        let khs = vec![KeyholderXpub {
+            key_id: 1,
+            xpub: heir.xpub,
+        }];
+        let mut blob = sample_descriptor_blob();
+        blob.version = BLOB_VERSION + 1;
+        let descriptor_json = serde_json::to_vec(&blob).unwrap();
+        let set = build_escrow_set(&khs, &descriptor_json, None).unwrap();
+
+        let heir2 = kh(b"version-heir-seed-vector-00000000000000000");
+        let k = recover_key(&heir2, &set[0]);
+        assert!(matches!(
+            open_blob(&set[0], &k),
+            Err(HeirDecryptError::BlobParse(_))
+        ));
+    }
+}

--- a/coincube-gui/src/services/inheritance/heir.rs
+++ b/coincube-gui/src/services/inheritance/heir.rs
@@ -393,4 +393,34 @@ mod tests {
             Err(HeirDecryptError::BlobParse(_))
         ));
     }
+
+    #[test]
+    fn open_blob_fails_closed_without_keyholder_key_id() {
+        // The AAD (SPEC §1) binds keyholder_key_id, so the gated release MUST
+        // carry it. If `coincube-api` omits it, we must fail closed with a clear
+        // error — never attempt an open with a guessed/missing id.
+        let heir = kh(b"missing-keyid-heir-seed-vector-0000000000000");
+        let khs = vec![KeyholderXpub {
+            key_id: 1,
+            xpub: heir.xpub,
+            account_derivation: "m/48'/0'/0'/2'".to_string(),
+        }];
+        let descriptor_json = serde_json::to_vec(&sample_descriptor_blob()).unwrap();
+        let mut set = build_escrow_set(&khs, CUBE, &descriptor_json, None).unwrap();
+
+        // Simulate a release response that dropped keyholderKeyId.
+        set[0].keyholder_key_id = None;
+
+        let heir2 = kh(b"missing-keyid-heir-seed-vector-0000000000000");
+        let k = recover_key(&heir2, &set[0]);
+        match open_blob(&set[0], &k, CUBE) {
+            Err(HeirDecryptError::Envelope(msg)) => {
+                assert!(msg.contains("keyholderKeyId"), "got: {}", msg)
+            }
+            other => panic!(
+                "expected a missing-keyholderKeyId envelope error, got {:?}",
+                other
+            ),
+        }
+    }
 }

--- a/coincube-gui/src/services/inheritance/heir.rs
+++ b/coincube-gui/src/services/inheritance/heir.rs
@@ -9,12 +9,14 @@
 //! The seed (if any) is reconstructed only here, transiently, on the heir's
 //! desktop. Keychain never returns the seed or the recovery private key.
 
+use std::time::Duration;
+
 use super::ecies::ArtifactKind;
 use super::error::EciesError;
 use super::wire::wire_to_envelope;
-use super::{open_with_shared_key, SCHEME};
+use super::{open_with_shared_key, transport_keypair, unwrap_shared_key, SCHEME};
 use crate::services::coincube::InheritanceEnvelopeWire;
-use crate::services::connect::grpc::session::GrpcSessionClient;
+use crate::services::connect::grpc::session::{DecryptOutcome, GrpcSessionClient};
 use crate::services::recovery::{DecryptedKit, DescriptorBlob, SeedBlob, BLOB_VERSION};
 
 /// Length of the HKDF-derived symmetric key Keychain returns.
@@ -34,6 +36,12 @@ pub enum HeirDecryptError {
     /// Decrypted cleanly but the plaintext JSON wasn't a blob we understand
     /// (or a newer blob version this client must refuse).
     BlobParse(String),
+    /// The heir's Keychain declined the decrypt — approval denied, or the
+    /// heir's own account is under duress.
+    Rejected,
+    /// The decrypt request expired before the Keychain answered (TTL elapsed,
+    /// Keychain offline, or the local wait timed out).
+    Expired,
     /// The release returned no envelopes at all, or none of the kind a given
     /// restore needs (e.g. Full-Cube with no seed envelope).
     MissingMaterial,
@@ -48,6 +56,11 @@ impl std::fmt::Display for HeirDecryptError {
                 write!(f, "The recovery data couldn't be decrypted on this device.")
             }
             Self::BlobParse(m) => write!(f, "The recovery data wasn't recognised: {}", m),
+            Self::Rejected => write!(f, "The recovery was declined on the Keychain."),
+            Self::Expired => write!(
+                f,
+                "The recovery request expired before it was approved. Please try again."
+            ),
             Self::MissingMaterial => write!(f, "There's nothing escrowed for you to recover here."),
         }
     }
@@ -91,9 +104,16 @@ fn check_blob_version(kind: &str, seen: u8) -> Result<(), HeirDecryptError> {
 pub fn open_blob(
     wire: &InheritanceEnvelopeWire,
     shared_key: &[u8; SHARED_KEY_LEN],
+    cube_id: u64,
 ) -> Result<OpenedArtifact, HeirDecryptError> {
+    // The AAD binds the envelope to (kind, cube_id, keyholder_key_id) — SPEC §1.
+    // The server must have stamped the keyholder key id on the released row; a
+    // missing one means we can't rebuild the AAD, so fail closed.
+    let keyholder_key_id = wire.keyholder_key_id.ok_or_else(|| {
+        HeirDecryptError::Envelope("recovery envelope is missing keyholderKeyId".to_string())
+    })?;
     let env = wire_to_envelope(wire)?;
-    let pt = open_with_shared_key(shared_key, &env)?;
+    let pt = open_with_shared_key(shared_key, &env, cube_id, keyholder_key_id)?;
     match env.artifact_kind {
         ArtifactKind::Seed => {
             let blob: SeedBlob = serde_json::from_slice(&pt)
@@ -125,11 +145,13 @@ pub fn assemble(artifacts: Vec<OpenedArtifact>) -> DecryptedKit {
     DecryptedKit { seed, descriptor }
 }
 
-/// Full heir decrypt: for each envelope, ask the heir's Keychain (via the API
-/// relay) for `K`, then open + parse locally. Returns the assembled
-/// [`DecryptedKit`] for the existing restore machinery. The `grpc` client is
-/// the authenticated Connect SessionService client; `cube_id` selects the
-/// recovery key on the heir's Keychain.
+/// Full heir decrypt over the async Connect relay (SPEC-ecies-v1 §4 + §4b).
+/// Generates a per-recovery transport keypair, then for each envelope brokers a
+/// decrypt to the heir's Keychain (which wraps the symmetric key `K` to our
+/// transport pubkey), unwraps `K` locally, and opens + parses the envelope.
+/// Returns the assembled [`DecryptedKit`] for the existing restore machinery.
+/// `grpc` is the authenticated Connect SessionService client; `cube_id` selects
+/// the recovery key on the heir's Keychain and is bound into each envelope's AAD.
 pub async fn decrypt_envelopes(
     grpc: &mut GrpcSessionClient,
     cube_id: u64,
@@ -138,6 +160,11 @@ pub async fn decrypt_envelopes(
     if wires.is_empty() {
         return Err(HeirDecryptError::MissingMaterial);
     }
+    // Fresh transport keypair for this recovery — in memory only, never
+    // persisted. The Keychain wraps each `K` to its pubkey; we unwrap with the
+    // private scalar. Reused across the descriptor + seed requests; the
+    // per-request `request_id` keeps each wrap bound to its own request (§4b).
+    let transport = transport_keypair();
     let cube_id_str = cube_id.to_string();
     let mut artifacts = Vec::with_capacity(wires.len());
     for wire in wires {
@@ -148,41 +175,68 @@ pub async fn decrypt_envelopes(
                 wire.scheme
             )));
         }
-        let env = wire_to_envelope(wire)?;
-        let shared = grpc
-            .decrypt_inheritance_envelope(
-                cube_id_str.clone(),
-                env.ephemeral_pubkey.clone(),
-                env.derivation.clone(),
-            )
-            .await
-            .map_err(|s| HeirDecryptError::Keychain(s.message().to_string()))?;
-        if shared.len() != SHARED_KEY_LEN {
-            return Err(HeirDecryptError::Keychain(
-                "Keychain returned a key of the wrong length".into(),
-            ));
-        }
-        let mut key = [0u8; SHARED_KEY_LEN];
-        key.copy_from_slice(&shared);
-        artifacts.push(open_blob(wire, &key)?);
+        // 1. Broker the decrypt; 2–4. wait for the Keychain's wrapped key.
+        let request_id = uuid::Uuid::new_v4().to_string();
+        grpc.create_decrypt_request(
+            request_id.clone(),
+            cube_id_str.clone(),
+            wire.artifact_kind.clone(),
+            transport.public_key().to_vec(),
+        )
+        .await
+        .map_err(|s| HeirDecryptError::Keychain(s.message().to_string()))?;
+        let wrapped = await_wrapped_key(grpc, &request_id).await?;
+
+        // 5. Unwrap `K` with the transport key, then open + parse the envelope.
+        let k = unwrap_shared_key(&transport, &request_id, &wrapped)?;
+        artifacts.push(open_blob(wire, &k, cube_id)?);
     }
     Ok(assemble(artifacts))
+}
+
+/// Polls `GetDecryptResult` until the Keychain answers or the wait elapses. The
+/// Keychain step needs a human (biometric/PIN) approval, so the deadline is
+/// generous; the best-effort `decrypt_result` stream push (not yet wired into
+/// the realtime handler) will later let this resolve promptly instead of at the
+/// poll cadence.
+async fn await_wrapped_key(
+    grpc: &mut GrpcSessionClient,
+    request_id: &str,
+) -> Result<Vec<u8>, HeirDecryptError> {
+    const POLL_INTERVAL: Duration = Duration::from_secs(2);
+    const MAX_ATTEMPTS: u32 = 150; // ~5 minutes of human-approval headroom
+    for _ in 0..MAX_ATTEMPTS {
+        match grpc
+            .get_decrypt_result(request_id.to_string())
+            .await
+            .map_err(|s| HeirDecryptError::Keychain(s.message().to_string()))?
+        {
+            DecryptOutcome::Completed(wrapped) => return Ok(wrapped),
+            DecryptOutcome::Rejected => return Err(HeirDecryptError::Rejected),
+            DecryptOutcome::Expired => return Err(HeirDecryptError::Expired),
+            DecryptOutcome::Pending => tokio::time::sleep(POLL_INTERVAL).await,
+        }
+    }
+    Err(HeirDecryptError::Expired)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::services::inheritance::ecies::shared_key_from_ecdh;
+    use crate::services::inheritance::ecies::{keychain_shared_key, ENCRYPTION_CHILD_INDEX};
     use crate::services::inheritance::{build_escrow_set, KeyholderXpub};
     use crate::services::recovery::{
         DescriptorBlobCube, DescriptorBlobVault, SeedBlobCube, SeedBlobMnemonic,
     };
     use base64::Engine;
-    use coincube_core::miniscript::bitcoin::bip32::{DerivationPath, Xpriv, Xpub};
+    use coincube_core::miniscript::bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv, Xpub};
     use coincube_core::miniscript::bitcoin::secp256k1::{PublicKey, Secp256k1};
     use coincube_core::miniscript::bitcoin::Network;
     use std::str::FromStr;
     use zeroize::Zeroizing;
+
+    // Connect cube id bound into the AAD; the open side must match the seal.
+    const CUBE: u64 = 1;
 
     struct Kh {
         xpub: Xpub,
@@ -198,17 +252,19 @@ mod tests {
         Kh { xpub, xpriv }
     }
 
+    /// Stands in for Keychain. The test xpriv is at the account level, so the
+    /// dedicated enc child is the single relative step `/7000`.
     fn recover_key(k: &Kh, wire: &InheritanceEnvelopeWire) -> Zeroizing<[u8; 32]> {
         let secp = Secp256k1::new();
-        let path = DerivationPath::from_str(&wire.derivation).unwrap();
-        let child_sk = k.xpriv.derive_priv(&secp, &path).unwrap().private_key;
+        let child = ChildNumber::from_normal_idx(ENCRYPTION_CHILD_INDEX).unwrap();
+        let child_sk = k.xpriv.derive_priv(&secp, &[child]).unwrap().private_key;
         let eph_pk = PublicKey::from_slice(
             &base64::engine::general_purpose::STANDARD
                 .decode(&wire.ephemeral_pubkey)
                 .unwrap(),
         )
         .unwrap();
-        shared_key_from_ecdh(&eph_pk, &child_sk)
+        keychain_shared_key(&child_sk, &eph_pk)
     }
 
     fn sample_seed_blob() -> SeedBlob {
@@ -254,18 +310,19 @@ mod tests {
         let khs = vec![KeyholderXpub {
             key_id: 5,
             xpub: heir.xpub,
+            account_derivation: "m/48'/0'/0'/2'".to_string(),
         }];
         let descriptor_json = serde_json::to_vec(&sample_descriptor_blob()).unwrap();
         let seed_json = serde_json::to_vec(&sample_seed_blob()).unwrap();
 
-        let set = build_escrow_set(&khs, &descriptor_json, Some(&seed_json)).unwrap();
+        let set = build_escrow_set(&khs, CUBE, &descriptor_json, Some(&seed_json)).unwrap();
 
         let opened: Vec<OpenedArtifact> = set
             .iter()
             .map(|w| {
                 let heir2 = kh(b"heir-full-cube-seed-vector-0000000000000000");
                 let k = recover_key(&heir2, w);
-                open_blob(w, &k).unwrap()
+                open_blob(w, &k, CUBE).unwrap()
             })
             .collect();
 
@@ -283,13 +340,14 @@ mod tests {
         let khs = vec![KeyholderXpub {
             key_id: 7,
             xpub: heir.xpub,
+            account_derivation: "m/48'/0'/0'/2'".to_string(),
         }];
         let descriptor_json = serde_json::to_vec(&sample_descriptor_blob()).unwrap();
-        let set = build_escrow_set(&khs, &descriptor_json, None).unwrap();
+        let set = build_escrow_set(&khs, CUBE, &descriptor_json, None).unwrap();
 
         let heir2 = kh(b"heir-vault-only-seed-vector-000000000000000");
         let k = recover_key(&heir2, &set[0]);
-        let kit = assemble(vec![open_blob(&set[0], &k).unwrap()]);
+        let kit = assemble(vec![open_blob(&set[0], &k, CUBE).unwrap()]);
         assert!(kit.descriptor.is_some());
         assert!(kit.seed.is_none());
     }
@@ -302,13 +360,14 @@ mod tests {
         let khs = vec![KeyholderXpub {
             key_id: 1,
             xpub: owner_heir.xpub,
+            account_derivation: "m/48'/0'/0'/2'".to_string(),
         }];
         let descriptor_json = serde_json::to_vec(&sample_descriptor_blob()).unwrap();
-        let set = build_escrow_set(&khs, &descriptor_json, None).unwrap();
+        let set = build_escrow_set(&khs, CUBE, &descriptor_json, None).unwrap();
 
         let wrong = recover_key(&attacker, &set[0]);
         assert!(matches!(
-            open_blob(&set[0], &wrong),
+            open_blob(&set[0], &wrong, CUBE),
             Err(HeirDecryptError::BadKeyOrCorrupt)
         ));
     }
@@ -320,16 +379,17 @@ mod tests {
         let khs = vec![KeyholderXpub {
             key_id: 1,
             xpub: heir.xpub,
+            account_derivation: "m/48'/0'/0'/2'".to_string(),
         }];
         let mut blob = sample_descriptor_blob();
         blob.version = BLOB_VERSION + 1;
         let descriptor_json = serde_json::to_vec(&blob).unwrap();
-        let set = build_escrow_set(&khs, &descriptor_json, None).unwrap();
+        let set = build_escrow_set(&khs, CUBE, &descriptor_json, None).unwrap();
 
         let heir2 = kh(b"version-heir-seed-vector-00000000000000000");
         let k = recover_key(&heir2, &set[0]);
         assert!(matches!(
-            open_blob(&set[0], &k),
+            open_blob(&set[0], &k, CUBE),
             Err(HeirDecryptError::BlobParse(_))
         ));
     }

--- a/coincube-gui/src/services/inheritance/mod.rs
+++ b/coincube-gui/src/services/inheritance/mod.rs
@@ -1,0 +1,30 @@
+//! Inheritance heir-escrow — client-side per-keyholder ECIES (COIN-377, rev 3).
+//!
+//! Server-blind heir recovery: the owner's desktop seals the recovery
+//! material to each designated keyholder's xpub; COINCUBE stores opaque
+//! ciphertext and only gates its release; the heir's Keychain does the ECDH
+//! to decrypt. See the decision record
+//! `decisions/2026-06-22-inheritance-ecies-heir-escrow.md` and
+//! `plans/PLAN-inheritance-recovery.md`.
+//!
+//! This module is UI-free and (for [`ecies`]) network-free. The Connect
+//! client lives in `services::coincube`; the Keychain ECDH-decrypt call lives
+//! in `services::connect::grpc`; the UI state machines live under `app::` and
+//! `recover_vault`.
+
+pub mod ecies;
+pub mod error;
+pub mod escrow;
+pub mod heir;
+pub mod owner;
+pub mod wire;
+
+pub use ecies::{
+    open_with_shared_key, seal_to_xpub, ArtifactKind, Envelope, ENCRYPTION_CHILD_DERIVATION,
+    HKDF_INFO, SCHEME,
+};
+pub use error::EciesError;
+pub use escrow::{build_escrow_set, keyholders_from_vault, EscrowError, EscrowTier, KeyholderXpub};
+pub use heir::{decrypt_envelopes, HeirDecryptError};
+pub use owner::{disable_escrow, enroll_escrow, OwnerEscrowError};
+pub use wire::{envelope_to_wire, wire_to_envelope};

--- a/coincube-gui/src/services/inheritance/mod.rs
+++ b/coincube-gui/src/services/inheritance/mod.rs
@@ -20,8 +20,8 @@ pub mod owner;
 pub mod wire;
 
 pub use ecies::{
-    open_with_shared_key, seal_to_xpub, ArtifactKind, Envelope, ENCRYPTION_CHILD_DERIVATION,
-    HKDF_INFO, SCHEME,
+    open_with_shared_key, seal_to_xpub, transport_keypair, unwrap_shared_key, ArtifactKind,
+    Envelope, TransportKeypair, ENCRYPTION_CHILD_INDEX, SCHEME, WRAP_SCHEME,
 };
 pub use error::EciesError;
 pub use escrow::{build_escrow_set, keyholders_from_vault, EscrowError, EscrowTier, KeyholderXpub};

--- a/coincube-gui/src/services/inheritance/owner.rs
+++ b/coincube-gui/src/services/inheritance/owner.rs
@@ -10,6 +10,8 @@
 //! escrow`); the heartbeat gate is keyed on the **vault** id
 //! (`…/vaults/{vaultId}/monitoring`).
 
+use zeroize::Zeroizing;
+
 use super::escrow::{build_escrow_set, keyholders_from_vault, EscrowError};
 use crate::services::coincube::{
     CoincubeClient, CoincubeError, SetVaultMonitoringRequest, VaultMonitoringLevel,
@@ -54,39 +56,51 @@ impl From<CoincubeError> for OwnerEscrowError {
 /// switches the server-blind heartbeat gate on. Returns the new monitoring
 /// status.
 ///
-/// Idempotent: the server replaces the stored set, so re-running on a keyholder
-/// change is safe. No plaintext descriptor or seed ever reaches the server.
+/// Idempotent: the server replaces the stored set, so re-running for the same
+/// Vault is safe. No plaintext descriptor or seed ever reaches the server.
 ///
-/// **Re-encryption on keyholder change** is this same call. It is *not*
-/// auto-fired from the membership-change paths because the Full-Cube tier
-/// re-seals the seed, which requires unlocking it behind the owner's PIN — a
-/// silent re-encrypt could only refresh the descriptor and would leave a newly
-/// added Full-Cube keyholder with a descriptor-only (silently degraded)
-/// envelope. Instead the owner re-confirms the tier in the Recovery-Alerts card
-/// (one tap for Vault-only; PIN re-entry for Full-Cube), which re-runs this over
-/// the current keyholder set.
+/// **The keyholder set is fixed for the life of a Vault.** Once a Vault is
+/// `active` its signing quorum is sealed: the server rejects adding a keyholder
+/// with 409 `VAULT_KEYHOLDER_LOCKED` and the role chooser hides the Keyholder
+/// role (`allowed_vault_member_roles`), and there is no key-rotation path
+/// (rotating a cosigner means a new descriptor, i.e. a new Vault). So there is
+/// no "re-encrypt on keyholder change" while a Vault is active, and the
+/// Recovery-Alerts card's same-tier early-return is correct — re-running this
+/// over an unchanged keyholder set would be a no-op. Re-encryption is only
+/// relevant when an *expired* Vault is rebuilt with a different keyholder set,
+/// which is a fresh enrolment on the rebuilt Vault, not a re-tap on the active
+/// one.
 pub async fn enroll_escrow(
     client: &CoincubeClient,
     server_cube_id: u64,
-    vault_id: u64,
     descriptor_json: Vec<u8>,
-    seed_json: Option<Vec<u8>>,
+    seed_json: Option<Zeroizing<Vec<u8>>>,
 ) -> Result<VaultMonitoringStatus, OwnerEscrowError> {
     // 1. Resolve the current keyholders + xpubs, then build the envelope set
-    //    locally (the server never sees plaintext).
+    //    locally (the server never sees plaintext). The `Zeroizing` seed buffer
+    //    is owned here so it's wiped when this fn returns; `build_escrow_set`
+    //    only borrows the bytes to seal them, so it needs no `Zeroizing` itself.
     let vault = client.get_connect_vault(server_cube_id).await?;
     let keyholders = keyholders_from_vault(&vault)?;
-    let set = build_escrow_set(&keyholders, &descriptor_json, seed_json.as_deref())?;
+    let set = build_escrow_set(
+        &keyholders,
+        server_cube_id,
+        &descriptor_json,
+        seed_json.as_ref().map(|s| s.as_slice()),
+    )?;
 
     // 2. Upload the opaque ciphertext set (cube-scoped).
     client.put_vault_escrow(server_cube_id, set).await?;
 
-    // 3. Switch the server-blind heartbeat gate on (vault-scoped). No
-    //    descriptor — under ECIES the server stores none. Keep the existing
-    //    download policy if the caller set one (None lets the server default).
+    // 3. Switch the server-blind heartbeat gate on, on the *freshly fetched*
+    //    vault rather than a caller-cached id that could be stale — so
+    //    monitoring lands on the same vault we just built the escrow set
+    //    against. No descriptor — under ECIES the server stores none. Keep the
+    //    existing download policy if the caller set one (None lets the server
+    //    default).
     let status = client
         .set_vault_monitoring(
-            vault_id,
+            vault.id,
             SetVaultMonitoringRequest {
                 level: VaultMonitoringLevel::Heartbeat,
                 descriptor: None,
@@ -98,15 +112,23 @@ pub async fn enroll_escrow(
     Ok(status)
 }
 
-/// Turns inheritance escrow off: true-delete the stored envelope set and the
-/// monitoring record. Idempotent (both deletes treat 404 as success).
+/// Turns inheritance escrow off: true-delete the monitoring record and the
+/// stored envelope set. Idempotent (both deletes treat 404 as success).
+///
+/// Order mirrors `enroll_escrow` in reverse to preserve its invariant — escrow
+/// is uploaded before monitoring is switched on, so "monitoring on" always
+/// implies "ciphertext present." Tearing down, we therefore switch monitoring
+/// **off first**, then delete the escrow set. If the second call fails the Vault
+/// is left un-monitored with a harmless leftover (opaque, server-blind)
+/// envelope set that a retry removes — never the inverse, a monitored Vault with
+/// no ciphertext, where a recovery window could open with nothing for heirs.
 pub async fn disable_escrow(
     client: &CoincubeClient,
     server_cube_id: u64,
     vault_id: u64,
 ) -> Result<VaultMonitoringStatus, OwnerEscrowError> {
-    client.delete_vault_escrow(server_cube_id).await?;
     client.delete_vault_monitoring(vault_id).await?;
+    client.delete_vault_escrow(server_cube_id).await?;
     Ok(VaultMonitoringStatus {
         level: VaultMonitoringLevel::Off,
         ..VaultMonitoringStatus::default()
@@ -137,7 +159,8 @@ mod tests {
 
         // get_connect_vault → one keyholder with a key.
         let vault_mock = server.mock(|when, then| {
-            when.method(Method::GET).path("/api/v1/connect/cubes/42/vault");
+            when.method(Method::GET)
+                .path("/api/v1/connect/cubes/42/vault");
             then.status(200).json_body(json!({
                 "success": true,
                 "data": {
@@ -185,7 +208,7 @@ mod tests {
         });
 
         let client = CoincubeClient::for_test(server.base_url());
-        let status = enroll_escrow(&client, 42, 9, b"wsh(desc)#ck".to_vec(), None)
+        let status = enroll_escrow(&client, 42, b"wsh(desc)#ck".to_vec(), None)
             .await
             .expect("enroll should succeed");
 
@@ -201,12 +224,14 @@ mod tests {
         let escrow_del = server.mock(|when, then| {
             when.method(Method::DELETE)
                 .path("/api/v1/connect/cubes/42/vault/escrow");
-            then.status(200).json_body(json!({ "success": true, "data": {} }));
+            then.status(200)
+                .json_body(json!({ "success": true, "data": {} }));
         });
         let monitoring_del = server.mock(|when, then| {
             when.method(Method::DELETE)
                 .path("/api/v1/connect/vaults/9/monitoring");
-            then.status(200).json_body(json!({ "success": true, "data": {} }));
+            then.status(200)
+                .json_body(json!({ "success": true, "data": {} }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -217,10 +242,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn disable_removes_monitoring_before_escrow() {
+        // Safety ordering: monitoring is switched off first. If that fails we
+        // must bail *before* deleting the escrow set, so a partial failure never
+        // leaves a monitored Vault with no ciphertext (a recovery window could
+        // open with nothing for heirs). The escrow DELETE mock is registered but
+        // must NOT be hit.
+        let server = MockServer::start();
+        let monitoring_del = server.mock(|when, then| {
+            when.method(Method::DELETE)
+                .path("/api/v1/connect/vaults/9/monitoring");
+            then.status(500).json_body(json!({ "success": false }));
+        });
+        let escrow_del = server.mock(|when, then| {
+            when.method(Method::DELETE)
+                .path("/api/v1/connect/cubes/42/vault/escrow");
+            then.status(200)
+                .json_body(json!({ "success": true, "data": {} }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = disable_escrow(&client, 42, 9)
+            .await
+            .expect_err("monitoring delete failure should propagate");
+        assert!(matches!(err, OwnerEscrowError::Connect(_)));
+        monitoring_del.assert();
+        // Escrow set is left intact (opaque, server-blind) for a retry to clear.
+        escrow_del.assert_hits(0);
+    }
+
+    #[tokio::test]
     async fn enroll_with_no_keyholders_errors_before_upload() {
         let server = MockServer::start();
         let vault_mock = server.mock(|when, then| {
-            when.method(Method::GET).path("/api/v1/connect/cubes/42/vault");
+            when.method(Method::GET)
+                .path("/api/v1/connect/cubes/42/vault");
             then.status(200).json_body(json!({
                 "success": true,
                 "data": {
@@ -235,7 +291,7 @@ mod tests {
         });
         // No escrow PUT mock — it must NOT be called.
         let client = CoincubeClient::for_test(server.base_url());
-        let err = enroll_escrow(&client, 42, 9, b"d".to_vec(), None)
+        let err = enroll_escrow(&client, 42, b"d".to_vec(), None)
             .await
             .expect_err("no keyholders should error");
         vault_mock.assert();

--- a/coincube-gui/src/services/inheritance/owner.rs
+++ b/coincube-gui/src/services/inheritance/owner.rs
@@ -14,8 +14,8 @@ use zeroize::Zeroizing;
 
 use super::escrow::{build_escrow_set, keyholders_from_vault, EscrowError};
 use crate::services::coincube::{
-    CoincubeClient, CoincubeError, SetVaultMonitoringRequest, VaultMonitoringLevel,
-    VaultMonitoringStatus,
+    CoincubeClient, CoincubeError, KeyholderDownloadPolicy, SetVaultMonitoringRequest,
+    VaultMonitoringLevel, VaultMonitoringStatus,
 };
 
 /// Errors from the owner escrow orchestration.
@@ -75,6 +75,7 @@ pub async fn enroll_escrow(
     server_cube_id: u64,
     descriptor_json: Vec<u8>,
     seed_json: Option<Zeroizing<Vec<u8>>>,
+    download_policy: KeyholderDownloadPolicy,
 ) -> Result<VaultMonitoringStatus, OwnerEscrowError> {
     // 1. Resolve the current keyholders + xpubs, then build the envelope set
     //    locally (the server never sees plaintext). The `Zeroizing` seed buffer
@@ -95,9 +96,11 @@ pub async fn enroll_escrow(
     // 3. Switch the server-blind heartbeat gate on, on the *freshly fetched*
     //    vault rather than a caller-cached id that could be stale — so
     //    monitoring lands on the same vault we just built the escrow set
-    //    against. No descriptor — under ECIES the server stores none. Keep the
-    //    existing download policy if the caller set one (None lets the server
-    //    default).
+    //    against. No descriptor — under ECIES the server stores none.
+    //    `download_policy` is the vault's *current* keyholder download policy,
+    //    forwarded explicitly so a re-enrol / tier switch (Vault-only ↔
+    //    Full-Cube) preserves the owner's choice instead of letting an omitted
+    //    field reset it to the server default.
     let status = client
         .set_vault_monitoring(
             vault.id,
@@ -105,7 +108,7 @@ pub async fn enroll_escrow(
                 level: VaultMonitoringLevel::Heartbeat,
                 descriptor: None,
                 gap_limit: None,
-                crk_keyholder_download: None,
+                crk_keyholder_download: Some(download_policy),
             },
         )
         .await?;
@@ -122,12 +125,27 @@ pub async fn enroll_escrow(
 /// is left un-monitored with a harmless leftover (opaque, server-blind)
 /// envelope set that a retry removes — never the inverse, a monitored Vault with
 /// no ciphertext, where a recovery window could open with nothing for heirs.
+///
+/// Monitoring is **vault-scoped** and escrow is **cube-scoped** — two different
+/// resources keyed on two different ids (not the same vault in two forms). The
+/// monitoring delete resolves the *current* vault id from the server rather than
+/// trusting the caller's cached `vault_id`: if the vault was rebuilt with a new
+/// id, a stale cached id would 404 (no-op) and leave the live vault monitored
+/// after escrow is gone — the dangerous state above. Best-effort: if the lookup
+/// fails (vault gone / offline) we fall back to the caller's id, and we always
+/// attempt the cube-scoped escrow delete so it's never stranded.
 pub async fn disable_escrow(
     client: &CoincubeClient,
     server_cube_id: u64,
     vault_id: u64,
 ) -> Result<VaultMonitoringStatus, OwnerEscrowError> {
-    client.delete_vault_monitoring(vault_id).await?;
+    let monitoring_vault_id = client
+        .get_connect_vault(server_cube_id)
+        .await
+        .ok()
+        .map(|v| v.id)
+        .unwrap_or(vault_id);
+    client.delete_vault_monitoring(monitoring_vault_id).await?;
     client.delete_vault_escrow(server_cube_id).await?;
     Ok(VaultMonitoringStatus {
         level: VaultMonitoringLevel::Off,
@@ -200,7 +218,11 @@ mod tests {
         let monitoring_mock = server.mock(|when, then| {
             when.method(Method::POST)
                 .path("/api/v1/connect/vaults/9/monitoring")
-                .json_body_partial(r#"{ "level": "heartbeat" }"#);
+                // The current download policy must be forwarded (camelCase
+                // field, snake_case value) so a re-enrol doesn't reset it.
+                .json_body_partial(
+                    r#"{ "level": "heartbeat", "crkKeyholderDownload": "anytime" }"#,
+                );
             then.status(200).json_body(json!({
                 "success": true,
                 "data": { "level": "heartbeat" }
@@ -208,9 +230,15 @@ mod tests {
         });
 
         let client = CoincubeClient::for_test(server.base_url());
-        let status = enroll_escrow(&client, 42, b"wsh(desc)#ck".to_vec(), None)
-            .await
-            .expect("enroll should succeed");
+        let status = enroll_escrow(
+            &client,
+            42,
+            b"wsh(desc)#ck".to_vec(),
+            None,
+            KeyholderDownloadPolicy::Anytime,
+        )
+        .await
+        .expect("enroll should succeed");
 
         vault_mock.assert();
         escrow_mock.assert();
@@ -272,6 +300,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn disable_resolves_fresh_vault_id_for_monitoring() {
+        // The server's current vault id (99) differs from the caller's stale
+        // cached id (9). Monitoring (vault-scoped) must be deleted on the FRESH
+        // id, not the stale one — otherwise a rebuilt vault stays monitored
+        // after escrow is gone. Escrow stays cube-scoped (42).
+        let server = MockServer::start();
+        let vault_mock = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/api/v1/connect/cubes/42/vault");
+            then.status(200).json_body(json!({
+                "success": true,
+                "data": {
+                    "id": 99,
+                    "cubeId": 42,
+                    "timelockDays": 365,
+                    "timelockExpiresAt": "2027-06-22T00:00:00Z",
+                    "lastResetAt": "2026-06-22T00:00:00Z",
+                    "status": "active",
+                    "members": [],
+                    "createdAt": "2026-06-22T00:00:00Z",
+                    "updatedAt": "2026-06-22T00:00:00Z"
+                }
+            }));
+        });
+        // Monitoring on the FRESH id 99 (a /9 delete would be the stale bug).
+        let monitoring_del = server.mock(|when, then| {
+            when.method(Method::DELETE)
+                .path("/api/v1/connect/vaults/99/monitoring");
+            then.status(200)
+                .json_body(json!({ "success": true, "data": {} }));
+        });
+        let escrow_del = server.mock(|when, then| {
+            when.method(Method::DELETE)
+                .path("/api/v1/connect/cubes/42/vault/escrow");
+            then.status(200)
+                .json_body(json!({ "success": true, "data": {} }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let status = disable_escrow(&client, 42, 9).await.expect("disable ok");
+        vault_mock.assert();
+        monitoring_del.assert(); // hit on /99, not the stale /9
+        escrow_del.assert();
+        assert_eq!(status.level, VaultMonitoringLevel::Off);
+    }
+
+    #[tokio::test]
     async fn enroll_with_no_keyholders_errors_before_upload() {
         let server = MockServer::start();
         let vault_mock = server.mock(|when, then| {
@@ -291,9 +366,15 @@ mod tests {
         });
         // No escrow PUT mock — it must NOT be called.
         let client = CoincubeClient::for_test(server.base_url());
-        let err = enroll_escrow(&client, 42, b"d".to_vec(), None)
-            .await
-            .expect_err("no keyholders should error");
+        let err = enroll_escrow(
+            &client,
+            42,
+            b"d".to_vec(),
+            None,
+            KeyholderDownloadPolicy::AtApproaching,
+        )
+        .await
+        .expect_err("no keyholders should error");
         vault_mock.assert();
         assert!(matches!(
             err,

--- a/coincube-gui/src/services/inheritance/owner.rs
+++ b/coincube-gui/src/services/inheritance/owner.rs
@@ -1,0 +1,247 @@
+//! Owner-side escrow orchestration (ECIES pivot PR 2).
+//!
+//! Glue between the Recovery-Alerts settings card and the Connect client: turn
+//! escrow on (build the per-keyholder envelope set, upload it, and switch the
+//! server-blind heartbeat gate on) or off (true-delete the set and the
+//! monitoring record). The card supplies the already-built blob JSON so this
+//! layer is network-only.
+//!
+//! The escrow set is keyed on the **cube** id (`PUT …/cubes/{cubeId}/vault/
+//! escrow`); the heartbeat gate is keyed on the **vault** id
+//! (`…/vaults/{vaultId}/monitoring`).
+
+use super::escrow::{build_escrow_set, keyholders_from_vault, EscrowError};
+use crate::services::coincube::{
+    CoincubeClient, CoincubeError, SetVaultMonitoringRequest, VaultMonitoringLevel,
+    VaultMonitoringStatus,
+};
+
+/// Errors from the owner escrow orchestration.
+#[derive(Debug)]
+pub enum OwnerEscrowError {
+    /// Building the envelope set failed (no keyholders, bad xpub, seal error).
+    Escrow(EscrowError),
+    /// A Connect call failed (fetch vault / upload / monitoring).
+    Connect(CoincubeError),
+}
+
+impl std::fmt::Display for OwnerEscrowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Escrow(e) => write!(f, "{}", e),
+            Self::Connect(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for OwnerEscrowError {}
+
+impl From<EscrowError> for OwnerEscrowError {
+    fn from(e: EscrowError) -> Self {
+        Self::Escrow(e)
+    }
+}
+
+impl From<CoincubeError> for OwnerEscrowError {
+    fn from(e: CoincubeError) -> Self {
+        Self::Connect(e)
+    }
+}
+
+/// Turns inheritance escrow on for a Vault. Fetches the current keyholder set,
+/// seals the descriptor (always) and the seed (`seed_json.is_some()` for the
+/// Full-Cube tier) to each keyholder's xpub, uploads the whole set, then
+/// switches the server-blind heartbeat gate on. Returns the new monitoring
+/// status.
+///
+/// Idempotent: the server replaces the stored set, so re-running on a keyholder
+/// change is safe. No plaintext descriptor or seed ever reaches the server.
+///
+/// **Re-encryption on keyholder change** is this same call. It is *not*
+/// auto-fired from the membership-change paths because the Full-Cube tier
+/// re-seals the seed, which requires unlocking it behind the owner's PIN — a
+/// silent re-encrypt could only refresh the descriptor and would leave a newly
+/// added Full-Cube keyholder with a descriptor-only (silently degraded)
+/// envelope. Instead the owner re-confirms the tier in the Recovery-Alerts card
+/// (one tap for Vault-only; PIN re-entry for Full-Cube), which re-runs this over
+/// the current keyholder set.
+pub async fn enroll_escrow(
+    client: &CoincubeClient,
+    server_cube_id: u64,
+    vault_id: u64,
+    descriptor_json: Vec<u8>,
+    seed_json: Option<Vec<u8>>,
+) -> Result<VaultMonitoringStatus, OwnerEscrowError> {
+    // 1. Resolve the current keyholders + xpubs, then build the envelope set
+    //    locally (the server never sees plaintext).
+    let vault = client.get_connect_vault(server_cube_id).await?;
+    let keyholders = keyholders_from_vault(&vault)?;
+    let set = build_escrow_set(&keyholders, &descriptor_json, seed_json.as_deref())?;
+
+    // 2. Upload the opaque ciphertext set (cube-scoped).
+    client.put_vault_escrow(server_cube_id, set).await?;
+
+    // 3. Switch the server-blind heartbeat gate on (vault-scoped). No
+    //    descriptor — under ECIES the server stores none. Keep the existing
+    //    download policy if the caller set one (None lets the server default).
+    let status = client
+        .set_vault_monitoring(
+            vault_id,
+            SetVaultMonitoringRequest {
+                level: VaultMonitoringLevel::Heartbeat,
+                descriptor: None,
+                gap_limit: None,
+                crk_keyholder_download: None,
+            },
+        )
+        .await?;
+    Ok(status)
+}
+
+/// Turns inheritance escrow off: true-delete the stored envelope set and the
+/// monitoring record. Idempotent (both deletes treat 404 as success).
+pub async fn disable_escrow(
+    client: &CoincubeClient,
+    server_cube_id: u64,
+    vault_id: u64,
+) -> Result<VaultMonitoringStatus, OwnerEscrowError> {
+    client.delete_vault_escrow(server_cube_id).await?;
+    client.delete_vault_monitoring(vault_id).await?;
+    Ok(VaultMonitoringStatus {
+        level: VaultMonitoringLevel::Off,
+        ..VaultMonitoringStatus::default()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coincube_core::miniscript::bitcoin::bip32::{DerivationPath, Xpriv, Xpub};
+    use coincube_core::miniscript::bitcoin::secp256k1::Secp256k1;
+    use coincube_core::miniscript::bitcoin::Network;
+    use httpmock::{Method, MockServer};
+    use serde_json::json;
+    use std::str::FromStr;
+
+    fn test_xpub(seed: &[u8]) -> Xpub {
+        let secp = Secp256k1::new();
+        let master = Xpriv::new_master(Network::Bitcoin, seed).unwrap();
+        let path = DerivationPath::from_str("m/48'/0'/0'/2'").unwrap();
+        Xpub::from_priv(&secp, &master.derive_priv(&secp, &path).unwrap())
+    }
+
+    #[tokio::test]
+    async fn enroll_vault_only_uploads_descriptor_set_and_enables_heartbeat() {
+        let xpub = test_xpub(b"owner-enroll-keyholder-seed-vector-00000000");
+        let server = MockServer::start();
+
+        // get_connect_vault → one keyholder with a key.
+        let vault_mock = server.mock(|when, then| {
+            when.method(Method::GET).path("/api/v1/connect/cubes/42/vault");
+            then.status(200).json_body(json!({
+                "success": true,
+                "data": {
+                    "id": 9,
+                    "cubeId": 42,
+                    "timelockDays": 365,
+                    "timelockExpiresAt": "2027-06-22T00:00:00Z",
+                    "lastResetAt": "2026-06-22T00:00:00Z",
+                    "status": "active",
+                    "members": [{
+                        "id": 1,
+                        "keyId": 10,
+                        "role": "keyholder",
+                        "key": {
+                            "id": 10,
+                            "name": "Heir",
+                            "xpub": xpub.to_string(),
+                            "derivationPath": "m/48'/0'/0'/2'"
+                        },
+                        "createdAt": "2026-06-22T00:00:00Z"
+                    }],
+                    "createdAt": "2026-06-22T00:00:00Z",
+                    "updatedAt": "2026-06-22T00:00:00Z"
+                }
+            }));
+        });
+
+        // PUT escrow — assert it carries exactly one (descriptor) envelope.
+        let escrow_mock = server.mock(|when, then| {
+            when.method(Method::PUT)
+                .path("/api/v1/connect/cubes/42/vault/escrow")
+                .json_body_partial(r#"{ "envelopes": [ { "artifactKind": "descriptor", "keyholderKeyId": 10 } ] }"#);
+            then.status(200).json_body(json!({ "success": true, "data": {} }));
+        });
+
+        // set monitoring → heartbeat, no descriptor.
+        let monitoring_mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/vaults/9/monitoring")
+                .json_body_partial(r#"{ "level": "heartbeat" }"#);
+            then.status(200).json_body(json!({
+                "success": true,
+                "data": { "level": "heartbeat" }
+            }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let status = enroll_escrow(&client, 42, 9, b"wsh(desc)#ck".to_vec(), None)
+            .await
+            .expect("enroll should succeed");
+
+        vault_mock.assert();
+        escrow_mock.assert();
+        monitoring_mock.assert();
+        assert_eq!(status.level, VaultMonitoringLevel::Heartbeat);
+    }
+
+    #[tokio::test]
+    async fn disable_deletes_escrow_and_monitoring() {
+        let server = MockServer::start();
+        let escrow_del = server.mock(|when, then| {
+            when.method(Method::DELETE)
+                .path("/api/v1/connect/cubes/42/vault/escrow");
+            then.status(200).json_body(json!({ "success": true, "data": {} }));
+        });
+        let monitoring_del = server.mock(|when, then| {
+            when.method(Method::DELETE)
+                .path("/api/v1/connect/vaults/9/monitoring");
+            then.status(200).json_body(json!({ "success": true, "data": {} }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let status = disable_escrow(&client, 42, 9).await.expect("disable ok");
+        escrow_del.assert();
+        monitoring_del.assert();
+        assert_eq!(status.level, VaultMonitoringLevel::Off);
+    }
+
+    #[tokio::test]
+    async fn enroll_with_no_keyholders_errors_before_upload() {
+        let server = MockServer::start();
+        let vault_mock = server.mock(|when, then| {
+            when.method(Method::GET).path("/api/v1/connect/cubes/42/vault");
+            then.status(200).json_body(json!({
+                "success": true,
+                "data": {
+                    "id": 9, "cubeId": 42, "timelockDays": 365,
+                    "timelockExpiresAt": "2027-06-22T00:00:00Z",
+                    "lastResetAt": "2026-06-22T00:00:00Z", "status": "active",
+                    "members": [],
+                    "createdAt": "2026-06-22T00:00:00Z",
+                    "updatedAt": "2026-06-22T00:00:00Z"
+                }
+            }));
+        });
+        // No escrow PUT mock — it must NOT be called.
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = enroll_escrow(&client, 42, 9, b"d".to_vec(), None)
+            .await
+            .expect_err("no keyholders should error");
+        vault_mock.assert();
+        assert!(matches!(
+            err,
+            OwnerEscrowError::Escrow(EscrowError::NoKeyholders)
+        ));
+    }
+}

--- a/coincube-gui/src/services/inheritance/wire.rs
+++ b/coincube-gui/src/services/inheritance/wire.rs
@@ -1,43 +1,45 @@
-//! Conversion between the in-memory [`Envelope`] and the base64 JSON wire DTO
+//! Conversion between the in-memory [`Envelope`] and the **hex** JSON wire DTO
 //! [`InheritanceEnvelopeWire`] that the Connect client uploads / downloads.
 //!
-//! Kept here (next to the crypto) rather than in `services::coincube` so the
-//! byte<->base64 boundary lives with the type that understands the bytes. The
-//! Connect DTO stays a plain serde struct.
-
-use base64::Engine;
+//! The byte fields (`ephemeralPubkey`, `nonce`, `ciphertext`) are **lowercase
+//! hex** per `SPEC-ecies-v1.md` §5 — `coincube-api` `hex.DecodeString`s them on
+//! `PUT …/vault/escrow` and `hex.EncodeToString`s them on
+//! `GET …/vault/recovery-envelope`, so the desktop MUST match (base64 here
+//! silently breaks *both* directions: the API rejects the upload, and the heir
+//! mis-decodes the release). The gRPC `wrapped_shared_key` is raw `bytes` and is
+//! unaffected — only this REST envelope JSON is hex-encoded.
+//!
+//! Kept next to the crypto so the byte<->hex boundary lives with the type that
+//! understands the bytes; the Connect DTO stays a plain serde struct.
 
 use super::ecies::{ArtifactKind, Envelope};
 use super::error::EciesError;
 use crate::services::coincube::InheritanceEnvelopeWire;
 
-fn b64(bytes: &[u8]) -> String {
-    base64::engine::general_purpose::STANDARD.encode(bytes)
-}
-
-fn unb64(s: &str, field: &'static str) -> Result<Vec<u8>, EciesError> {
-    base64::engine::general_purpose::STANDARD
-        .decode(s)
-        .map_err(|_| EciesError::MalformedEnvelope(field))
+/// Hex-decode a wire field, mapping any malformed input to a fail-closed
+/// [`EciesError::MalformedEnvelope`].
+fn hex_decode(s: &str, field: &'static str) -> Result<Vec<u8>, EciesError> {
+    hex::decode(s).map_err(|_| EciesError::MalformedEnvelope(field))
 }
 
 /// Serialises a sealed envelope to the wire DTO for upload, tagging it with the
 /// recipient keyholder's `models.Key` id so the server can validate membership.
+/// Byte fields are lowercase hex (SPEC §5), matching `coincube-api`.
 pub fn envelope_to_wire(env: &Envelope, keyholder_key_id: u64) -> InheritanceEnvelopeWire {
     InheritanceEnvelopeWire {
         keyholder_key_id: Some(keyholder_key_id),
         artifact_kind: env.artifact_kind.as_wire().to_string(),
         scheme: env.scheme.clone(),
-        ephemeral_pubkey: b64(&env.ephemeral_pubkey),
-        ciphertext: b64(&env.ciphertext),
-        nonce: b64(&env.nonce),
+        ephemeral_pubkey: hex::encode(&env.ephemeral_pubkey),
+        ciphertext: hex::encode(&env.ciphertext),
+        nonce: hex::encode(&env.nonce),
         derivation: env.derivation.clone(),
     }
 }
 
-/// Parses a released wire DTO back into an [`Envelope`]. base64-decodes the
-/// byte fields and validates the `artifactKind`; a bad kind or non-base64 field
-/// is a malformed envelope (fail-closed). The `scheme` is carried through
+/// Parses a released wire DTO back into an [`Envelope`]. Hex-decodes the byte
+/// fields (SPEC §5) and validates the `artifactKind`; a bad kind or non-hex
+/// field is a malformed envelope (fail-closed). The `scheme` is carried through
 /// verbatim — [`super::open_with_shared_key`] rejects an unsupported one.
 pub fn wire_to_envelope(w: &InheritanceEnvelopeWire) -> Result<Envelope, EciesError> {
     let artifact_kind = ArtifactKind::from_wire(&w.artifact_kind)
@@ -45,9 +47,9 @@ pub fn wire_to_envelope(w: &InheritanceEnvelopeWire) -> Result<Envelope, EciesEr
     Ok(Envelope {
         artifact_kind,
         scheme: w.scheme.clone(),
-        ephemeral_pubkey: unb64(&w.ephemeral_pubkey, "ephemeral_pubkey")?,
-        ciphertext: unb64(&w.ciphertext, "ciphertext")?,
-        nonce: unb64(&w.nonce, "nonce")?,
+        ephemeral_pubkey: hex_decode(&w.ephemeral_pubkey, "ephemeral_pubkey")?,
+        ciphertext: hex_decode(&w.ciphertext, "ciphertext")?,
+        nonce: hex_decode(&w.nonce, "nonce")?,
         derivation: w.derivation.clone(),
     })
 }
@@ -64,7 +66,7 @@ mod tests {
             ephemeral_pubkey: vec![0x02; 33],
             ciphertext: vec![0xAB; 48],
             nonce: vec![0x11; 12],
-            derivation: "9/0".to_string(),
+            derivation: "m/48h/1h/0h/2h/7000".to_string(),
         }
     }
 
@@ -84,6 +86,39 @@ mod tests {
         assert_eq!(back.derivation, env.derivation);
     }
 
+    // SPEC-ecies-v1 §5/§7.1: byte fields are **lowercase hex**. Pinning the
+    // exact strings for the §7.1 known-answer bytes locks the desktop wire
+    // encoding to the same strings `coincube-api` produces/consumes — the
+    // cross-repo boundary the earlier base64 self-round-trip test never crossed.
+    // These bytes are the §7.1 vector shared by `ecies.rs`, `SPEC-ecies-v1.md`,
+    // and the API's KAT.
+    const KAT_E_HEX: &str = "034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa";
+    const KAT_NONCE_HEX: &str = "0000000000000000deadbeef";
+    const KAT_CT_HEX: &str = "2e283e30ebac64ec0741b8f0281b3ae458196e5563bf95ac308414d1a457e261c15b99ed0606c4ccd7d44645c52ad3874cf6030efacb5891b7df4c98d426e7cda4ee173ecb5334bd8bae6dea9f2428a5d8920f5b4c8779db83baf40e8ad890ca7465a4964f6ed2d4fc";
+
+    #[test]
+    fn wire_encodes_bytes_as_lowercase_hex_spec_v1() {
+        let env = Envelope {
+            artifact_kind: ArtifactKind::Descriptor,
+            scheme: SCHEME.to_string(),
+            ephemeral_pubkey: hex::decode(KAT_E_HEX).unwrap(),
+            ciphertext: hex::decode(KAT_CT_HEX).unwrap(),
+            nonce: hex::decode(KAT_NONCE_HEX).unwrap(),
+            derivation: "m/48h/1h/0h/2h/7000".to_string(),
+        };
+        let wire = envelope_to_wire(&env, 7);
+        // Exact lowercase-hex strings — must match coincube-api byte-for-byte.
+        assert_eq!(wire.ephemeral_pubkey, KAT_E_HEX);
+        assert_eq!(wire.nonce, KAT_NONCE_HEX);
+        assert_eq!(wire.ciphertext, KAT_CT_HEX);
+
+        // And hex round-trips back to the exact bytes.
+        let back = wire_to_envelope(&wire).unwrap();
+        assert_eq!(back.ephemeral_pubkey, env.ephemeral_pubkey);
+        assert_eq!(back.ciphertext, env.ciphertext);
+        assert_eq!(back.nonce, env.nonce);
+    }
+
     #[test]
     fn unknown_artifact_kind_is_malformed() {
         let mut wire = envelope_to_wire(&sample_envelope(), 1);
@@ -95,9 +130,9 @@ mod tests {
     }
 
     #[test]
-    fn non_base64_ciphertext_is_malformed() {
+    fn non_hex_ciphertext_is_malformed() {
         let mut wire = envelope_to_wire(&sample_envelope(), 1);
-        wire.ciphertext = "not base64 !!!".to_string();
+        wire.ciphertext = "not hex zz".to_string();
         assert!(matches!(
             wire_to_envelope(&wire),
             Err(EciesError::MalformedEnvelope("ciphertext"))

--- a/coincube-gui/src/services/inheritance/wire.rs
+++ b/coincube-gui/src/services/inheritance/wire.rs
@@ -1,0 +1,106 @@
+//! Conversion between the in-memory [`Envelope`] and the base64 JSON wire DTO
+//! [`InheritanceEnvelopeWire`] that the Connect client uploads / downloads.
+//!
+//! Kept here (next to the crypto) rather than in `services::coincube` so the
+//! byte<->base64 boundary lives with the type that understands the bytes. The
+//! Connect DTO stays a plain serde struct.
+
+use base64::Engine;
+
+use super::ecies::{ArtifactKind, Envelope};
+use super::error::EciesError;
+use crate::services::coincube::InheritanceEnvelopeWire;
+
+fn b64(bytes: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+fn unb64(s: &str, field: &'static str) -> Result<Vec<u8>, EciesError> {
+    base64::engine::general_purpose::STANDARD
+        .decode(s)
+        .map_err(|_| EciesError::MalformedEnvelope(field))
+}
+
+/// Serialises a sealed envelope to the wire DTO for upload, tagging it with the
+/// recipient keyholder's `models.Key` id so the server can validate membership.
+pub fn envelope_to_wire(env: &Envelope, keyholder_key_id: u64) -> InheritanceEnvelopeWire {
+    InheritanceEnvelopeWire {
+        keyholder_key_id: Some(keyholder_key_id),
+        artifact_kind: env.artifact_kind.as_wire().to_string(),
+        scheme: env.scheme.clone(),
+        ephemeral_pubkey: b64(&env.ephemeral_pubkey),
+        ciphertext: b64(&env.ciphertext),
+        nonce: b64(&env.nonce),
+        derivation: env.derivation.clone(),
+    }
+}
+
+/// Parses a released wire DTO back into an [`Envelope`]. base64-decodes the
+/// byte fields and validates the `artifactKind`; a bad kind or non-base64 field
+/// is a malformed envelope (fail-closed). The `scheme` is carried through
+/// verbatim — [`super::open_with_shared_key`] rejects an unsupported one.
+pub fn wire_to_envelope(w: &InheritanceEnvelopeWire) -> Result<Envelope, EciesError> {
+    let artifact_kind = ArtifactKind::from_wire(&w.artifact_kind)
+        .ok_or(EciesError::MalformedEnvelope("artifact_kind"))?;
+    Ok(Envelope {
+        artifact_kind,
+        scheme: w.scheme.clone(),
+        ephemeral_pubkey: unb64(&w.ephemeral_pubkey, "ephemeral_pubkey")?,
+        ciphertext: unb64(&w.ciphertext, "ciphertext")?,
+        nonce: unb64(&w.nonce, "nonce")?,
+        derivation: w.derivation.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::inheritance::ecies::SCHEME;
+
+    fn sample_envelope() -> Envelope {
+        Envelope {
+            artifact_kind: ArtifactKind::Seed,
+            scheme: SCHEME.to_string(),
+            ephemeral_pubkey: vec![0x02; 33],
+            ciphertext: vec![0xAB; 48],
+            nonce: vec![0x11; 12],
+            derivation: "9/0".to_string(),
+        }
+    }
+
+    #[test]
+    fn wire_roundtrip_preserves_all_fields() {
+        let env = sample_envelope();
+        let wire = envelope_to_wire(&env, 77);
+        assert_eq!(wire.keyholder_key_id, Some(77));
+        assert_eq!(wire.artifact_kind, "seed");
+
+        let back = wire_to_envelope(&wire).unwrap();
+        assert_eq!(back.artifact_kind, env.artifact_kind);
+        assert_eq!(back.scheme, env.scheme);
+        assert_eq!(back.ephemeral_pubkey, env.ephemeral_pubkey);
+        assert_eq!(back.ciphertext, env.ciphertext);
+        assert_eq!(back.nonce, env.nonce);
+        assert_eq!(back.derivation, env.derivation);
+    }
+
+    #[test]
+    fn unknown_artifact_kind_is_malformed() {
+        let mut wire = envelope_to_wire(&sample_envelope(), 1);
+        wire.artifact_kind = "private_key".to_string();
+        assert!(matches!(
+            wire_to_envelope(&wire),
+            Err(EciesError::MalformedEnvelope("artifact_kind"))
+        ));
+    }
+
+    #[test]
+    fn non_base64_ciphertext_is_malformed() {
+        let mut wire = envelope_to_wire(&sample_envelope(), 1);
+        wire.ciphertext = "not base64 !!!".to_string();
+        assert!(matches!(
+            wire_to_envelope(&wire),
+            Err(EciesError::MalformedEnvelope("ciphertext"))
+        ));
+    }
+}

--- a/coincube-gui/src/services/mod.rs
+++ b/coincube-gui/src/services/mod.rs
@@ -7,6 +7,7 @@ pub mod keys;
 
 pub mod coincube;
 pub mod duress;
+pub mod inheritance;
 pub mod mavapay;
 pub mod meld;
 pub mod passkey;

--- a/coincube-gui/src/services/recovery/keyholder.rs
+++ b/coincube-gui/src/services/recovery/keyholder.rs
@@ -248,7 +248,7 @@ mod integration_tests {
     //! End-to-end against a mocked Connect API, exercising the client's URL +
     //! status handling together with this module's gate mapping.
     use super::*;
-    use crate::services::coincube::{RecoveryState, VaultMonitoringLevel};
+    use crate::services::coincube::RecoveryState;
     use httpmock::{Method as MockMethod, MockServer};
     use serde_json::json;
 
@@ -371,35 +371,31 @@ mod integration_tests {
                     "data": [
                         {
                             "cubeId": 7,
-                            "ownerLabel": "Dad's Vault",
+                            "ownerLabel": "Dad's Cube",
                             "role": "keyholder",
-                            "monitoringLevel": "full",
                             "state": "available",
-                            "requiresRecoveryPassword": false
+                            "availableTiers": ["descriptor", "seed"]
                         },
                         {
                             "cubeId": 8,
                             "ownerLabel": "Mum's Vault",
                             "role": "keyholder",
-                            "monitoringLevel": "heartbeat",
                             "state": "approaching",
-                            "requiresRecoveryPassword": true
+                            "availableTiers": ["descriptor"]
                         },
                         {
                             "cubeId": 9,
-                            "ownerLabel": "Open but pw-gated",
+                            "ownerLabel": "Open, keyholder, nothing escrowed for me",
                             "role": "keyholder",
-                            "monitoringLevel": "heartbeat",
                             "state": "reminding",
-                            "requiresRecoveryPassword": true
+                            "availableTiers": []
                         },
                         {
                             "cubeId": 10,
                             "ownerLabel": "Open but beneficiary",
                             "role": "beneficiary",
-                            "monitoringLevel": "full",
                             "state": "available",
-                            "requiresRecoveryPassword": false
+                            "availableTiers": []
                         }
                     ],
                     "error": null
@@ -414,26 +410,26 @@ mod integration_tests {
         mock.assert();
         assert_eq!(rows.len(), 4);
 
-        // Row 0: Full + available + keyholder → open + actionable now.
+        // Row 0: Full-Cube escrow + available + keyholder → actionable now.
         assert_eq!(rows[0].cube_id, 7);
-        assert_eq!(rows[0].monitoring_level, VaultMonitoringLevel::Full);
         assert_eq!(rows[0].recovery_state(), RecoveryState::Open);
         assert!(rows[0].is_keyholder());
+        assert!(rows[0].is_full_cube());
         assert!(rows[0].is_recoverable_now());
 
-        // Row 1: Heartbeat + approaching → not open, not actionable.
+        // Row 1: Vault-only escrow but approaching → not open, not actionable.
         assert_eq!(rows[1].recovery_state(), RecoveryState::Approaching);
+        assert!(rows[1].has_descriptor_tier());
         assert!(!rows[1].is_recoverable_now());
-        assert!(rows[1].requires_recovery_password);
 
-        // Row 2: open (`reminding`) but password-required → NOT actionable in
-        // v1 (deferred to COIN-375), even though the window is open.
+        // Row 2: open (`reminding`) + keyholder, but nothing escrowed for this
+        // caller → NOT actionable (there's nothing they can decrypt).
         assert_eq!(rows[2].recovery_state(), RecoveryState::Open);
+        assert!(!rows[2].has_descriptor_tier());
         assert!(!rows[2].is_recoverable_now());
 
-        // Row 3: Full + available but the caller is a beneficiary → open, yet
-        // NOT actionable: the descriptor pull-down is keyholder-only (the
-        // release endpoint 403s non-keyholders).
+        // Row 3: open but the caller is a beneficiary → NOT actionable: the
+        // release endpoint serves envelopes only to keyholders.
         assert_eq!(rows[3].recovery_state(), RecoveryState::Open);
         assert!(!rows[3].is_keyholder());
         assert!(!rows[3].is_recoverable_now());

--- a/coincube-ui/src/component/badge.rs
+++ b/coincube-ui/src/component/badge.rs
@@ -89,6 +89,13 @@ pub fn spent<'a, T: 'a>() -> Container<'a, T> {
     )
 }
 
+pub fn beta<'a, T: 'a>() -> Container<'a, T> {
+    badge_pill(
+        "  Beta  ",
+        "This feature is in beta — review carefully and expect changes.",
+    )
+}
+
 pub fn badge_pill<'a, T: 'a>(label: &'a str, tooltip: &'a str) -> Container<'a, T> {
     Container::new({
         tooltip::Tooltip::new(

--- a/grpc/connect.proto
+++ b/grpc/connect.proto
@@ -97,6 +97,10 @@ message SigningSession {
   string created_by_device_id = 13;
   string note = 14;
   repeated SubmittedSignature submitted_signatures = 15;
+  // is_recovery_spend records that this session spends the vault's recovery
+  // branch (inheritance recovery). Server-recorded at creation after the
+  // recovery gate passes; lets clients render recovery sessions distinctly.
+  bool is_recovery_spend = 16;
 }
 
 message CreateSigningSessionRequest {
@@ -108,6 +112,12 @@ message CreateSigningSessionRequest {
   string note = 6;
   google.protobuf.Duration ttl = 7;
   bool require_user_presence = 8;
+  // is_recovery_spend declares that this PSBT spends the vault's recovery
+  // branch. The server cannot infer the spent branch from the PSBT, so the
+  // client must declare it; the server then gates creation on the recovery
+  // path being open (keyholder caller + monitoring state available/reminding +
+  // owner not under duress). Ignored (false) for ordinary owner-branch spends.
+  bool is_recovery_spend = 9;
 }
 
 message CreateSigningSessionResponse {
@@ -275,6 +285,38 @@ message Pong {
   int64 ts_unix_ms = 1;
 }
 
+// Inheritance heir-escrow ECIES decrypt (COIN-377, rev 3). The heir's
+// Keychain holds the recovery private key; on recovery it derives the
+// dedicated encryption child, performs the secp256k1 ECDH against the
+// envelope's ephemeral pubkey, HKDFs the shared secret, and returns only the
+// derived symmetric key. The desktop completes the AES-256-GCM open and the
+// restore locally, so the seed/descriptor plaintext never leaves the heir's
+// machine and Keychain never sees it. Requires biometric/PIN approval and is
+// refused while the heir's own account is under duress. The API relays the
+// request to the heir's Keychain and returns its response; it never reads the
+// shared key. See keychain-app/plans/PLAN-inheritance-recovery.md.
+message DecryptInheritanceEnvelopeRequest {
+  // The cube being recovered — selects which recovery key/account the heir's
+  // Keychain derives from.
+  string cube_id = 1;
+  // Compressed 33-byte secp256k1 ephemeral public key from the ECIES envelope.
+  bytes ephemeral_pubkey = 2;
+  // Non-hardened child path (relative to the heir's registered xpub) of the
+  // dedicated encryption key (invariant I5). Keychain derives this child
+  // private key, ECDHs against ephemeral_pubkey, then HKDFs → shared_key.
+  string derivation = 3;
+  // Scheme tag; must equal "ecies-secp256k1-hkdf-aes256gcm-v1" so Keychain can
+  // refuse a scheme it does not implement.
+  string purpose = 4;
+}
+
+message DecryptInheritanceEnvelopeResponse {
+  // 32-byte HKDF-derived symmetric key K. Keychain NEVER returns the recovery
+  // private key or the seed/descriptor plaintext — the desktop opens the
+  // AES-256-GCM ciphertext with this key.
+  bytes shared_key = 1;
+}
+
 service SessionService {
   rpc CreateSigningSession(CreateSigningSessionRequest) returns (CreateSigningSessionResponse);
   rpc GetSigningSession(GetSigningSessionRequest) returns (GetSigningSessionResponse);
@@ -286,6 +328,9 @@ service SessionService {
   rpc RejectSession(RejectSessionRequest) returns (RejectSessionResponse);
   rpc SubmitPartialSignature(SubmitPartialSignatureRequest) returns (SubmitPartialSignatureResponse);
   rpc ResolveSigners(ResolveSignersRequest) returns (ResolveSignersResponse);
+  // Heir-escrow ECIES decrypt — relayed to the heir's Keychain, which approves
+  // (biometric/PIN) and returns the HKDF-derived key. Never returns plaintext.
+  rpc DecryptInheritanceEnvelope(DecryptInheritanceEnvelopeRequest) returns (DecryptInheritanceEnvelopeResponse);
 }
 
 service DeviceService {

--- a/grpc/connect.proto
+++ b/grpc/connect.proto
@@ -206,6 +206,10 @@ message StreamEnvelope {
     Pong pong = 6;
     DuressActivatedEvent duress_activated = 7;
     DuressClearedEvent duress_cleared = 8;
+    // Inheritance decrypt relay (best-effort live push; backed by the
+    // ListPendingDecryptRequests / GetDecryptResult fetches for reliability).
+    DecryptRequestedEvent decrypt_requested = 9; // → heir's Keychain
+    DecryptResultEvent decrypt_result = 10;      // → heir's desktop
   }
 }
 
@@ -285,36 +289,114 @@ message Pong {
   int64 ts_unix_ms = 1;
 }
 
-// Inheritance heir-escrow ECIES decrypt (COIN-377, rev 3). The heir's
-// Keychain holds the recovery private key; on recovery it derives the
-// dedicated encryption child, performs the secp256k1 ECDH against the
-// envelope's ephemeral pubkey, HKDFs the shared secret, and returns only the
-// derived symmetric key. The desktop completes the AES-256-GCM open and the
-// restore locally, so the seed/descriptor plaintext never leaves the heir's
-// machine and Keychain never sees it. Requires biometric/PIN approval and is
-// refused while the heir's own account is under duress. The API relays the
-// request to the heir's Keychain and returns its response; it never reads the
-// shared key. See keychain-app/plans/PLAN-inheritance-recovery.md.
-message DecryptInheritanceEnvelopeRequest {
-  // The cube being recovered — selects which recovery key/account the heir's
-  // Keychain derives from.
-  string cube_id = 1;
-  // Compressed 33-byte secp256k1 ephemeral public key from the ECIES envelope.
-  bytes ephemeral_pubkey = 2;
-  // Non-hardened child path (relative to the heir's registered xpub) of the
-  // dedicated encryption key (invariant I5). Keychain derives this child
-  // private key, ECDHs against ephemeral_pubkey, then HKDFs → shared_key.
-  string derivation = 3;
-  // Scheme tag; must equal "ecies-secp256k1-hkdf-aes256gcm-v1" so Keychain can
-  // refuse a scheme it does not implement.
-  string purpose = 4;
+// ─── Inheritance heir-escrow ECIES decrypt relay (COIN-377, rev 3) ──────────
+//
+// The heir's Keychain holds the recovery private key and is the ONLY party that
+// can derive the envelope's symmetric key (ECDH against the ephemeral pubkey +
+// HKDF). The Keychain is a stream CLIENT (RealtimeService.Connect), not a
+// callable server, so the decrypt is brokered async over the Connect rail,
+// mirroring the signing event→fetch→submit pattern:
+//
+//   1. heir desktop  → CreateDecryptRequest        (picks the envelope; supplies
+//                                                    a per-recovery transport pubkey)
+//   2. server        → DecryptRequestedEvent       (stream-pushed to the Keychain;
+//                                                    also fetchable via ListPending…)
+//   3. heir Keychain → SubmitDecryptResult         (approves; ECDH+HKDF → K; wraps
+//                                                    K to the desktop transport pubkey)
+//                      or RejectDecryptRequest
+//   4. server        → DecryptResultEvent          (stream-pushed to the desktop;
+//                                                    also fetchable via GetDecryptResult)
+//   5. heir desktop  unwraps K with its transport priv key, AES-256-GCM-opens
+//                    the envelope, and restores — all locally.
+//
+// SERVER-BLIND (invariant I1): K is never relayed in the clear. The Keychain
+// ECIES-WRAPS K to the desktop's transport pubkey, so the API only ever stores /
+// relays an opaque blob it has no key to open — even though it also holds the
+// envelope ciphertext. The wrap format is SPEC-ecies-v1.md (same ECIES as the
+// envelope). See keychain-app + coincube desktop plans.
+
+enum DecryptRequestStatus {
+  DECRYPT_REQUEST_STATUS_UNSPECIFIED = 0;
+  DECRYPT_REQUEST_STATUS_PENDING = 1;   // awaiting the heir's Keychain
+  DECRYPT_REQUEST_STATUS_COMPLETED = 2; // wrapped_shared_key is available
+  DECRYPT_REQUEST_STATUS_REJECTED = 3;  // Keychain declined (approval denied / heir duress)
+  DECRYPT_REQUEST_STATUS_EXPIRED = 4;   // not answered within the TTL
 }
 
-message DecryptInheritanceEnvelopeResponse {
-  // 32-byte HKDF-derived symmetric key K. Keychain NEVER returns the recovery
-  // private key or the seed/descriptor plaintext — the desktop opens the
-  // AES-256-GCM ciphertext with this key.
-  bytes shared_key = 1;
+// CreateDecryptRequest is called by the heir's DESKTOP. The server identifies the
+// envelope addressed to the caller's keyholder key for (cube_id, artifact_kind),
+// applies the same gate as the recovery-envelope endpoint (keyholder + recovery
+// path open on-chain + owner not in duress), and notifies the heir's Keychain.
+message CreateDecryptRequestRequest {
+  string request_id = 1;   // client-generated idempotency key
+  string cube_id = 2;
+  string artifact_kind = 3; // "descriptor" | "seed" — which envelope to decrypt
+  // Per-recovery transport public key (compressed 33-byte secp256k1) that the
+  // Keychain wraps the derived key to. Lets the server stay blind: it relays only
+  // a blob encrypted to the desktop. The desktop holds the matching private key
+  // in memory for this recovery only.
+  bytes desktop_transport_pubkey = 4;
+}
+message CreateDecryptRequestResponse {
+  string request_id = 1;
+  DecryptRequestStatus status = 2;
+}
+
+// DecryptRequestedEvent is delivered to the heir's Keychain (stream push +
+// ListPendingDecryptRequests fetch). It carries the envelope params the Keychain
+// needs to ECDH/HKDF — all already held by the server; the server never holds the
+// heir's private key.
+message DecryptRequestedEvent {
+  string request_id = 1;
+  string cube_id = 2;
+  string artifact_kind = 3;
+  bytes ephemeral_pubkey = 4;          // 33-byte compressed, from the envelope
+  string derivation = 5;               // dedicated-child path (invariant I5)
+  string purpose = 6;                  // ECIES scheme tag (SPEC-ecies-v1.md)
+  bytes desktop_transport_pubkey = 7;  // wrap target — see CreateDecryptRequest
+}
+
+message ListPendingDecryptRequestsRequest {}
+message ListPendingDecryptRequestsResponse {
+  repeated DecryptRequestedEvent requests = 1;
+}
+
+// SubmitDecryptResult is called by the heir's Keychain after biometric/PIN
+// approval. wrapped_shared_key is the derived symmetric key ECIES-wrapped to the
+// request's desktop_transport_pubkey — OPAQUE to the server (SPEC-ecies-v1.md
+// wrap format). The Keychain NEVER returns the private key, the raw shared key,
+// or any plaintext.
+message SubmitDecryptResultRequest {
+  string request_id = 1;
+  bytes wrapped_shared_key = 2;
+}
+message SubmitDecryptResultResponse {
+  DecryptRequestStatus status = 1;
+}
+
+// RejectDecryptRequest is called by the Keychain when the heir declines or is
+// under duress. reason is a non-sensitive machine tag ("declined" | "duress").
+message RejectDecryptRequestRequest {
+  string request_id = 1;
+  string reason = 2;
+}
+message RejectDecryptRequestResponse {}
+
+// DecryptResultEvent is delivered to the heir's DESKTOP (stream push +
+// GetDecryptResult fetch). wrapped_shared_key is present only when COMPLETED and
+// is opaque to the server.
+message DecryptResultEvent {
+  string request_id = 1;
+  DecryptRequestStatus status = 2;
+  bytes wrapped_shared_key = 3;
+}
+
+message GetDecryptResultRequest {
+  string request_id = 1;
+}
+message GetDecryptResultResponse {
+  DecryptRequestStatus status = 1;
+  bytes wrapped_shared_key = 2;
 }
 
 service SessionService {
@@ -328,9 +410,15 @@ service SessionService {
   rpc RejectSession(RejectSessionRequest) returns (RejectSessionResponse);
   rpc SubmitPartialSignature(SubmitPartialSignatureRequest) returns (SubmitPartialSignatureResponse);
   rpc ResolveSigners(ResolveSignersRequest) returns (ResolveSignersResponse);
-  // Heir-escrow ECIES decrypt — relayed to the heir's Keychain, which approves
-  // (biometric/PIN) and returns the HKDF-derived key. Never returns plaintext.
-  rpc DecryptInheritanceEnvelope(DecryptInheritanceEnvelopeRequest) returns (DecryptInheritanceEnvelopeResponse);
+
+  // Heir-escrow ECIES decrypt relay (server-blind; see the message block above).
+  // The server brokers the request to the heir's Keychain and relays back only
+  // an opaque wrapped key — it never sees the derived key or any plaintext.
+  rpc CreateDecryptRequest(CreateDecryptRequestRequest) returns (CreateDecryptRequestResponse);                   // heir desktop
+  rpc ListPendingDecryptRequests(ListPendingDecryptRequestsRequest) returns (ListPendingDecryptRequestsResponse); // heir Keychain
+  rpc SubmitDecryptResult(SubmitDecryptResultRequest) returns (SubmitDecryptResultResponse);                      // heir Keychain
+  rpc RejectDecryptRequest(RejectDecryptRequestRequest) returns (RejectDecryptRequestResponse);                   // heir Keychain
+  rpc GetDecryptResult(GetDecryptResultRequest) returns (GetDecryptResultResponse);                               // heir desktop
 }
 
 service DeviceService {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches master-seed export, envelope crypto, and new Connect escrow/decrypt APIs—core inheritance and secret-handling paths with a large behavioral pivot away from server-visible descriptors.
> 
> **Overview**
> Replaces **Vault Recovery Alerts** monitoring tiers (Off / Alerts-only / server-visible “Full” descriptor) with **inheritance escrow tiers** — **Off**, **Vault only**, and **Full Cube** — backed by per-keyholder **ECIES** ciphertext the server stores opaquely. Owners enroll via `enroll_escrow` / `disable_escrow` (descriptor JSON from the live wallet; Full Cube adds a **PIN-gated** seed blob on a blocking thread with zeroizing buffers). The settings UI and state track **session tier** vs **“on but tier unknown”** after reload so copy never falsely claims seed escrow.
> 
> Adds the **inheritance service stack** (seal/open, escrow set build, Connect **PUT/DELETE escrow** and **GET recovery-envelope**, gRPC **decrypt relay** + local unwrap) and wires **heir discovery** to `available_tiers` (no recovery-password path). **Recover** launches **`UserFlow::RecoverInheritedVault`** with a new **`InheritanceRestoreStep`** that fetches envelopes, Keychain-decrypts, and reuses shared **`stage_restore`** with existing Recovery Kit restore steps.
> 
> Owner signing sessions explicitly set **`is_recovery_spend: false`**; **`EscrowPin`** and redacted message/debug paths keep PINs and decrypt results off logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5888026674b3f18c7c673738fc6674ccab846b2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added inheritance escrow tiers: **Off**, **Vault Only**, and **Full Cube**.
  * Enabled **ECIES-based inheritance recovery** with Keychain decryption (no recovery password required).
  * Introduced an **installer flow** for inherited vault restoration (descriptor-only or full).

* **User Interface / UX**
  * Updated **Vault Recovery Alerts** to select an escrow tier.
  * Added **Full Cube PIN** collection with **confirm/cancel** and safe PIN handling during enrollment.
  * Updated vault recovery discovery/action labels to reflect tier availability, including **“not escrowed”** states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->