### PR TITLE
fix: deserialize duress contact channels as string values for consistency with backend response

### DIFF
--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -2047,17 +2047,17 @@ impl ConnectAccountPanel {
                     dc.error = Some("That email doesn't look right.".to_string());
                     return iced::Task::none();
                 }
-                let mut channels: u8 = 0;
+                let mut channels = Vec::new();
                 if dc.form_ch_sms && !phone.is_empty() {
-                    channels |= DURESS_CHANNEL_SMS;
+                    channels.push("sms".to_string());
                 }
                 if dc.form_ch_whatsapp && !phone.is_empty() {
-                    channels |= DURESS_CHANNEL_WHATSAPP;
+                    channels.push("whatsapp".to_string());
                 }
                 if dc.form_ch_email && !email.is_empty() {
-                    channels |= DURESS_CHANNEL_EMAIL;
+                    channels.push("email".to_string());
                 }
-                if channels == 0 {
+                if channels.is_empty() {
                     dc.error = Some(
                         "Pick at least one way to reach them (SMS, WhatsApp, or email)."
                             .to_string(),
@@ -2088,6 +2088,13 @@ impl ConnectAccountPanel {
                             email: email_opt,
                             channels,
                         };
+
+                        println!("Submitting new duress contact: {:?}", req);
+                        println!(
+                            "JSON payload: {}",
+                            serde_json::to_string_pretty(&req).unwrap()
+                        );
+
                         iced::Task::perform(
                             async move { client.create_duress_alert_contact(req).await },
                             move |res| {
@@ -5192,11 +5199,11 @@ mod duress_contacts_tests {
             display_name: format!("Contact {id}"),
             phone: Some("+15551234567".into()),
             email: None,
-            channels: DURESS_CHANNEL_SMS,
+            channels: vec![DURESS_CHANNEL_SMS.to_string()],
             intro_sent_at: None,
             opted_out_at: None,
-            created_at: "2026-06-11T00:00:00Z".into(),
-            updated_at: "2026-06-11T00:00:00Z".into(),
+             created_at: Some("2026-06-11T00:00:00Z".to_string()),
+            updated_at: Some("2026-06-11T00:00:00Z".to_string()),
         }
     }
 

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -5195,7 +5195,7 @@ mod duress_contacts_tests {
             channels: vec![DURESS_CHANNEL_SMS.to_string()],
             intro_sent_at: None,
             opted_out_at: None,
-             created_at: Some("2026-06-11T00:00:00Z".to_string()),
+            created_at: Some("2026-06-11T00:00:00Z".to_string()),
             updated_at: Some("2026-06-11T00:00:00Z".to_string()),
         }
     }

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -2049,13 +2049,13 @@ impl ConnectAccountPanel {
                 }
                 let mut channels = Vec::new();
                 if dc.form_ch_sms && !phone.is_empty() {
-                    channels.push("sms".to_string());
+                    channels.push(DURESS_CHANNEL_SMS.to_string());
                 }
                 if dc.form_ch_whatsapp && !phone.is_empty() {
-                    channels.push("whatsapp".to_string());
+                    channels.push(DURESS_CHANNEL_WHATSAPP.to_string());
                 }
                 if dc.form_ch_email && !email.is_empty() {
-                    channels.push("email".to_string());
+                    channels.push(DURESS_CHANNEL_EMAIL.to_string());
                 }
                 if channels.is_empty() {
                     dc.error = Some(
@@ -2088,13 +2088,6 @@ impl ConnectAccountPanel {
                             email: email_opt,
                             channels,
                         };
-
-                        println!("Submitting new duress contact: {:?}", req);
-                        println!(
-                            "JSON payload: {}",
-                            serde_json::to_string_pretty(&req).unwrap()
-                        );
-
                         iced::Task::perform(
                             async move { client.create_duress_alert_contact(req).await },
                             move |res| {

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -1735,7 +1735,6 @@ impl DownloadError {
 /// coincube-api "channels mask" wire field. SMS/WhatsApp require a phone;
 /// Email requires an email — the UI enforces that pairing before letting a
 /// bit be set.
-
 pub const DURESS_CHANNEL_SMS: &str = "sms";
 pub const DURESS_CHANNEL_WHATSAPP: &str = "whatsapp";
 pub const DURESS_CHANNEL_EMAIL: &str = "email";

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -1735,9 +1735,10 @@ impl DownloadError {
 /// coincube-api "channels mask" wire field. SMS/WhatsApp require a phone;
 /// Email requires an email — the UI enforces that pairing before letting a
 /// bit be set.
-pub const DURESS_CHANNEL_SMS: u8 = 1 << 0;
-pub const DURESS_CHANNEL_WHATSAPP: u8 = 1 << 1;
-pub const DURESS_CHANNEL_EMAIL: u8 = 1 << 2;
+
+pub const DURESS_CHANNEL_SMS: &str = "sms";
+pub const DURESS_CHANNEL_WHATSAPP: &str = "whatsapp";
+pub const DURESS_CHANNEL_EMAIL: &str = "email";
 
 /// A duress alert contact as returned by
 /// `GET /api/v1/connect/duress/contacts`.
@@ -1755,7 +1756,7 @@ pub struct DuressAlertContact {
     pub email: Option<String>,
     /// Bitmask of [`DURESS_CHANNEL_SMS`] / `_WHATSAPP` / `_EMAIL`.
     #[serde(default)]
-    pub channels: u8,
+    pub channels: Vec<String>,
     /// RFC 3339 timestamp of when the one-time intro message was sent,
     /// or `None` if it hasn't gone out yet (just-created contact).
     #[serde(default)]
@@ -1764,8 +1765,10 @@ pub struct DuressAlertContact {
     /// contact is permanently opted out and never messaged again.
     #[serde(default)]
     pub opted_out_at: Option<String>,
-    pub created_at: String,
-    pub updated_at: String,
+    #[serde(default)]
+    pub created_at: Option<String>,
+    #[serde(default)]
+    pub updated_at: Option<String>,
 }
 
 impl DuressAlertContact {
@@ -1773,9 +1776,8 @@ impl DuressAlertContact {
     pub fn is_opted_out(&self) -> bool {
         self.opted_out_at.is_some()
     }
-
-    pub fn has_channel(&self, bit: u8) -> bool {
-        self.channels & bit != 0
+    pub fn has_channel(&self, channel: &str) -> bool {
+        self.channels.iter().any(|c| c == channel)
     }
 }
 
@@ -1791,7 +1793,7 @@ pub struct CreateDuressAlertContactRequest {
     pub phone: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
-    pub channels: u8,
+    pub channels: Vec<String>,
 }
 
 /// Body for `PATCH /api/v1/connect/duress/contacts/{id}`. Every field is
@@ -1809,7 +1811,7 @@ pub struct UpdateDuressAlertContactRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub channels: Option<u8>,
+    pub channels: Option<Vec<String>>,
 }
 
 /// Maximum duress alert contacts per account. Cost + abuse bound, mirrored
@@ -1867,19 +1869,16 @@ mod duress_alert_contact_tests {
 
     #[test]
     fn channel_bits_are_distinct() {
-        assert_eq!(DURESS_CHANNEL_SMS, 1);
-        assert_eq!(DURESS_CHANNEL_WHATSAPP, 2);
-        assert_eq!(DURESS_CHANNEL_EMAIL, 4);
         let c = DuressAlertContact {
             id: 1,
             display_name: "Jane".into(),
             phone: Some("+15551234567".into()),
             email: None,
-            channels: DURESS_CHANNEL_SMS | DURESS_CHANNEL_WHATSAPP,
+            channels: vec![ DURESS_CHANNEL_SMS.to_string(), DURESS_CHANNEL_WHATSAPP.to_string()],
             intro_sent_at: None,
             opted_out_at: None,
-            created_at: "2026-06-11T00:00:00Z".into(),
-            updated_at: "2026-06-11T00:00:00Z".into(),
+            created_at: Some("2026-06-11T00:00:00Z".to_string()),
+            updated_at: Some("2026-06-11T00:00:00Z".to_string()),
         };
         assert!(c.has_channel(DURESS_CHANNEL_SMS));
         assert!(c.has_channel(DURESS_CHANNEL_WHATSAPP));

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -1874,7 +1874,10 @@ mod duress_alert_contact_tests {
             display_name: "Jane".into(),
             phone: Some("+15551234567".into()),
             email: None,
-            channels: vec![ DURESS_CHANNEL_SMS.to_string(), DURESS_CHANNEL_WHATSAPP.to_string()],
+            channels: vec![
+                DURESS_CHANNEL_SMS.to_string(),
+                DURESS_CHANNEL_WHATSAPP.to_string(),
+            ],
             intro_sent_at: None,
             opted_out_at: None,
             created_at: Some("2026-06-11T00:00:00Z".to_string()),

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -1893,9 +1893,7 @@ mod duress_alert_contact_tests {
             "id": 7,
             "displayName": "Sam",
             "email": "sam@example.com",
-            "channels": 4,
-            "createdAt": "2026-06-11T00:00:00Z",
-            "updatedAt": "2026-06-11T00:00:00Z"
+            "channels": [DURESS_CHANNEL_EMAIL],
         });
         let c: DuressAlertContact = serde_json::from_value(v).unwrap();
         assert_eq!(c.display_name, "Sam");
@@ -1903,6 +1901,8 @@ mod duress_alert_contact_tests {
         assert_eq!(c.email.as_deref(), Some("sam@example.com"));
         assert!(c.has_channel(DURESS_CHANNEL_EMAIL));
         assert!(c.intro_sent_at.is_none());
+        assert!(c.created_at.is_none());
+        assert!(c.updated_at.is_none());
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duress emergency contacts now use named channel selections (SMS, WhatsApp, email) instead of a numeric bitmask.
  * Contact details better handle missing timestamps without breaking display or syncing.

* **Bug Fixes**
  * Improved validation so duress contact submission fails when no channel is selected.
  * Updated duress contact saving and editing to correctly persist the selected channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->