### PR TITLE
Duress Disable

### DIFF
--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1043,6 +1043,130 @@ pub(crate) async fn persist_duress_enrollment(
     Ok(())
 }
 
+/// User-facing message when the step-up PIN doesn't match any Cube's real unlock
+/// PIN. The duress PIN never satisfies `verify_pin` (distinct hash, collision
+/// forbidden at enroll), so entering it lands here too — without revealing that
+/// it was the duress PIN.
+pub(crate) const DURESS_STEP_UP_BAD_PIN_MSG: &str =
+    "That PIN doesn't match any of your Cubes' unlock PINs.";
+
+/// Step-up re-auth for the duress *disable* flow: verify `pin` is the REAL
+/// unlock PIN of at least one Cube. Because `verify_pin` checks the regular-PIN
+/// hash (never the duress one), entering the duress PIN here is rejected —
+/// exactly the plan's "do not accept the duress PIN at step-up".
+///
+/// `Ok` when a Cube's regular PIN matches, or when no Cube has a regular PIN at
+/// all (no second factor to demand). `Err` on an empty PIN, a mismatch, no
+/// Cubes, or when settings can't be read.
+pub(crate) fn verify_regular_cube_pin(
+    root: &std::path::Path,
+    pin: &str,
+) -> Result<(), String> {
+    if pin.is_empty() {
+        return Err("Enter your Cube unlock PIN to continue.".to_string());
+    }
+    let network_dirs = duress_enroll_network_dirs(root);
+    if network_dirs.is_empty() {
+        return Err(DURESS_NO_CUBES_MSG.to_string());
+    }
+    let mut any_pin = false;
+    for network_dir in &network_dirs {
+        let settings = crate::app::settings::Settings::from_file(network_dir)
+            .map_err(|e| format!("Couldn't read your Cube settings to verify your PIN: {e}"))?;
+        for cube in &settings.cubes {
+            // `verify_pin` returns true for a PIN-less Cube, so gate on
+            // `has_pin()` — a Cube with no PIN can't anchor the step-up.
+            if cube.has_pin() {
+                any_pin = true;
+                if cube.verify_pin(pin) {
+                    return Ok(());
+                }
+            }
+        }
+    }
+    if !any_pin {
+        // No regular PIN on any Cube — there's no second factor to demand, so
+        // let the disable proceed.
+        return Ok(());
+    }
+    Err(DURESS_STEP_UP_BAD_PIN_MSG.to_string())
+}
+
+/// Local disarm — the inverse of [`persist_duress_enrollment`]. Turns duress
+/// off ON THIS DEVICE without wiping anything: clears the per-Cube duress PIN
+/// hash on every Cube across every network, resets `DuressLocalState` to the
+/// un-enrolled baseline (zeroizing the encrypted device code), and empties the
+/// durable activation queue. Cube funds and data are left untouched.
+///
+/// Short-circuits when `DuressLocalState` already reports un-enrolled, so the
+/// common never-enrolled case (e.g. a launch reconcile) costs one small JSON
+/// read and never rewrites settings files.
+///
+/// Ordering mirrors persist in reverse: clear the Cube PIN hashes FIRST (so the
+/// duress PIN can no longer trip a wipe), THEN drop the local state. A failure
+/// midway leaves a consistent "still enrolled" view that a retry completes —
+/// every step is idempotent.
+pub(crate) async fn clear_duress_enrollment(datadir: CoincubeDirectory) -> Result<(), String> {
+    let root = datadir.path().to_path_buf();
+
+    // Efficiency + safety guard: if this device never armed duress, there's
+    // nothing to clear. A real read error is surfaced rather than papered over.
+    let mut st = crate::services::duress::DuressLocalState::load(&root)
+        .map_err(|e| format!("Couldn't read existing duress state: {e}"))?;
+    if !st.enrolled {
+        return Ok(());
+    }
+
+    // 1. Clear the duress PIN hash on every Cube on every network. Setting it to
+    //    None is idempotent; stop at the first failure so a retry re-clears the
+    //    rest (the local state still says enrolled until step 2).
+    let network_dirs = duress_enroll_network_dirs(&root);
+    for network_dir in &network_dirs {
+        crate::app::settings::update_settings_file(network_dir, move |mut s| {
+            for cube in s.cubes.iter_mut() {
+                cube.duress_pin_hash = None;
+            }
+            Some(s)
+        })
+        .await
+        .map_err(|e| format!("Couldn't clear the duress PIN on all your Cubes ({e})."))?;
+    }
+
+    // 2. Reset DuressLocalState to the un-enrolled baseline (zeroizes the
+    //    encrypted device code). Only now is the device truly disarmed.
+    st.disarm();
+    st.save(&root)
+        .map_err(|e| format!("Couldn't update local duress state: {e}"))?;
+
+    // 3. Empty the durable activation queue — no pending activation should
+    //    survive an un-enroll. Best-effort: a stale entry would only retry an
+    //    already-disabled activation, so log rather than fail the disarm.
+    if let Err(e) = crate::services::duress::queue::DuressQueue::new(&root).clear() {
+        log::warn!("duress: failed to clear activation queue on disarm: {e}");
+    }
+    Ok(())
+}
+
+/// Reconcile a possibly remote/offline duress *disable* against this device's
+/// local state. Disarms ONLY when this device holds a Connect enrollment
+/// (`account_id` set) for `account_id` — the account the server now reports as
+/// no longer enrolled. Sovereign (`account_id == None`) enrollments are
+/// local-only and must NEVER be disarmed by a server "not enrolled". Returns
+/// whether a disarm actually ran.
+pub(crate) async fn reconcile_duress_disarm(
+    datadir: CoincubeDirectory,
+    account_id: String,
+) -> Result<bool, String> {
+    let root = datadir.path().to_path_buf();
+    let st = crate::services::duress::DuressLocalState::load(&root)
+        .map_err(|e| format!("Couldn't read existing duress state: {e}"))?;
+    if !(st.enrolled && st.account_id.as_deref() == Some(account_id.as_str())) {
+        return Ok(false);
+    }
+    clear_duress_enrollment(datadir).await?;
+    Ok(true)
+}
+
 /// Poll the local bitcoind's IBD progress via its JSON-RPC interface.
 /// Returns `(verificationprogress, initialblockdownload)` or an error string.
 async fn check_bitcoind_sync_progress(
@@ -2259,6 +2383,27 @@ impl App {
                         }
                     },
                     |_| Message::CacheUpdated,
+                )
+            }
+            M::DuressDisabled { account_id } => {
+                // Issue 2: duress disabled account-wide on another device. Disarm
+                // THIS device locally (clear Cube PIN hashes + local state +
+                // queue) — no UI lock, no wipe. `reconcile_duress_disarm` only
+                // touches a matching Connect enrollment, so a sovereign local
+                // enrollment (or an unrelated account) is left untouched. Refresh
+                // the Duress panel afterwards if the user is sitting in it.
+                log::info!("[CONNECT GRPC] Duress disabled remotely");
+                let datadir = self.datadir.clone();
+                let gen = self.panels.connect.account.session_generation();
+                Task::perform(
+                    async move { reconcile_duress_disarm(datadir, account_id).await },
+                    move |res| {
+                        Message::View(view::Message::ConnectAccount(
+                            view::ConnectAccountMessage::Duress(
+                                view::DuressMessage::DisarmComplete(res, gen),
+                            ),
+                        ))
+                    },
                 )
             }
         }

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1095,9 +1095,12 @@ pub(crate) fn verify_regular_cube_pin(root: &std::path::Path, pin: &str) -> Resu
 /// un-enrolled baseline (zeroizing the encrypted device code), and empties the
 /// durable activation queue. Cube funds and data are left untouched.
 ///
-/// Short-circuits when `DuressLocalState` already reports un-enrolled, so the
-/// common never-enrolled case (e.g. a launch reconcile) costs one small JSON
-/// read and never rewrites settings files.
+/// The per-Cube hashes are cleared UNCONDITIONALLY — never gated on
+/// `DuressLocalState.enrolled`. A hard crash between persist's Cube-arming step
+/// and its state-write step can leave Cubes armed while the local state still
+/// reads "not enrolled"; trusting that flag here would let a disable report
+/// success while the duress PIN could still trip a wipe. Setting each hash to
+/// `None` is idempotent, so always clearing is cheap and safe.
 ///
 /// Ordering mirrors persist in reverse: clear the Cube PIN hashes FIRST (so the
 /// duress PIN can no longer trip a wipe), THEN drop the local state. A failure
@@ -1106,17 +1109,9 @@ pub(crate) fn verify_regular_cube_pin(root: &std::path::Path, pin: &str) -> Resu
 pub(crate) async fn clear_duress_enrollment(datadir: CoincubeDirectory) -> Result<(), String> {
     let root = datadir.path().to_path_buf();
 
-    // Efficiency + safety guard: if this device never armed duress, there's
-    // nothing to clear. A real read error is surfaced rather than papered over.
-    let mut st = crate::services::duress::DuressLocalState::load(&root)
-        .map_err(|e| format!("Couldn't read existing duress state: {e}"))?;
-    if !st.enrolled {
-        return Ok(());
-    }
-
-    // 1. Clear the duress PIN hash on every Cube on every network. Setting it to
-    //    None is idempotent; stop at the first failure so a retry re-clears the
-    //    rest (the local state still says enrolled until step 2).
+    // 1. Clear the duress PIN hash on every Cube on every network — ALWAYS,
+    //    whatever DuressLocalState records. Setting it to None is idempotent;
+    //    stop at the first failure so a retry re-clears the rest.
     let network_dirs = duress_enroll_network_dirs(&root);
     for network_dir in &network_dirs {
         crate::app::settings::update_settings_file(network_dir, move |mut s| {
@@ -1130,7 +1125,11 @@ pub(crate) async fn clear_duress_enrollment(datadir: CoincubeDirectory) -> Resul
     }
 
     // 2. Reset DuressLocalState to the un-enrolled baseline (zeroizes the
-    //    encrypted device code). Only now is the device truly disarmed.
+    //    encrypted device code). `load` maps a missing file to default, so a
+    //    never-enrolled device just rewrites a default; a real parse/IO error is
+    //    surfaced rather than papered over. Only now is the device truly disarmed.
+    let mut st = crate::services::duress::DuressLocalState::load(&root)
+        .map_err(|e| format!("Couldn't read existing duress state: {e}"))?;
     st.disarm();
     st.save(&root)
         .map_err(|e| format!("Couldn't update local duress state: {e}"))?;
@@ -1144,12 +1143,40 @@ pub(crate) async fn clear_duress_enrollment(datadir: CoincubeDirectory) -> Resul
     Ok(())
 }
 
+/// Whether any Cube on any network still has a duress PIN hash armed. Read-only.
+/// Used to detect the *orphaned* state — Cubes armed while `DuressLocalState`
+/// reads "not enrolled" — so a reconcile doesn't skip a device that a crash left
+/// half-armed. A settings read error is surfaced rather than papered over (a
+/// false "nothing armed" could leave a live wipe trigger in place).
+fn any_cube_duress_armed(root: &std::path::Path) -> Result<bool, String> {
+    for network_dir in &duress_enroll_network_dirs(root) {
+        let settings = crate::app::settings::Settings::from_file(network_dir)
+            .map_err(|e| format!("Couldn't read your Cube settings: {e}"))?;
+        if settings.cubes.iter().any(|c| c.has_duress_pin()) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 /// Reconcile a possibly remote/offline duress *disable* against this device's
-/// local state. Disarms ONLY when this device holds a Connect enrollment
-/// (`account_id` set) for `account_id` — the account the server now reports as
-/// no longer enrolled. Sovereign (`account_id == None`) enrollments are
-/// local-only and must NEVER be disarmed by a server "not enrolled". Returns
-/// whether a disarm actually ran.
+/// local state, returning whether a disarm actually ran. Disarms when EITHER:
+///
+/// * this device holds a Connect enrollment (`account_id` set) for `account_id`
+///   — the account the server now reports as no longer enrolled; OR
+/// * the device is *orphaned* — Cubes are still armed while `DuressLocalState`
+///   reads "not enrolled". A hard crash between persist's Cube-arming step and
+///   its state-write step leaves exactly this state. A properly-armed enrollment
+///   (sovereign included) reads `enrolled == true`, so "armed while not enrolled"
+///   uniquely flags an unfinished enrollment whose wipe trigger is still live —
+///   we fail toward disarmed rather than leave it able to wipe after a disable.
+///
+/// A fully sovereign enrollment (`enrolled == true`, `account_id == None`) is
+/// matched by neither branch and is therefore never disarmed by a server "not
+/// enrolled" — sovereign duress is local-only and the server has no say over it.
+/// The only sovereign state this can touch is an *orphaned* (crashed, unfinished)
+/// one, which never reached the "enabled" confirmation; clearing its stale wipe
+/// trigger is the safe, recoverable (re-enrollable) outcome.
 pub(crate) async fn reconcile_duress_disarm(
     datadir: CoincubeDirectory,
     account_id: String,
@@ -1157,7 +1184,44 @@ pub(crate) async fn reconcile_duress_disarm(
     let root = datadir.path().to_path_buf();
     let st = crate::services::duress::DuressLocalState::load(&root)
         .map_err(|e| format!("Couldn't read existing duress state: {e}"))?;
-    if !(st.enrolled && st.account_id.as_deref() == Some(account_id.as_str())) {
+
+    let connect_enrollment_matches =
+        st.enrolled && st.account_id.as_deref() == Some(account_id.as_str());
+    // Only pay for the settings scan when the cheap flag check didn't already
+    // decide it, and only when the local state claims "not enrolled" (a properly
+    // enrolled device is handled by the flag check above).
+    let orphaned_armed =
+        !connect_enrollment_matches && !st.enrolled && any_cube_duress_armed(&root)?;
+
+    if !(connect_enrollment_matches || orphaned_armed) {
+        return Ok(false);
+    }
+    clear_duress_enrollment(datadir).await?;
+    Ok(true)
+}
+
+/// Launch-time orphan check for an account the server still reports as ENROLLED.
+/// Disarms ONLY when this device is *orphaned* — Cubes armed while
+/// `DuressLocalState` never recorded the enrollment, the state a hard crash
+/// between persist's Cube-arming and state-write steps leaves behind. The lost
+/// device code can't be recovered, so the enrollment can't be completed; the
+/// armed Cubes would otherwise stay a live wipe trigger that the panel reports
+/// as inert ("not armed on this device"). Disarming makes the device honestly
+/// match that copy and re-enrollable.
+///
+/// A healthy device (local state present → `enrolled == true`) or one with no
+/// armed Cubes is a no-op, so a normally-enrolled device is NEVER disarmed here.
+/// Returns whether a disarm ran.
+pub(crate) async fn reconcile_duress_orphan(datadir: CoincubeDirectory) -> Result<bool, String> {
+    let root = datadir.path().to_path_buf();
+    let st = crate::services::duress::DuressLocalState::load(&root)
+        .map_err(|e| format!("Couldn't read existing duress state: {e}"))?;
+    // Local state present → a healthy, fully-recorded enrollment. Leave it.
+    if st.enrolled {
+        return Ok(false);
+    }
+    // Local state missing but Cubes armed → orphan. Disarm.
+    if !any_cube_duress_armed(&root)? {
         return Ok(false);
     }
     clear_duress_enrollment(datadir).await?;

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1058,10 +1058,7 @@ pub(crate) const DURESS_STEP_UP_BAD_PIN_MSG: &str =
 /// `Ok` when a Cube's regular PIN matches, or when no Cube has a regular PIN at
 /// all (no second factor to demand). `Err` on an empty PIN, a mismatch, no
 /// Cubes, or when settings can't be read.
-pub(crate) fn verify_regular_cube_pin(
-    root: &std::path::Path,
-    pin: &str,
-) -> Result<(), String> {
+pub(crate) fn verify_regular_cube_pin(root: &std::path::Path, pin: &str) -> Result<(), String> {
     if pin.is_empty() {
         return Err("Enter your Cube unlock PIN to continue.".to_string());
     }

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1829,9 +1829,7 @@ impl ConnectAccountPanel {
                         // `clear_duress_enrollment` no-ops when nothing is armed,
                         // so this is cheap for the common never-enrolled account.
                         if !server_enrolled {
-                            if let Some(account_id) =
-                                self.user.as_ref().map(|u| u.id.to_string())
-                            {
+                            if let Some(account_id) = self.user.as_ref().map(|u| u.id.to_string()) {
                                 if let Ok(dir) = crate::dir::CoincubeDirectory::active() {
                                     let gen = self.session_generation;
                                     return iced::Task::perform(
@@ -2449,7 +2447,8 @@ impl ConnectAccountPanel {
             }
             DuressMessage::DuressPinConfirmChanged(v) => {
                 if let Some(e) = &mut self.duress_enroll {
-                   e.duress_pin_confirm = v.chars().filter(|c| c.is_ascii_digit()).take(4).collect();
+                    e.duress_pin_confirm =
+                        v.chars().filter(|c| c.is_ascii_digit()).take(4).collect();
                 }
             }
             DuressMessage::AllClearChanged(v) => {
@@ -2794,9 +2793,7 @@ impl ConnectAccountPanel {
                 // PIN makes no call at all.
                 match crate::dir::CoincubeDirectory::active() {
                     Ok(dir) => {
-                        if let Err(msg) =
-                            crate::app::verify_regular_cube_pin(dir.path(), &d.pin)
-                        {
+                        if let Err(msg) = crate::app::verify_regular_cube_pin(dir.path(), &d.pin) {
                             d.error = Some(msg);
                             return iced::Task::none();
                         }
@@ -2856,7 +2853,9 @@ impl ConnectAccountPanel {
                         };
                         return iced::Task::perform(
                             async move {
-                                crate::app::clear_duress_enrollment(dir).await.map(|()| true)
+                                crate::app::clear_duress_enrollment(dir)
+                                    .await
+                                    .map(|()| true)
                             },
                             move |res| {
                                 Message::View(view::Message::ConnectAccount(
@@ -2910,15 +2909,14 @@ impl ConnectAccountPanel {
                         // disable (a dialog was open). The cross-device event and
                         // launch reconcile disarm silently.
                         if changed && had_dialog {
-                            return iced::Task::done(Message::View(
-                                view::Message::ShowSuccess("Duress mode disabled.".to_string()),
-                            ));
+                            return iced::Task::done(Message::View(view::Message::ShowSuccess(
+                                "Duress mode disabled.".to_string(),
+                            )));
                         }
                     }
                     Err(e) => {
                         log::error!("[CONNECT] duress disarm failed: {e}");
-                        let msg =
-                            format!("Couldn't turn off duress mode: {e}. Please try again.");
+                        let msg = format!("Couldn't turn off duress mode: {e}. Please try again.");
                         if let Some(d) = &mut self.duress_disable {
                             d.submitting = false;
                             d.error = Some(msg);
@@ -4090,7 +4088,13 @@ fn device_fingerprint() -> Result<String, String> {
 fn enroll_steps(tier: EnrollTier, require_backup_ack: bool) -> Vec<DuressEnrollStep> {
     use DuressEnrollStep::*;
     let mut steps = match tier {
-        EnrollTier::Tier1 => vec![SetDuressPin, SetAllClear, SetCrkPassword, PickDelay, Confirm],
+        EnrollTier::Tier1 => vec![
+            SetDuressPin,
+            SetAllClear,
+            SetCrkPassword,
+            PickDelay,
+            Confirm,
+        ],
         EnrollTier::Tier2 => vec![SetDuressPin, SetAllClear, PickDelay, Confirm],
         EnrollTier::Sovereign => vec![Encourage, SetDuressPin, Confirm],
     };
@@ -4277,15 +4281,27 @@ mod duress_enroll_tests {
 
         // Tier 1 with every cube backed up → skip the gate.
         panel.duress_cubes = Some(vec![
-            DuressCube { name: "A".into(), has_recovery_kit: true },
-            DuressCube { name: "B".into(), has_recovery_kit: true },
+            DuressCube {
+                name: "A".into(),
+                has_recovery_kit: true,
+            },
+            DuressCube {
+                name: "B".into(),
+                has_recovery_kit: true,
+            },
         ]);
         assert!(!panel.compute_require_backup_ack(EnrollTier::Tier1));
 
         // Tier 1 with any cube lacking a recovery kit → gate.
         panel.duress_cubes = Some(vec![
-            DuressCube { name: "A".into(), has_recovery_kit: true },
-            DuressCube { name: "B".into(), has_recovery_kit: false },
+            DuressCube {
+                name: "A".into(),
+                has_recovery_kit: true,
+            },
+            DuressCube {
+                name: "B".into(),
+                has_recovery_kit: false,
+            },
         ]);
         assert!(panel.compute_require_backup_ack(EnrollTier::Tier1));
     }

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -358,21 +358,34 @@ pub enum EnrollTier {
 }
 
 /// Steps of the duress enrollment wizard. Sovereign opens at `Encourage`;
-/// Connect tiers skip straight to `SetDuressPin`. `SetCrkPassword` is Tier 1
-/// only.
+/// Connect tiers skip straight to `SetDuressPin` (or `BackupAck` when the gate
+/// applies). `SetCrkPassword` is Tier 1 only.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DuressEnrollStep {
     /// Sovereign Step 0 — Connect-encouragement (primary CTA "Sign up for
     /// Connect", secondary "Continue without Connect").
     Encourage,
-    /// Sovereign friction — type "I have my seed-phrase backup".
-    SovereignConfirm,
+    /// Mandated backup-acknowledgement gate — type the exact, case-sensitive
+    /// [`BACKUP_ACK_PHRASE`] before duress can be armed. Shown when any Cube a
+    /// duress wipe would destroy lacks a Cube Recovery Kit, or when the user is
+    /// sovereign (no server-side recovery at all). Skipped when every protected
+    /// Cube is backed up (Tier 1). Was the sovereign-only "I have my seed-phrase
+    /// backup" friction step.
+    BackupAck,
     SetDuressPin,
     SetAllClear,
     SetCrkPassword,
     PickDelay,
     Confirm,
 }
+
+/// The exact phrase a user must type, character-for-character, at the
+/// [`DuressEnrollStep::BackupAck`] gate before duress can be armed. Naming both
+/// destroyed artifacts — the Master Seed Phrase(s) and the Vault Wallet
+/// Descriptor(s) — and the funds consequence is deliberate (Robert, 2026-06-30):
+/// the match is strict, case-sensitive, with no whitespace normalization, so
+/// the user can't pass by paraphrase, a checkbox, or muscle memory.
+pub const BACKUP_ACK_PHRASE: &str = "I understand my Cubes will be permanently destroyed (along with access to any funds held within) if I activate duress without my own external backup of the Master Seed Phrases and Vault Wallet Descriptors.";
 
 /// In-flight enrollment wizard state (Phases 2 & 8). `None` on the panel when
 /// the wizard isn't open.
@@ -386,7 +399,15 @@ pub struct DuressEnrollState {
     pub all_clear: String,
     pub crk_password: String,
     pub delay: crate::services::duress::enroll::DuressDelay,
-    pub sovereign_confirm: String,
+    /// Typed input for the mandated backup-acknowledgement gate
+    /// ([`DuressEnrollStep::BackupAck`]). Must exactly (case-sensitively) equal
+    /// [`BACKUP_ACK_PHRASE`] before enrollment can proceed.
+    pub backup_ack: String,
+    /// Whether this enrollment must pass the backup-acknowledgement gate. Set at
+    /// `open_enroll_wizard` time: always for sovereign and Tier 2, and for Tier 1
+    /// only when some protected Cube lacks a recovery kit (or the per-Cube state
+    /// is unknown — fail toward showing the warning).
+    pub require_backup_ack: bool,
     pub memorized: bool,
     pub submitting: bool,
     pub error: Option<String>,
@@ -398,6 +419,14 @@ pub struct DuressEnrollState {
 }
 
 impl DuressEnrollState {
+    /// Whether the backup-acknowledgement gate's typed input is an exact,
+    /// case-sensitive match for [`BACKUP_ACK_PHRASE`]. Drives the disabled state
+    /// of the wizard's advance button on the [`DuressEnrollStep::BackupAck`]
+    /// step, so it can't be cleared by a paraphrase or near-miss.
+    pub fn backup_ack_satisfied(&self) -> bool {
+        self.backup_ack == BACKUP_ACK_PHRASE
+    }
+
     /// Scrubs the in-memory secret fields (PINs, passphrases, and the generated
     /// duress code) so they don't linger on the heap after the wizard is torn
     /// down — e.g. on logout, where the rest of the session is reset.
@@ -407,10 +436,32 @@ impl DuressEnrollState {
         self.duress_pin_confirm.zeroize();
         self.all_clear.zeroize();
         self.crk_password.zeroize();
-        self.sovereign_confirm.zeroize();
+        self.backup_ack.zeroize();
         if let Some(code) = self.pending_code.as_mut() {
             code.zeroize();
         }
+    }
+}
+
+/// Step-up re-auth dialog for the "Disable Duress Mode" control (Issue 2).
+/// `None` when the dialog is closed. The user must re-enter their regular Cube
+/// unlock PIN — NOT the duress PIN — to authorize turning duress off.
+#[derive(Debug, Default)]
+pub struct DuressDisableState {
+    /// The regular Cube unlock PIN re-entered to authorize the disable.
+    pub pin: String,
+    /// True while the server `disable_duress` and the subsequent local disarm
+    /// are in flight; disables the dialog's confirm button.
+    pub submitting: bool,
+    pub error: Option<String>,
+}
+
+impl DuressDisableState {
+    /// Scrubs the re-entered PIN before the dialog is dropped, so it doesn't
+    /// linger on the heap after the disable flow ends.
+    fn zeroize_secrets(&mut self) {
+        use zeroize::Zeroize;
+        self.pin.zeroize();
     }
 }
 
@@ -533,6 +584,8 @@ pub struct ConnectAccountPanel {
     pub show_billing_history: bool,
     /// Active duress enrollment wizard (Phases 2 & 8); `None` when closed.
     pub duress_enroll: Option<DuressEnrollState>,
+    /// Active "Disable Duress Mode" step-up dialog (Issue 2); `None` when closed.
+    pub duress_disable: Option<DuressDisableState>,
     /// Duress "Emergency contacts" section (Estate Notifications — PR 1).
     pub duress_contacts: DuressContactsState,
     /// Mainnet cubes + recovery-kit status for the Duress intro screen's
@@ -586,6 +639,7 @@ impl ConnectAccountPanel {
             billing_history: None,
             show_billing_history: false,
             duress_enroll: None,
+            duress_disable: None,
             duress_contacts: DuressContactsState::default(),
             duress_cubes: None,
             duress_state: None,
@@ -1750,6 +1804,7 @@ impl ConnectAccountPanel {
                         // Duress tab reflects the enabled state on its first paint
                         // rather than briefly showing enrollment CTAs.
                         let needs_device_register = s.enrolled && !s.this_device_registered;
+                        let server_enrolled = s.enrolled;
                         self.duress_state = Some(s);
                         // Phase 0: a signed-in device on an already-enrolled
                         // account that isn't yet registered server-side mints +
@@ -1763,6 +1818,36 @@ impl ConnectAccountPanel {
                                     self.client.clone(),
                                     account_id,
                                 );
+                            }
+                        }
+                        // Launch reconcile (Issue 2, PR 4): the account is no
+                        // longer enrolled server-side, but this device may still
+                        // hold a Connect duress enrollment from before a disable
+                        // it missed while offline. Disarm it locally so the duress
+                        // PIN can't still trip a wipe. `reconcile_duress_disarm`
+                        // no-ops for sovereign / non-matching local state, and
+                        // `clear_duress_enrollment` no-ops when nothing is armed,
+                        // so this is cheap for the common never-enrolled account.
+                        if !server_enrolled {
+                            if let Some(account_id) =
+                                self.user.as_ref().map(|u| u.id.to_string())
+                            {
+                                if let Ok(dir) = crate::dir::CoincubeDirectory::active() {
+                                    let gen = self.session_generation;
+                                    return iced::Task::perform(
+                                        async move {
+                                            crate::app::reconcile_duress_disarm(dir, account_id)
+                                                .await
+                                        },
+                                        move |res| {
+                                            Message::View(view::Message::ConnectAccount(
+                                                ConnectAccountMessage::Duress(
+                                                    DuressMessage::DisarmComplete(res, gen),
+                                                ),
+                                            ))
+                                        },
+                                    );
+                                }
                             }
                         }
                     }
@@ -1848,12 +1933,19 @@ impl ConnectAccountPanel {
         iced::Task::none()
     }
 
-    /// Opens the duress enrollment wizard at `step` for `tier`, resetting all
-    /// inputs. Shared by the Tier 1 / Tier 2 / Sovereign entry points.
-    fn open_enroll_wizard(&mut self, tier: EnrollTier, step: DuressEnrollStep) {
+    /// Opens the duress enrollment wizard for `tier`, resetting all inputs. The
+    /// starting step and whether the mandated backup-acknowledgement gate
+    /// applies are both derived here from `tier` and the per-Cube recovery-kit
+    /// state. Shared by the Tier 1 / Tier 2 / Sovereign entry points.
+    fn open_enroll_wizard(&mut self, tier: EnrollTier) {
         // Scrub any wizard already in flight before replacing it, so re-opening
         // never drops its secrets unzeroized.
         self.clear_duress_enroll();
+        let require_backup_ack = self.compute_require_backup_ack(tier);
+        // The wizard opens at the first step of the tier's (gate-aware) sequence
+        // — `Encourage` for sovereign, `BackupAck` when a Connect tier gates, or
+        // `SetDuressPin` for a fully-backed-up Tier 1.
+        let step = enroll_steps(tier, require_backup_ack)[0];
         self.duress_enroll = Some(DuressEnrollState {
             tier,
             step,
@@ -1862,12 +1954,29 @@ impl ConnectAccountPanel {
             all_clear: String::new(),
             crk_password: String::new(),
             delay: crate::services::duress::enroll::DuressDelay::default(),
-            sovereign_confirm: String::new(),
+            backup_ack: String::new(),
+            require_backup_ack,
             memorized: false,
             submitting: false,
             error: None,
             pending_code: None,
         });
+    }
+
+    /// Whether this enrollment must pass the mandated backup-acknowledgement
+    /// gate ([`DuressEnrollStep::BackupAck`]). Always for sovereign (no
+    /// server-side recovery) and Tier 2 (Connect, explicitly no recovery kit);
+    /// for Tier 1 only when some Cube a duress wipe would destroy still lacks a
+    /// recovery kit. When the per-Cube state hasn't loaded (`None`), fail toward
+    /// showing the gate — over-warning is safe, silently skipping it isn't.
+    fn compute_require_backup_ack(&self, tier: EnrollTier) -> bool {
+        match tier {
+            EnrollTier::Sovereign | EnrollTier::Tier2 => true,
+            EnrollTier::Tier1 => self
+                .duress_cubes
+                .as_ref()
+                .map_or(true, |cubes| cubes.iter().any(|c| !c.has_recovery_kit)),
+        }
     }
 
     /// Tears down all session state: bumps `session_generation` (so any
@@ -1903,6 +2012,9 @@ impl ConnectAccountPanel {
         // generated code) and the recovery all-clear passphrase before
         // dropping them, so they don't survive the session reset.
         self.clear_duress_enroll();
+        if let Some(mut d) = self.duress_disable.take() {
+            d.zeroize_secrets();
+        }
         self.scrub_recovery_passphrase();
         self.clear_keyring_session();
         self.client = CoincubeClient::new();
@@ -2301,16 +2413,16 @@ impl ConnectAccountPanel {
                 // takes the Tier 2 path via StartEnrollmentWithoutCrk. Non-
                 // Connect users get the sovereign encouragement flow.
                 if entitled {
-                    self.open_enroll_wizard(EnrollTier::Tier1, DuressEnrollStep::SetDuressPin);
+                    self.open_enroll_wizard(EnrollTier::Tier1);
                 } else {
-                    self.open_enroll_wizard(EnrollTier::Sovereign, DuressEnrollStep::Encourage);
+                    self.open_enroll_wizard(EnrollTier::Sovereign);
                 }
             }
             DuressMessage::StartEnrollmentWithoutCrk => {
                 // Tier 2 — Connect, no recovery kit: same as Tier 1 minus the
-                // CRK-password step (see `enroll_steps`). The BIG "set up a
-                // recovery kit first" warning is shown on the eligibility gate.
-                self.open_enroll_wizard(EnrollTier::Tier2, DuressEnrollStep::SetDuressPin);
+                // CRK-password step (see `enroll_steps`), and always behind the
+                // backup-acknowledgement gate (no recovery kit by definition).
+                self.open_enroll_wizard(EnrollTier::Tier2);
             }
             DuressMessage::SignUpForConnect => {
                 self.clear_duress_enroll();
@@ -2355,9 +2467,9 @@ impl ConnectAccountPanel {
                     e.delay = d;
                 }
             }
-            DuressMessage::SovereignConfirmChanged(v) => {
+            DuressMessage::BackupAckChanged(v) => {
                 if let Some(e) = &mut self.duress_enroll {
-                    e.sovereign_confirm = v;
+                    e.backup_ack = v;
                 }
             }
             DuressMessage::MemorizedToggled(v) => {
@@ -2368,7 +2480,7 @@ impl ConnectAccountPanel {
             DuressMessage::EnrollBack => {
                 if let Some(e) = &mut self.duress_enroll {
                     e.error = None;
-                    e.step = prev_enroll_step(e.tier, e.step);
+                    e.step = prev_enroll_step(e.tier, e.require_backup_ack, e.step);
                 }
             }
             DuressMessage::EnrollNext => {
@@ -2377,7 +2489,7 @@ impl ConnectAccountPanel {
                         e.error = Some(msg);
                     } else {
                         e.error = None;
-                        e.step = next_enroll_step(e.tier, e.step);
+                        e.step = next_enroll_step(e.tier, e.require_backup_ack, e.step);
                     }
                 }
             }
@@ -2526,7 +2638,7 @@ impl ConnectAccountPanel {
                         // Clone the forwarded secrets into the Zeroizing payload,
                         // then scrub the wizard via the shared helper — this path
                         // must not drop the leftover fields (all_clear, CRK
-                        // password, sovereign_confirm) unzeroized.
+                        // password, backup_ack) unzeroized.
                         let payload = self.duress_enroll.as_ref().map(|e| {
                             crate::app::message::DuressEnrollmentPayload {
                                 duress_pin: zeroize::Zeroizing::new(e.duress_pin.clone()),
@@ -2649,6 +2761,172 @@ impl ConnectAccountPanel {
                 // `mark_duress_enrolled` mirrors the account-level server state.
                 self.duress_locally_armed = true;
                 self.mark_duress_enrolled();
+            }
+
+            // ── Disable (Issue 2 — turn duress off) ──
+            DuressMessage::DisableStart => {
+                // Open the step-up re-auth dialog. The trigger is only surfaced
+                // when enrolled & inactive (see `duress_ux`).
+                self.duress_disable = Some(DuressDisableState::default());
+            }
+            DuressMessage::DisablePinChanged(v) => {
+                if let Some(d) = &mut self.duress_disable {
+                    d.pin = v;
+                    d.error = None;
+                }
+            }
+            DuressMessage::DisableCancel => {
+                if let Some(mut d) = self.duress_disable.take() {
+                    d.zeroize_secrets();
+                }
+            }
+            DuressMessage::DisableSubmit => {
+                let Some(d) = &mut self.duress_disable else {
+                    return iced::Task::none();
+                };
+                // Re-entrancy guard: the confirm button is disabled while
+                // submitting, but two presses can queue in one frame.
+                if d.submitting {
+                    return iced::Task::none();
+                }
+                // Step-up: the entered PIN must match a Cube's REAL unlock PIN
+                // (never the duress PIN). Verify BEFORE any server call — a wrong
+                // PIN makes no call at all.
+                match crate::dir::CoincubeDirectory::active() {
+                    Ok(dir) => {
+                        if let Err(msg) =
+                            crate::app::verify_regular_cube_pin(dir.path(), &d.pin)
+                        {
+                            d.error = Some(msg);
+                            return iced::Task::none();
+                        }
+                    }
+                    Err(err) => {
+                        d.error = Some(format!(
+                            "Couldn't access your Cube data to verify your PIN: {err}"
+                        ));
+                        return iced::Task::none();
+                    }
+                }
+                d.submitting = true;
+                d.error = None;
+                let gen = self.session_generation;
+                let client = self.client.clone();
+                return iced::Task::perform(
+                    async move { client.disable_duress().await },
+                    move |res| {
+                        let mapped = res.map_err(|e| match &e {
+                            crate::services::coincube::CoincubeError::Unsuccessful(info)
+                                if info.status_code == 423 =>
+                            {
+                                view::DuressDisableError::Active
+                            }
+                            _ => view::DuressDisableError::Failed(e.to_string()),
+                        });
+                        Message::View(view::Message::ConnectAccount(
+                            ConnectAccountMessage::Duress(DuressMessage::DisableResult(
+                                mapped, gen,
+                            )),
+                        ))
+                    },
+                );
+            }
+            DuressMessage::DisableResult(res, gen) => {
+                if gen != self.session_generation {
+                    return iced::Task::none();
+                }
+                match res {
+                    Ok(()) => {
+                        // Server disabled — now disarm THIS device locally (clear
+                        // Cube PIN hashes + local state + queue), via the active
+                        // datadir (same one the enroll pre-flight uses).
+                        let dir = match crate::dir::CoincubeDirectory::active() {
+                            Ok(d) => d,
+                            Err(err) => {
+                                if let Some(d) = &mut self.duress_disable {
+                                    d.submitting = false;
+                                    d.error = Some(format!(
+                                        "Duress was turned off on the server, but this \
+                                         device couldn't be disarmed: {err}. Reopen \
+                                         Settings to retry."
+                                    ));
+                                }
+                                return iced::Task::none();
+                            }
+                        };
+                        return iced::Task::perform(
+                            async move {
+                                crate::app::clear_duress_enrollment(dir).await.map(|()| true)
+                            },
+                            move |res| {
+                                Message::View(view::Message::ConnectAccount(
+                                    ConnectAccountMessage::Duress(DuressMessage::DisarmComplete(
+                                        res, gen,
+                                    )),
+                                ))
+                            },
+                        );
+                    }
+                    Err(view::DuressDisableError::Active) => {
+                        if let Some(d) = &mut self.duress_disable {
+                            d.submitting = false;
+                            d.error = Some(
+                                "Duress is currently active and can't be disabled.".to_string(),
+                            );
+                        }
+                        // Re-sync state: if duress really is active, the
+                        // `StateLoaded` handler routes this device to recovery.
+                        return self.reload_duress_state();
+                    }
+                    Err(view::DuressDisableError::Failed(msg)) => {
+                        if let Some(d) = &mut self.duress_disable {
+                            d.submitting = false;
+                            d.error = Some(msg);
+                        }
+                    }
+                }
+            }
+            DuressMessage::DisarmComplete(res, gen) => {
+                if gen != self.session_generation {
+                    return iced::Task::none();
+                }
+                let had_dialog = self.duress_disable.is_some();
+                match res {
+                    Ok(changed) => {
+                        if changed {
+                            // This device is no longer armed; reflect the
+                            // disabled state in the panel immediately.
+                            self.duress_locally_armed = false;
+                            if let Some(s) = &mut self.duress_state {
+                                s.enrolled = false;
+                                s.active = false;
+                                s.this_device_registered = false;
+                            }
+                        }
+                        if let Some(mut d) = self.duress_disable.take() {
+                            d.zeroize_secrets();
+                        }
+                        // Confirmation toast only for the explicit, user-driven
+                        // disable (a dialog was open). The cross-device event and
+                        // launch reconcile disarm silently.
+                        if changed && had_dialog {
+                            return iced::Task::done(Message::View(
+                                view::Message::ShowSuccess("Duress mode disabled.".to_string()),
+                            ));
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("[CONNECT] duress disarm failed: {e}");
+                        let msg =
+                            format!("Couldn't turn off duress mode: {e}. Please try again.");
+                        if let Some(d) = &mut self.duress_disable {
+                            d.submitting = false;
+                            d.error = Some(msg);
+                        } else {
+                            self.error = Some(msg);
+                        }
+                    }
+                }
             }
         }
         iced::Task::none()
@@ -3805,31 +4083,42 @@ fn device_fingerprint() -> Result<String, String> {
 /// The ordered steps for a tier. Sovereign opens with the Connect
 /// encouragement + friction confirm; Connect tiers skip those. `SetCrkPassword`
 /// is Tier 1 only.
-fn enroll_steps(tier: EnrollTier) -> &'static [DuressEnrollStep] {
+/// The ordered steps for `tier`, with the mandated backup-acknowledgement gate
+/// spliced in when `require_backup_ack` is set. The gate sits right after the
+/// sovereign `Encourage` screen, or at the very front for Connect tiers (which
+/// have no `Encourage` screen).
+fn enroll_steps(tier: EnrollTier, require_backup_ack: bool) -> Vec<DuressEnrollStep> {
     use DuressEnrollStep::*;
-    match tier {
-        EnrollTier::Tier1 => &[
-            SetDuressPin,
-            SetAllClear,
-            SetCrkPassword,
-            PickDelay,
-            Confirm,
-        ],
-        EnrollTier::Tier2 => &[SetDuressPin, SetAllClear, PickDelay, Confirm],
-        EnrollTier::Sovereign => &[Encourage, SovereignConfirm, SetDuressPin, Confirm],
+    let mut steps = match tier {
+        EnrollTier::Tier1 => vec![SetDuressPin, SetAllClear, SetCrkPassword, PickDelay, Confirm],
+        EnrollTier::Tier2 => vec![SetDuressPin, SetAllClear, PickDelay, Confirm],
+        EnrollTier::Sovereign => vec![Encourage, SetDuressPin, Confirm],
+    };
+    if require_backup_ack {
+        let pos = usize::from(matches!(tier, EnrollTier::Sovereign));
+        steps.insert(pos, BackupAck);
     }
+    steps
 }
 
-fn next_enroll_step(tier: EnrollTier, cur: DuressEnrollStep) -> DuressEnrollStep {
-    let steps = enroll_steps(tier);
+fn next_enroll_step(
+    tier: EnrollTier,
+    require_backup_ack: bool,
+    cur: DuressEnrollStep,
+) -> DuressEnrollStep {
+    let steps = enroll_steps(tier, require_backup_ack);
     match steps.iter().position(|s| *s == cur) {
         Some(i) if i + 1 < steps.len() => steps[i + 1],
         _ => cur,
     }
 }
 
-fn prev_enroll_step(tier: EnrollTier, cur: DuressEnrollStep) -> DuressEnrollStep {
-    let steps = enroll_steps(tier);
+fn prev_enroll_step(
+    tier: EnrollTier,
+    require_backup_ack: bool,
+    cur: DuressEnrollStep,
+) -> DuressEnrollStep {
+    let steps = enroll_steps(tier, require_backup_ack);
     match steps.iter().position(|s| *s == cur) {
         Some(i) if i > 0 => steps[i - 1],
         _ => cur,
@@ -3842,8 +4131,10 @@ fn validate_enroll_step(e: &DuressEnrollState) -> Result<(), String> {
     use crate::services::duress::enroll;
     match e.step {
         DuressEnrollStep::Encourage => Ok(()),
-        DuressEnrollStep::SovereignConfirm => {
-            if e.sovereign_confirm.trim() == "I have my seed-phrase backup" {
+        DuressEnrollStep::BackupAck => {
+            // Strict, case-sensitive, no whitespace normalization — the gate
+            // can't be passed by paraphrase or a near-miss.
+            if e.backup_ack == BACKUP_ACK_PHRASE {
                 Ok(())
             } else {
                 Err("Type the confirmation phrase exactly to continue.".to_string())
@@ -3880,7 +4171,10 @@ mod duress_enroll_tests {
             all_clear: String::new(),
             crk_password: String::new(),
             delay: crate::services::duress::enroll::DuressDelay::default(),
-            sovereign_confirm: String::new(),
+            backup_ack: String::new(),
+            // Default the tests to "gate on" so a `BackupAck` step is always
+            // reachable; individual gate-inclusion tests set this explicitly.
+            require_backup_ack: true,
             memorized: false,
             submitting: false,
             error: None,
@@ -3894,7 +4188,7 @@ mod duress_enroll_tests {
         s.duress_pin = "8765".to_string();
         s.all_clear = "correct horse battery".to_string();
         s.crk_password = "a-long-crk-password".to_string();
-        s.sovereign_confirm = "I have my seed-phrase backup".to_string();
+        s.backup_ack = BACKUP_ACK_PHRASE.to_string();
         s.pending_code = Some("deadbeefcafebabe".to_string());
 
         s.zeroize_secrets();
@@ -3902,12 +4196,13 @@ mod duress_enroll_tests {
         assert!(s.duress_pin.is_empty());
         assert!(s.all_clear.is_empty());
         assert!(s.crk_password.is_empty());
-        assert!(s.sovereign_confirm.is_empty());
+        assert!(s.backup_ack.is_empty());
         assert!(s.pending_code.as_deref().unwrap_or("").is_empty());
     }
 
     #[test]
-    fn tier1_step_order() {
+    fn tier1_step_order_no_gate() {
+        // Fully-backed-up Tier 1 (gate skipped) keeps the original sequence.
         let mut s = DuressEnrollStep::SetDuressPin;
         let order = [
             DuressEnrollStep::SetDuressPin,
@@ -3917,34 +4212,82 @@ mod duress_enroll_tests {
             DuressEnrollStep::Confirm,
         ];
         for expected in &order[1..] {
-            s = next_enroll_step(EnrollTier::Tier1, s);
+            s = next_enroll_step(EnrollTier::Tier1, false, s);
             assert_eq!(s, *expected);
         }
         // Saturates at the end.
         assert_eq!(
-            next_enroll_step(EnrollTier::Tier1, DuressEnrollStep::Confirm),
+            next_enroll_step(EnrollTier::Tier1, false, DuressEnrollStep::Confirm),
             DuressEnrollStep::Confirm
         );
     }
 
     #[test]
-    fn tier2_skips_crk_password() {
+    fn tier1_gate_prepends_backup_ack() {
+        // A Tier 1 with a Cube lacking a recovery kit opens at the gate, then
+        // flows into the normal sequence.
+        let steps = enroll_steps(EnrollTier::Tier1, true);
+        assert_eq!(steps[0], DuressEnrollStep::BackupAck);
         assert_eq!(
-            next_enroll_step(EnrollTier::Tier2, DuressEnrollStep::SetAllClear),
+            next_enroll_step(EnrollTier::Tier1, true, DuressEnrollStep::BackupAck),
+            DuressEnrollStep::SetDuressPin
+        );
+        // Back from the gate saturates (it's the first step).
+        assert_eq!(
+            prev_enroll_step(EnrollTier::Tier1, true, DuressEnrollStep::BackupAck),
+            DuressEnrollStep::BackupAck
+        );
+    }
+
+    #[test]
+    fn tier2_always_gates_and_skips_crk_password() {
+        let steps = enroll_steps(EnrollTier::Tier2, true);
+        assert_eq!(steps[0], DuressEnrollStep::BackupAck);
+        assert!(!steps.contains(&DuressEnrollStep::SetCrkPassword));
+        assert_eq!(
+            next_enroll_step(EnrollTier::Tier2, true, DuressEnrollStep::SetAllClear),
             DuressEnrollStep::PickDelay
         );
     }
 
     #[test]
-    fn sovereign_opens_with_encourage_and_confirm() {
+    fn sovereign_opens_with_encourage_then_gate() {
+        // Sovereign always gates; the gate sits right after the Encourage screen.
         assert_eq!(
-            enroll_steps(EnrollTier::Sovereign)[0],
+            enroll_steps(EnrollTier::Sovereign, true)[0],
             DuressEnrollStep::Encourage
         );
         assert_eq!(
-            next_enroll_step(EnrollTier::Sovereign, DuressEnrollStep::Encourage),
-            DuressEnrollStep::SovereignConfirm
+            next_enroll_step(EnrollTier::Sovereign, true, DuressEnrollStep::Encourage),
+            DuressEnrollStep::BackupAck
         );
+    }
+
+    #[test]
+    fn require_backup_ack_gating() {
+        let mut panel = ConnectAccountPanel::new();
+
+        // Sovereign and Tier 2 always gate, regardless of cube state.
+        assert!(panel.compute_require_backup_ack(EnrollTier::Sovereign));
+        assert!(panel.compute_require_backup_ack(EnrollTier::Tier2));
+
+        // Tier 1 with unknown cube state (not yet loaded) → fail toward the gate.
+        panel.duress_cubes = None;
+        assert!(panel.compute_require_backup_ack(EnrollTier::Tier1));
+
+        // Tier 1 with every cube backed up → skip the gate.
+        panel.duress_cubes = Some(vec![
+            DuressCube { name: "A".into(), has_recovery_kit: true },
+            DuressCube { name: "B".into(), has_recovery_kit: true },
+        ]);
+        assert!(!panel.compute_require_backup_ack(EnrollTier::Tier1));
+
+        // Tier 1 with any cube lacking a recovery kit → gate.
+        panel.duress_cubes = Some(vec![
+            DuressCube { name: "A".into(), has_recovery_kit: true },
+            DuressCube { name: "B".into(), has_recovery_kit: false },
+        ]);
+        assert!(panel.compute_require_backup_ack(EnrollTier::Tier1));
     }
 
     #[test]
@@ -3963,12 +4306,40 @@ mod duress_enroll_tests {
     }
 
     #[test]
-    fn sovereign_confirm_requires_exact_phrase() {
-        let mut s = state(EnrollTier::Sovereign, DuressEnrollStep::SovereignConfirm);
-        s.sovereign_confirm = "nope".to_string();
-        assert!(validate_enroll_step(&s).is_err());
-        s.sovereign_confirm = "I have my seed-phrase backup".to_string();
+    fn backup_ack_requires_exact_case_sensitive_phrase() {
+        let mut s = state(EnrollTier::Sovereign, DuressEnrollStep::BackupAck);
+        // Near-misses keep the gate closed: empty, a paraphrase, the old phrase,
+        // a case change, and trailing/leading whitespace (no normalization).
+        for near_miss in [
+            "",
+            "nope",
+            "I have my seed-phrase backup",
+            &BACKUP_ACK_PHRASE.to_lowercase(),
+            &format!("{BACKUP_ACK_PHRASE} "),
+            &format!(" {BACKUP_ACK_PHRASE}"),
+            &BACKUP_ACK_PHRASE.replace('.', ""),
+        ] {
+            s.backup_ack = near_miss.to_string();
+            assert!(
+                validate_enroll_step(&s).is_err(),
+                "near-miss should keep the gate closed: {near_miss:?}"
+            );
+            assert!(!s.backup_ack_satisfied());
+        }
+        // The exact, character-for-character phrase passes.
+        s.backup_ack = BACKUP_ACK_PHRASE.to_string();
         assert!(validate_enroll_step(&s).is_ok());
+        assert!(s.backup_ack_satisfied());
+    }
+
+    #[test]
+    fn backup_ack_phrase_names_both_artifacts() {
+        // The mandated phrase must name both destroyed artifacts and the funds
+        // consequence (snapshot of the spec wording).
+        assert!(BACKUP_ACK_PHRASE.contains("Master Seed Phrases"));
+        assert!(BACKUP_ACK_PHRASE.contains("Vault Wallet Descriptors"));
+        assert!(BACKUP_ACK_PHRASE.contains("permanently destroyed"));
+        assert!(BACKUP_ACK_PHRASE.contains("funds"));
     }
 
     #[test]

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -1820,19 +1820,35 @@ impl ConnectAccountPanel {
                                 );
                             }
                         }
-                        // Launch reconcile (Issue 2, PR 4): the account is no
-                        // longer enrolled server-side, but this device may still
-                        // hold a Connect duress enrollment from before a disable
-                        // it missed while offline. Disarm it locally so the duress
-                        // PIN can't still trip a wipe. `reconcile_duress_disarm`
-                        // no-ops for sovereign / non-matching local state, and
-                        // `clear_duress_enrollment` no-ops when nothing is armed,
-                        // so this is cheap for the common never-enrolled account.
-                        if !server_enrolled {
-                            if let Some(account_id) = self.user.as_ref().map(|u| u.id.to_string()) {
-                                if let Ok(dir) = crate::dir::CoincubeDirectory::active() {
-                                    let gen = self.session_generation;
-                                    return iced::Task::perform(
+                        // Launch reconcile (Issue 2, PR 4): bring this device's
+                        // local duress state in line with the server's, catching
+                        // a disable missed while offline AND an orphaned device
+                        // (Cubes armed while the local state never finished, e.g.
+                        // a crash mid-enroll) whose duress PIN would otherwise
+                        // still trip a wipe behind a UI that reports it inert.
+                        //
+                        // `reconcile_duress_disarm` (server says NOT enrolled)
+                        // disarms a matching local enrollment or any orphaned
+                        // armed Cubes; `reconcile_duress_orphan` (server says
+                        // STILL enrolled — reached only with this device already
+                        // registered) disarms ONLY an orphan, never a healthy
+                        // enrollment. Both no-op cheaply for a consistent device.
+                        if let Some(account_id) = self.user.as_ref().map(|u| u.id.to_string()) {
+                            if let Ok(dir) = crate::dir::CoincubeDirectory::active() {
+                                let gen = self.session_generation;
+                                let task = if server_enrolled {
+                                    iced::Task::perform(
+                                        async move { crate::app::reconcile_duress_orphan(dir).await },
+                                        move |res| {
+                                            Message::View(view::Message::ConnectAccount(
+                                                ConnectAccountMessage::Duress(
+                                                    DuressMessage::DisarmComplete(res, gen),
+                                                ),
+                                            ))
+                                        },
+                                    )
+                                } else {
+                                    iced::Task::perform(
                                         async move {
                                             crate::app::reconcile_duress_disarm(dir, account_id)
                                                 .await
@@ -1844,8 +1860,9 @@ impl ConnectAccountPanel {
                                                 ),
                                             ))
                                         },
-                                    );
-                                }
+                                    )
+                                };
+                                return task;
                             }
                         }
                     }
@@ -1973,7 +1990,7 @@ impl ConnectAccountPanel {
             EnrollTier::Tier1 => self
                 .duress_cubes
                 .as_ref()
-                .map_or(true, |cubes| cubes.iter().any(|c| !c.has_recovery_kit)),
+                .is_none_or(|cubes| cubes.iter().any(|c| !c.has_recovery_kit)),
         }
     }
 
@@ -4338,7 +4355,8 @@ mod duress_enroll_tests {
             s.backup_ack = near_miss.to_string();
             assert!(
                 validate_enroll_step(&s).is_err(),
-                "near-miss should keep the gate closed: {near_miss:?}"
+                "near-miss should keep the gate closed: {:?}",
+                near_miss
             );
             assert!(!s.backup_ack_satisfied());
         }

--- a/coincube-gui/src/app/state/connect/mod.rs
+++ b/coincube-gui/src/app/state/connect/mod.rs
@@ -83,8 +83,8 @@ pub(crate) fn delete_connect_secret(user_key: &str) {
 
 pub use account::{
     AddToCubeDialog, CheckoutPhase, CheckoutState, ConnectAccountPanel, ConnectFlowStep,
-    ContactsState, ContactsStep, DuressCube, DuressDisableState, DuressContactsState,
-    DuressContactsStep, DuressEnrollState, DuressEnrollStep, DuressGateStatus, EnrollTier,
+    ContactsState, ContactsStep, DuressContactsState, DuressContactsStep, DuressCube,
+    DuressDisableState, DuressEnrollState, DuressEnrollStep, DuressGateStatus, EnrollTier,
     InviteCubeOption, PlanLifecycle, BACKUP_ACK_PHRASE,
 };
 pub use cube::ConnectCubePanel;

--- a/coincube-gui/src/app/state/connect/mod.rs
+++ b/coincube-gui/src/app/state/connect/mod.rs
@@ -83,9 +83,9 @@ pub(crate) fn delete_connect_secret(user_key: &str) {
 
 pub use account::{
     AddToCubeDialog, CheckoutPhase, CheckoutState, ConnectAccountPanel, ConnectFlowStep,
-    ContactsState, ContactsStep, DuressContactsState, DuressContactsStep, DuressCube,
-    DuressEnrollState, DuressEnrollStep, DuressGateStatus, EnrollTier, InviteCubeOption,
-    PlanLifecycle,
+    ContactsState, ContactsStep, DuressCube, DuressDisableState, DuressContactsState,
+    DuressContactsStep, DuressEnrollState, DuressEnrollStep, DuressGateStatus, EnrollTier,
+    InviteCubeOption, PlanLifecycle, BACKUP_ACK_PHRASE,
 };
 pub use cube::ConnectCubePanel;
 pub use cube_members::ConnectCubeMembersState;

--- a/coincube-gui/src/app/view/connect/duress_enroll.rs
+++ b/coincube-gui/src/app/view/connect/duress_enroll.rs
@@ -225,8 +225,8 @@ pub fn enroll_ux(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage
             // the phrase is an exact, case-sensitive match — no paraphrase, no
             // checkbox shortcut. Every other step advances freely (its own
             // validation runs on press).
-            let ready = !matches!(state.step, DuressEnrollStep::BackupAck)
-                || state.backup_ack_satisfied();
+            let ready =
+                !matches!(state.step, DuressEnrollStep::BackupAck) || state.backup_ack_satisfied();
             button::primary(None, "Next")
                 .width(Length::Fixed(120.0))
                 .on_press_maybe(ready.then(|| msg(DuressMessage::EnrollNext)))
@@ -331,8 +331,8 @@ fn backup_ack_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessa
 }
 
 fn duress_pin_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
-    let pin_valid = state.duress_pin.len() == 4
-        && state.duress_pin.chars().all(|c| c.is_ascii_digit());
+    let pin_valid =
+        state.duress_pin.len() == 4 && state.duress_pin.chars().all(|c| c.is_ascii_digit());
     let confirm_valid = state.duress_pin == state.duress_pin_confirm;
 
     let hint_color = if state.duress_pin.is_empty() {

--- a/coincube-gui/src/app/view/connect/duress_enroll.rs
+++ b/coincube-gui/src/app/view/connect/duress_enroll.rs
@@ -14,7 +14,9 @@ use coincube_ui::{
 };
 use iced::Length;
 
-use crate::app::state::connect::{DuressEnrollState, DuressEnrollStep, EnrollTier};
+use crate::app::state::connect::{
+    DuressDisableState, DuressEnrollState, DuressEnrollStep, EnrollTier, BACKUP_ACK_PHRASE,
+};
 use crate::app::view::{ConnectAccountMessage, DuressMessage};
 use crate::services::duress::enroll::{DuressDelay, MIN_ALL_CLEAR_LEN};
 
@@ -115,6 +117,71 @@ pub fn recovery_ux<'a>(
 }
 
 // =============================================================================
+// Issue 2 — disable (step-up re-auth)
+// =============================================================================
+
+/// The "Disable Duress Mode" step-up dialog. Takes over the duress panel (like
+/// the enrollment wizard) while `ConnectAccountPanel::duress_disable` is `Some`.
+/// The user re-enters their regular Cube unlock PIN — not the duress PIN — to
+/// authorize turning duress off on every device.
+pub fn disable_ux(state: &DuressDisableState) -> Element<'_, ConnectAccountMessage> {
+    let confirm: Element<ConnectAccountMessage> = if state.submitting {
+        button::primary(None, "Disabling…")
+            .width(Length::Fixed(220.0))
+            .into()
+    } else {
+        button::primary(None, "Disable Duress Mode")
+            .width(Length::Fixed(220.0))
+            .on_press_maybe((!state.pin.is_empty()).then(|| msg(DuressMessage::DisableSubmit)))
+            .into()
+    };
+
+    let mut col = Column::new()
+        .spacing(16)
+        .max_width(560)
+        .push(text::h4_bold("Disable Duress Mode").style(theme::text::primary))
+        .push(card(
+            Column::new()
+                .push(text::p1_bold("Confirm with your Cube PIN").style(theme::text::primary))
+                .push(
+                    text::p2_regular(
+                        "Turning off duress disarms it on all your devices. Re-enter your \
+                         regular Cube unlock PIN to confirm — not your duress PIN.",
+                    )
+                    .color(color::GREY_3),
+                )
+                .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+                .push(
+                    TextInput::new("Cube unlock PIN", &state.pin)
+                        .on_input(|v| msg(DuressMessage::DisablePinChanged(v)))
+                        .on_submit(msg(DuressMessage::DisableSubmit))
+                        .secure(true)
+                        .padding(15),
+                ),
+        ));
+
+    if let Some(err) = &state.error {
+        col = col.push(text::p2_regular(err.clone()).color(color::RED));
+    }
+
+    col = col.push(
+        Row::new()
+            .spacing(12)
+            .push(
+                // Disabled mid-flight: cancelling between the server disable and
+                // the local disarm would orphan the in-flight result.
+                button::secondary(None, "Cancel")
+                    .width(Length::Fixed(120.0))
+                    .on_press_maybe((!state.submitting).then(|| msg(DuressMessage::DisableCancel))),
+            )
+            .push(iced::widget::Space::new().width(Length::Fill))
+            .push(confirm),
+    );
+
+    col.width(Length::Fill).into()
+}
+
+// =============================================================================
 // Phases 2 & 8 — enrollment wizard
 // =============================================================================
 
@@ -123,7 +190,7 @@ pub fn recovery_ux<'a>(
 pub fn enroll_ux(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
     let body = match state.step {
         DuressEnrollStep::Encourage => encourage_step(),
-        DuressEnrollStep::SovereignConfirm => sovereign_confirm_step(state),
+        DuressEnrollStep::BackupAck => backup_ack_step(state),
         DuressEnrollStep::SetDuressPin => duress_pin_step(state),
         DuressEnrollStep::SetAllClear => all_clear_step(state),
         DuressEnrollStep::SetCrkPassword => crk_password_step(state),
@@ -154,9 +221,15 @@ pub fn enroll_ux(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage
                     .on_press(msg(DuressMessage::SubmitEnrollment))
             }
         } else {
+            // On the backup-acknowledgement gate, "Next" stays disabled until
+            // the phrase is an exact, case-sensitive match — no paraphrase, no
+            // checkbox shortcut. Every other step advances freely (its own
+            // validation runs on press).
+            let ready = !matches!(state.step, DuressEnrollStep::BackupAck)
+                || state.backup_ack_satisfied();
             button::primary(None, "Next")
                 .width(Length::Fixed(120.0))
-                .on_press(msg(DuressMessage::EnrollNext))
+                .on_press_maybe(ready.then(|| msg(DuressMessage::EnrollNext)))
         };
         col = col.push(
             Row::new()
@@ -216,26 +289,45 @@ fn encourage_step<'a>() -> Element<'a, ConnectAccountMessage> {
     )
 }
 
-fn sovereign_confirm_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
-    card(
-        Column::new()
-            .push(text::p1_bold("No server-side recovery").style(theme::text::warning))
-            .push(
-                text::p2_regular(
-                    "Without a Connect account, duress mode will erase your Cubes on this device \
-                 and there is NO server-side recovery path. You will need your seed-phrase \
-                 backup to restore. Continue only if you have a verified offline backup.",
-                )
-                .color(color::GREY_3),
+fn backup_ack_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
+    // Name BOTH destroyed artifacts explicitly — the Master Seed Phrase(s) AND
+    // the Vault Wallet Descriptor(s) — and the funds consequence. A duress wipe
+    // without a Cube Recovery Kit is only reversible from the user's own
+    // external backup of both.
+    let mut col = Column::new()
+        .push(text::p1_bold("No recovery without your own backup").style(theme::text::warning))
+        .push(
+            text::p2_regular(
+                "Activating duress permanently destroys every Cube on this device. Without a \
+                 Cube Recovery Kit, the only way back is your OWN external backup of BOTH your \
+                 Master Seed Phrase(s) AND your Vault Wallet Descriptor(s). If you don't have \
+                 both, the wipe is irreversible and any funds held in those Cubes are gone — \
+                 there is no server-side recovery path.",
             )
+            .color(color::GREY_3),
+        )
+        .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
+        .push(text::p2_regular("Type the following exactly to continue:").color(color::GREY_3))
+        .push(text::p2_bold(BACKUP_ACK_PHRASE).style(theme::text::primary))
+        .push(
+            TextInput::new("Type the confirmation phrase exactly", &state.backup_ack)
+                .on_input(|v| msg(DuressMessage::BackupAckChanged(v)))
+                .padding(15),
+        );
+
+    // Connect tiers: keep the recommended path one tap away. Cancelling returns
+    // to the Duress panel, where the per-Cube recovery-kit checklist lives.
+    // Sovereign has no recovery kit, so there's no off-ramp to offer.
+    if state.tier != EnrollTier::Sovereign {
+        col = col
             .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
-            .push(text::p2_regular("Type: I have my seed-phrase backup").color(color::GREY_3))
             .push(
-                TextInput::new("I have my seed-phrase backup", &state.sovereign_confirm)
-                    .on_input(|v| msg(DuressMessage::SovereignConfirmChanged(v)))
-                    .padding(15),
-            ),
-    )
+                button::secondary(None, "Set up a Recovery Kit first")
+                    .on_press(msg(DuressMessage::CancelEnrollment)),
+            );
+    }
+
+    card(col)
 }
 
 fn duress_pin_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -1581,6 +1581,12 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
         return duress_enroll::enroll_ux(enroll);
     }
 
+    // The step-up re-auth dialog takes over the panel while a disable is in
+    // progress (Issue 2).
+    if let Some(disable) = &state.duress_disable {
+        return duress_enroll::disable_ux(disable);
+    }
+
     // The Emergency-contacts add/edit form takes over the panel too (only
     // reachable from the Estate-entitled list, so the guard is belt-and-
     // suspenders against a mid-session downgrade).
@@ -1657,6 +1663,13 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
         .as_ref()
         .map(|s| s.enrolled)
         .unwrap_or(false);
+    // Active duress hides the disable control (the app is on the cryptic /
+    // recovery screen then anyway, but guard defensively).
+    let duress_active = state
+        .duress_state
+        .as_ref()
+        .map(|s| s.active)
+        .unwrap_or(false);
     let locally_armed = state.duress_locally_armed;
 
     if locally_armed {
@@ -1680,19 +1693,25 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
             .width(Length::Fill),
         );
 
-        col = col.push(iced::widget::Space::new().height(Length::Fixed(16.0)));
-        // Reset is intentionally inert for now: there is no un-enroll path yet
-        // (the backend has no disable endpoint), so we surface the action as a
-        // disabled button with a note rather than hide it.
-        col = col.push(
-            button::secondary(None, "Reset Duress Mode")
-                .width(Length::Fixed(240.0))
-                .on_press_maybe(None),
-        );
-        col = col.push(iced::widget::Space::new().height(Length::Fixed(6.0)));
-        col = col.push(
-            text::p2_regular("Disabling duress mode isn't available yet.").color(color::GREY_3),
-        );
+        // Disable control — shown only when enrolled & inactive (this whole
+        // branch is unreachable during active duress, which routes to the
+        // recovery/cryptic screen, but guard anyway). Styled as a
+        // destructive-secondary action with a one-line explainer.
+        if !duress_active {
+            col = col.push(iced::widget::Space::new().height(Length::Fixed(16.0)));
+            col = col.push(
+                button::secondary(None, "Disable Duress Mode")
+                    .width(Length::Fixed(240.0))
+                    .on_press(ConnectAccountMessage::Duress(DuressMessage::DisableStart)),
+            );
+            col = col.push(iced::widget::Space::new().height(Length::Fixed(6.0)));
+            col = col.push(
+                text::p2_regular(
+                    "Turns off duress on all your devices. You can re-enable it anytime.",
+                )
+                .color(color::GREY_3),
+            );
+        }
     } else if server_enrolled {
         // Enrolled on the account but not armed on THIS device (set up on
         // another device, or a local persist that didn't complete). Be honest:
@@ -1721,6 +1740,25 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
             .style(card_style)
             .width(Length::Fill),
         );
+
+        // Duress can still be turned off account-wide from here (the server
+        // disable propagates to every device); this one just has no local PIN
+        // hashes to clear. Shown only while inactive.
+        if !duress_active {
+            col = col.push(iced::widget::Space::new().height(Length::Fixed(16.0)));
+            col = col.push(
+                button::secondary(None, "Disable Duress Mode")
+                    .width(Length::Fixed(240.0))
+                    .on_press(ConnectAccountMessage::Duress(DuressMessage::DisableStart)),
+            );
+            col = col.push(iced::widget::Space::new().height(Length::Fixed(6.0)));
+            col = col.push(
+                text::p2_regular(
+                    "Turns off duress on all your devices. You can re-enable it anytime.",
+                )
+                .color(color::GREY_3),
+            );
+        }
     } else {
         let delays: String = DuressDelay::ALL
             .iter()

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1429,7 +1429,11 @@ pub enum DuressMessage {
     AllClearChanged(String),
     CrkPasswordChanged(String),
     DelaySelected(crate::services::duress::enroll::DuressDelay),
-    SovereignConfirmChanged(String),
+    /// The mandated backup-acknowledgement gate's typed-confirmation input
+    /// (formerly `SovereignConfirmChanged`). The gate now covers the Tier-2
+    /// (Connect, no CRK) and any-Cube-without-a-recovery-kit paths too, not
+    /// just sovereign — see [`crate::app::state::connect::DuressEnrollStep`].
+    BackupAckChanged(String),
     MemorizedToggled(bool),
     SubmitEnrollment,
     EnrollResult(Result<(), String>, u64),
@@ -1449,6 +1453,37 @@ pub enum DuressMessage {
     /// it's actually true — never on the optimistic pre-persist path, where a
     /// later collision / disk failure would leave a false "enabled" view.
     EnrollmentPersisted,
+
+    // ── Disable (Issue 2 — turn duress off) ──
+    /// User tapped "Disable Duress Mode" in Settings → opens the step-up
+    /// re-auth dialog (re-enter the regular Cube PIN).
+    DisableStart,
+    /// The step-up regular-PIN input changed.
+    DisablePinChanged(String),
+    /// Dismiss the step-up dialog without disabling.
+    DisableCancel,
+    /// Confirm the step-up: verify the regular Cube PIN locally, then call
+    /// `disable_duress()` on the server.
+    DisableSubmit,
+    /// Result of the server `disable_duress()` call. `Active` (423) means duress
+    /// is currently active and can't be disabled.
+    DisableResult(Result<(), DuressDisableError>, u64),
+    /// Result of the local disarm (`clear_duress_enrollment` /
+    /// `reconcile_duress_disarm`). `Ok(true)` = a disarm actually ran (drop the
+    /// armed state); `Ok(false)` = nothing to disarm (e.g. a sovereign-only
+    /// enrollment a server "not enrolled" must never touch). Shared by the
+    /// explicit-disable, cross-device event, and launch-reconcile paths.
+    DisarmComplete(Result<bool, String>, u64),
+}
+
+/// Outcome of a server `disable_duress()` call, classified so the panel can
+/// branch on the 423 "currently active" case without re-parsing the error body.
+#[derive(Debug, Clone)]
+pub enum DuressDisableError {
+    /// 423 — duress is currently active and can't be disabled.
+    Active,
+    /// Any other failure; carries a user-facing message.
+    Failed(String),
 }
 
 impl std::fmt::Debug for DuressMessage {
@@ -1461,7 +1496,8 @@ impl std::fmt::Debug for DuressMessage {
             DuressPinConfirmChanged(_) => write!(f, "DuressPinConfirmChanged(<redacted>)"),
             AllClearChanged(_) => write!(f, "AllClearChanged(<redacted>)"),
             CrkPasswordChanged(_) => write!(f, "CrkPasswordChanged(<redacted>)"),
-            SovereignConfirmChanged(_) => write!(f, "SovereignConfirmChanged(<redacted>)"),
+            BackupAckChanged(_) => write!(f, "BackupAckChanged(<redacted>)"),
+            DisablePinChanged(_) => write!(f, "DisablePinChanged(<redacted>)"),
             // Non-sensitive — `ClearResult`/`EnrollResult` carry only an error
             // string (no secret), so they format normally.
             SubmitClear => write!(f, "SubmitClear"),
@@ -1488,6 +1524,11 @@ impl std::fmt::Debug for DuressMessage {
             ),
             StateLoaded(s, gen) => write!(f, "StateLoaded({:?}, {})", s, gen),
             EnrollmentPersisted => write!(f, "EnrollmentPersisted"),
+            DisableStart => write!(f, "DisableStart"),
+            DisableCancel => write!(f, "DisableCancel"),
+            DisableSubmit => write!(f, "DisableSubmit"),
+            DisableResult(res, gen) => write!(f, "DisableResult({:?}, {})", res, gen),
+            DisarmComplete(res, gen) => write!(f, "DisarmComplete({:?}, {})", res, gen),
         }
     }
 }
@@ -2144,7 +2185,8 @@ mod duress_message_debug_tests {
             DuressMessage::DuressPinConfirmChanged(CANARY.to_string()),
             DuressMessage::AllClearChanged(CANARY.to_string()),
             DuressMessage::CrkPasswordChanged(CANARY.to_string()),
-            DuressMessage::SovereignConfirmChanged(CANARY.to_string()),
+            DuressMessage::BackupAckChanged(CANARY.to_string()),
+            DuressMessage::DisablePinChanged(CANARY.to_string()),
         ];
         for msg in &sensitive {
             let rendered = format!("{:?}", msg);

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -2996,6 +2996,12 @@ fn map_connect_task(task: Task<app::message::Message>) -> Task<Message> {
         app::message::Message::CompleteDuressEnrollment(payload) => {
             Message::PersistDuressEnrollment(payload)
         }
+        // The duress-disable confirmation toast (Issue 2). Home has no toast
+        // surface; the Duress panel already reflects the disabled state in its
+        // own fields, so swallow it quietly rather than warn.
+        app::message::Message::View(app::view::Message::ShowSuccess(_)) => {
+            Message::View(ViewMessage::Check)
+        }
         _ => {
             log::warn!("[LAUNCHER] Unexpected message from ConnectAccountPanel");
             Message::View(ViewMessage::Check)

--- a/coincube-gui/src/launcher.rs
+++ b/coincube-gui/src/launcher.rs
@@ -2718,6 +2718,12 @@ fn map_connect_task(task: Task<app::message::Message>) -> Task<Message> {
         app::message::Message::CompleteDuressEnrollment(payload) => {
             Message::PersistDuressEnrollment(payload)
         }
+        // The duress-disable confirmation toast (Issue 2). The launcher has no
+        // toast surface; the Duress panel already reflects the disabled state in
+        // its own fields, so swallow it quietly rather than warn.
+        app::message::Message::View(app::view::Message::ShowSuccess(_)) => {
+            Message::View(ViewMessage::Check)
+        }
         _ => {
             log::warn!("[LAUNCHER] Unexpected message from ConnectAccountPanel");
             Message::View(ViewMessage::Check)

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -1239,6 +1239,18 @@ impl CoincubeClient {
         Ok(())
     }
 
+    /// `POST /api/v1/connect/duress/disable` (authenticated). The inverse of
+    /// [`enroll_duress`](Self::enroll_duress): turns duress off for the whole
+    /// account (clears every device's enrollment server-side). A `423` means
+    /// duress is currently active and can't be disabled — the caller must clear
+    /// it from a trusted device first.
+    pub async fn disable_duress(&self) -> Result<(), CoincubeError> {
+        let url = format!("{}/api/v1/connect/duress/disable", self.base_url);
+        let res = self.client.post(&url).send().await?;
+        res.check_success().await?;
+        Ok(())
+    }
+
     /// `GET /api/v1/connect/duress` (authenticated). Returns the account's
     /// duress state plus whether THIS device is already registered.
     pub async fn get_duress_state(&self) -> Result<super::DuressState, CoincubeError> {
@@ -3213,6 +3225,57 @@ mod duress_tests {
             .await
             .expect("clear should succeed");
         mock.assert();
+    }
+
+    #[tokio::test]
+    async fn disable_duress_200_ok() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::POST)
+                .path("/api/v1/connect/duress/disable");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "success": true, "data": {} }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        client
+            .disable_duress()
+            .await
+            .expect("disable should succeed");
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn disable_duress_423_surfaces_status() {
+        // Duress currently active → 423. The caller (settings panel) classifies
+        // this as `DuressDisableError::Active`; here we just prove the status
+        // survives as an `Unsuccessful` error.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::POST)
+                .path("/api/v1/connect/duress/disable");
+            then.status(423)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": false,
+                    "error": { "code": "DURESS_LOCKED", "message": "duress is active" }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .disable_duress()
+            .await
+            .expect_err("active duress should fail disable");
+        mock.assert();
+        assert!(matches!(
+            err,
+            CoincubeError::Unsuccessful(crate::services::http::NotSuccessResponseInfo {
+                status_code: 423,
+                ..
+            })
+        ));
     }
 
     #[tokio::test]

--- a/coincube-gui/src/services/connect/grpc/mod.rs
+++ b/coincube-gui/src/services/connect/grpc/mod.rs
@@ -30,6 +30,13 @@ pub enum ConnectStreamMessage {
     },
     /// Duress was cleared server-side — exit the cryptic screen.
     DuressCleared,
+    /// Duress was *disabled* (turned off) account-wide (Issue 2). Every device
+    /// disarms its local enrollment — no UI lock, no wipe. `account_id`
+    /// identifies the account so a device only disarms a matching local
+    /// (Connect) enrollment, never an unrelated sovereign one.
+    DuressDisabled {
+        account_id: String,
+    },
 }
 
 #[derive(Debug)]

--- a/coincube-gui/src/services/connect/grpc/stream.rs
+++ b/coincube-gui/src/services/connect/grpc/stream.rs
@@ -180,6 +180,22 @@ pub fn connect_stream(
                                                     );
                                                 }
                                             }
+                                            Some(Body::DuressDisabled(event)) => {
+                                                // Issue 2: duress turned off account-wide.
+                                                // Forward the account id so the app can
+                                                // disarm only a matching local enrollment.
+                                                if let Err(e) = channel
+                                                    .send(ConnectStreamMessage::DuressDisabled {
+                                                        account_id: event.account_id,
+                                                    })
+                                                    .await
+                                                {
+                                                    log::warn!(
+                                                        "[CONNECT GRPC] Failed to forward DuressDisabled: {}",
+                                                        e
+                                                    );
+                                                }
+                                            }
                                             _ => {}
                                         },
                                         Ok(None) => {

--- a/coincube-gui/src/services/duress/mod.rs
+++ b/coincube-gui/src/services/duress/mod.rs
@@ -171,6 +171,24 @@ impl DuressLocalState {
     pub fn save(&self, coincube_dir: &Path) -> io::Result<()> {
         write_json_atomic(&Self::path(coincube_dir), self)
     }
+
+    /// Resets this state to the un-enrolled baseline for a duress *disable*
+    /// (disarm, not wipe): zeroizes the encrypted device code (and any queued
+    /// copy of it) in place before dropping it, then clears every duress field —
+    /// `enrolled`/`active` flags, `unlock_at`, the Connect `account_id`, and any
+    /// mirrored pending activation. Cube funds and data are untouched (this
+    /// struct holds none); the caller separately clears the per-Cube duress PIN
+    /// hashes and the durable queue.
+    pub fn disarm(&mut self) {
+        use zeroize::Zeroize;
+        if let Some(code) = self.duress_code.as_mut() {
+            code.zeroize();
+        }
+        if let Some(pending) = self.pending_activation.as_mut() {
+            pending.duress_code.zeroize();
+        }
+        *self = DuressLocalState::default();
+    }
 }
 
 /// Reads and deserializes a JSON document, treating "file not found" as
@@ -287,6 +305,20 @@ mod tests {
         // The corrupt content is gone, and the value is now stable.
         assert_eq!(device_fingerprint(&dir).unwrap(), fp);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn disarm_resets_to_unenrolled_baseline() {
+        let mut st = sample_state();
+        st.active = true;
+        st.disarm();
+        assert_eq!(st, DuressLocalState::default());
+        assert!(!st.enrolled);
+        assert!(!st.active);
+        assert!(st.unlock_at.is_none());
+        assert!(st.duress_code.is_none());
+        assert!(st.account_id.is_none());
+        assert!(st.pending_activation.is_none());
     }
 
     #[test]

--- a/coincube-gui/src/services/duress/queue.rs
+++ b/coincube-gui/src/services/duress/queue.rs
@@ -76,6 +76,14 @@ impl DuressQueue {
         self.write_locked(items)
     }
 
+    /// Drops every queued activation. Used by the duress *disable* (disarm)
+    /// path — no pending activation should survive an un-enroll. Idempotent: an
+    /// already-empty (or absent) queue is left empty.
+    pub fn clear(&self) -> io::Result<()> {
+        let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
+        self.write_locked(&[])
+    }
+
     fn read_locked(&self) -> io::Result<Vec<PendingActivation>> {
         match std::fs::read(self.path.as_path()) {
             Ok(bytes) => serde_json::from_slice(&bytes)
@@ -155,6 +163,21 @@ mod tests {
         let dir = temp_dir("noop");
         let q = DuressQueue::new(&dir);
         q.dequeue("nope").unwrap();
+        assert!(q.is_empty().unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn clear_empties_the_queue() {
+        let dir = temp_dir("clear");
+        let q = DuressQueue::new(&dir);
+        q.enqueue(item("acct_1")).unwrap();
+        q.enqueue(item("acct_2")).unwrap();
+        assert_eq!(q.entries().unwrap().len(), 2);
+        q.clear().unwrap();
+        assert!(q.is_empty().unwrap());
+        // Idempotent: clearing an already-empty queue is fine.
+        q.clear().unwrap();
         assert!(q.is_empty().unwrap());
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/grpc/connect.proto
+++ b/grpc/connect.proto
@@ -210,6 +210,9 @@ message StreamEnvelope {
     // ListPendingDecryptRequests / GetDecryptResult fetches for reliability).
     DecryptRequestedEvent decrypt_requested = 9; // → heir's Keychain
     DecryptResultEvent decrypt_result = 10;      // → heir's desktop
+    // Duress was disabled (turned off) account-wide; every connected device
+    // disarms locally. Offline clients reconcile via GET /connect/duress.
+    DuressDisabledEvent duress_disabled = 11;
   }
 }
 
@@ -227,6 +230,15 @@ message DuressActivatedEvent {
 message DuressClearedEvent {
   string account_id = 1;
   google.protobuf.Timestamp cleared_at = 2;
+}
+
+// DuressDisabledEvent is broadcast when duress is turned OFF for an account
+// (the inverse of enrollment — not the same as all-clear, which only ends an
+// active episode). Every connected device disarms locally; offline clients
+// reconcile via GET /connect/duress.
+message DuressDisabledEvent {
+  string account_id = 1;
+  google.protobuf.Timestamp disabled_at = 2;
 }
 
 message ClientHello {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes security-critical duress arming/disarming, PIN step-up, and multi-device sync; incorrect reconcile or hash clearing could leave a live wipe trigger or disable the wrong enrollment.
> 
> **Overview**
> Adds a full **duress disable** path: Settings exposes **Disable Duress Mode** (when inactive), opens a step-up dialog that requires a **regular Cube unlock PIN** (duress PIN is rejected), then calls **`POST /connect/duress/disable`** and **`clear_duress_enrollment`** on this device (Cube duress hashes, `DuressLocalState::disarm`, activation queue clear). **gRPC `DuressDisabled`** and **post-login reconcile** (`reconcile_duress_disarm` / `reconcile_duress_orphan`) keep other or offline devices aligned and clean up **orphaned** half-enrollments (armed Cubes without finished local state).
> 
> Enrollment UX replaces the short sovereign phrase with a **`BackupAck`** step and strict **`BACKUP_ACK_PHRASE`** typing. The gate applies for sovereign and Tier 2 always, and for Tier 1 when any protected Cube lacks a recovery kit (or cube state is unknown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a620f4836c8a21b8ff8757f58f8c40610562d77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an account-wide “Disable Duress Mode” flow with step-up PIN verification and guided UI steps.
  * Strengthened duress enrollment with a typed backup acknowledgment gate and recovery-kit callouts.
  * Added syncing for duress-disable events across connected devices.
* **Bug Fixes**
  * Improved post-disable reconciliation so devices correctly disarm and recover from orphaned local state.
  * Success toasts now refresh the UI cleanly without unexpected warnings.
* **Security**
  * Enhanced sensitive input handling with zeroization and redaction during the disable/enrollment flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->