### PR TITLE
Require key_id match alongside fingerprint to detect existing keychain key

### DIFF
--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -1112,6 +1112,15 @@ impl SelectKeySource {
 
         if existing_same_key {
             self.selected_key = SelectedKey::Existing(fingerprint);
+        } else if self.keys.contains_key(&fingerprint) {
+            // A different key (Keychain or otherwise) already occupies this
+            // fingerprint slot. Reject instead of letting a `SelectedKey::New`
+            // reach the KeysEdited handler and silently overwrite it.
+            self.error = Some(
+                "A different key with the same master fingerprint is already in this Vault."
+                    .to_string(),
+            );
+            return Task::none();
         } else {
             let key = Key {
                 source: KeySource::KeychainKey {

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -1100,8 +1100,17 @@ impl SelectKeySource {
                 Some("This owner already has a Keychain key placed in this Vault.".to_string());
             return Task::none();
         }
+        
+        // Fingerprint alone doesn't uniquely identify a Keychain key —
+        // two distinct keys can share a master fingerprint if they come
+        // from the same seed. Compare `key_id` to tell whether
+        // this is genuinely the same key already placed,
+        // vs. a different key that happens to collide on fingerprint.
+        let existing_same_key = self.keys.get(&fingerprint).is_some_and(|(_, k)| {
+            matches!(&k.source, KeySource::KeychainKey { key_id, .. } if *key_id == resolved.raw.id)
+        });
 
-        if self.keys.contains_key(&fingerprint) {
+        if existing_same_key {
             self.selected_key = SelectedKey::Existing(fingerprint);
         } else {
             let key = Key {

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -1100,7 +1100,7 @@ impl SelectKeySource {
                 Some("This owner already has a Keychain key placed in this Vault.".to_string());
             return Task::none();
         }
-        
+
         // Fingerprint alone doesn't uniquely identify a Keychain key —
         // two distinct keys can share a master fingerprint if they come
         // from the same seed. Compare `key_id` to tell whether


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved key selection logic to safely detect already-added Keychain keys by validating both fingerprint and the underlying key identifier.
  * Prevented the setup flow from misidentifying different keys that share the same master fingerprint as the same existing key, avoiding incorrect duplicates or wrong key handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->