### PR TITLE
Cleanup Your Cubes functionality

### DIFF
--- a/coincube-gui/src/app/state/settings/general.rs
+++ b/coincube-gui/src/app/state/settings/general.rs
@@ -158,7 +158,6 @@ pub struct GeneralSettingsState {
     new_price_setting: PriceSetting,
     new_unit_setting: UnitSetting,
     currencies: Vec<Currency>,
-    developer_mode: bool,
     show_direction_badges: bool,
     error: Option<Error>,
     /// Master seed backup flow state.
@@ -189,14 +188,12 @@ impl GeneralSettingsState {
     ) -> Self {
         use crate::app::settings::global::GlobalSettings;
         let global_path = GlobalSettings::path(datadir_path);
-        let developer_mode = GlobalSettings::load_developer_mode(&global_path);
         let show_direction_badges = GlobalSettings::load_show_direction_badges(&global_path);
         Self {
             cube_id,
             new_price_setting: price_setting,
             new_unit_setting: unit_setting,
             currencies: Vec::new(),
-            developer_mode,
             show_direction_badges,
             error: None,
             backup_state: BackupSeedState::None,
@@ -546,7 +543,6 @@ impl GeneralSettingsState {
             &self.new_price_setting,
             &self.new_unit_setting,
             &self.currencies,
-            self.developer_mode,
             self.show_direction_badges,
             &self.backup_state,
             &self.backup_pin,
@@ -569,7 +565,6 @@ impl State for GeneralSettingsState {
             &self.new_price_setting,
             &self.new_unit_setting,
             &self.currencies,
-            self.developer_mode,
             self.show_direction_badges,
             &self.backup_state,
             &self.backup_pin,
@@ -809,19 +804,6 @@ impl State for GeneralSettingsState {
                         Err(e) => Message::SettingsSaveFailed(e.into()),
                     },
                 )
-            }
-            Message::View(view::Message::Settings(view::SettingsMessage::TestToast(level))) => {
-                let label = match level {
-                    log::Level::Error => "Error",
-                    log::Level::Warn => "Warn",
-                    log::Level::Info => "Info",
-                    log::Level::Debug => "Debug",
-                    log::Level::Trace => "Trace",
-                };
-                Task::done(Message::View(view::Message::ShowToast(
-                    level,
-                    format!("Test {} toast", label),
-                )))
             }
             // --- Master seed backup flow ---
             Message::View(view::Message::Settings(view::SettingsMessage::BackupMasterSeed(

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -379,7 +379,6 @@ pub enum SettingsMessage {
     NodeSettings(NodeSettingsMessage),
     InstallStatsSection,
     InstallStats(InstallStatsViewMessage),
-    TestToast(log::Level),
     ToggleDirectionBadges(bool),
     /// Master seed backup flow (moved from Liquid Settings to Cube/General Settings).
     BackupMasterSeed(BackupWalletMessage),

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -26,7 +26,6 @@ pub fn general_section<'a>(
     new_price_setting: &'a PriceSetting,
     new_unit_setting: &'a UnitSetting,
     currencies_list: &'a [Currency],
-    developer_mode: bool,
     show_direction_badges: bool,
     backup_state: &'a crate::app::state::settings::general::BackupSeedState,
     backup_pin: &'a crate::pin_input::PinInput,
@@ -92,10 +91,6 @@ pub fn general_section<'a>(
     // threading discipline as the Recovery Kit card above.
     if let Some(ra) = recovery_alerts {
         col = col.push(recovery_alerts_card(ra));
-    }
-
-    if developer_mode {
-        col = col.push(toast_testing());
     }
 
     dashboard(menu, cache, col)
@@ -609,32 +604,6 @@ fn direction_badges_toggle<'a>(show: bool) -> Element<'a, Message> {
                     .on_toggle(|new_val| SettingsMessage::ToggleDirectionBadges(new_val).into())
                     .width(50)
                     .style(theme::toggler::orange),
-            ),
-    )
-    .width(Length::Fill)
-    .into()
-}
-
-fn toast_testing<'a>() -> Element<'a, Message> {
-    let btn = |label: &'static str, level: log::Level| {
-        iced::widget::Button::new(text(label).bold())
-            .padding([8, 16])
-            .style(theme::button::secondary)
-            .on_press(SettingsMessage::TestToast(level).into())
-    };
-
-    card::simple(
-        Column::new()
-            .spacing(15)
-            .push(text("Toast Testing").bold())
-            .push(
-                Row::new()
-                    .spacing(10)
-                    .push(btn("Error", log::Level::Error))
-                    .push(btn("Warn", log::Level::Warn))
-                    .push(btn("Info", log::Level::Info))
-                    .push(btn("Debug", log::Level::Debug))
-                    .push(btn("Trace", log::Level::Trace)),
             ),
     )
     .width(Length::Fill)

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1859,38 +1859,42 @@ impl Home {
                                 // Determine restorability per cube. `has_recovery_kit`
                                 // comes free from `list_cubes()`; the seed half (what a
                                 // full restore needs) lives on a separate endpoint, so
-                                // probe it only when a kit actually exists. A flaky probe
-                                // must not blank the whole list — on a non-NotFound error
-                                // we log and treat the seed half as absent (the row still
-                                // shows, just without the restore icon).
-                                let mut remote_only: Vec<RemoteCube> =
-                                    Vec::with_capacity(remote_source.len());
-                                for sc in remote_source {
-                                    let has_encrypted_seed = if sc.has_recovery_kit {
-                                        match rc_client.get_recovery_kit_status(sc.id).await {
-                                            Ok(status) => status.has_encrypted_seed,
-                                            Err(CoincubeError::NotFound) => false,
-                                            Err(e) => {
-                                                log::warn!(
-                                                    "[LAUNCHER] Recovery Kit status probe \
-                                                     failed for \"{}\": {}",
-                                                    sc.name,
-                                                    e
-                                                );
-                                                false
+                                // probe it only when a kit actually exists. Probes run
+                                // concurrently (`join_all`) so latency is one round-trip,
+                                // not N. A flaky probe must not blank the whole list — on
+                                // a non-NotFound error we log and treat the seed half as
+                                // absent (the row still shows, just without the restore
+                                // icon). `join_all` preserves input order.
+                                let client_ref = &rc_client;
+                                let remote_only: Vec<RemoteCube> = iced::futures::future::join_all(
+                                    remote_source.into_iter().map(|sc| async move {
+                                        let has_encrypted_seed = if sc.has_recovery_kit {
+                                            match client_ref.get_recovery_kit_status(sc.id).await {
+                                                Ok(status) => status.has_encrypted_seed,
+                                                Err(CoincubeError::NotFound) => false,
+                                                Err(e) => {
+                                                    log::warn!(
+                                                        "[LAUNCHER] Recovery Kit status probe \
+                                                         failed for \"{}\": {}",
+                                                        sc.name,
+                                                        e
+                                                    );
+                                                    false
+                                                }
                                             }
+                                        } else {
+                                            false
+                                        };
+                                        RemoteCube {
+                                            uuid: sc.uuid,
+                                            name: sc.name,
+                                            network: sc.network,
+                                            has_recovery_kit: sc.has_recovery_kit,
+                                            has_encrypted_seed,
                                         }
-                                    } else {
-                                        false
-                                    };
-                                    remote_only.push(RemoteCube {
-                                        uuid: sc.uuid,
-                                        name: sc.name,
-                                        network: sc.network,
-                                        has_recovery_kit: sc.has_recovery_kit,
-                                        has_encrypted_seed,
-                                    });
-                                }
+                                    }),
+                                )
+                                .await;
 
                                 Ok(remote_only)
                             },

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -2802,8 +2802,17 @@ fn remote_cube_list_item<'a>(cube: &'a RemoteCube) -> Element<'a, ViewMessage> {
     // `Status::Disabled` (alpha 0.2 on the text), which made the whole
     // row read as "disabled" to users and obscured the fact that the
     // cloud-download icon on the right is an active restore trigger.
+    // Three distinct states, so the copy tells the user *why* a row is
+    // (not) restorable rather than lumping "descriptor-only kit" in with
+    // "nothing backed up":
+    //   * kit + seed  → restorable here
+    //   * kit, no seed → a descriptor-only kit exists, but a full
+    //     restore needs the seed half, which lives on the original device
+    //   * no kit       → merely registered in Connect, nothing to restore
     let status_line = if restorable {
         "Recovery Kit available — click the download icon to restore"
+    } else if cube.has_recovery_kit {
+        "Recovery Kit has no Master Seed — restore from the device where it was backed up"
     } else {
         "Registered in Connect (no Recovery Kit backed up)"
     };

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -18,7 +18,8 @@ use crate::pin_input;
 use crate::recover_own_cube::{self, RecoverOwnCubeMessage, RecoverOwnCubePanel};
 use crate::recover_vault::{self, RecoverVaultMessage, RecoverVaultPanel};
 use crate::services::coincube::{
-    CoincubeClient, CubeLimitsResponse, CubeResponse, RegisterCubeRequest, UpdateCubeRequest,
+    CoincubeClient, CoincubeError, CubeLimitsResponse, CubeResponse, RegisterCubeRequest,
+    UpdateCubeRequest,
 };
 #[cfg(not(target_os = "macos"))]
 use crate::services::passkey::CeremonyMode;
@@ -82,6 +83,12 @@ pub struct RemoteCube {
     pub uuid: String,
     pub name: String,
     pub network: String, // API string: "mainnet", "testnet", etc.
+    /// Whether the server holds a Cube Recovery Kit for this cube.
+    pub has_recovery_kit: bool,
+    /// Whether that kit carries the encrypted seed half — the piece a
+    /// full restore needs. Only `true` implies the row is restorable
+    /// from this screen (kit present *and* the seed inside it).
+    pub has_encrypted_seed: bool,
 }
 
 /// Which section is shown in the home's main content area.
@@ -318,10 +325,12 @@ impl Home {
                     Message::Install(d, n, UserFlow::CreateWallet, None)
                 })
             }
-            Message::View(ViewMessage::RestoreFromRecoveryKit) => {
+            Message::View(ViewMessage::RestoreFromRecoveryKit(cube_uuid)) => {
                 // W13 — same launch shape as CreateWallet; the
                 // installer picks the Recovery-Kit step sequence off
-                // the UserFlow.
+                // the UserFlow. The clicked cube's `uuid` is threaded
+                // through so the step preselects it and skips the cube
+                // picker.
                 //
                 // Forward the home's already-authenticated Connect
                 // client so `RecoveryKitRestoreStep` can skip its own
@@ -338,7 +347,16 @@ impl Home {
                 let client = self.connect_account.authenticated_client();
                 Task::perform(
                     async move { (datadir_path, network, client) },
-                    |(d, n, c)| Message::Install(d, n, UserFlow::RestoreFromRecoveryKit, c),
+                    move |(d, n, c)| {
+                        Message::Install(
+                            d,
+                            n,
+                            UserFlow::RestoreFromRecoveryKit {
+                                cube_uuid: Some(cube_uuid),
+                            },
+                            c,
+                        )
+                    },
                 )
             }
             Message::View(ViewMessage::ShowCreateCube(show)) => {
@@ -1833,15 +1851,46 @@ impl Home {
                                 }
 
                                 // Keep only server cubes with no local counterpart
-                                let remote_only: Vec<RemoteCube> = server_cubes
+                                let remote_source: Vec<CubeResponse> = server_cubes
                                     .into_iter()
                                     .filter(|sc| !local_uuids.contains(&sc.uuid))
-                                    .map(|sc| RemoteCube {
+                                    .collect();
+
+                                // Determine restorability per cube. `has_recovery_kit`
+                                // comes free from `list_cubes()`; the seed half (what a
+                                // full restore needs) lives on a separate endpoint, so
+                                // probe it only when a kit actually exists. A flaky probe
+                                // must not blank the whole list — on a non-NotFound error
+                                // we log and treat the seed half as absent (the row still
+                                // shows, just without the restore icon).
+                                let mut remote_only: Vec<RemoteCube> =
+                                    Vec::with_capacity(remote_source.len());
+                                for sc in remote_source {
+                                    let has_encrypted_seed = if sc.has_recovery_kit {
+                                        match rc_client.get_recovery_kit_status(sc.id).await {
+                                            Ok(status) => status.has_encrypted_seed,
+                                            Err(CoincubeError::NotFound) => false,
+                                            Err(e) => {
+                                                log::warn!(
+                                                    "[LAUNCHER] Recovery Kit status probe \
+                                                     failed for \"{}\": {}",
+                                                    sc.name,
+                                                    e
+                                                );
+                                                false
+                                            }
+                                        }
+                                    } else {
+                                        false
+                                    };
+                                    remote_only.push(RemoteCube {
                                         uuid: sc.uuid,
                                         name: sc.name,
                                         network: sc.network,
-                                    })
-                                    .collect();
+                                        has_recovery_kit: sc.has_recovery_kit,
+                                        has_encrypted_seed,
+                                    });
+                                }
 
                                 Ok(remote_only)
                             },
@@ -2741,57 +2790,73 @@ fn cubes_list_item<'a>(
 }
 
 fn remote_cube_list_item<'a>(cube: &'a RemoteCube) -> Element<'a, ViewMessage> {
+    // A remote cube is only restorable from this screen when the server
+    // holds a Recovery Kit *and* that kit carries the encrypted seed a
+    // full restore needs. Kit-less cubes (merely registered in Connect)
+    // and descriptor-only kits can't be rebuilt here, so they show no
+    // restore affordance — only the honest status and a delete button.
+    let restorable = cube.has_recovery_kit && cube.has_encrypted_seed;
+
     // Render the cube-name area as a plain card, NOT a Button. Using a
     // Button without `.on_press` makes Iced render it in
     // `Status::Disabled` (alpha 0.2 on the text), which made the whole
     // row read as "disabled" to users and obscured the fact that the
     // cloud-download icon on the right is an active restore trigger.
+    let status_line = if restorable {
+        "Recovery Kit available — click the download icon to restore"
+    } else {
+        "Registered in Connect (no Recovery Kit backed up)"
+    };
+    // Mute the whole remote row (title included) relative to local
+    // cubes: these cubes have no data on this machine, so rendering
+    // their name in the same bright white as a locally-available Cube
+    // over-states their presence. `theme::text::secondary` on the bold
+    // title greys it back a notch while keeping the weight contrast.
     let card = Container::new(
-        Column::new().spacing(4).push(p1_bold(&cube.name)).push(
-            p1_regular("On another device — click the download icon to restore")
-                .style(theme::text::secondary),
-        ),
+        Column::new()
+            .spacing(4)
+            .push(p1_bold(&cube.name).style(theme::text::secondary))
+            .push(p1_regular(status_line).style(theme::text::secondary)),
     )
     .padding(15)
     .width(Length::Fixed(500.0))
     .style(theme::card::simple);
 
     // W13 entry point on the home: clicking cloud-arrow-down on a
-    // remote-only cube kicks off the Connect-Recovery-Kit restore flow.
-    // The flow's cube picker (`RecoveryKitRestoreStep`) lets the user
-    // choose which cube on their Connect account to restore — clicking
-    // this specific row doesn't preselect `cube.uuid`, so the tooltip
-    // is deliberately generic to avoid implying otherwise. Threading
-    // the clicked uuid through `ViewMessage::RestoreFromRecoveryKit`
-    // → `UserFlow::RestoreFromRecoveryKit` → the step's cube picker
-    // is a future refinement.
-    let restore_button = iced_tooltip::Tooltip::new(
-        Button::new(icon::cloud_arrow_down_icon())
+    // restorable remote cube kicks off the Cube-Recovery-Kit restore
+    // flow, threading this row's `uuid` through
+    // `ViewMessage::RestoreFromRecoveryKit` →
+    // `UserFlow::RestoreFromRecoveryKit { cube_uuid }` → the step, which
+    // preselects it and skips the cube picker entirely. The icon is only
+    // shown when the cube is actually restorable, so the click always
+    // has a valid target.
+    let restore_button = restorable.then(|| {
+        iced_tooltip::Tooltip::new(
+            Button::new(icon::cloud_arrow_down_icon())
+                .style(theme::button::secondary)
+                .padding(10)
+                .on_press(ViewMessage::RestoreFromRecoveryKit(cube.uuid.clone())),
+            Container::new(p1_regular("Restore this Cube from its Recovery Kit"))
+                .padding(8)
+                .style(theme::card::simple),
+            iced_tooltip::Position::Bottom,
+        )
+    });
+
+    let mut row = Row::new().align_y(Alignment::Center).spacing(20).push(card);
+    if let Some(restore_button) = restore_button {
+        row = row.push(restore_button);
+    }
+    row = row.push(
+        Button::new(icon::trash_icon())
             .style(theme::button::secondary)
             .padding(10)
-            .on_press(ViewMessage::RestoreFromRecoveryKit),
-        Container::new(p1_regular("Choose a Recovery Kit to restore"))
-            .padding(8)
-            .style(theme::card::simple),
-        iced_tooltip::Position::Bottom,
+            .on_press(ViewMessage::DeleteCube(DeleteCubeMessage::ShowRemoteModal(
+                cube.uuid.clone(),
+            ))),
     );
 
-    Container::new(
-        Row::new()
-            .align_y(Alignment::Center)
-            .spacing(20)
-            .push(card)
-            .push(restore_button)
-            .push(
-                Button::new(icon::trash_icon())
-                    .style(theme::button::secondary)
-                    .padding(10)
-                    .on_press(ViewMessage::DeleteCube(DeleteCubeMessage::ShowRemoteModal(
-                        cube.uuid.clone(),
-                    ))),
-            ),
-    )
-    .into()
+    Container::new(row).into()
 }
 
 fn recovery_input_view(
@@ -3076,10 +3141,10 @@ pub enum Message {
 pub enum ViewMessage {
     ImportWallet,
     CreateWallet,
-    /// W13 — launch the installer in "restore from Connect Recovery
-    /// Kit" mode. Sibling to `CreateWallet` / `ImportWallet` in the
-    /// cube-setup menu.
-    RestoreFromRecoveryKit,
+    /// W13 — launch the installer in "restore from Cube Recovery Kit"
+    /// mode for a specific remote cube (payload is its `uuid`). The
+    /// installer preselects the cube and skips the picker.
+    RestoreFromRecoveryKit(String),
     ShowCreateCube(bool),
     CubeNameEdited(String),
     CreateCube,

--- a/coincube-gui/src/installer/mod.rs
+++ b/coincube-gui/src/installer/mod.rs
@@ -116,13 +116,19 @@ use step::{
 pub enum UserFlow {
     CreateWallet,
     AddWallet,
-    /// W13 — full install restore from a Connect Recovery Kit.
+    /// W13 — full install restore from a Cube Recovery Kit.
     /// Skips the descriptor-editor, backup-mnemonic, and register-
     /// descriptor steps because the kit provides both the seed and
     /// the descriptor. The flow is: RecoveryKitRestore(Full) →
     /// CoincubeConnect (noop — already authed) → Node setup →
     /// WalletAlias → Final.
-    RestoreFromRecoveryKit,
+    ///
+    /// `cube_uuid` preselects a specific remote cube (set when launched
+    /// from a home "Your Cubes" row) so the step skips its picker; `None`
+    /// falls back to the picker.
+    RestoreFromRecoveryKit {
+        cube_uuid: Option<String>,
+    },
     /// W15 — restore the Wallet Descriptor only, from a running
     /// Cube. Assumes the Cube's seed is already on disk (the user
     /// just needs to rehydrate the vault). Launched from the
@@ -265,7 +271,7 @@ impl Installer {
                         // this match arm `ctx.remote_backend` stays at
                         // `Undefined` and the `Message::Install` match panics
                         // with `unreachable!("Must be defined at this point")`.
-                        (UserFlow::RestoreFromRecoveryKit, _)
+                        (UserFlow::RestoreFromRecoveryKit { .. }, _)
                         | (UserFlow::RestoreVaultFromRecoveryKit, _)
                         | (UserFlow::RecoverInheritedVault { .. }, _)
                         | (UserFlow::RecoverOwnCubeWithPhone { .. }, _) => RemoteBackend::None,
@@ -328,6 +334,7 @@ impl Installer {
                         RecoveryKitRestoreStep::new(
                             RestoreScope::DescriptorOnly,
                             network_str.clone(),
+                            None,
                         )
                         .into(),
                         RegisterDescriptor::new_import_wallet().into(),
@@ -342,8 +349,13 @@ impl Installer {
                     // and the descriptor, so the flow skips the editor +
                     // register-descriptor + backup-mnemonic steps that
                     // only make sense for a fresh install.
-                    UserFlow::RestoreFromRecoveryKit => vec![
-                        RecoveryKitRestoreStep::new(RestoreScope::Full, network_str.clone()).into(),
+                    UserFlow::RestoreFromRecoveryKit { cube_uuid } => vec![
+                        RecoveryKitRestoreStep::new(
+                            RestoreScope::Full,
+                            network_str.clone(),
+                            cube_uuid,
+                        )
+                        .into(),
                         // Collect a PIN *after* the kit is decrypted
                         // (so `ctx.recovered_signer` is populated and
                         // the step's `skip()` doesn't short-circuit)
@@ -371,6 +383,7 @@ impl Installer {
                         RecoveryKitRestoreStep::new(
                             RestoreScope::DescriptorOnly,
                             network_str.clone(),
+                            None,
                         )
                         .into(),
                         RegisterDescriptor::new_import_wallet().into(),

--- a/coincube-gui/src/installer/step/recovery_kit_restore.rs
+++ b/coincube-gui/src/installer/step/recovery_kit_restore.rs
@@ -120,6 +120,10 @@ pub struct RecoveryKitRestoreStep {
     /// Network filter applied to the cube picker. The user can only
     /// restore into the same network they're installing for.
     network_filter: String,
+    /// When set (W13 launched from a home "Your Cubes" row), the cube
+    /// list is filtered to just this uuid so `phase_after_cubes_loaded`
+    /// auto-selects it and the picker is skipped entirely.
+    preselect_uuid: Option<String>,
     client: CoincubeClient,
     phase: Phase,
     // Transient UI inputs held outside Phase so typing during an
@@ -140,10 +144,15 @@ pub struct RecoveryKitRestoreStep {
 }
 
 impl RecoveryKitRestoreStep {
-    pub fn new(scope: RestoreScope, network_filter: String) -> Self {
+    pub fn new(
+        scope: RestoreScope,
+        network_filter: String,
+        preselect_uuid: Option<String>,
+    ) -> Self {
         Self {
             scope,
             network_filter,
+            preselect_uuid,
             client: CoincubeClient::new(),
             phase: Phase::Email,
             email: form::Value {
@@ -208,6 +217,7 @@ impl RecoveryKitRestoreStep {
     fn list_cubes_task(&self) -> Task<Message> {
         let client = self.client.clone();
         let network = self.network_filter.clone();
+        let preselect_uuid = self.preselect_uuid.clone();
         Task::perform(
             async move {
                 let all = client.list_cubes().await.map_err(|e| e.to_string())?;
@@ -215,8 +225,20 @@ impl RecoveryKitRestoreStep {
                 // filter by `has_recovery_kit` at list time because the
                 // kit status lives on a separate endpoint — fetch
                 // status in parallel.
-                let matches: Vec<CubeResponse> =
-                    all.into_iter().filter(|c| c.network == network).collect();
+                //
+                // When a specific cube was preselected (home restore
+                // row), narrow to just that uuid so the loaded list has
+                // a single entry and `phase_after_cubes_loaded`
+                // auto-selects it, skipping the picker.
+                let matches: Vec<CubeResponse> = all
+                    .into_iter()
+                    .filter(|c| c.network == network)
+                    .filter(|c| {
+                        preselect_uuid
+                            .as_ref()
+                            .is_none_or(|uuid| &c.uuid == uuid)
+                    })
+                    .collect();
                 let mut out = Vec::with_capacity(matches.len());
                 for cube in matches {
                     // Only NotFound is a signal that this particular

--- a/coincube-gui/src/installer/step/recovery_kit_restore.rs
+++ b/coincube-gui/src/installer/step/recovery_kit_restore.rs
@@ -233,11 +233,7 @@ impl RecoveryKitRestoreStep {
                 let matches: Vec<CubeResponse> = all
                     .into_iter()
                     .filter(|c| c.network == network)
-                    .filter(|c| {
-                        preselect_uuid
-                            .as_ref()
-                            .is_none_or(|uuid| &c.uuid == uuid)
-                    })
+                    .filter(|c| preselect_uuid.as_ref().is_none_or(|uuid| &c.uuid == uuid))
                     .collect();
                 let mut out = Vec::with_capacity(matches.len());
                 for cube in matches {

--- a/coincube-gui/src/installer/step/recovery_kit_restore.rs
+++ b/coincube-gui/src/installer/step/recovery_kit_restore.rs
@@ -232,8 +232,9 @@ impl RecoveryKitRestoreStep {
                 // auto-selects it, skipping the picker.
                 let matches: Vec<CubeResponse> = all
                     .into_iter()
-                    .filter(|c| c.network == network)
-                    .filter(|c| preselect_uuid.as_ref().is_none_or(|uuid| &c.uuid == uuid))
+                    .filter(|c| {
+                        cube_passes_filter(&c.network, &c.uuid, &network, preselect_uuid.as_deref())
+                    })
                     .collect();
                 let mut out = Vec::with_capacity(matches.len());
                 for cube in matches {
@@ -396,6 +397,23 @@ pub(crate) fn stage_restore(
     };
 
     Ok(StagedRestore { descriptor, signer })
+}
+
+/// Filter applied to the server cube list before status probing:
+/// keep cubes on the network we're installing for, and — when a
+/// specific cube was preselected from a home "Your Cubes" row — only
+/// the row with that uuid. Both conditions must hold; a preselected
+/// uuid that lives on a different network is still excluded, so the
+/// caller never probes (or auto-selects) a cross-network cube.
+/// Extracted as a pure fn so the network×preselect matrix is
+/// unit-testable without standing up the async task.
+fn cube_passes_filter(
+    cube_network: &str,
+    cube_uuid: &str,
+    network: &str,
+    preselect_uuid: Option<&str>,
+) -> bool {
+    cube_network == network && preselect_uuid.is_none_or(|uuid| cube_uuid == uuid)
 }
 
 /// Does `c` carry the specific encrypted half this restore flow
@@ -936,6 +954,77 @@ mod tests {
                 updated_at: None,
             },
         }
+    }
+
+    // --- `cube_passes_filter`: the network × preselect matrix that
+    // `list_cubes_task` uses to narrow the server cube list. ---
+
+    #[test]
+    fn filter_keeps_matching_cube_on_network_when_preselected() {
+        // Preselected uuid on the requested network → kept.
+        assert!(cube_passes_filter(
+            "mainnet",
+            "cube-a",
+            "mainnet",
+            Some("cube-a")
+        ));
+    }
+
+    #[test]
+    fn filter_drops_mismatched_uuid_when_preselected() {
+        // Right network, wrong uuid → excluded so only the clicked cube
+        // survives to auto-select.
+        assert!(!cube_passes_filter(
+            "mainnet",
+            "cube-b",
+            "mainnet",
+            Some("cube-a")
+        ));
+    }
+
+    #[test]
+    fn filter_drops_preselected_uuid_on_wrong_network() {
+        // Matching uuid but a different network → still excluded; we
+        // never restore into a network we're not installing for.
+        assert!(!cube_passes_filter(
+            "testnet",
+            "cube-a",
+            "mainnet",
+            Some("cube-a")
+        ));
+    }
+
+    #[test]
+    fn filter_without_preselect_keeps_all_on_network() {
+        // No preselection (W14/W15, or a home launch without a uuid):
+        // network is the only gate.
+        assert!(cube_passes_filter("mainnet", "cube-a", "mainnet", None));
+        assert!(cube_passes_filter("mainnet", "cube-b", "mainnet", None));
+    }
+
+    #[test]
+    fn filter_without_preselect_drops_off_network() {
+        assert!(!cube_passes_filter("testnet", "cube-a", "mainnet", None));
+    }
+
+    #[test]
+    fn preselect_then_auto_select_advances_to_password() {
+        // End-to-end of the home restore path: after the filter narrows
+        // to the single preselected cube, `phase_after_cubes_loaded`
+        // auto-selects it (no picker). Model the survivor as a
+        // restorable candidate and confirm the auto-select branch.
+        let survivors: Vec<RestoreCubeCandidate> =
+            vec![candidate("Preselected", true), candidate("Other", true)]
+                .into_iter()
+                .filter(|c| cube_passes_filter(&c.network, "uuid", "mainnet", Some("uuid")))
+                .collect();
+        // Both share the test uuid "uuid"; the point exercised here is
+        // the auto-select on a single-entry list.
+        let phase = phase_after_cubes_loaded(RestoreScope::Full, vec![survivors[0].clone()]);
+        assert!(
+            matches!(phase, Phase::PasswordEntry { .. }),
+            "single preselected restorable cube should auto-advance to PasswordEntry"
+        );
     }
 
     // Regression tests for the auto-select-skips-kit-check bug. Before

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -1431,8 +1431,8 @@ pub fn select_bitcoind_type<'a>(
                 .max_width(620)
                 .push(text("Start with COINCUBE | Connect").bold())
                 .push(text(
-                    "Your Vault will use our hosted Esplora server immediately. \
-                    No setup required.",
+                    "Your Vault will use our hosted Esplora server immediately \
+                    (backed by Bitcoin Knots). No setup required.",
                 ))
                 .push(
                     checkbox(install_node)
@@ -2534,7 +2534,7 @@ pub fn recovery_kit_restore<'a>(
     use crate::installer::step::recovery_kit_restore::RestorePhase;
 
     let title = match scope {
-        crate::installer::step::RestoreScope::Full => "Restore from Connect Recovery Kit",
+        crate::installer::step::RestoreScope::Full => "Restore from Cube Recovery Kit",
         crate::installer::step::RestoreScope::DescriptorOnly => {
             "Restore Wallet Descriptor from Connect"
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect Connect-backed cube restore entry points and extra per-cube API probes on the home screen; incorrect gating or preselect could block or mis-route recovery, but scope is UI/installer flow rather than crypto or auth.
> 
> **Overview**
> **Your Cubes** remote rows now reflect whether a **Cube Recovery Kit** with an encrypted **master seed** is actually on Connect, and only those rows get the restore action.
> 
> When the home screen builds the remote-only list, it keeps server `has_recovery_kit` from `list_cubes()` and, for kits that exist, **concurrently** calls `get_recovery_kit_status` to learn `has_encrypted_seed`. Probe failures (except `NotFound`) are logged and treated as non-restorable so the list still renders. Row copy distinguishes restorable kit, descriptor-only kit, and Connect registration with no kit; remote names use secondary styling. Restore launches the installer with that cube’s **uuid** so `RecoveryKitRestoreStep` filters to one cube, auto-selects it, and skips the picker.
> 
> `UserFlow::RestoreFromRecoveryKit` is now `{ cube_uuid: Option<String> }`; the restore step constructor takes an optional preselect uuid (other flows pass `None`). Installer copy says **Cube Recovery Kit** and notes hosted Esplora is backed by **Bitcoin Knots**.
> 
> **General settings** drops **developer mode** and the **Toast Testing** card (`TestToast` message and handler removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6019600a6cc6eefb7fb60deb9b0d08a0596a2c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more guided remote cube restore flow, with eligible cubes now preselected when starting recovery.
  * Updated recovery wording to refer to “Cube Recovery Kit” for clearer setup steps.
  * Improved the start/connect description to note the hosted Esplora service is backed by Bitcoin Knots.

* **Bug Fixes**
  * Removed the toast testing option from settings.
  * Fixed remote cube restore actions so only actually restorable cubes show the restore option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->