### PR TITLE
fix: restrict duress PIN to 4 numeric digits

### DIFF
--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -2332,12 +2332,12 @@ impl ConnectAccountPanel {
             }
             DuressMessage::DuressPinChanged(v) => {
                 if let Some(e) = &mut self.duress_enroll {
-                    e.duress_pin = v;
+                    e.duress_pin = v.chars().filter(|c| c.is_ascii_digit()).take(4).collect();
                 }
             }
             DuressMessage::DuressPinConfirmChanged(v) => {
                 if let Some(e) = &mut self.duress_enroll {
-                    e.duress_pin_confirm = v;
+                   e.duress_pin_confirm = v.chars().filter(|c| c.is_ascii_digit()).take(4).collect();
                 }
             }
             DuressMessage::AllClearChanged(v) => {

--- a/coincube-gui/src/app/view/connect/duress_enroll.rs
+++ b/coincube-gui/src/app/view/connect/duress_enroll.rs
@@ -239,32 +239,49 @@ fn sovereign_confirm_step(state: &DuressEnrollState) -> Element<'_, ConnectAccou
 }
 
 fn duress_pin_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
-    card(
-        Column::new()
-            .push(text::p1_bold("Set your duress PIN").style(theme::text::primary))
-            .push(
-                text::p2_regular(
-                    "Choose a PIN you don't use to unlock any of your Cubes. Entering it at any \
+    let pin_valid = state.duress_pin.len() == 4
+        && state.duress_pin.chars().all(|c| c.is_ascii_digit());
+    let confirm_valid = state.duress_pin == state.duress_pin_confirm;
+
+    let hint_color = if state.duress_pin.is_empty() {
+        color::GREY_3
+    } else if pin_valid {
+        color::GREEN
+    } else {
+        color::RED
+    };
+
+    let mut col = Column::new()
+        .push(text::p1_bold("Set your duress PIN").style(theme::text::primary))
+        .push(
+            text::p2_regular(
+                "Choose a PIN you don't use to unlock any of your Cubes. Entering it at any \
                  Cube's unlock screen triggers a duress wipe, so it can't be one of your real \
                  unlock PINs.",
-                )
-                .color(color::GREY_3),
             )
-            .push(text::p2_regular("Duress PIN").color(color::GREY_3))
-            .push(
-                TextInput::new("Duress PIN", &state.duress_pin)
-                    .on_input(|v| msg(DuressMessage::DuressPinChanged(v)))
-                    .secure(true)
-                    .padding(15),
-            )
-            .push(text::p2_regular("Confirm duress PIN").color(color::GREY_3))
-            .push(
-                TextInput::new("Confirm duress PIN", &state.duress_pin_confirm)
-                    .on_input(|v| msg(DuressMessage::DuressPinConfirmChanged(v)))
-                    .secure(true)
-                    .padding(15),
-            ),
-    )
+            .color(color::GREY_3),
+        )
+        .push(text::p2_regular("Duress PIN (4 digits)").color(color::GREY_3))
+        .push(
+            TextInput::new("Duress PIN", &state.duress_pin)
+                .on_input(|v| msg(DuressMessage::DuressPinChanged(v)))
+                .secure(true)
+                .padding(15),
+        )
+        .push(text::caption("Must be exactly 4 digits.").color(hint_color))
+        .push(text::p2_regular("Confirm duress PIN").color(color::GREY_3))
+        .push(
+            TextInput::new("Confirm duress PIN", &state.duress_pin_confirm)
+                .on_input(|v| msg(DuressMessage::DuressPinConfirmChanged(v)))
+                .secure(true)
+                .padding(15),
+        );
+
+    if !state.duress_pin_confirm.is_empty() && !confirm_valid {
+        col = col.push(text::caption("PINs do not match.").color(color::RED));
+    }
+
+    card(col)
 }
 
 fn all_clear_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {

--- a/coincube-gui/src/services/duress/enroll.rs
+++ b/coincube-gui/src/services/duress/enroll.rs
@@ -93,6 +93,12 @@ pub fn validate_duress_pin(duress_pin: &str, confirm: &str) -> Result<(), String
     if duress_pin.is_empty() {
         return Err("Enter a duress PIN.".to_string());
     }
+    if duress_pin.len() != 4 {
+        return Err("Duress PIN must be exactly 4 digits.".to_string());
+    }
+    if !duress_pin.chars().all(|c| c.is_ascii_digit()) {
+        return Err("Duress PIN must contain only digits.".to_string());
+    }
     if duress_pin != confirm {
         return Err("The duress PINs don't match.".to_string());
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duress PIN entry validation with clearer on-screen feedback.
  * PIN fields now only accept ASCII digits and are limited to 4 characters.
  * Added messages for invalid PIN length and mismatched confirmation entries.
  * Strengthened validation so only exactly 4-digit PINs can be submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->