### PR TITLE
Gate Marketplace

### DIFF
--- a/coincube-gui/src/app/cache.rs
+++ b/coincube-gui/src/app/cache.rs
@@ -82,6 +82,14 @@ pub struct Cache {
     /// panel (`P2PPanel::has_test_coordinator`), since the stateless sidebar
     /// view can't reach the panel.
     pub p2p_test_coordinator: bool,
+    /// Server-controlled Marketplace availability, mirrored from the Connect
+    /// account panel's `/connect/features` response (see
+    /// `ConnectAccountPanel::marketplace_server_flags`). Drives whether the
+    /// Marketplace nav + its routes are shown at all, on top of the per-network
+    /// gate. Fail-closed: defaults to [`MarketplaceServerFlags::OFF`] until
+    /// features load, so a launch build hides the untested money feature while
+    /// the API stance is unknown.
+    pub marketplace_flags: crate::app::features::MarketplaceServerFlags,
     /// Current theme mode (dark/light) — used for theme-aware widget rendering
     pub theme_mode: coincube_ui::theme::palette::ThemeMode,
     /// BTC price in USD, always fetched regardless of the user's selected fiat
@@ -170,6 +178,7 @@ impl std::default::Default for Cache {
             current_cube_is_passkey: false,
             has_p2p: false,
             p2p_test_coordinator: false,
+            marketplace_flags: crate::app::features::MarketplaceServerFlags::OFF,
             theme_mode: coincube_ui::theme::palette::ThemeMode::default(),
             btc_usd_price: None,
             show_direction_badges: true,

--- a/coincube-gui/src/app/features.rs
+++ b/coincube-gui/src/app/features.rs
@@ -38,6 +38,64 @@ impl Availability {
     }
 }
 
+/// Server-controlled availability of the Marketplace, sourced from
+/// `GET /connect/features`. This is a second, independent dimension on top
+/// of the per-network gate above: the network gate greys features out with
+/// a "not on this network" reason, whereas these flags are a launch
+/// kill-switch — when off, the whole surface is *hidden*, not greyed.
+///
+/// Fails **closed**. Every flag defaults to `false`, and callers hand this
+/// its [`OFF`](Self::OFF) value before `/connect/features` has loaded (right
+/// after sign-in), when the response omits the flags, or when the API is
+/// unreachable. A launch build must never surface the untested money feature
+/// because of a stale or missing API response. (Contrast the network gate,
+/// which defaults to showing-but-disabled.)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct MarketplaceServerFlags {
+    /// Master switch. When `false` the entire Marketplace section is hidden
+    /// and every route under it — including the otherwise always-reachable
+    /// P2P `Settings` sub-route — is unreachable.
+    pub marketplace_enabled: bool,
+    /// Whether the server permits Buy/Sell. Only meaningful when
+    /// `marketplace_enabled` is also `true` (see [`Self::buy_sell_on`]).
+    pub buy_sell_enabled: bool,
+    /// Whether the server permits P2P trading. Only meaningful when
+    /// `marketplace_enabled` is also `true` (see [`Self::p2p_on`]).
+    pub p2p_enabled: bool,
+}
+
+impl MarketplaceServerFlags {
+    /// Fail-closed value: everything off. The default state before features
+    /// load, and the value used when the API is unreachable or silent.
+    pub const OFF: Self = Self {
+        marketplace_enabled: false,
+        buy_sell_enabled: false,
+        p2p_enabled: false,
+    };
+
+    /// Whether the server permits Buy/Sell at all: the master switch AND the
+    /// Buy/Sell flag. The single source of truth for "should Buy/Sell show".
+    pub fn buy_sell_on(&self) -> bool {
+        self.marketplace_enabled && self.buy_sell_enabled
+    }
+
+    /// Whether the server permits P2P at all: the master switch AND the P2P
+    /// flag. The single source of truth for "should P2P show".
+    pub fn p2p_on(&self) -> bool {
+        self.marketplace_enabled && self.p2p_enabled
+    }
+}
+
+/// Placeholder reason for a Marketplace route reached while the server has
+/// the feature switched off. These routes are hidden from the nav, so this
+/// only surfaces on a restored or deep-linked route (fail-closed backstop) —
+/// deliberately generic, since "off at the server" is not a per-network state.
+fn marketplace_off() -> Availability {
+    Availability::Unavailable {
+        reason: "The Marketplace isn't available right now.".to_string(),
+    }
+}
+
 /// Display name for a network, used in popover text.
 fn net_label(n: Network) -> &'static str {
     match n {
@@ -105,17 +163,44 @@ pub fn p2p(net: Network, has_test_coordinator: bool) -> Availability {
 /// feature renders the shared "unavailable" placeholder instead of a live
 /// panel (the rail items themselves are already greyed and inert). Routes
 /// not tied to a gated feature are always available.
-pub fn route_availability(menu: &Menu, net: Network, p2p_test_coordinator: bool) -> Availability {
+pub fn route_availability(
+    menu: &Menu,
+    net: Network,
+    p2p_test_coordinator: bool,
+    flags: MarketplaceServerFlags,
+) -> Availability {
     match menu {
         Menu::Spark(_) => spark(net),
         Menu::Liquid(_) => liquid(net),
-        Menu::Marketplace(MarketplaceSubMenu::BuySell) => buy_sell(net),
-        // P2P Settings stays reachable even when trading is gated, so users
-        // can configure a coordinator to lift the gate — otherwise it's a
-        // catch-22 (you'd need a working coordinator to reach the page that
-        // adds one, and removing the last test node would lock you out).
-        Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Settings)) => Availability::Available,
-        Menu::Marketplace(MarketplaceSubMenu::P2P(_)) => p2p(net, p2p_test_coordinator),
+        // Buy/Sell: hidden entirely when the server switch is off, otherwise
+        // subject to the per-network gate.
+        Menu::Marketplace(MarketplaceSubMenu::BuySell) => {
+            if flags.buy_sell_on() {
+                buy_sell(net)
+            } else {
+                marketplace_off()
+            }
+        }
+        // P2P Settings stays reachable even when *network* trading is gated,
+        // so users can configure a coordinator to lift that gate — otherwise
+        // it's a catch-22 (you'd need a working coordinator to reach the page
+        // that adds one, and removing the last test node would lock you out).
+        // But when the *server* has P2P off, there's nothing to configure, so
+        // Settings is unreachable too — matching the hide-everything intent.
+        Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Settings)) => {
+            if flags.p2p_on() {
+                Availability::Available
+            } else {
+                marketplace_off()
+            }
+        }
+        Menu::Marketplace(MarketplaceSubMenu::P2P(_)) => {
+            if flags.p2p_on() {
+                p2p(net, p2p_test_coordinator)
+            } else {
+                marketplace_off()
+            }
+        }
         _ => Availability::Available,
     }
 }
@@ -179,6 +264,116 @@ mod tests {
                 net
             );
         }
+    }
+
+    /// Every marketplace flag combination that gates a route. Kept as its
+    /// own table so the server dimension is legible next to the network one.
+    const ALL_ON: MarketplaceServerFlags = MarketplaceServerFlags {
+        marketplace_enabled: true,
+        buy_sell_enabled: true,
+        p2p_enabled: true,
+    };
+
+    fn buy_sell_route() -> Menu {
+        Menu::Marketplace(MarketplaceSubMenu::BuySell)
+    }
+    fn p2p_route() -> Menu {
+        Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Overview))
+    }
+    fn p2p_settings_route() -> Menu {
+        Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Settings))
+    }
+
+    fn avail(menu: &Menu, net: Network, flags: MarketplaceServerFlags) -> bool {
+        route_availability(menu, net, false, flags).is_available()
+    }
+
+    #[test]
+    fn server_flags_default_and_off_are_fail_closed() {
+        // Default derives to all-false, matching the explicit OFF constant.
+        assert_eq!(
+            MarketplaceServerFlags::default(),
+            MarketplaceServerFlags::OFF
+        );
+        assert!(!MarketplaceServerFlags::OFF.buy_sell_on());
+        assert!(!MarketplaceServerFlags::OFF.p2p_on());
+    }
+
+    #[test]
+    fn sub_flags_require_the_master_switch() {
+        // Sub-flags on but master off → still off (fail-closed).
+        let master_off = MarketplaceServerFlags {
+            marketplace_enabled: false,
+            buy_sell_enabled: true,
+            p2p_enabled: true,
+        };
+        assert!(!master_off.buy_sell_on());
+        assert!(!master_off.p2p_on());
+    }
+
+    #[test]
+    fn marketplace_off_hides_every_route_including_p2p_settings() {
+        // Fail-closed: with the server switch off, no Marketplace route is
+        // reachable on mainnet — not even P2P Settings, which is otherwise
+        // always available.
+        for flags in [
+            MarketplaceServerFlags::OFF,
+            MarketplaceServerFlags::default(),
+        ] {
+            assert!(!avail(&buy_sell_route(), Network::Bitcoin, flags));
+            assert!(!avail(&p2p_route(), Network::Bitcoin, flags));
+            assert!(!avail(&p2p_settings_route(), Network::Bitcoin, flags));
+        }
+    }
+
+    #[test]
+    fn buy_sell_on_p2p_off_leaves_only_buy_sell_reachable() {
+        let flags = MarketplaceServerFlags {
+            marketplace_enabled: true,
+            buy_sell_enabled: true,
+            p2p_enabled: false,
+        };
+        assert!(avail(&buy_sell_route(), Network::Bitcoin, flags));
+        assert!(!avail(&p2p_route(), Network::Bitcoin, flags));
+        assert!(!avail(&p2p_settings_route(), Network::Bitcoin, flags));
+    }
+
+    #[test]
+    fn p2p_on_buy_sell_off_leaves_only_p2p_reachable() {
+        let flags = MarketplaceServerFlags {
+            marketplace_enabled: true,
+            buy_sell_enabled: false,
+            p2p_enabled: true,
+        };
+        assert!(!avail(&buy_sell_route(), Network::Bitcoin, flags));
+        assert!(avail(&p2p_route(), Network::Bitcoin, flags));
+        // Settings reachable so a coordinator can be configured.
+        assert!(avail(&p2p_settings_route(), Network::Bitcoin, flags));
+    }
+
+    #[test]
+    fn network_gate_still_applies_once_server_flags_are_on() {
+        // Server says yes everywhere, but Buy/Sell + P2P have no backend on
+        // signet, so the per-network gate still blocks them — while P2P
+        // Settings stays reachable (configure a coordinator).
+        assert!(!avail(&buy_sell_route(), Network::Signet, ALL_ON));
+        assert!(!avail(&p2p_route(), Network::Signet, ALL_ON));
+        assert!(avail(&p2p_settings_route(), Network::Signet, ALL_ON));
+        // On mainnet everything is reachable once the flags are on.
+        assert!(avail(&buy_sell_route(), Network::Bitcoin, ALL_ON));
+        assert!(avail(&p2p_route(), Network::Bitcoin, ALL_ON));
+    }
+
+    #[test]
+    fn non_marketplace_routes_ignore_server_flags() {
+        // A Spark route is unaffected by marketplace flags (still network-gated).
+        let spark_route = Menu::Spark(crate::app::menu::SparkSubMenu::Overview);
+        assert!(avail(
+            &spark_route,
+            Network::Bitcoin,
+            MarketplaceServerFlags::OFF
+        ));
+        assert!(!avail(&spark_route, Network::Signet, ALL_ON));
     }
 
     #[test]

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -3538,6 +3538,13 @@ impl App {
                     .connect
                     .update(self.daemon.clone(), &self.cache, msg);
                 self.cache.connect_authenticated = self.panels.connect.account.is_authenticated();
+                // Mirror the server-controlled Marketplace flags so the nav
+                // rails and route guard reflect the latest `/connect/features`
+                // stance. Recomputed after every ConnectAccount/ConnectCube
+                // message (FeaturesLoaded flows through here, and logout clears
+                // `features` back to fail-closed OFF via the accessor).
+                self.cache.marketplace_flags =
+                    self.panels.connect.account.marketplace_server_flags();
                 // Sync lightning address to cache for sidebar display
                 self.cache.lightning_address = self
                     .panels
@@ -3556,6 +3563,10 @@ impl App {
                     });
                 if let Some(p2p) = self.panels.p2p.as_mut() {
                     p2p.sync_lightning_address_from_cache(&self.cache);
+                    // Keep the panel's server-P2P mirror current so its Mostro
+                    // subscription gate drops the relay stream when the server
+                    // has P2P off (the cache flag was just refreshed above).
+                    p2p.sync_marketplace_flags_from_cache(&self.cache);
                 }
                 // Sync avatar handle to cache for sidebar display across all panels.
                 // Only update when Some to avoid blinking during in-flight image loads.
@@ -4380,6 +4391,7 @@ impl App {
             &self.panels.current,
             self.cache.network,
             self.cache.p2p_test_coordinator,
+            self.cache.marketplace_flags,
         )
         .reason()
         .map(str::to_string)

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -3580,6 +3580,27 @@ impl ConnectAccountPanel {
         }
     }
 
+    /// Server-controlled Marketplace availability, sourced from
+    /// `GET /connect/features` (`marketplaceEnabled` / `buySellEnabled` /
+    /// `p2pEnabled`). Mirrored into [`crate::app::cache::Cache`] so the nav
+    /// rails and route guard can hide the Marketplace surface.
+    ///
+    /// Fails **closed**, unlike [`Self::purchasing_enabled`]: while features
+    /// are unloaded (`None` — in flight after sign-in, or the fetch failed) or
+    /// a flag is absent, every flag reads `false`. A launch build must never
+    /// surface the untested money feature on a stale, silent, or unreachable
+    /// API. See [`crate::app::features::MarketplaceServerFlags`].
+    pub fn marketplace_server_flags(&self) -> crate::app::features::MarketplaceServerFlags {
+        match &self.features {
+            None => crate::app::features::MarketplaceServerFlags::OFF,
+            Some(f) => crate::app::features::MarketplaceServerFlags {
+                marketplace_enabled: f.marketplace_enabled.unwrap_or(false),
+                buy_sell_enabled: f.buy_sell_enabled.unwrap_or(false),
+                p2p_enabled: f.p2p_enabled.unwrap_or(false),
+            },
+        }
+    }
+
     /// Whether the pre-expiry renewal banner should render: the plan is
     /// within its renewal window AND the user hasn't dismissed it this
     /// session. The expired state has its own dedicated UX (D3), so the
@@ -5192,6 +5213,9 @@ mod plan_lifecycle_tests {
             }],
             pricing_schema_version: version,
             purchasing_enabled,
+            marketplace_enabled: None,
+            buy_sell_enabled: None,
+            p2p_enabled: None,
         }
     }
 
@@ -5492,6 +5516,55 @@ mod plan_lifecycle_tests {
         let mut panel = ConnectAccountPanel::new();
         panel.features = Some(features_with_purchasing(None, Some(false)));
         assert!(!panel.purchasing_enabled());
+    }
+
+    // ── Marketplace server flags (COIN-346) ───────────────────────────
+    fn features_with_marketplace(
+        marketplace: Option<bool>,
+        buy_sell: Option<bool>,
+        p2p: Option<bool>,
+    ) -> FeaturesResponse {
+        let mut f = features_with_purchasing(None, None);
+        f.marketplace_enabled = marketplace;
+        f.buy_sell_enabled = buy_sell;
+        f.p2p_enabled = p2p;
+        f
+    }
+
+    #[test]
+    fn marketplace_flags_fail_closed_until_features_load() {
+        let panel = ConnectAccountPanel::new();
+        // Unloaded (fetch in flight / failed / unreachable) → everything off.
+        assert_eq!(
+            panel.marketplace_server_flags(),
+            crate::app::features::MarketplaceServerFlags::OFF
+        );
+    }
+
+    #[test]
+    fn marketplace_flags_absent_read_as_off() {
+        let mut panel = ConnectAccountPanel::new();
+        // Loaded but the flags are absent (older backend) → still off, unlike
+        // the purchasing gate which treats absent as on.
+        panel.features = Some(features_with_marketplace(None, None, None));
+        assert_eq!(
+            panel.marketplace_server_flags(),
+            crate::app::features::MarketplaceServerFlags::OFF
+        );
+    }
+
+    #[test]
+    fn marketplace_flags_mirror_the_response() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.features = Some(features_with_marketplace(
+            Some(true),
+            Some(true),
+            Some(false),
+        ));
+        let flags = panel.marketplace_server_flags();
+        assert!(flags.marketplace_enabled);
+        assert!(flags.buy_sell_on());
+        assert!(!flags.p2p_on());
     }
 
     #[test]

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -2497,6 +2497,9 @@ mod renewal_banner_tests {
             }],
             pricing_schema_version: None,
             purchasing_enabled: enabled,
+            marketplace_enabled: None,
+            buy_sell_enabled: None,
+            p2p_enabled: None,
         }
     }
 

--- a/coincube-gui/src/app/view/mod.rs
+++ b/coincube-gui/src/app/view/mod.rs
@@ -149,6 +149,7 @@ pub fn dashboard_with_info<'a, T: Into<Element<'a, Message>>>(
         has_p2p,
         network: cache.network,
         p2p_test_coordinator: cache.p2p_test_coordinator,
+        marketplace_flags: cache.marketplace_flags,
         cube_name,
         lightning_address,
         avatar: avatar_handle,

--- a/coincube-gui/src/app/view/nav/marketplace.rs
+++ b/coincube-gui/src/app/view/nav/marketplace.rs
@@ -10,14 +10,21 @@ use coincube_ui::icon::{bitcoin_icon, person_icon};
 /// the rail — they render as a tab bar inside the P2P content panel
 /// (plan §12, decision Q1-B).
 ///
-/// On top of those structural gates, each item carries a network gate
-/// (via [`crate::app::features`]): rather than being hidden on networks
-/// where the feature has no backend, it stays in the rail but renders
-/// greyed out with an explanatory popover.
+/// On top of those structural gates, each item carries two more:
+/// - A **server gate** (`/connect/features` via [`NavContext::marketplace_flags`]):
+///   when the server switches a feature off, its item is *hidden* — a launch
+///   kill-switch, not a "coming soon on this network" state. Fail-closed, so
+///   the whole section is hidden until features load. See
+///   [`crate::app::features::MarketplaceServerFlags`].
+/// - A **network gate** (via [`crate::app::features`]): a server-enabled
+///   feature with no backend on the current network stays in the rail but
+///   renders greyed out with an explanatory popover.
 pub fn items(ctx: &NavContext) -> Vec<SubItem> {
     let mut items = Vec::new();
 
-    if ctx.has_p2p {
+    // Server gate first (`p2p_on`/`buy_sell_on` fold in the Marketplace master
+    // switch), so a server-disabled feature is omitted rather than greyed.
+    if ctx.has_p2p && ctx.marketplace_flags.p2p_on() {
         items.push(
             SubItem::new(
                 "P2P",
@@ -37,7 +44,7 @@ pub fn items(ctx: &NavContext) -> Vec<SubItem> {
     // requires a vault wallet. Until that panel can render a "needs
     // vault" placeholder without a wallet, keep it gated here so
     // users aren't sent to an orphan route.
-    if ctx.has_vault {
+    if ctx.has_vault && ctx.marketplace_flags.buy_sell_on() {
         items.push(
             SubItem::new(
                 "Buy/Sell",

--- a/coincube-gui/src/app/view/nav/mod.rs
+++ b/coincube-gui/src/app/view/nav/mod.rs
@@ -252,6 +252,12 @@ pub struct NavContext<'a> {
     /// Whether a non-mainnet Mostro coordinator is configured. Only
     /// affects P2P on test networks (mainnet P2P is always available).
     pub p2p_test_coordinator: bool,
+    /// Server-controlled Marketplace availability (from `/connect/features`).
+    /// Gates whether the Marketplace top-level nav and its Buy/Sell + P2P
+    /// sub-items are shown at all — on top of the per-network gate. Fail-closed
+    /// [`MarketplaceServerFlags::OFF`](crate::app::features::MarketplaceServerFlags::OFF)
+    /// until features load, hiding the section while the API stance is unknown.
+    pub marketplace_flags: crate::app::features::MarketplaceServerFlags,
     pub cube_name: &'a str,
     pub lightning_address: Option<&'a str>,
     pub avatar: Option<&'a iced::widget::image::Handle>,

--- a/coincube-gui/src/app/view/nav/primary.rs
+++ b/coincube-gui/src/app/view/nav/primary.rs
@@ -56,13 +56,17 @@ pub fn rail<'a>(menu: &Menu, ctx: &NavContext<'a>) -> Element<'a, Message> {
         top = top.push(setup_vault_item());
     }
 
-    // Marketplace is hidden entirely when the cube has neither P2P nor a
-    // vault — those are the only two surfaces it can link into, and
-    // `TopLevel::Marketplace.default_menu()` would otherwise route the
-    // user to a P2P Overview panel that isn't mounted (blank content).
-    // Marketplace itself is never network-gated — its *children*
-    // (Buy/Sell, P2P) carry the per-feature gate in the secondary rail.
-    if ctx.has_p2p || ctx.has_vault {
+    // Marketplace is hidden entirely unless the cube has a structurally
+    // present child (P2P or a vault) that the *server* also permits. The two
+    // surfaces it links into are P2P and Buy/Sell; `p2p_on`/`buy_sell_on` fold
+    // in the Marketplace master switch, so when the server has Marketplace off
+    // (or fails closed before features load) neither branch holds and the whole
+    // top-level entry disappears — not greyed, since this is a feature-off state
+    // rather than a "coming soon on this network" one (per-network gating lives
+    // on the *children* in the secondary rail).
+    let show_marketplace = (ctx.has_p2p && ctx.marketplace_flags.p2p_on())
+        || (ctx.has_vault && ctx.marketplace_flags.buy_sell_on());
+    if show_marketplace {
         let landing = marketplace_landing_menu(ctx);
         top = top.push(item_with_route(
             TopLevel::Marketplace,
@@ -171,37 +175,37 @@ fn item_with_route<'a>(
 
 /// Landing route for a Marketplace rail click.
 ///
-/// The secondary rail only surfaces P2P when `has_p2p` is set and
-/// Buy/Sell when `has_vault` is set. We prefer landing on a child that
-/// is both structurally present *and* available on the current network,
-/// so the click never drops the user onto a network-disabled panel when
-/// an enabled sibling exists. If every available child is also
-/// network-disabled we still pick a structurally-present one (its panel
-/// shows the section, the rail item stays greyed) and finally fall back
-/// to P2P to match `TopLevel::default_menu`.
+/// Only reached when the rail item is shown, i.e. at least one child is
+/// structurally present *and* server-permitted. A child must clear the server
+/// gate (`p2p_on`/`buy_sell_on`) to be a candidate at all; among those we
+/// prefer one also available on the current network, so the click never drops
+/// the user onto a disabled panel when an enabled sibling exists. If every
+/// server-permitted child is network-disabled we still pick one — P2P routes
+/// to Settings (where the user adds a coordinator to lift the network gate;
+/// the greyed rail item is otherwise inert, so this avoids a configure
+/// catch-22), Buy/Sell to its own (greyed) panel.
 fn marketplace_landing_menu(ctx: &NavContext<'_>) -> Menu {
     let p2p = Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Overview));
-    // P2P Settings stays reachable even when trading is gated (see
-    // `features::route_availability`), so it's the landing for a gated-but-
-    // present P2P section — that's where the user adds a coordinator to lift
-    // the gate. The greyed secondary-rail P2P item is otherwise inert, so this
-    // is the path that avoids a configure catch-22.
     let p2p_settings = Menu::Marketplace(MarketplaceSubMenu::P2P(P2PSubMenu::Settings));
     let buy_sell = Menu::Marketplace(MarketplaceSubMenu::BuySell);
 
-    let p2p_enabled =
-        ctx.has_p2p && features::p2p(ctx.network, ctx.p2p_test_coordinator).is_available();
-    let buy_sell_enabled = ctx.has_vault && features::buy_sell(ctx.network).is_available();
+    let p2p_server = ctx.has_p2p && ctx.marketplace_flags.p2p_on();
+    let buy_sell_server = ctx.has_vault && ctx.marketplace_flags.buy_sell_on();
+    let p2p_net_ok =
+        p2p_server && features::p2p(ctx.network, ctx.p2p_test_coordinator).is_available();
+    let buy_sell_net_ok = buy_sell_server && features::buy_sell(ctx.network).is_available();
 
-    if p2p_enabled {
+    if p2p_net_ok {
         p2p
-    } else if buy_sell_enabled {
+    } else if buy_sell_net_ok {
         buy_sell
-    } else if ctx.has_p2p {
+    } else if p2p_server {
         p2p_settings
-    } else if ctx.has_vault {
+    } else if buy_sell_server {
         buy_sell
     } else {
+        // Unreachable in practice — the rail item is hidden when no child is
+        // server-permitted — but keep a sane default matching `default_menu`.
         p2p_settings
     }
 }

--- a/coincube-gui/src/app/view/p2p/panel.rs
+++ b/coincube-gui/src/app/view/p2p/panel.rs
@@ -4784,6 +4784,21 @@ impl State for P2PPanel {
             Message::View(view::Message::P2P(msg)) => msg,
             _ => return Task::none(),
         };
+        // Fail-closed server gate (defense-in-depth, mirroring the
+        // `subscription()` gate and the `StartCheckout` chokepoint). When the
+        // server has P2P switched off the whole surface is hidden and every
+        // route unreachable, so no P2P message is legitimate — drop them all
+        // before any side-effecting work (order submit/take/cancel, trade
+        // actions, chat/dispute sends, attachment uploads, Spark hold-invoice
+        // payments) can run. A stale, deep-linked, or async-completion message
+        // must never drive externally visible Mostro work while P2P is
+        // disabled. Keyed on `p2p_on()` (the server switch) only — NOT the
+        // per-network gate — so P2P Settings stays usable on a server-enabled
+        // but network-gated cube, where the user configures a coordinator to
+        // lift that gate.
+        if !cache.marketplace_flags.p2p_on() {
+            return Task::none();
+        }
         if !self.lightning_address_user_edited && self.create_lightning_address.value.is_empty() {
             if let Some(addr) = cache.lightning_address.as_ref() {
                 self.create_lightning_address.value = addr.clone();

--- a/coincube-gui/src/app/view/p2p/panel.rs
+++ b/coincube-gui/src/app/view/p2p/panel.rs
@@ -395,6 +395,12 @@ pub struct P2PPanel {
     // selection (`MostroConfig::active_for`) — needed in `subscription`,
     // which has no `Cache` access.
     network: Network,
+    /// Server-controlled P2P availability (`MarketplaceServerFlags::p2p_on`),
+    /// mirrored from [`Cache`] via [`Self::sync_marketplace_flags_from_cache`].
+    /// Read by `subscription` (which has no `Cache` access) so no live Mostro
+    /// relay stream is held while the server has P2P switched off. Fail-closed:
+    /// starts `false` and stays off until `/connect/features` loads it on.
+    marketplace_p2p_enabled: bool,
     // Mostro settings
     mostro_config: MostroConfig,
     new_relay_input: form::Value<String>,
@@ -527,6 +533,9 @@ impl P2PPanel {
             dispute_chat_input: Default::default(),
             pending_dispute_chat_message: None,
             network,
+            // Fail-closed until the account panel mirrors `/connect/features`
+            // in (via `sync_marketplace_flags_from_cache`).
+            marketplace_p2p_enabled: false,
             mostro_config,
             new_relay_input: Default::default(),
             new_node_name_input: Default::default(),
@@ -775,6 +784,15 @@ impl P2PPanel {
         if let Some(addr) = cache.lightning_address.as_ref() {
             self.create_lightning_address.value = addr.clone();
         }
+    }
+
+    /// Mirror the server-controlled P2P availability from [`Cache`] (sourced
+    /// from `/connect/features`). Read by `subscription`, which has no `Cache`
+    /// access — so a Mostro relay stream is never held while the server has
+    /// P2P switched off. Called after each ConnectAccount/ConnectCube message,
+    /// which is when the cache flag can change (features load / logout).
+    pub fn sync_marketplace_flags_from_cache(&mut self, cache: &Cache) {
+        self.marketplace_p2p_enabled = cache.marketplace_flags.p2p_on();
     }
 
     fn clear_create_form(&mut self) {
@@ -4192,6 +4210,7 @@ impl State for P2PPanel {
                                         has_p2p: cache.has_p2p,
                                         network: cache.network,
                                         p2p_test_coordinator: cache.p2p_test_coordinator,
+                                        marketplace_flags: cache.marketplace_flags,
                                         cube_name: &cache.cube_name,
                                         lightning_address: None,
                                         avatar: None,
@@ -4355,6 +4374,7 @@ impl State for P2PPanel {
                                             has_p2p: cache.has_p2p,
                                             network: cache.network,
                                             p2p_test_coordinator: cache.p2p_test_coordinator,
+                                            marketplace_flags: cache.marketplace_flags,
                                             cube_name: &cache.cube_name,
                                             lightning_address: None,
                                             avatar: None,
@@ -4414,6 +4434,7 @@ impl State for P2PPanel {
                                             has_p2p: cache.has_p2p,
                                             network: cache.network,
                                             p2p_test_coordinator: cache.p2p_test_coordinator,
+                                            marketplace_flags: cache.marketplace_flags,
                                             cube_name: &cache.cube_name,
                                             lightning_address: None,
                                             avatar: None,
@@ -4545,6 +4566,7 @@ impl State for P2PPanel {
                                             has_p2p: cache.has_p2p,
                                             network: cache.network,
                                             p2p_test_coordinator: cache.p2p_test_coordinator,
+                                            marketplace_flags: cache.marketplace_flags,
                                             cube_name: &cache.cube_name,
                                             lightning_address: None,
                                             avatar: None,
@@ -4601,6 +4623,7 @@ impl State for P2PPanel {
                                             has_p2p: cache.has_p2p,
                                             network: cache.network,
                                             p2p_test_coordinator: cache.p2p_test_coordinator,
+                                            marketplace_flags: cache.marketplace_flags,
                                             cube_name: &cache.cube_name,
                                             lightning_address: None,
                                             avatar: None,
@@ -4711,14 +4734,17 @@ impl State for P2PPanel {
     fn subscription(&self) -> Subscription<Message> {
         // Only stream from Mostro when P2P is actually usable, so the panel
         // never holds a live relay subscription while the nav/content show P2P
-        // disabled. Two conditions, mirroring the rest of the gate:
+        // disabled. Three conditions, mirroring the rest of the gate:
+        //  - the server permits P2P at all (`/connect/features`, mirrored in
+        //    via `sync_marketplace_flags_from_cache`) — so a launch build with
+        //    Marketplace off never opens a Mostro relay stream, and
         //  - the feature is available on this network (test coordinator + a
         //    connected Spark escrow backend — same as the nav gate), and
         //  - the active coordinator matches the wallet's network (else
         //    `resolved_coordinator` could stream from a different coordinator
         //    than the one shown as active; COIN-371 Q4).
-        let p2p_available =
-            crate::app::features::p2p(self.network, self.has_test_coordinator()).is_available();
+        let p2p_available = self.marketplace_p2p_enabled
+            && crate::app::features::p2p(self.network, self.has_test_coordinator()).is_available();
         let mostro_sub = if p2p_available && self.coordinator_network_matches() {
             let cube_name = self.cube_name();
             let mnemonic = self.mnemonic.clone();

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -1945,6 +1945,9 @@ pub fn create_app_with_remote_backend(
             datadir_path: coincube_dir.clone(),
             // Recomputed from the P2P panel's Mostro config once panels are built.
             p2p_test_coordinator: false,
+            // Fail-closed until `/connect/features` loads and the account panel
+            // mirrors the real flags in (see `App::update`'s ConnectAccount arm).
+            marketplace_flags: crate::app::features::MarketplaceServerFlags::OFF,
             // We ignore last poll fields for remote backend.
             last_poll_at_startup: None,
             daemon_cache: DaemonCache {

--- a/coincube-gui/src/loader.rs
+++ b/coincube-gui/src/loader.rs
@@ -629,6 +629,9 @@ pub async fn load_application(
         network: config.info.network,
         // Recomputed from the P2P panel's Mostro config once panels are built.
         p2p_test_coordinator: false,
+        // Fail-closed until `/connect/features` loads and the account panel
+        // mirrors the real flags in (see `App::update`'s ConnectAccount arm).
+        marketplace_flags: crate::app::features::MarketplaceServerFlags::OFF,
         last_poll_at_startup: config.info.last_poll_timestamp,
         daemon_cache: DaemonCache {
             blockheight: config.info.block_height,

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -414,6 +414,24 @@ pub struct FeaturesResponse {
     /// `ConnectAccountPanel::purchasing_enabled`.
     #[serde(default, alias = "purchasingEnabled", alias = "purchasing_enabled")]
     pub purchasing_enabled: Option<bool>,
+    /// Master server switch for the whole Marketplace section (Buy/Sell +
+    /// P2P). When `Some(false)` — or absent/unreachable — the desktop hides
+    /// the Marketplace nav entirely and makes every route under it
+    /// unreachable. Unlike `purchasing_enabled`, this fails **closed**: an
+    /// absent flag reads as *off*, so a launch build never surfaces the
+    /// untested money feature on a stale or missing API response. See
+    /// `ConnectAccountPanel::marketplace_server_flags` and
+    /// `crate::app::features::MarketplaceServerFlags`.
+    #[serde(default, alias = "marketplaceEnabled", alias = "marketplace_enabled")]
+    pub marketplace_enabled: Option<bool>,
+    /// Server switch for Buy/Sell (fiat on/off-ramp). Only consulted when
+    /// `marketplace_enabled` is on. Fails closed (absent → off).
+    #[serde(default, alias = "buySellEnabled", alias = "buy_sell_enabled")]
+    pub buy_sell_enabled: Option<bool>,
+    /// Server switch for P2P trading. Only consulted when
+    /// `marketplace_enabled` is on. Fails closed (absent → off).
+    #[serde(default, alias = "p2pEnabled", alias = "p2p_enabled")]
+    pub p2p_enabled: Option<bool>,
 }
 
 // ── Checkout / Billing ──────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how money-adjacent Marketplace and P2P surfaces are exposed and blocks P2P side effects when disabled; behavior is fail-closed but incorrect flag handling could hide or allow trading incorrectly.
> 
> **Overview**
> Adds a **server-controlled Marketplace kill-switch** from `GET /connect/features` (`marketplaceEnabled`, `buySellEnabled`, `p2pEnabled`), modeled as `MarketplaceServerFlags` and mirrored into `Cache` after Connect account/cube updates. Until features load—or if flags are missing—the client **fails closed** (everything off), unlike the existing purchasing gate.
> 
> **Navigation and routing** now hide Marketplace (top-level and Buy/Sell / P2P sub-items) when the server disallows them, instead of only greying network-disabled entries. `route_availability` layers this on top of per-network gates; when the server has P2P off, **P2P Settings is no longer reachable** (including deep links), with a generic unavailable placeholder.
> 
> **P2P runtime** stops holding a Mostro relay subscription when server P2P is off, and **drops all P2P panel messages** at the update chokepoint so async or deep-linked actions cannot run trades, chat, or payments while disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec65f0c6a6274d5ee2d7679ddc413cac91693e53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Marketplace availability now reflects server-controlled feature flags, with a fail-closed default until settings load.
  * Buy/Sell and P2P sections are shown only when allowed by both server and network conditions.

* **Bug Fixes**
  * Marketplace navigation and route handling now consistently hide unavailable options instead of showing disabled entries.
  * P2P relay streaming is blocked when server-side P2P is turned off.

* **Tests**
  * Expanded coverage for default-off behavior, missing flags, and network-vs-server gating interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->