### PR TITLE
cleanup

### DIFF
--- a/coincube-gui/src/app/view/buysell/mavapay/ui.rs
+++ b/coincube-gui/src/app/view/buysell/mavapay/ui.rs
@@ -670,7 +670,10 @@ fn order_success_view<'a>(
                         .width(Length::Fill),
                         widget::column![
                             text::p2_medium("Bitcoin Received").style(theme::text::secondary),
-                            text::p1_bold(format!("{:.8} BTC", sats as f64 / 100_000_000.0))
+                            text::p1_bold(format!(
+                                "{} BTC",
+                                format_f64_as_string(sats as f64 / 100_000_000.0, ",", 8, false)
+                            ))
                         ]
                         .width(Length::Fill)
                     ],
@@ -1060,8 +1063,8 @@ fn order_detail_view<'a>(
                             info_field(
                                 "Fee (USD)",
                                 format!(
-                                    "${:.2}",
-                                    quote.transaction_fees_in_usd_cent as f64 / 100.0
+                                    "${}",
+                                    format_fiat_cents(quote.transaction_fees_in_usd_cent)
                                 )
                             ),
                         ],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Display-only string formatting in the Mavapay buy/sell UI; no payment or API logic changes.
> 
> **Overview**
> Aligns **Mavapay** order confirmation and quote detail labels with the shared amount formatters used elsewhere in the same module.
> 
> **Bitcoin Received** on the order success screen no longer uses a raw `{:.8}` `f64` format; it now goes through `format_f64_as_string` (comma grouping, 8 decimal places). **Fee (USD)** on quote cards switches from dividing USD cents with `f64` and `{:.2}` to `format_fiat_cents`, matching other fiat fields and avoiding precision issues on large cent values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbf645738b5538d898119cebd9c5a725e7469761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved number formatting in order screens for clearer financial values.
  * The “BTC Received” amount now displays with consistent precision and separators.
  * The “Fee (USD)” field now shows a more accurate dollar value from stored cents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->