### PR TITLE
fix(auth): resend signup OTP for unverified users during vault creation

### DIFF
--- a/coincube-gui/src/installer/message.rs
+++ b/coincube-gui/src/installer/message.rs
@@ -228,7 +228,10 @@ pub enum CoincubeConnectMsg {
     EmailNotVerified { email: String },
     ToggleMode,
     RequestOtp,
-    OtpRequested(Result<(), String>),
+    OtpRequested {
+        email: String,
+        result: Result<(), String>,
+    },
     OtpEdited(String),
     OtpVerified(Result<zeroize::Zeroizing<String>, String>),
     ResendOtp,
@@ -243,7 +246,11 @@ impl std::fmt::Debug for CoincubeConnectMsg {
             Self::EmailNotVerified { email } => f.debug_tuple("EmailNotVerified").field(email).finish(),
             Self::ToggleMode => write!(f, "ToggleMode"),
             Self::RequestOtp => write!(f, "RequestOtp"),
-            Self::OtpRequested(r) => f.debug_tuple("OtpRequested").field(r).finish(),
+            Self::OtpRequested { email, result } => f
+                .debug_struct("OtpRequested")
+                .field("email", email)
+                .field("result", result)
+                .finish(),
             Self::OtpEdited(s) => f.debug_tuple("OtpEdited").field(s).finish(),
             Self::OtpVerified(Ok(_)) => write!(f, "OtpVerified(Ok(<redacted>))"),
             Self::OtpVerified(Err(e)) => f

--- a/coincube-gui/src/installer/message.rs
+++ b/coincube-gui/src/installer/message.rs
@@ -225,6 +225,7 @@ pub enum SelectBitcoindTypeMsg {
 #[derive(Clone)]
 pub enum CoincubeConnectMsg {
     EmailEdited(String),
+    EmailNotVerified { email: String },
     ToggleMode,
     RequestOtp,
     OtpRequested(Result<(), String>),
@@ -239,6 +240,7 @@ impl std::fmt::Debug for CoincubeConnectMsg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::EmailEdited(s) => f.debug_tuple("EmailEdited").field(s).finish(),
+            Self::EmailNotVerified { email } => f.debug_tuple("EmailNotVerified").field(email).finish(),
             Self::ToggleMode => write!(f, "ToggleMode"),
             Self::RequestOtp => write!(f, "RequestOtp"),
             Self::OtpRequested(r) => f.debug_tuple("OtpRequested").field(r).finish(),

--- a/coincube-gui/src/installer/step/coincube_connect.rs
+++ b/coincube-gui/src/installer/step/coincube_connect.rs
@@ -214,15 +214,54 @@ impl Step for CoincubeConnectStep {
                             self.error = None;
                         }
                         Err(e) => {
+                            // When the user tries to sign in with a registered-but-unverified
+                            // email, the backend returns "Email not verified". Re-route to the
+                            // same resend flow the app-level ConnectAccountPanel uses: switch
+                            // to signup mode, fire resend_signup_otp, and advance to OTP entry.
+                            if !self.is_signup && e.contains("Email not verified") {
+                                return Task::done(Message::CoincubeConnect(
+                                    CoincubeConnectMsg::EmailNotVerified {
+                                        email: self.email.value.clone(),
+                                    },
+                                ));
+                            }
                             self.error = Some(e);
                         }
                     }
                 }
                 CoincubeConnectMsg::OtpResent(res) => {
-                    self.processing = false;
-                    if let Err(e) = res {
-                        self.error = Some(e);
+                   self.processing = false;
+                    match res {
+                        Ok(()) => {
+                            // Works for both the resend-button path (otp_sent already
+                            // true) and the EmailNotVerified recovery path (needs to
+                            // flip otp_sent to show the OTP entry screen).
+                            self.otp_sent = true;
+                            self.otp = form::Value::default();
+                            self.error = None;
+                        }
+                        Err(e) => {
+                            self.error = Some(e);
+                        }
                     }
+                }
+                CoincubeConnectMsg::EmailNotVerified { email } => {
+                    // The email exists but signup was never completed. Switch to
+                    // signup mode, fire resend_signup_otp, and land on OTP entry —
+                    // identical to the app-level ConnectAccountPanel recovery path.
+                    self.is_signup = true;
+                    self.processing = true;
+                    self.error = None;
+                    let client = self.client.clone();
+                    return Task::perform(
+                        async move {
+                            client
+                                .resend_signup_otp(&email)
+                                .await
+                                .map_err(|e| e.to_string())
+                        },
+                        |res| Message::CoincubeConnect(CoincubeConnectMsg::OtpResent(res)),
+                    );
                 }
                 CoincubeConnectMsg::OtpEdited(value) => {
                     self.otp.value = value.trim().to_string();

--- a/coincube-gui/src/installer/step/coincube_connect.rs
+++ b/coincube-gui/src/installer/step/coincube_connect.rs
@@ -184,13 +184,15 @@ impl Step for CoincubeConnectStep {
                 CoincubeConnectMsg::RequestOtp => {
                     self.processing = true;
                     self.error = None;
+                    let email = self.email.value.clone();
                     return Task::perform(
-                        send_otp(
-                            self.client.clone(),
-                            self.email.value.clone(),
-                            self.is_signup,
-                        ),
-                        |res| Message::CoincubeConnect(CoincubeConnectMsg::OtpRequested(res)),
+                        send_otp(self.client.clone(), email.clone(), self.is_signup),
+                         move |result| {
+                            Message::CoincubeConnect(CoincubeConnectMsg::OtpRequested {
+                                email: email.clone(),
+                                result,
+                            })
+                        },
                     );
                 }
                 CoincubeConnectMsg::ResendOtp => {
@@ -205,24 +207,18 @@ impl Step for CoincubeConnectStep {
                         |res| Message::CoincubeConnect(CoincubeConnectMsg::OtpResent(res)),
                     );
                 }
-                CoincubeConnectMsg::OtpRequested(res) => {
+                CoincubeConnectMsg::OtpRequested { email, result } => {
                     self.processing = false;
-                    match res {
+                    match result {
                         Ok(()) => {
                             self.otp_sent = true;
                             self.otp = form::Value::default();
                             self.error = None;
                         }
                         Err(e) => {
-                            // When the user tries to sign in with a registered-but-unverified
-                            // email, the backend returns "Email not verified". Re-route to the
-                            // same resend flow the app-level ConnectAccountPanel uses: switch
-                            // to signup mode, fire resend_signup_otp, and advance to OTP entry.
                             if !self.is_signup && e.contains("Email not verified") {
                                 return Task::done(Message::CoincubeConnect(
-                                    CoincubeConnectMsg::EmailNotVerified {
-                                        email: self.email.value.clone(),
-                                    },
+                                    CoincubeConnectMsg::EmailNotVerified { email },
                                 ));
                             }
                             self.error = Some(e);
@@ -233,9 +229,6 @@ impl Step for CoincubeConnectStep {
                    self.processing = false;
                     match res {
                         Ok(()) => {
-                            // Works for both the resend-button path (otp_sent already
-                            // true) and the EmailNotVerified recovery path (needs to
-                            // flip otp_sent to show the OTP entry screen).
                             self.otp_sent = true;
                             self.otp = form::Value::default();
                             self.error = None;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for sign-in when the email is not yet verified, guiding users into the signup OTP flow.
  * Enhanced the OTP resend experience to keep the UI in sync with the correct verification step.
* **Bug Fixes**
  * Improved error handling for OTP requests and resend actions, including clearer routing when verification is required.
  * Successful OTP resend now resets the OTP input, marks the OTP as sent, and clears prior error messages for a smoother retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->