### PR TITLE
Added commas to numbers

### DIFF
--- a/coincube-gui/src/app/breez_liquid/assets.rs
+++ b/coincube-gui/src/app/breez_liquid/assets.rs
@@ -1,4 +1,5 @@
 use breez_sdk_liquid::bitcoin::Network;
+use coincube_ui::component::amount::format_u64_as_string;
 
 // ---------------------------------------------------------------------------
 // Mainnet Liquid asset IDs
@@ -150,7 +151,7 @@ pub fn format_usdt_display(amount: u64) -> String {
     }
     format!(
         "{}.{:0>width$}",
-        whole,
+        format_u64_as_string(whole, ","),
         frac_2dp,
         width = USDT_DISPLAY_DECIMALS as usize
     )

--- a/coincube-gui/src/app/breez_spark/assets.rs
+++ b/coincube-gui/src/app/breez_spark/assets.rs
@@ -12,6 +12,8 @@
 //! backend state (it'll need to pull from the bridge once per-cube asset
 //! discovery is wired).
 
+use coincube_ui::component::amount::format_u64_as_string;
+
 /// A Spark-side asset that the UI can display in a picker / balance row.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum SparkAsset {
@@ -69,7 +71,7 @@ pub fn format_token_display(amount: u64, decimals: u32) -> String {
         let scale = 10_u64.pow(DISPLAY_DECIMALS - decimals);
         return format!(
             "{}.{:0>width$}",
-            whole,
+            format_u64_as_string(whole, ","),
             frac * scale,
             width = DISPLAY_DECIMALS as usize
         );
@@ -83,7 +85,7 @@ pub fn format_token_display(amount: u64, decimals: u32) -> String {
     }
     format!(
         "{}.{:0>width$}",
-        whole,
+        format_u64_as_string(whole, ","),
         frac_2dp,
         width = DISPLAY_DECIMALS as usize
     )

--- a/coincube-gui/src/app/state/spark/send.rs
+++ b/coincube-gui/src/app/state/spark/send.rs
@@ -242,7 +242,8 @@ impl State for SparkSend {
                 )
             }
             SparkSendMessage::SendSucceeded(ok) => {
-                self.sent_amount_display = format!("{} sats", format_u64_as_string(ok.amount_sat, ","));
+                self.sent_amount_display =
+                    format!("{} sats", format_u64_as_string(ok.amount_sat, ","));
                 self.phase = SparkSendPhase::Sent(ok);
                 // Clear the inputs so a follow-up send doesn't re-use them.
                 self.destination_input.clear();

--- a/coincube-gui/src/app/state/spark/send.rs
+++ b/coincube-gui/src/app/state/spark/send.rs
@@ -28,6 +28,7 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use coincube_spark_protocol::{ParseInputKind, PrepareSendOk, SendPaymentOk};
+use coincube_ui::component::amount::format_u64_as_string;
 use coincube_ui::widget::Element;
 use iced::Task;
 
@@ -241,7 +242,7 @@ impl State for SparkSend {
                 )
             }
             SparkSendMessage::SendSucceeded(ok) => {
-                self.sent_amount_display = format!("{} sats", ok.amount_sat);
+                self.sent_amount_display = format!("{} sats", format_u64_as_string(ok.amount_sat, ","));
                 self.phase = SparkSendPhase::Sent(ok);
                 // Clear the inputs so a follow-up send doesn't re-use them.
                 self.destination_input.clear();

--- a/coincube-gui/src/app/view/buysell/mavapay/ui.rs
+++ b/coincube-gui/src/app/view/buysell/mavapay/ui.rs
@@ -854,12 +854,17 @@ fn info_field<'a>(
     .width(Length::Fill)
 }
 
+/// Format a minor-unit (cents) fiat amount with two decimal places and comma
+/// grouping, e.g. `1234567` -> `12,345.67`.
+fn format_fiat_cents(cents: u64) -> String {
+    format_f64_as_string(cents as f64 / 100.0, ",", 2, false)
+}
+
 fn format_currency_amount(amount: u64, currency: &MavapayUnitCurrency) -> String {
-    let fiat = |v: f64| format_f64_as_string(v, ",", 2, false);
     match currency {
-        MavapayUnitCurrency::KenyanShillingCent => format!("{} KES", fiat(amount as f64 / 100.0)),
-        MavapayUnitCurrency::SouthAfricanRandCent => format!("{} ZAR", fiat(amount as f64 / 100.0)),
-        MavapayUnitCurrency::NigerianNairaKobo => format!("{} NGN", fiat(amount as f64 / 100.0)),
+        MavapayUnitCurrency::KenyanShillingCent => format!("{} KES", format_fiat_cents(amount)),
+        MavapayUnitCurrency::SouthAfricanRandCent => format!("{} ZAR", format_fiat_cents(amount)),
+        MavapayUnitCurrency::NigerianNairaKobo => format!("{} NGN", format_fiat_cents(amount)),
         MavapayUnitCurrency::BitcoinSatoshi => format!(
             "{} BTC",
             format_f64_as_string(amount as f64 / 100_000_000.0, ",", 8, false)
@@ -1310,15 +1315,14 @@ fn transaction_status_info(transaction: &OrderTransaction) -> (&'static str, ice
 }
 
 fn format_amount(amount: u64, currency: &MavapayCurrency) -> String {
-    let fiat = |v: f64| format_f64_as_string(v, ",", 2, false);
     match currency {
         MavapayCurrency::Bitcoin => format!(
             "{} BTC",
             format_f64_as_string(amount as f64 / 100_000_000.0, ",", 8, false)
         ),
-        MavapayCurrency::KenyanShilling => format!("{} KSh", fiat(amount as f64 / 100.0)),
-        MavapayCurrency::SouthAfricanRand => format!("{} ZAR", fiat(amount as f64 / 100.0)),
-        MavapayCurrency::NigerianNaira => format!("{} NGN", fiat(amount as f64 / 100.0)),
+        MavapayCurrency::KenyanShilling => format!("{} KSh", format_fiat_cents(amount)),
+        MavapayCurrency::SouthAfricanRand => format!("{} ZAR", format_fiat_cents(amount)),
+        MavapayCurrency::NigerianNaira => format!("{} NGN", format_fiat_cents(amount)),
     }
 }
 

--- a/coincube-gui/src/app/view/buysell/mavapay/ui.rs
+++ b/coincube-gui/src/app/view/buysell/mavapay/ui.rs
@@ -855,9 +855,14 @@ fn info_field<'a>(
 }
 
 /// Format a minor-unit (cents) fiat amount with two decimal places and comma
-/// grouping, e.g. `1234567` -> `12,345.67`.
+/// grouping, e.g. `1234567` -> `12,345.67`. Uses integer division so large
+/// amounts stay exact (an `f64` cast would lose precision above 2^53).
 fn format_fiat_cents(cents: u64) -> String {
-    format_f64_as_string(cents as f64 / 100.0, ",", 2, false)
+    format!(
+        "{}.{:02}",
+        format_u64_as_string(cents / 100, ","),
+        cents % 100
+    )
 }
 
 fn format_currency_amount(amount: u64, currency: &MavapayUnitCurrency) -> String {

--- a/coincube-gui/src/app/view/buysell/mavapay/ui.rs
+++ b/coincube-gui/src/app/view/buysell/mavapay/ui.rs
@@ -8,6 +8,7 @@ use crate::{
 
 use iced::{widget, Alignment, Length};
 
+use coincube_ui::component::amount::{format_f64_as_string, format_u64_as_string};
 use coincube_ui::component::{button, card, text};
 use coincube_ui::{color, icon::*, theme};
 
@@ -854,11 +855,15 @@ fn info_field<'a>(
 }
 
 fn format_currency_amount(amount: u64, currency: &MavapayUnitCurrency) -> String {
+    let fiat = |v: f64| format_f64_as_string(v, ",", 2, false);
     match currency {
-        MavapayUnitCurrency::KenyanShillingCent => format!("{:.2} KES", amount as f64 / 100.0),
-        MavapayUnitCurrency::SouthAfricanRandCent => format!("{:.2} ZAR", amount as f64 / 100.0),
-        MavapayUnitCurrency::NigerianNairaKobo => format!("{:.2} NGN", amount as f64 / 100.0),
-        MavapayUnitCurrency::BitcoinSatoshi => format!("{:.8} BTC", amount as f64 / 100_000_000.0),
+        MavapayUnitCurrency::KenyanShillingCent => format!("{} KES", fiat(amount as f64 / 100.0)),
+        MavapayUnitCurrency::SouthAfricanRandCent => format!("{} ZAR", fiat(amount as f64 / 100.0)),
+        MavapayUnitCurrency::NigerianNairaKobo => format!("{} NGN", fiat(amount as f64 / 100.0)),
+        MavapayUnitCurrency::BitcoinSatoshi => format!(
+            "{} BTC",
+            format_f64_as_string(amount as f64 / 100_000_000.0, ",", 8, false)
+        ),
     }
 }
 
@@ -1305,17 +1310,21 @@ fn transaction_status_info(transaction: &OrderTransaction) -> (&'static str, ice
 }
 
 fn format_amount(amount: u64, currency: &MavapayCurrency) -> String {
+    let fiat = |v: f64| format_f64_as_string(v, ",", 2, false);
     match currency {
-        MavapayCurrency::Bitcoin => format!("{:.8} BTC", amount as f64 / 100_000_000.0),
-        MavapayCurrency::KenyanShilling => format!("{:.2} KSh", amount as f64 / 100.0),
-        MavapayCurrency::SouthAfricanRand => format!("{:.2} ZAR", amount as f64 / 100.0),
-        MavapayCurrency::NigerianNaira => format!("{:.2} NGN", amount as f64 / 100.0),
+        MavapayCurrency::Bitcoin => format!(
+            "{} BTC",
+            format_f64_as_string(amount as f64 / 100_000_000.0, ",", 8, false)
+        ),
+        MavapayCurrency::KenyanShilling => format!("{} KSh", fiat(amount as f64 / 100.0)),
+        MavapayCurrency::SouthAfricanRand => format!("{} ZAR", fiat(amount as f64 / 100.0)),
+        MavapayCurrency::NigerianNaira => format!("{} NGN", fiat(amount as f64 / 100.0)),
     }
 }
 
 fn format_fees(fees: u64, currency: &MavapayCurrency) -> String {
     match currency {
-        MavapayCurrency::Bitcoin => format!("{} sats", fees),
+        MavapayCurrency::Bitcoin => format!("{} sats", format_u64_as_string(fees, ",")),
         _ => format_amount(fees, currency),
     }
 }

--- a/coincube-gui/src/app/view/liquid/overview.rs
+++ b/coincube-gui/src/app/view/liquid/overview.rs
@@ -101,7 +101,7 @@ pub fn liquid_overview_view<'a>(
     // L-BTC asset row
     let lbtc_fiat_str = btc_fiat
         .as_ref()
-        .map(|f| format!("{} {}", f.to_rounded_string(), f.currency()))
+        .map(|f| format!("{} {}", f.to_formatted_string(), f.currency()))
         .unwrap_or_default();
     let lbtc_row = Row::new()
         .spacing(10)
@@ -246,7 +246,7 @@ pub fn liquid_overview_view<'a>(
                 let fiat_str = tx
                     .fiat_amount
                     .as_ref()
-                    .map(|fiat| format!("{} {}", fiat.to_rounded_string(), fiat.currency()));
+                    .map(|fiat| format!("{} {}", fiat.to_formatted_string(), fiat.currency()));
                 if let Some(fiat) = fiat_str {
                     item = item.with_fiat_amount(fiat);
                 }

--- a/coincube-gui/src/app/view/liquid/receive.rs
+++ b/coincube-gui/src/app/view/liquid/receive.rs
@@ -232,7 +232,7 @@ pub fn liquid_receive_view<'a>(
                 let fiat_str = tx
                     .fiat_amount
                     .as_ref()
-                    .map(|fiat| format!("{} {}", fiat.to_rounded_string(), fiat.currency()));
+                    .map(|fiat| format!("{} {}", fiat.to_formatted_string(), fiat.currency()));
                 if let Some(fiat) = fiat_str {
                     item = item.with_fiat_amount(fiat);
                 }

--- a/coincube-gui/src/app/view/liquid/send.rs
+++ b/coincube-gui/src/app/view/liquid/send.rs
@@ -475,7 +475,7 @@ pub fn liquid_send_view<'a>(
             } else {
                 tx.fiat_amount
                     .as_ref()
-                    .map(|fiat| format!("{} {}", fiat.to_rounded_string(), fiat.currency()))
+                    .map(|fiat| format!("{} {}", fiat.to_formatted_string(), fiat.currency()))
             };
 
             let display_amount = if tx.usdt_display.is_some() {

--- a/coincube-gui/src/app/view/liquid/swap.rs
+++ b/coincube-gui/src/app/view/liquid/swap.rs
@@ -350,7 +350,7 @@ fn swap_leg_row<'a>(
     if is_usdt {
         item = item.with_amount_override(format!("{} USDt", format_usdt_display(amount.to_sat())));
     } else if let Some(fiat) = config.fiat_converter.as_ref().map(|c| c.convert(amount)) {
-        item = item.with_fiat_amount(format!("{} {}", fiat.to_rounded_string(), fiat.currency()));
+        item = item.with_fiat_amount(format!("{} {}", fiat.to_formatted_string(), fiat.currency()));
     }
 
     if matches!(payment.status, DomainPaymentStatus::Pending) {

--- a/coincube-gui/src/app/view/liquid/swap.rs
+++ b/coincube-gui/src/app/view/liquid/swap.rs
@@ -350,7 +350,11 @@ fn swap_leg_row<'a>(
     if is_usdt {
         item = item.with_amount_override(format!("{} USDt", format_usdt_display(amount.to_sat())));
     } else if let Some(fiat) = config.fiat_converter.as_ref().map(|c| c.convert(amount)) {
-        item = item.with_fiat_amount(format!("{} {}", fiat.to_formatted_string(), fiat.currency()));
+        item = item.with_fiat_amount(format!(
+            "{} {}",
+            fiat.to_formatted_string(),
+            fiat.currency()
+        ));
     }
 
     if matches!(payment.status, DomainPaymentStatus::Pending) {

--- a/coincube-gui/src/app/view/liquid/transactions.rs
+++ b/coincube-gui/src/app/view/liquid/transactions.rs
@@ -349,7 +349,7 @@ fn transaction_row<'a>(
 
     if let Some(fiat_amount) = fiat_converter.map(|converter| {
         let fiat = converter.convert(btc_amount);
-        format!("{} {}", fiat.to_rounded_string(), fiat.currency())
+        format!("{} {}", fiat.to_formatted_string(), fiat.currency())
     }) {
         item = item.with_fiat_amount(fiat_amount);
     }
@@ -429,7 +429,7 @@ fn refundable_row<'a>(
 
     if let Some(fiat_amount) = fiat_converter.map(|converter| {
         let fiat = converter.convert(btc_amount);
-        format!("{} {}", fiat.to_rounded_string(), fiat.currency())
+        format!("{} {}", fiat.to_formatted_string(), fiat.currency())
     }) {
         item = item.with_fiat_amount(fiat_amount);
     }

--- a/coincube-gui/src/app/view/p2p/components/order_card.rs
+++ b/coincube-gui/src/app/view/p2p/components/order_card.rs
@@ -10,6 +10,8 @@ use iced::{
 
 use crate::app::view::{self, message::P2PMessage};
 
+use coincube_ui::component::amount::format_f64_as_string;
+
 use super::format_with_separators;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -103,17 +105,19 @@ pub fn order_card<'a>(order: &'a P2POrder) -> Button<'a, view::Message> {
             if order.is_range_order() {
                 row!(
                     h1(format!(
-                        "{:.0} - {:.0}",
-                        order.min_amount.unwrap_or(0.0),
-                        order.max_amount.unwrap_or(0.0)
-                    )),
+                        "{} - {}",
+                        format_f64_as_string(order.min_amount.unwrap_or(0.0), ",", 0, false),
+                        format_f64_as_string(order.max_amount.unwrap_or(0.0), ",", 0, false)
+                    ))
+                    .style(theme::text::primary),
                     h3(format!(" {}", order.fiat_currency)).style(theme::text::secondary)
                 )
                 .spacing(8)
                 .align_y(iced::alignment::Vertical::Center)
             } else {
                 row!(
-                    h1(format!("{:.2}", order.fiat_amount)),
+                    h1(format_f64_as_string(order.fiat_amount, ",", 2, false))
+                        .style(theme::text::primary),
                     h3(format!(" {}", order.fiat_currency)).style(theme::text::secondary)
                 )
                 .spacing(8)
@@ -237,17 +241,19 @@ pub fn order_detail<'a>(
             if order.is_range_order() {
                 row!(
                     h1(format!(
-                        "{:.0} - {:.0}",
-                        order.min_amount.unwrap_or(0.0),
-                        order.max_amount.unwrap_or(0.0)
-                    )),
+                        "{} - {}",
+                        format_f64_as_string(order.min_amount.unwrap_or(0.0), ",", 0, false),
+                        format_f64_as_string(order.max_amount.unwrap_or(0.0), ",", 0, false)
+                    ))
+                    .style(theme::text::primary),
                     h3(format!(" {}", order.fiat_currency)).style(theme::text::secondary)
                 )
                 .spacing(8)
                 .align_y(iced::alignment::Vertical::Center)
             } else {
                 row!(
-                    h1(format!("{:.2}", order.fiat_amount)),
+                    h1(format_f64_as_string(order.fiat_amount, ",", 2, false))
+                        .style(theme::text::primary),
                     h3(format!(" {}", order.fiat_currency)).style(theme::text::secondary)
                 )
                 .spacing(8)
@@ -459,9 +465,9 @@ pub fn order_detail<'a>(
                 detail_col = detail_col.push(
                     column![
                         p2_regular(format!(
-                            "Enter fiat amount ({:.0} - {:.0} {})",
-                            order.min_amount.unwrap_or(0.0),
-                            order.max_amount.unwrap_or(0.0),
+                            "Enter fiat amount ({} - {} {})",
+                            format_f64_as_string(order.min_amount.unwrap_or(0.0), ",", 0, false),
+                            format_f64_as_string(order.max_amount.unwrap_or(0.0), ",", 0, false),
                             order.fiat_currency
                         ))
                         .style(theme::text::secondary),

--- a/coincube-gui/src/app/view/p2p/components/trade_card.rs
+++ b/coincube-gui/src/app/view/p2p/components/trade_card.rs
@@ -8,8 +8,10 @@ use iced::{
     Length,
 };
 
+use super::format_with_separators;
 use super::order_card::OrderType;
 use crate::app::view::{self, message::P2PMessage};
+use coincube_ui::component::amount::format_f64_as_string;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TradeStatus {
@@ -160,17 +162,19 @@ pub fn trade_card<'a>(trade: &'a P2PTrade) -> Button<'a, view::Message> {
             if trade.is_range_order() {
                 row!(
                     h2(format!(
-                        "{:.0} - {:.0}",
-                        trade.min_amount.unwrap_or(0.0),
-                        trade.max_amount.unwrap_or(0.0)
-                    )),
+                        "{} - {}",
+                        format_f64_as_string(trade.min_amount.unwrap_or(0.0), ",", 0, false),
+                        format_f64_as_string(trade.max_amount.unwrap_or(0.0), ",", 0, false)
+                    ))
+                    .style(theme::text::primary),
                     p1_bold(format!(" {}", trade.fiat_currency)).style(theme::text::secondary)
                 )
                 .spacing(8)
                 .align_y(iced::alignment::Vertical::Center)
             } else {
                 row!(
-                    h2(format!("{:.2}", trade.fiat_amount)),
+                    h2(format_f64_as_string(trade.fiat_amount, ",", 2, false))
+                        .style(theme::text::primary),
                     p1_bold(format!(" {}", trade.fiat_currency)).style(theme::text::secondary)
                 )
                 .spacing(8)
@@ -180,7 +184,10 @@ pub fn trade_card<'a>(trade: &'a P2PTrade) -> Button<'a, view::Message> {
             if trade.is_fixed_price() {
                 row![
                     p2_regular("for").style(theme::text::secondary),
-                    p2_bold(format!("{} sats", trade.sats_amount.unwrap_or(0)))
+                    p2_bold(format!(
+                        "{} sats",
+                        format_with_separators(trade.sats_amount.unwrap_or(0))
+                    ))
                 ]
                 .spacing(8)
             } else {

--- a/coincube-gui/src/app/view/spark/last_tx.rs
+++ b/coincube-gui/src/app/view/spark/last_tx.rs
@@ -72,8 +72,11 @@ pub fn last_transactions_section<'a, M: 'a + Clone + 'static>(
             item = item.with_amount_override(token_str.clone());
         }
         if let Some(fiat) = tx.fiat_amount.as_ref() {
-            item =
-                item.with_fiat_amount(format!("{} {}", fiat.to_formatted_string(), fiat.currency()));
+            item = item.with_fiat_amount(format!(
+                "{} {}",
+                fiat.to_formatted_string(),
+                fiat.currency()
+            ));
         }
 
         if matches!(tx.status, DomainPaymentStatus::Pending) {

--- a/coincube-gui/src/app/view/spark/last_tx.rs
+++ b/coincube-gui/src/app/view/spark/last_tx.rs
@@ -5,7 +5,7 @@
 use coincube_ui::{
     color,
     component::{
-        amount::BitcoinDisplayUnit,
+        amount::{BitcoinDisplayUnit, DisplayAmount},
         text::*,
         transaction::{TransactionDirection, TransactionListItem},
     },
@@ -73,7 +73,7 @@ pub fn last_transactions_section<'a, M: 'a + Clone + 'static>(
         }
         if let Some(fiat) = tx.fiat_amount.as_ref() {
             item =
-                item.with_fiat_amount(format!("{} {}", fiat.to_rounded_string(), fiat.currency()));
+                item.with_fiat_amount(format!("{} {}", fiat.to_formatted_string(), fiat.currency()));
         }
 
         if matches!(tx.status, DomainPaymentStatus::Pending) {

--- a/coincube-gui/src/app/view/spark/overview.rs
+++ b/coincube-gui/src/app/view/spark/overview.rs
@@ -243,7 +243,7 @@ fn connected_view<'a>(
 
     let btc_fiat_str = btc_row_fiat
         .as_ref()
-        .map(|f| format!("{} {}", f.to_rounded_string(), f.currency()))
+        .map(|f| format!("{} {}", f.to_formatted_string(), f.currency()))
         .unwrap_or_default();
     let btc_row = Row::new()
         .spacing(10)
@@ -334,7 +334,7 @@ fn connected_view<'a>(
             if let Some(fiat) = tx.fiat_amount.as_ref() {
                 item = item.with_fiat_amount(format!(
                     "{} {}",
-                    fiat.to_rounded_string(),
+                    fiat.to_formatted_string(),
                     fiat.currency()
                 ));
             }

--- a/coincube-gui/src/app/view/spark/receive.rs
+++ b/coincube-gui/src/app/view/spark/receive.rs
@@ -366,7 +366,7 @@ fn method_chip<'a>(
     let btn = if active {
         button::primary(None, label)
     } else {
-        button::transparent_border(None, label)
+        button::transparent_border_centered(None, label)
     };
     btn.on_press(Message::SparkReceive(
         crate::app::view::SparkReceiveMessage::MethodSelected(target),

--- a/coincube-gui/src/app/view/spark/transactions.rs
+++ b/coincube-gui/src/app/view/spark/transactions.rs
@@ -25,7 +25,7 @@ use crate::export::ImportExportMessage;
 use crate::utils::{format_timestamp, truncate_middle};
 use coincube_ui::{
     component::{
-        amount::{amount_with_size_and_unit, BitcoinDisplayUnit},
+        amount::{amount_with_size_and_unit, BitcoinDisplayUnit, DisplayAmount},
         button, card,
         pagination::pagination_controls,
         quote_display::{self, Quote, QuoteDisplayProps},
@@ -232,11 +232,11 @@ fn transaction_row<'a>(
     let fiat_label = if tx.token_display.is_some() {
         tx.fiat_amount
             .as_ref()
-            .map(|f| format!("{} {}", f.to_rounded_string(), f.currency()))
+            .map(|f| format!("{} {}", f.to_formatted_string(), f.currency()))
     } else {
         fiat_converter.map(|converter| {
             let fiat = converter.convert(display_amount);
-            format!("{} {}", fiat.to_rounded_string(), fiat.currency())
+            format!("{} {}", fiat.to_formatted_string(), fiat.currency())
         })
     };
     if let Some(fiat_amount) = fiat_label {
@@ -321,7 +321,7 @@ pub fn transaction_detail_view<'a>(
     let date_text = format_timestamp(tx.timestamp).unwrap_or_else(|| "Unknown".to_string());
     let fiat_str = total_fiat
         .as_ref()
-        .map(|f| format!("{} {}", f.to_rounded_string(), f.currency()));
+        .map(|f| format!("{} {}", f.to_formatted_string(), f.currency()));
 
     let amount_row = if let Some(token_str) = tx.token_display.as_ref() {
         Row::new()

--- a/coincube-gui/src/app/view/vault/overview.rs
+++ b/coincube-gui/src/app/view/vault/overview.rs
@@ -117,7 +117,7 @@ pub fn vault_overview_view<'a>(
     };
     let btc_fiat_str = fiat_balance
         .as_ref()
-        .map(|f| format!("{} {}", f.to_rounded_string(), f.currency()))
+        .map(|f| format!("{} {}", f.to_formatted_string(), f.currency()))
         .unwrap_or_default();
     let vault_btc_row = Row::new()
         .spacing(10)
@@ -390,7 +390,7 @@ fn event_list_view(
 
     if let Some(fiat_amount) = fiat_converter.map(|converter| {
         let fiat = converter.convert(event.amount);
-        format!("{} {}", fiat.to_rounded_string(), fiat.currency())
+        format!("{} {}", fiat.to_formatted_string(), fiat.currency())
     }) {
         item = item.with_fiat_amount(fiat_amount);
     }

--- a/coincube-gui/src/app/view/vault/transactions.rs
+++ b/coincube-gui/src/app/view/vault/transactions.rs
@@ -168,7 +168,7 @@ fn tx_list_view(
 
     if let Some(fiat_amount) = fiat_converter.map(|converter| {
         let fiat = converter.convert(*amount);
-        format!("{} {}", fiat.to_rounded_string(), fiat.currency())
+        format!("{} {}", fiat.to_formatted_string(), fiat.currency())
     }) {
         item = item.with_fiat_amount(fiat_amount);
     }

--- a/coincube-gui/src/app/view/wallet_header.rs
+++ b/coincube-gui/src/app/view/wallet_header.rs
@@ -19,7 +19,7 @@ use coincube_ui::{
     component::{
         amount::{
             amount_with_size_and_unit, amount_with_size_colors_and_unit,
-            unconfirmed_amount_with_size_and_unit, BitcoinDisplayUnit,
+            unconfirmed_amount_with_size_and_unit, BitcoinDisplayUnit, DisplayAmount,
         },
         spinner,
         text::{text, Text as TextExt, H1_SIZE, H2_SIZE, H3_SIZE, H4_SIZE, P1_SIZE, P2_SIZE},
@@ -318,7 +318,7 @@ enum FiatStyle {
 ///   " NGN") renders at `value_size` in `color::GREY_3` — same look as
 ///   the SATS suffix that follows the satoshi balance.
 fn fiat_amount_row<'a, M: 'a>(fiat: &FiatAmount, value_size: u32, style: FiatStyle) -> Row<'a, M> {
-    let value_str = fiat.to_rounded_string();
+    let value_str = fiat.to_formatted_string();
     let value_text = match style {
         FiatStyle::Primary => text(value_str).size(value_size).bold(),
         FiatStyle::Secondary => text(value_str).size(value_size).color(color::GREY_3),

--- a/coincube-ui/src/component/amount.rs
+++ b/coincube-ui/src/component/amount.rs
@@ -42,11 +42,17 @@ impl DisplayAmount for Amount {
 /// Format a BTC amount (as f64) with commas grouping the whole-number part and
 /// spaces grouping the 8 fractional digits, e.g. `1,000.00 799 800`.
 pub fn format_btc_string(value: f64) -> String {
+    // Non-finite inputs (NaN, ±inf) format without a decimal point; return them
+    // as-is rather than panicking in the split below. `to_btc()` is always
+    // finite, so this only guards misuse of the public helper.
+    if !value.is_finite() {
+        return value.to_string();
+    }
     let amount = format!("{:.8}", value);
-    // `{:.8}` always emits a decimal point for the finite values `to_btc()` yields.
+    // `{:.8}` always emits a decimal point for finite values.
     let (integer, fraction) = amount
         .split_once('.')
-        .expect("formatted amount always contains a decimal point");
+        .expect("formatted finite amount always contains a decimal point");
     format!(
         "{}.{}",
         group_digits(integer, ","),
@@ -368,6 +374,14 @@ mod tests {
             format_u64_as_string(u64::MAX, ","),
             "18,446,744,073,709,551,615"
         );
+    }
+
+    #[test]
+    fn format_btc_string_handles_non_finite_without_panicking() {
+        assert_eq!(format_btc_string(f64::NAN), "NaN");
+        assert_eq!(format_btc_string(f64::INFINITY), "inf");
+        assert_eq!(format_btc_string(f64::NEG_INFINITY), "-inf");
+        assert_eq!(format_btc_string(1234.5), "1,234.50 000 000");
     }
 
     #[test]

--- a/coincube-ui/src/component/amount.rs
+++ b/coincube-ui/src/component/amount.rs
@@ -28,15 +28,27 @@ pub trait DisplayAmount {
 
 impl DisplayAmount for Amount {
     fn to_formatted_string(&self) -> String {
-        format_f64_as_string(self.to_btc(), " ", 8, true)
+        format_btc_string(self.to_btc())
     }
 
     fn to_formatted_string_with_unit(&self, unit: BitcoinDisplayUnit) -> String {
         match unit {
-            BitcoinDisplayUnit::BTC => format_f64_as_string(self.to_btc(), " ", 8, true),
-            BitcoinDisplayUnit::Sats => format_u64_as_string(self.to_sat(), " "),
+            BitcoinDisplayUnit::BTC => format_btc_string(self.to_btc()),
+            BitcoinDisplayUnit::Sats => format_u64_as_string(self.to_sat(), ","),
         }
     }
+}
+
+/// Format a BTC amount (as f64) with commas grouping the whole-number part and
+/// spaces grouping the 8 fractional digits, e.g. `1,000.00 799 800`.
+pub fn format_btc_string(value: f64) -> String {
+    let amount = format!("{:.8}", value);
+    let (integer, fraction) = amount.split_once('.').unwrap_or((amount.as_str(), ""));
+    format!(
+        "{}.{}",
+        group_digits(integer, ","),
+        group_digits(fraction, " ")
+    )
 }
 
 /// Amount with default size and colors.
@@ -138,11 +150,11 @@ pub fn format_f64_as_string(
         None => (amount.as_str(), ""), // num_decimals must be 0
     };
 
-    let integer = format_amount_number_part(integer, sep);
+    let integer = group_digits(integer, sep);
 
     if num_decimals > 0 {
         let fraction = if sep_decimals {
-            format_amount_number_part(fraction, sep)
+            group_digits(fraction, sep)
         } else {
             fraction.to_string()
         };
@@ -152,20 +164,20 @@ pub fn format_f64_as_string(
     }
 }
 
-/// Format a u64 (sats) as a string with space separators
+/// Format a u64 (sats) as a string with the given separator
 pub fn format_u64_as_string(value: u64, sep: &str) -> String {
     let s = value.to_string();
-    format_amount_number_part(&s, sep)
+    group_digits(&s, sep)
 }
 
-// Format a "part" of a number string with spaces to fit display requirements.
-// Currently using French formatting rules so digits are space-separated in groups
-// of three, starting from the right side. Incidentally, this works for both the
-// integer portion of the number as well as the fraction part.
+// Group the digits of a number string with `sep` to fit display requirements.
+// Digits are separated in groups of three, starting from the right side.
+// Incidentally, this works for both the integer portion of the number as well
+// as the fraction part.
 // Ex:
-//   1000 => 1 000
-//   100000 => 100 000
-fn format_amount_number_part(s: &str, sep: &str) -> String {
+//   group_digits("1000", ",") => 1,000
+//   group_digits("100000", " ") => 100 000
+pub fn group_digits(s: &str, sep: &str) -> String {
     let (sign, digits) = s.strip_prefix('-').map_or(("", s), |digits| ("-", digits));
     let mut part = digits
         .chars()
@@ -259,13 +271,13 @@ mod tests {
                 .to_formatted_string()
         );
         assert_eq!(
-            "1 000.00 799 800",
+            "1,000.00 799 800",
             bitcoin::Amount::from_btc(1000.00799800)
                 .unwrap()
                 .to_formatted_string()
         );
         assert_eq!(
-            "1 000.00 000 000",
+            "1,000.00 000 000",
             bitcoin::Amount::from_btc(1000.0)
                 .unwrap()
                 .to_formatted_string()
@@ -377,7 +389,7 @@ mod tests {
         );
         assert_eq!(
             amount.to_formatted_string_with_unit(BitcoinDisplayUnit::Sats),
-            "123 456 789"
+            "123,456,789"
         );
     }
 }

--- a/coincube-ui/src/component/amount.rs
+++ b/coincube-ui/src/component/amount.rs
@@ -43,7 +43,10 @@ impl DisplayAmount for Amount {
 /// spaces grouping the 8 fractional digits, e.g. `1,000.00 799 800`.
 pub fn format_btc_string(value: f64) -> String {
     let amount = format!("{:.8}", value);
-    let (integer, fraction) = amount.split_once('.').unwrap_or((amount.as_str(), ""));
+    // `{:.8}` always emits a decimal point for the finite values `to_btc()` yields.
+    let (integer, fraction) = amount
+        .split_once('.')
+        .expect("formatted amount always contains a decimal point");
     format!(
         "{}.{}",
         group_digits(integer, ","),

--- a/coincube-ui/src/component/button.rs
+++ b/coincube-ui/src/component/button.rs
@@ -104,6 +104,23 @@ pub fn transparent_border<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str) ->
     .style(theme::button::container_border)
 }
 
+/// Transparent bordered button with centered content — for segmented toggles
+/// where the button has a fixed/fill width and the label should sit in the
+/// middle (e.g. the Spark Receive method picker). Same style as
+/// [`transparent_border`], but centered rather than left-aligned.
+pub fn transparent_border_centered<'a, T: 'a>(
+    icon: Option<Text<'a>>,
+    t: &'static str,
+) -> Button<'a, T> {
+    Button::new(content(
+        icon,
+        text(t)
+            .align_y(iced::Alignment::Center)
+            .align_x(iced::Alignment::Center),
+    ))
+    .style(theme::button::container_border)
+}
+
 /// Orange-on-transparent outline button with a solid `DARK_ORANGE`
 /// fill + black text on hover. Centered content — use this for
 /// "Receive" and similar secondary actions that should read as


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Display-only formatting with no changes to amounts sent or stored; Mavapay fiat formatting is a precision improvement, not a behavior change in payment flows.
> 
> **Overview**
> Standardizes **thousands separators** across the app: satoshi and fiat whole parts use **commas**, BTC fractional digits keep **space** grouping via a new `format_btc_string` / public `group_digits` in `coincube-ui`.
> 
> Wallet surfaces (Liquid, Spark, Vault, headers, transaction lists) switch fiat labels from `to_rounded_string` to **`to_formatted_string`** so secondary amounts match the new grouping. **USDt** and Spark token display format the integer part with commas; Spark send success and Mavapay order/history amounts use the shared `format_u64_as_string` / `format_f64_as_string` helpers. Mavapay fiat amounts are formatted from **minor units with integer math** (`format_fiat_cents`) instead of `f64` division for large values.
> 
> P2P order/trade cards get the same comma rules for fiat ranges and sats. Spark Receive method chips use a new **centered** transparent border button for fixed-width toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6332d1ba488adfcbd0a8bfd5609faf0ec1c0e01c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new centered transparent-bordered button style for inactive method chips.

* **Improvements (UI/Formatting)**
  * Updated BTC, sats, and fiat displays to use consistent thousands separators (commas) and more readable formatting across portfolio, history, swaps, receive, send, vault, and P2P order/trade cards.

* **Bug Fixes**
  * Improved display formatting consistency (replacing rounded/space-grouped output) for transaction lists and summary amounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->