### PR TITLE
Use Connect Esplora as default

### DIFF
--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -150,37 +150,20 @@ impl BitcoindSettingsState {
             self.warning = Some(err);
             return Task::done(Message::View(view::Message::ShowError(err_msg)));
         };
-        // Reconstruct URLs from cache.network so a stale fallback_esplora.addr
-        // (e.g. written before Testnet4 was handled) is never used. Three-tier
-        // chain: mempool.space → blockstream.info (where available) → Connect
-        // (JWT). Two independent public providers in front means a 429 from
-        // one doesn't immediately push the user onto the metered Connect URL.
-        use coincubed::config::EsploraConfig;
-        let primary_url = crate::installer::public_esplora_url(cache.network);
-        let public_fallback = crate::installer::public_esplora_fallback_url(cache.network);
-        let connect_url = crate::installer::connect_url(cache.network);
+        // Reconstruct the provider chain from cache.network so a stale
+        // fallback_esplora.addr (e.g. written before Testnet4 was handled) is
+        // never used. Mainnet routes primary traffic through COINCUBE API
+        // (keeps addresses off public providers); every other network keeps a
+        // public-primary chain (mempool.space → blockstream.info → Connect).
+        // See `connect_esplora_config` for the assembled chain.
+        let esplora = crate::installer::connect_esplora_config(cache.network, &jwt);
         info!(
-            "Switching to Connect: primary={} public_fallback={:?} backstop={} token_len={}",
-            primary_url,
-            public_fallback,
-            connect_url,
+            "Switching to Connect: primary={} fallback={:?} secondary_fallback={:?} token_len={}",
+            esplora.addr,
+            esplora.fallback_addr,
+            esplora.secondary_fallback_addr,
             jwt.len()
         );
-        let (fallback_addr, fallback_token, secondary_fallback_addr, secondary_fallback_token) =
-            match public_fallback {
-                Some(public_fallback) => {
-                    (Some(public_fallback), None, Some(connect_url), Some(jwt))
-                }
-                None => (Some(connect_url), Some(jwt), None, None),
-            };
-        let esplora = EsploraConfig {
-            addr: primary_url,
-            token: None,
-            fallback_addr,
-            fallback_token,
-            secondary_fallback_addr,
-            secondary_fallback_token,
-        };
         let mut new_cfg = cfg.clone();
         if let Some(BitcoinBackend::Bitcoind(current)) = cfg.bitcoin_backend.clone() {
             new_cfg.pending_bitcoind = Some(current);

--- a/coincube-gui/src/installer/mod.rs
+++ b/coincube-gui/src/installer/mod.rs
@@ -20,14 +20,19 @@ pub(crate) fn connect_url(network: bitcoin::Network) -> String {
     format!("{}/api/v1/esplora/{}", base, network_path)
 }
 
-/// Public-Esplora URL for the given network, used as the daemon's primary
-/// endpoint so wallet sync traffic distributes across users' IPs instead of
-/// consolidating onto coincube-api's IP (which is where the per-IP rate limits
-/// bite). The chain in the same flow goes
+/// Public-Esplora URL for the given network. On non-mainnet networks this is
+/// the daemon's primary endpoint so wallet sync traffic distributes across
+/// users' IPs instead of consolidating onto coincube-api's IP (which is where
+/// the per-IP rate limits bite). The chain in that flow goes
 /// `public_esplora_url` (mempool.space) → [`public_esplora_fallback_url`]
 /// (blockstream.info) → [`connect_url`] (authenticated backstop), so a
 /// throttled mempool doesn't immediately push the user to the metered
 /// Connect URL.
+///
+/// Mainnet inverts this: [`connect_esplora_config`] makes [`connect_url`]
+/// (COINCUBE API) the primary and demotes these public URLs to fallbacks, so
+/// mainnet address lookups stay on COINCUBE infrastructure. See
+/// [`connect_esplora_config`] for the assembled chain.
 ///
 /// Regtest has no public counterpart — callers in regtest builds should
 /// configure their own endpoint via the installer's manual-Esplora step.
@@ -62,7 +67,49 @@ pub(crate) fn public_esplora_fallback_url(network: bitcoin::Network) -> Option<S
     }
 }
 
+/// Build the Esplora provider chain for a Connect-backed install.
+///
+/// Mainnet routes primary traffic through COINCUBE API (self-hosted node —
+/// keeps mainnet addresses off public providers) with mempool.space and
+/// blockstream.info demoted to fallbacks. Every other network keeps the
+/// public-primary chain (mempool.space → blockstream.info → Connect) so sync
+/// load stays distributed across user IPs.
+pub(crate) fn connect_esplora_config(network: bitcoin::Network, jwt: &str) -> EsploraConfig {
+    if network == bitcoin::Network::Bitcoin {
+        EsploraConfig {
+            addr: connect_url(network),
+            token: Some(jwt.to_owned()),
+            fallback_addr: Some(public_esplora_url(network)),
+            fallback_token: None,
+            // Some(blockstream.info) for mainnet.
+            secondary_fallback_addr: public_esplora_fallback_url(network),
+            secondary_fallback_token: None,
+        }
+    } else {
+        // Unchanged public-primary chain for testnet/testnet4/signet/regtest.
+        let (fallback_addr, fallback_token, secondary_fallback_addr, secondary_fallback_token) =
+            match public_esplora_fallback_url(network) {
+                Some(public_fallback) => (
+                    Some(public_fallback),
+                    None,
+                    Some(connect_url(network)),
+                    Some(jwt.to_owned()),
+                ),
+                None => (Some(connect_url(network)), Some(jwt.to_owned()), None, None),
+            };
+        EsploraConfig {
+            addr: public_esplora_url(network),
+            token: None,
+            fallback_addr,
+            fallback_token,
+            secondary_fallback_addr,
+            secondary_fallback_token,
+        }
+    }
+}
+
 use coincube_core::miniscript::bitcoin::{self, Network};
+use coincubed::config::EsploraConfig;
 use coincube_ui::{
     component::network_banner,
     widget::{Column, Element},

--- a/coincube-gui/src/installer/mod.rs
+++ b/coincube-gui/src/installer/mod.rs
@@ -109,11 +109,11 @@ pub(crate) fn connect_esplora_config(network: bitcoin::Network, jwt: &str) -> Es
 }
 
 use coincube_core::miniscript::bitcoin::{self, Network};
-use coincubed::config::EsploraConfig;
 use coincube_ui::{
     component::network_banner,
     widget::{Column, Element},
 };
+use coincubed::config::EsploraConfig;
 use coincubed::config::{BitcoinBackend, BitcoindConfig, BitcoindRpcAuth, Config};
 pub use context::{Context, RemoteBackend};
 use iced::{clipboard, Subscription, Task};

--- a/coincube-gui/src/installer/step/node/bitcoind.rs
+++ b/coincube-gui/src/installer/step/node/bitcoind.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use bitcoin_hashes::sha256;
 use coincube_core::miniscript::bitcoin::Network;
-use coincubed::config::{BitcoinBackend, BitcoindConfig, BitcoindRpcAuth, EsploraConfig};
+use coincubed::config::{BitcoinBackend, BitcoindConfig, BitcoindRpcAuth};
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use flate2::read::GzDecoder;
 use iced::{Subscription, Task};
@@ -572,48 +572,21 @@ impl Step for SelectBitcoindTypeStep {
                     ctx.bitcoin_backend = None;
                 }
             } else {
-                // Connect-only: set Esplora backend now. Primary is a public
-                // Esplora so wallet sync traffic distributes across user IPs;
-                // Connect is the fallback so the safety net still exists when
-                // a public provider rate-limits an individual user.
+                // Connect-only: set Esplora backend now. Mainnet routes
+                // primary traffic through COINCUBE API (keeps addresses off
+                // public providers); every other network keeps a public
+                // Esplora primary so sync traffic distributes across user
+                // IPs, with Connect as the safety-net fallback. See
+                // `connect_esplora_config` for the assembled chain.
                 // `EsploraConfig.token` is a plain `String` (serialized
                 // to disk in `coincubed` config), so we copy the inner
                 // string out of the `Zeroizing<String>` wrapper here.
                 let Some(token) = &ctx.connect_jwt else {
                     return false;
                 };
-                // Three-tier chain: mempool.space → blockstream.info →
-                // Connect (JWT). Picking up `public_esplora_fallback_url`
-                // when it's available for this network distributes
-                // sync load across two independent public providers
-                // before falling back to the metered Connect URL.
-                let (
-                    fallback_addr,
-                    fallback_token,
-                    secondary_fallback_addr,
-                    secondary_fallback_token,
-                ) = match crate::installer::public_esplora_fallback_url(ctx.network) {
-                    Some(public_fallback) => (
-                        Some(public_fallback),
-                        None,
-                        Some(crate::installer::connect_url(ctx.network)),
-                        Some(token.as_str().to_owned()),
-                    ),
-                    None => (
-                        Some(crate::installer::connect_url(ctx.network)),
-                        Some(token.as_str().to_owned()),
-                        None,
-                        None,
-                    ),
-                };
-                ctx.bitcoin_backend = Some(BitcoinBackend::Esplora(EsploraConfig {
-                    addr: crate::installer::public_esplora_url(ctx.network),
-                    token: None,
-                    fallback_addr,
-                    fallback_token,
-                    secondary_fallback_addr,
-                    secondary_fallback_token,
-                }));
+                ctx.bitcoin_backend = Some(BitcoinBackend::Esplora(
+                    crate::installer::connect_esplora_config(ctx.network, token.as_str()),
+                ));
                 ctx.internal_bitcoind_config = None;
                 ctx.pending_bitcoind_config = None;
                 ctx.internal_bitcoind = None;
@@ -1192,38 +1165,12 @@ impl Step for InternalBitcoindStep {
                 // Inner `String` copy: `EsploraConfig.token` is a plain
                 // `String` (persisted to disk), so extract it from the
                 // `Zeroizing<String>` wrapper rather than cloning the
-                // wrapper itself. Primary/fallback split: see the
-                // Connect-only branch above for the rationale.
-                // Same three-tier chain as the Connect-only branch above:
-                // mempool.space → blockstream.info (where available) →
-                // Connect (JWT).
-                let (
-                    fallback_addr,
-                    fallback_token,
-                    secondary_fallback_addr,
-                    secondary_fallback_token,
-                ) = match crate::installer::public_esplora_fallback_url(ctx.network) {
-                    Some(public_fallback) => (
-                        Some(public_fallback),
-                        None,
-                        Some(crate::installer::connect_url(ctx.network)),
-                        Some(token.as_str().to_owned()),
-                    ),
-                    None => (
-                        Some(crate::installer::connect_url(ctx.network)),
-                        Some(token.as_str().to_owned()),
-                        None,
-                        None,
-                    ),
-                };
-                ctx.bitcoin_backend = Some(BitcoinBackend::Esplora(EsploraConfig {
-                    addr: crate::installer::public_esplora_url(ctx.network),
-                    token: None,
-                    fallback_addr,
-                    fallback_token,
-                    secondary_fallback_addr,
-                    secondary_fallback_token,
-                }));
+                // wrapper itself. Primary/fallback split (mainnet →
+                // COINCUBE API primary, others → public primary): see
+                // `connect_esplora_config`.
+                ctx.bitcoin_backend = Some(BitcoinBackend::Esplora(
+                    crate::installer::connect_esplora_config(ctx.network, token.as_str()),
+                ));
             } else {
                 ctx.bitcoin_backend = bitcoind_config.map(BitcoinBackend::Bitcoind);
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which Esplora URL handles mainnet wallet sync and address queries (privacy and rate-limit behavior); testnet/signet behavior is unchanged but all Connect paths now depend on one helper.
> 
> **Overview**
> **Mainnet Connect/Esplora routing is inverted:** authenticated COINCUBE API (`connect_url` + JWT) becomes the **primary** endpoint, with mempool.space and blockstream.info as fallbacks. Non-mainnet networks keep the existing public-primary chain (mempool → blockstream → Connect).
> 
> A shared **`connect_esplora_config(network, jwt)`** in `installer/mod.rs` centralizes that logic. Duplicated three-tier `EsploraConfig` assembly is removed from vault **Switch to Connect** (`apply_connect_jwt`) and from installer **Connect-only** / **Connect + local node** paths in `bitcoind.rs`, which now call the helper. Docs on `public_esplora_url` note the mainnet exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd4d24c7d0b5cf26f9f0e1c8eec5e7e975090087. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Connect-backed node setup so Esplora sources are chosen more consistently across installation flows.
  * Mainnet and non-mainnet setups now use a clearer primary/fallback provider order.

* **Bug Fixes**
  * Fixed inconsistent backend selection when configuring Connect with or without a local node.
  * Improved handling when Connect credentials are unavailable, preventing incomplete setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->