### PR TITLE
Fix/hw key picker ux

### DIFF
--- a/coincube-gui/src/app/cache.rs
+++ b/coincube-gui/src/app/cache.rs
@@ -43,6 +43,11 @@ pub struct Cache {
     /// Whether the pending local Bitcoind is currently in initial block download.
     /// `None` when no local node is pending.
     pub node_bitcoind_ibd: Option<bool>,
+    /// Mirror of `App::daemon_switch_in_progress` so the stateless Node
+    /// settings view can reflect an in-flight backend switch (disable the
+    /// switch buttons and show a "switching…" status) instead of offering a
+    /// button that just errors with "a switch is already in progress".
+    pub daemon_switch_in_progress: bool,
     /// Latest UpdateTip/blockheaders line from the pending internal bitcoind's
     /// debug.log.  `None` until the first line is received.
     pub node_bitcoind_last_log: Option<String>,
@@ -184,6 +189,7 @@ impl std::default::Default for Cache {
             datadir_path: CoincubeDirectory::new(std::path::PathBuf::new()),
             node_bitcoind_sync_progress: None,
             node_bitcoind_ibd: None,
+            daemon_switch_in_progress: false,
             node_bitcoind_last_log: None,
             node_net_stats: None,
             network: Network::Bitcoin,

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -3473,9 +3473,9 @@ impl App {
                     // the panel resets and the user can retry once the in-flight
                     // switch finishes.
                     return self.update_dispatch(Message::DaemonConfigLoaded(Err(Error::Config(
-                        "A switch to your local node is already in progress. If the node is \
-                         still scanning the blockchain this can take a while — please wait for \
-                         it to finish, then try again."
+                        "A backend switch is already in progress. If a local node is still \
+                         scanning the blockchain this can take a while — please wait for it \
+                         to finish, then try again."
                             .to_string(),
                     ))));
                 } else {

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -3473,8 +3473,9 @@ impl App {
                     // the panel resets and the user can retry once the in-flight
                     // switch finishes.
                     return self.update_dispatch(Message::DaemonConfigLoaded(Err(Error::Config(
-                        "A Bitcoin backend switch is already in progress. \
-                         Please wait for it to finish, then try again."
+                        "A switch to your local node is already in progress. If the node is \
+                         still scanning the blockchain this can take a while — please wait for \
+                         it to finish, then try again."
                             .to_string(),
                     ))));
                 } else {
@@ -3483,6 +3484,7 @@ impl App {
             }
             Message::DaemonRestarted(outcome) => {
                 self.daemon_switch_in_progress = false;
+                self.cache.daemon_switch_in_progress = false;
                 // Non-blocking toast emitted on top of the normal result (e.g. a
                 // switch that succeeded but couldn't be persisted to disk).
                 let mut extra = Task::none();
@@ -4404,6 +4406,8 @@ impl App {
         // Mark a switch in flight so subsequent sync probes / triggers don't
         // re-fire it before it completes (the config only changes on success).
         self.daemon_switch_in_progress = true;
+        // Mirror into the cache so the Node settings view reflects it.
+        self.cache.daemon_switch_in_progress = true;
         let old_daemon = self.daemon.clone();
         let network = cfg.bitcoin_config.network;
         let wallet_id = self.wallet.as_ref().expect("wallet should exist").id();

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -1030,7 +1030,11 @@ impl Modal for SignModal {
                     ..
                 }) = self.hws.list.get(i)
                 {
-                    self.display_modal = false;
+                    // Keep the modal open (as the master-signer path below
+                    // does) so the selected device shows its "Processing… /
+                    // Please check your device" state while we wait for the
+                    // signature, rather than the modal vanishing with no
+                    // indication that the device is awaiting confirmation.
                     self.signing.insert(*fingerprint);
                     let psbt = tx.psbt.clone();
                     let fingerprint = *fingerprint;

--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -879,6 +879,7 @@ impl State for BitcoindSettingsState {
                         can_switch_to_bitcoind,
                         can_setup_local_node,
                         self.node_switch_processing,
+                        cache.daemon_switch_in_progress,
                         warning_str,
                     )
                     .map(map_node_msg),

--- a/coincube-gui/src/app/state/vault/spend/mod.rs
+++ b/coincube-gui/src/app/state/vault/spend/mod.rs
@@ -37,6 +37,11 @@ pub struct CreateSpendPanel {
     /// Additional filtering should be performed by individual steps.
     coins: Vec<Coin>,
     tip_height: i32,
+    /// Whether the one-time "default to Normal feerate" fetch has been
+    /// dispatched. Fired on the first `reload` so the fee/amount compute
+    /// immediately, without the user first picking a feerate — but only once,
+    /// so a later re-entry doesn't clobber a feerate they set.
+    initial_feerate_requested: bool,
 }
 
 impl CreateSpendPanel {
@@ -75,6 +80,7 @@ impl CreateSpendPanel {
             ],
             coins: coins.to_vec(),
             tip_height: blockheight.try_into().expect("i32 by consensus"),
+            initial_feerate_requested: false,
         }
     }
 
@@ -121,6 +127,7 @@ impl CreateSpendPanel {
             ],
             coins: coins.to_vec(),
             tip_height: blockheight.try_into().expect("i32 by consensus"),
+            initial_feerate_requested: false,
         }
     }
 
@@ -161,6 +168,7 @@ impl CreateSpendPanel {
             ],
             coins: coins.to_vec(),
             tip_height: blockheight.try_into().expect("i32 by consensus"),
+            initial_feerate_requested: false,
         }
     }
 
@@ -263,7 +271,7 @@ impl State for CreateSpendPanel {
         // spendable balance reflects the optimistic spend immediately.
         let wallet_for_coins_1 = wallet.clone();
         let wallet_for_coins_2 = wallet.clone();
-        Task::batch(vec![
+        let mut tasks = vec![
             Task::perform(
                 async move {
                     (
@@ -308,7 +316,17 @@ impl State for CreateSpendPanel {
                 },
                 Message::Labels,
             ),
-        ])
+        ];
+        // Default the feerate to "Normal" (~1h, 6-block target) the first time
+        // this panel loads, so amounts/fees compute immediately. Recovery
+        // starts on the path-selection step, which wouldn't consume it.
+        if !self.initial_feerate_requested && !self.draft.is_recovery() {
+            self.initial_feerate_requested = true;
+            tasks.push(Task::done(Message::View(view::Message::CreateSpend(
+                view::CreateSpendMessage::FetchFeeEstimate(6),
+            ))));
+        }
+        Task::batch(tasks)
     }
 }
 

--- a/coincube-gui/src/app/state/vault/spend/step.rs
+++ b/coincube-gui/src/app/state/vault/spend/step.rs
@@ -171,6 +171,10 @@ pub struct DefineSpend {
     amount_left_to_select: Option<Amount>,
     feerate: form::Value<String>,
     loading_fee_estimate: Option<usize>,
+    /// Block target (1/6/24) of the preset whose estimate currently fills the
+    /// feerate field, so the matching Fast/Normal/Slow button can render as
+    /// selected. Cleared when the user types a feerate manually.
+    selected_feerate_target: Option<usize>,
     fee_amount: Option<Amount>,
     generated: Option<(Psbt, Vec<String>)>,
     generating: bool,
@@ -228,6 +232,7 @@ impl DefineSpend {
             is_duplicate: false,
             feerate: form::Value::default(),
             fee_amount: None,
+            selected_feerate_target: None,
             amount_left_to_select: None,
             warning: None,
             is_first_step,
@@ -748,6 +753,11 @@ impl Step for DefineSpend {
                             self.feerate.valid = false;
                         }
                         self.warning = None;
+                        // A FeerateEdited arriving while a preset fetch is in
+                        // flight is that fetch's result — keep the preset
+                        // highlighted. A manual edit (no fetch pending) has
+                        // `loading_fee_estimate == None`, clearing the selection.
+                        self.selected_feerate_target = self.loading_fee_estimate;
                         self.loading_fee_estimate = None;
                         // A feerate change must re-run coin selection: it
                         // changes the fee and therefore `amount_left_to_select`
@@ -1081,6 +1091,7 @@ impl Step for DefineSpend {
             &self.sync_status,
             self.is_first_step,
             self.loading_fee_estimate,
+            self.selected_feerate_target,
             self.generating,
             self.bitcoin_unit,
         )

--- a/coincube-gui/src/app/state/vault/spend/step.rs
+++ b/coincube-gui/src/app/state/vault/spend/step.rs
@@ -1038,6 +1038,14 @@ impl Step for DefineSpend {
     fn view<'a>(&'a self, menu: &'a Menu, cache: &'a Cache) -> Element<'a, view::Message> {
         let converter: Option<view::FiatAmountConverter> =
             cache.fiat_price.as_ref().and_then(|p| p.try_into().ok());
+        // Mirror the view's "Insufficient funds." disabled-action hint: a
+        // non-recovery draft with ≥1 coin selected that still has a non-zero
+        // amount left to select can't be funded. (An unset/invalid feerate or
+        // duplicate recipient forces `amount_left_to_select` to `None`, so
+        // those states don't trip this.)
+        let insufficient = self.recovery_timelock.is_none()
+            && self.coins.iter().any(|(_, selected)| *selected)
+            && self.amount_left_to_select.is_some_and(|a| a.to_sat() != 0);
         view::vault::spend::create_spend_tx(
             &self.balance,
             &self.unconfirmed_balance,
@@ -1054,6 +1062,7 @@ impl Step for DefineSpend {
                             self.send_max_to_recipient == Some(i),
                             converter.as_ref(),
                             self.bitcoin_unit,
+                            insufficient,
                         )
                         .map(view::Message::CreateSpend)
                 })
@@ -1246,6 +1255,7 @@ impl Recipient {
         is_max_selected: bool,
         fiat_converter: Option<&view::FiatAmountConverter>,
         bitcoin_unit: BitcoinDisplayUnit,
+        insufficient: bool,
     ) -> Element<view::CreateSpendMessage> {
         let mut fiat_form_value = self.fiat_amount.as_ref();
 
@@ -1275,6 +1285,7 @@ impl Recipient {
             is_max_selected,
             self.is_recovery,
             bitcoin_unit,
+            insufficient,
         )
     }
 }

--- a/coincube-gui/src/app/view/vault/hw.rs
+++ b/coincube-gui/src/app/view/vault/hw.rs
@@ -65,10 +65,12 @@ pub fn hw_list_view(
             }
             UnsupportedReason::Version {
                 minimal_supported_version,
+                note,
             } => hw::unsupported_version_hardware_wallet(
                 kind.to_string(),
                 version.as_ref(),
                 minimal_supported_version,
+                *note,
             ),
             _ => hw::unsupported_hardware_wallet(kind.to_string(), version.as_ref()),
         },
@@ -130,10 +132,12 @@ pub fn hw_list_view_for_registration(
             }
             UnsupportedReason::Version {
                 minimal_supported_version,
+                note,
             } => hw::unsupported_version_hardware_wallet(
                 kind.to_string(),
                 version.as_ref(),
                 minimal_supported_version,
+                *note,
             ),
             _ => hw::unsupported_hardware_wallet(kind.to_string(), version.as_ref()),
         },
@@ -206,10 +210,12 @@ pub fn hw_list_view_verify_address(
                 }
                 UnsupportedReason::Version {
                     minimal_supported_version,
+                    note,
                 } => hw::unsupported_version_hardware_wallet(
                     kind.to_string(),
                     version.as_ref(),
                     minimal_supported_version,
+                    *note,
                 ),
                 _ => hw::unsupported_hardware_wallet(kind.to_string(), version.as_ref()),
             },

--- a/coincube-gui/src/app/view/vault/hw.rs
+++ b/coincube-gui/src/app/view/vault/hw.rs
@@ -78,8 +78,18 @@ pub fn hw_list_view(
             kind, pairing_code, ..
         } => hw::locked_hardware_wallet(kind, pairing_code.as_ref()),
     })
-    .style(theme::button::secondary)
     .width(Length::Fill);
+    // While signing, the row is intentionally not clickable (no `on_press`),
+    // but it shouldn't read as disabled/greyed — the user is actively being
+    // asked to confirm on the device. Force the active style so the
+    // "Processing… / Please check your device" prompt stays legible.
+    bttn = if signing {
+        bttn.style(|theme, _status| {
+            theme::button::secondary(theme, iced::widget::button::Status::Active)
+        })
+    } else {
+        bttn.style(theme::button::secondary)
+    };
     if can_sign && !signing {
         if let HardwareWallet::Supported { registered, .. } = hw {
             if *registered != Some(false) {

--- a/coincube-gui/src/app/view/vault/psbt.rs
+++ b/coincube-gui/src/app/view/vault/psbt.rs
@@ -555,24 +555,13 @@ pub fn signatures<'a>(
                         .push(icon::square_check_icon().style(theme::text::success))
                         .push(text("Ready").bold().style(theme::text::success))
                         .push(text("  signed by"))
-                        .push(sigs.signed_pubkeys.keys().fold(
-                            Row::new().spacing(5),
-                            |row, value| {
-                                row.push(if let Some(alias) = keys_aliases.get(value) {
-                                    Container::new(tooltip::Tooltip::new(
-                                        Container::new(text(alias))
-                                            .padding(10)
-                                            .style(theme::pill::simple),
-                                        text(value.to_string()),
-                                        tooltip::Position::Bottom,
-                                    ))
-                                } else {
-                                    Container::new(text(value.to_string()))
-                                        .padding(10)
-                                        .style(theme::pill::simple)
-                                })
-                            },
-                        )),
+                        .push(
+                            sigs.signed_pubkeys
+                                .keys()
+                                .fold(Row::new().spacing(5), |row, value| {
+                                    row.push(container_from_fg(*value, keys_aliases))
+                                }),
+                        ),
                 )
                 .direction(scrollable::Direction::Horizontal(
                     scrollable::Scrollbar::new().width(2).scroller_width(2),

--- a/coincube-gui/src/app/view/vault/psbt.rs
+++ b/coincube-gui/src/app/view/vault/psbt.rs
@@ -580,47 +580,19 @@ pub fn signatures<'a>(
             )
             .padding(15)
         } else {
-            Container::new(Collapse::new(
-                move || {
-                    Button::new(
-                        Row::new()
-                            .align_y(Alignment::Center)
-                            .spacing(20)
-                            .push(p1_bold("Status"))
-                            .push(
-                                Row::new()
-                                    .spacing(5)
-                                    .align_y(Alignment::Center)
-                                    .push(icon::square_cross_icon().style(theme::text::error))
-                                    .push(text("Not ready").style(theme::text::error))
-                                    .width(Length::Fill),
-                            )
-                            .push(icon::collapse_icon()),
-                    )
-                    .padding(15)
-                    .width(Length::Fill)
-                    .style(theme::button::transparent_border)
-                },
-                move || {
-                    Button::new(
-                        Row::new()
-                            .align_y(Alignment::Center)
-                            .spacing(20)
-                            .push(p1_bold("Status"))
-                            .push(
-                                Row::new()
-                                    .spacing(5)
-                                    .align_y(Alignment::Center)
-                                    .push(icon::square_cross_icon().style(theme::text::error))
-                                    .push(text("Not ready").style(theme::text::error))
-                                    .width(Length::Fill),
-                            )
-                            .push(icon::collapsed_icon()),
-                    )
-                    .padding(15)
-                    .width(Length::Fill)
-                    .style(theme::button::transparent_border)
-                },
+            // Not broadcastable yet. If some (but not enough) signatures are
+            // present, surface a "Partially signed" banner with the signers so
+            // the user sees progress instead of a bare "Not ready".
+            let signed: Vec<Fingerprint> = {
+                let mut v: Vec<_> = tx.signers().into_iter().collect();
+                v.sort_by_key(|fg| fg.to_string());
+                v
+            };
+            let is_partial = !signed.is_empty();
+
+            let collapse = Collapse::new(
+                move || requirements_header(is_partial, icon::collapse_icon()),
+                move || requirements_header(is_partial, icon::collapsed_icon()),
                 move || {
                     Into::<Element<'a, Message>>::into(
                         Column::new()
@@ -641,9 +613,76 @@ pub fn signatures<'a>(
                             }),
                     )
                 },
-            ))
+            );
+
+            let mut col = Column::new();
+            if is_partial {
+                col = col.push(
+                    Container::new(
+                        scrollable(
+                            Row::new()
+                                .spacing(10)
+                                .align_y(Alignment::Center)
+                                .push(p1_bold("Status"))
+                                .push(icon::clock_icon().style(theme::text::warning))
+                                .push(text("Partially signed").bold().style(theme::text::warning))
+                                .push(text("  signed by"))
+                                .push(signed.iter().fold(Row::new().spacing(5), |row, fg| {
+                                    row.push(container_from_fg(*fg, keys_aliases))
+                                })),
+                        )
+                        .direction(scrollable::Direction::Horizontal(
+                            scrollable::Scrollbar::new().width(2).scroller_width(2),
+                        )),
+                    )
+                    .padding(15),
+                );
+            }
+            Container::new(col.push(collapse))
         })
         .into()
+}
+
+/// Header for the collapsible "what's still required" section of a PSBT that
+/// can't be broadcast yet. With nothing signed it shows the red "Not ready";
+/// once there are signatures the "Partially signed" banner above carries the
+/// status, so this becomes a neutral "Remaining requirements" toggle.
+fn requirements_header<'a, T: 'a>(
+    is_partial: bool,
+    collapse_icon: coincube_ui::widget::Text<'a>,
+) -> Button<'a, T> {
+    // When partial, the "Partially signed" banner above is the status line, so
+    // this header is just a neutral "Remaining requirements" toggle (no second
+    // "Status" label). With nothing signed it is the primary "Not ready" line.
+    let content = if is_partial {
+        Row::new()
+            .align_y(Alignment::Center)
+            .spacing(20)
+            .push(
+                text("Remaining requirements")
+                    .style(theme::text::secondary)
+                    .width(Length::Fill),
+            )
+            .push(collapse_icon)
+    } else {
+        Row::new()
+            .align_y(Alignment::Center)
+            .spacing(20)
+            .push(p1_bold("Status"))
+            .push(
+                Row::new()
+                    .spacing(5)
+                    .align_y(Alignment::Center)
+                    .push(icon::square_cross_icon().style(theme::text::error))
+                    .push(text("Not ready").style(theme::text::error))
+                    .width(Length::Fill),
+            )
+            .push(collapse_icon)
+    };
+    Button::new(content)
+        .padding(15)
+        .width(Length::Fill)
+        .style(theme::button::transparent_border)
 }
 
 // Display a fingerprint first by its alias if there is any, or in hex otherwise.

--- a/coincube-gui/src/app/view/vault/psbt.rs
+++ b/coincube-gui/src/app/view/vault/psbt.rs
@@ -1233,7 +1233,10 @@ pub fn sign_action<'a>(
             .width(Length::Fill)
             .align_x(Alignment::Center),
     )
-    .width(Length::Fixed(500.0))
+    // Wider than the other action cards so long device names (e.g. "Ledger
+    // Nano S Plus #…") and the "Processing… / Please check your device"
+    // prompt don't crowd each other while signing.
+    .width(Length::Fixed(620.0))
     .into()
 }
 

--- a/coincube-gui/src/app/view/vault/settings/mod.rs
+++ b/coincube-gui/src/app/view/vault/settings/mod.rs
@@ -1362,12 +1362,12 @@ pub fn node_backend_status<'a>(
                 Column::new()
                     .spacing(8)
                     .push(caption("Switching backend"))
-                    .push(text("Switching to your local node…"))
+                    .push(text("Applying your node change…"))
                     .push(
                         p2_regular(
-                            "If the node is still scanning the blockchain this can take a \
-                             while. COINCUBE will finish the switch automatically — no need \
-                             to do anything.",
+                            "This may take a moment. If a local node is still scanning the \
+                             blockchain it can take a while. COINCUBE will finish the switch \
+                             automatically — no need to do anything.",
                         )
                         .style(theme::text::secondary),
                     ),

--- a/coincube-gui/src/app/view/vault/settings/mod.rs
+++ b/coincube-gui/src/app/view/vault/settings/mod.rs
@@ -1322,8 +1322,13 @@ pub fn node_backend_status<'a>(
     can_switch_to_bitcoind: bool,
     can_setup_local_node: bool,
     processing: bool,
+    switch_in_progress: bool,
     warning: Option<String>,
 ) -> Element<'a, NodeSettingsMessage> {
+    // A backend switch (manual or the background auto-promotion) is running.
+    // Treat it like `processing` so the switch buttons are disabled rather
+    // than offering an action that just errors "already in progress".
+    let processing = processing || switch_in_progress;
     // Once the node reports it has left initial block download, treat it as
     // ready even if `verificationprogress` still pins at 1.0 — otherwise the
     // syncing copy/button label keep saying "syncing" at 100%.
@@ -1346,6 +1351,32 @@ pub fn node_backend_status<'a>(
         .padding(15)
         .width(Length::Fill),
     );
+
+    // Surface an in-flight backend switch so the disabled buttons read as
+    // "busy" rather than broken. This covers the promotion/rescan window
+    // after the pending node reports synced, where `pending_progress` is
+    // already cleared but the switch itself is still loading the wallet.
+    if switch_in_progress {
+        col = col.push(
+            Container::new(
+                Column::new()
+                    .spacing(8)
+                    .push(caption("Switching backend"))
+                    .push(text("Switching to your local node…"))
+                    .push(
+                        p2_regular(
+                            "If the node is still scanning the blockchain this can take a \
+                             while. COINCUBE will finish the switch automatically — no need \
+                             to do anything.",
+                        )
+                        .style(theme::text::secondary),
+                    ),
+            )
+            .padding(15)
+            .width(Length::Fill)
+            .style(theme::card::border),
+        );
+    }
 
     if let Some(progress) = pending_progress.filter(|_| still_syncing) {
         let pace = if progress > 0.98 {

--- a/coincube-gui/src/app/view/vault/spend/mod.rs
+++ b/coincube-gui/src/app/view/vault/spend/mod.rs
@@ -545,6 +545,9 @@ pub fn recipient_view<'a>(
     is_max_selected: bool,
     is_recovery: bool,
     bitcoin_unit: BitcoinDisplayUnit,
+    // Flag the amount input red when the draft can't be funded, mirroring the
+    // "Insufficient funds." disabled-action hint.
+    insufficient: bool,
 ) -> Element<'a, CreateSpendMessage> {
     let btc_amt = match bitcoin_unit {
         BitcoinDisplayUnit::BTC => Amount::from_str_in(&amount.value, Denomination::Bitcoin).ok(),
@@ -651,6 +654,7 @@ pub fn recipient_view<'a>(
                                 };
 
                                 form
+                                .invalid(insufficient)
                                 .size(P1_SIZE)
                                 .padding(10)
                                 .into_container()

--- a/coincube-gui/src/app/view/vault/spend/mod.rs
+++ b/coincube-gui/src/app/view/vault/spend/mod.rs
@@ -142,6 +142,28 @@ pub fn spend_view<'a>(
     )
 }
 
+/// A Fast/Normal/Slow feerate preset button. Renders with an orange outline
+/// when its estimate currently fills the feerate field, and is disabled while
+/// its own estimate is being fetched.
+fn feerate_preset_button<'a>(
+    label: &'static str,
+    block_target: usize,
+    loading_fee_estimate: Option<usize>,
+    selected_feerate_target: Option<usize>,
+) -> Element<'a, Message> {
+    let btn = button::secondary(None, label)
+        .width(Length::Fixed(130.0))
+        .on_press_maybe(
+            (loading_fee_estimate != Some(block_target))
+                .then(|| Message::CreateSpend(CreateSpendMessage::FetchFeeEstimate(block_target))),
+        );
+    if selected_feerate_target == Some(block_target) {
+        btn.style(theme::button::orange_outline).into()
+    } else {
+        btn.into()
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn create_spend_tx<'a>(
     balance: &'a Amount,
@@ -164,6 +186,7 @@ pub fn create_spend_tx<'a>(
     sync_status: &SyncStatus,
     is_first_step: bool,
     loading_fee_estimate: Option<usize>,
+    selected_feerate_target: Option<usize>,
     generating: bool,
     bitcoin_unit: BitcoinDisplayUnit,
 ) -> Element<'a, Message> {
@@ -350,27 +373,24 @@ pub fn create_spend_tx<'a>(
                     .spacing(10)
                     .align_y(Alignment::Center)
                     .push(Container::new(p1_bold("Feerate:")).padding(10))
-                    .push(
-                        button::secondary(None, "Fast (~10m)")
-                            .width(Length::Fixed(130.0))
-                            .on_press_maybe((!matches!(loading_fee_estimate, Some(1))).then(
-                                || Message::CreateSpend(CreateSpendMessage::FetchFeeEstimate(1)),
-                            )),
-                    )
-                    .push(
-                        button::secondary(None, "Normal (~1h)")
-                            .width(Length::Fixed(130.0))
-                            .on_press_maybe((!matches!(loading_fee_estimate, Some(6))).then(
-                                || Message::CreateSpend(CreateSpendMessage::FetchFeeEstimate(6)),
-                            )),
-                    )
-                    .push(
-                        button::secondary(None, "Slow (~4h)")
-                            .width(Length::Fixed(130.0))
-                            .on_press_maybe((!matches!(loading_fee_estimate, Some(24))).then(
-                                || Message::CreateSpend(CreateSpendMessage::FetchFeeEstimate(24)),
-                            )),
-                    )
+                    .push(feerate_preset_button(
+                        "Fast (~10m)",
+                        1,
+                        loading_fee_estimate,
+                        selected_feerate_target,
+                    ))
+                    .push(feerate_preset_button(
+                        "Normal (~1h)",
+                        6,
+                        loading_fee_estimate,
+                        selected_feerate_target,
+                    ))
+                    .push(feerate_preset_button(
+                        "Slow (~4h)",
+                        24,
+                        loading_fee_estimate,
+                        selected_feerate_target,
+                    ))
                     .push(
                         Container::new(
                             form::Form::new_trimmed("42 (in sats/vbyte)", feerate, move |msg| {

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -1976,6 +1976,7 @@ pub fn create_app_with_remote_backend(
             .unwrap_or_default(),
             node_bitcoind_sync_progress: None,
             node_bitcoind_ibd: None,
+            daemon_switch_in_progress: false,
             node_bitcoind_last_log: None,
             node_net_stats: None,
             connect_authenticated: false,

--- a/coincube-gui/src/hw.rs
+++ b/coincube-gui/src/hw.rs
@@ -23,6 +23,11 @@ use tracing::{debug, warn};
 pub enum UnsupportedReason {
     Version {
         minimal_supported_version: &'static str,
+        /// Optional extra guidance shown on its own line, for cases where the
+        /// bare version isn't self-explanatory (e.g. Coldcard's Edge branch).
+        /// Kept separate from `minimal_supported_version` so the latter stays
+        /// version-like for the "Install version {v} or later" templates.
+        note: Option<&'static str>,
     },
     Method(&'static str),
     NotPartOfWallet(Fingerprint),
@@ -666,7 +671,11 @@ fn refresh(mut state: State) -> impl Stream<Item = HardwareWalletMessage> {
                                         kind: device.device_kind(),
                                         version: Some(version),
                                         reason: UnsupportedReason::Version {
-                                            minimal_supported_version: "Edge firmware v6.2.1 — this is the experimental Edge branch, Mk4/Q only, not available on the Mk3",
+                                            minimal_supported_version: "Edge firmware v6.2.1",
+                                            note: Some(
+                                                "This is the experimental Edge branch, Mk4/Q \
+                                                 only — not available on the Mk3.",
+                                            ),
                                         },
                                     });
                                 }
@@ -981,6 +990,7 @@ async fn handle_ledger_device<'a, T: async_hwi::ledger::Transport + Sync + Send 
                     version: Some(version),
                     reason: UnsupportedReason::Version {
                         minimal_supported_version: "2.1.0",
+                        note: None,
                     },
                 })
             }

--- a/coincube-gui/src/hw.rs
+++ b/coincube-gui/src/hw.rs
@@ -666,7 +666,7 @@ fn refresh(mut state: State) -> impl Stream<Item = HardwareWalletMessage> {
                                         kind: device.device_kind(),
                                         version: Some(version),
                                         reason: UnsupportedReason::Version {
-                                            minimal_supported_version: "Edge firmware v6.2.1",
+                                            minimal_supported_version: "Edge firmware v6.2.1 — this is the experimental Edge branch, Mk4/Q only, not available on the Mk3",
                                         },
                                     });
                                 }

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -1322,8 +1322,7 @@ impl SelectKeySource {
                         Some(fp) => self.owner_placed_elsewhere(owner_id, fp),
                         None => true,
                     };
-                    let key_reused =
-                        candidate_fp.is_some_and(|fp| self.key_placed_elsewhere(fp));
+                    let key_reused = candidate_fp.is_some_and(|fp| self.key_placed_elsewhere(fp));
                     let used_elsewhere = rk.raw.used_by_vault;
                     let disabled = owner_blocked || key_reused || used_elsewhere;
                     let fp = &rk.raw.fingerprint;
@@ -1596,12 +1595,21 @@ impl SelectKeySource {
     ) -> Element<Message> {
         let header = modal::header(Some("Hardware Device".to_string()), Some(|| Message::Close));
 
-        let listening = column![
-            icon::usb_icon().size(100),
-            p1_regular("Plug in a hardware device ..."),
-        ]
-        .align_x(Horizontal::Center)
-        .spacing(20);
+        // Present the "waiting for a device" prompt as its own full-width
+        // card so it reads as a peer of the device rows below rather than a
+        // loose icon floating above them.
+        let listening = Container::new(
+            column![
+                icon::usb_icon().size(60),
+                p1_regular("Plug in a hardware device ..."),
+            ]
+            .align_x(Horizontal::Center)
+            .width(Length::Fill)
+            .spacing(15),
+        )
+        .width(Length::Fill)
+        .padding(25)
+        .style(theme::card::border);
 
         // Reuse the existing detected-devices rendering.
         let devices =
@@ -1816,9 +1824,12 @@ impl SelectKeySource {
             bool, /* support taproot */
         )>,
     ) -> Element<Message> {
+        // Full width so the heading and device rows sit flush-left,
+        // lining up with the "Already used sources" section below
+        // (which also uses a full-width column).
         let mut col = column![p1_bold("Detected hardware")]
             .spacing(5)
-            .width(modal::BTN_W);
+            .width(Length::Fill);
         for hw in hws {
             col = col.push(self.widget_signing_device(hw));
         }

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -1883,9 +1883,17 @@ impl SelectKeySource {
                 match ur {
                     UnsupportedReason::Version {
                         minimal_supported_version,
+                        note,
                     } => {
                         enabled = true;
-                        Some(format!("Device version not supported, upgrade to version > {minimal_supported_version}"))
+                        let mut msg = format!(
+                            "Device version not supported, upgrade to version > {minimal_supported_version}"
+                        );
+                        if let Some(note) = note {
+                            msg.push_str(". ");
+                            msg.push_str(note);
+                        }
+                        Some(msg)
                     }
                     UnsupportedReason::Method(m) => {
                         Some(format!("Device not supported, method: {m}"))

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -1095,15 +1095,19 @@ impl SelectKeySource {
             return Task::none();
         }
 
-        if self.owner_placed_elsewhere(resolved.owner.primary_owner_id(), fingerprint) {
-            self.error =
-                Some("This owner already has a Keychain key placed in this Vault.".to_string());
-            return Task::none();
-        }
-
+        // Check exact-key reuse before owner reuse so this backstop's error
+        // matches the row-warning priority in the views (which surface
+        // "already used in this Vault" ahead of "already selected" when both
+        // an identical key and another key from the same owner are placed).
         if self.key_placed_elsewhere(fingerprint) {
             self.error =
                 Some("This Keychain key is already used elsewhere in this Vault.".to_string());
+            return Task::none();
+        }
+
+        if self.owner_placed_elsewhere(resolved.owner.primary_owner_id(), fingerprint) {
+            self.error =
+                Some("This owner already has a Keychain key placed in this Vault.".to_string());
             return Task::none();
         }
 

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -2565,4 +2565,82 @@ mod tests {
         assert_eq!(picker.step, Step::KeychainKeys);
         assert!(!picker.keychain_keys_fetched);
     }
+
+    // ── key_placed_elsewhere: exact-key reuse across quorum slots ─────
+    //
+    // `key_placed_elsewhere` disables selecting a key already placed at
+    // coordinates outside the currently-edited slot, so the same key
+    // can't be used twice in a quorum — while still allowing re-selecting
+    // the key at the active slot. `keys` is `Fingerprint -> (coords, Key)`
+    // and `actual_path.coordinates` is the slot being edited.
+
+    // Any parseable descriptor key works — `key_placed_elsewhere` only
+    // reads `Key::fingerprint`, never the descriptor key itself.
+    fn manual_key(fingerprint: Fingerprint) -> Key {
+        let key = DescriptorPublicKey::from_str(
+            "tpubD6NzVbkrYhZ4XHQ1pLJ7pdpEGWCVbSUEaUakxnrtENzaZaDp4vL6gBgGH7n983ZPgsVe5G2JEAM2oYZkEPCNrfo9XLq8nHFhp9GzFjGc1uQ",
+        )
+        .unwrap();
+        Key {
+            source: KeySource::Manual,
+            name: "test".to_string(),
+            fingerprint,
+            key,
+            account: None,
+        }
+    }
+
+    fn picker_with_placed_key(
+        active: Vec<(usize, usize)>,
+        placed_at: Vec<(usize, usize)>,
+        placed_fg: Fingerprint,
+    ) -> SelectKeySource {
+        let mut picker = empty_picker();
+        picker.actual_path.coordinates = active;
+        picker
+            .keys
+            .insert(placed_fg, (placed_at, manual_key(placed_fg)));
+        picker
+    }
+
+    #[test]
+    fn key_placed_elsewhere_blocks_reuse_at_other_slot() {
+        let fg = Fingerprint::from_str("8a550171").unwrap();
+        // Editing slot (0,0); the same key is already placed at (1,0).
+        let picker = picker_with_placed_key(vec![(0, 0)], vec![(1, 0)], fg);
+        assert!(picker.key_placed_elsewhere(fg));
+    }
+
+    #[test]
+    fn key_placed_elsewhere_allows_reselect_at_active_slot() {
+        let fg = Fingerprint::from_str("8a550171").unwrap();
+        // The key is placed only at the slot currently being edited.
+        let picker = picker_with_placed_key(vec![(0, 0)], vec![(0, 0)], fg);
+        assert!(!picker.key_placed_elsewhere(fg));
+    }
+
+    #[test]
+    fn key_placed_elsewhere_false_for_unplaced_key() {
+        let placed = Fingerprint::from_str("8a550171").unwrap();
+        let other = Fingerprint::from_str("c658b283").unwrap();
+        let picker = picker_with_placed_key(vec![(0, 0)], vec![(1, 0)], placed);
+        // A different, not-yet-placed key is free to select.
+        assert!(!picker.key_placed_elsewhere(other));
+    }
+
+    #[test]
+    fn key_placed_elsewhere_blocks_when_spanning_active_and_other_slot() {
+        let fg = Fingerprint::from_str("8a550171").unwrap();
+        // Placed at the active slot AND another — the other placement blocks.
+        let picker = picker_with_placed_key(vec![(0, 0)], vec![(0, 0), (1, 0)], fg);
+        assert!(picker.key_placed_elsewhere(fg));
+    }
+
+    #[test]
+    fn key_placed_elsewhere_blocks_when_placed_without_coordinates() {
+        let fg = Fingerprint::from_str("8a550171").unwrap();
+        // A placement carrying no coordinates is treated as used elsewhere.
+        let picker = picker_with_placed_key(vec![(0, 0)], vec![], fg);
+        assert!(picker.key_placed_elsewhere(fg));
+    }
 }

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -1101,6 +1101,12 @@ impl SelectKeySource {
             return Task::none();
         }
 
+        if self.key_placed_elsewhere(fingerprint) {
+            self.error =
+                Some("This Keychain key is already used elsewhere in this Vault.".to_string());
+            return Task::none();
+        }
+
         if self.keys.contains_key(&fingerprint) {
             self.selected_key = SelectedKey::Existing(fingerprint);
         } else {
@@ -1158,6 +1164,25 @@ impl SelectKeySource {
         })
     }
 
+    /// Companion to `owner_placed_elsewhere`: returns true when *this
+    /// exact* key is already placed at coordinates outside the
+    /// currently-edited slot, i.e. it's already used elsewhere in this
+    /// Vault's quorum. Selecting it again would put one key at two
+    /// positions, so we disable the row. Re-selecting the key at the
+    /// active slot stays allowed — its coordinates are the current slot,
+    /// so this returns false.
+    fn key_placed_elsewhere(&self, candidate_fingerprint: Fingerprint) -> bool {
+        self.keys.values().any(|(coords, k)| {
+            if k.fingerprint != candidate_fingerprint {
+                return false;
+            }
+            coords.is_empty()
+                || coords
+                    .iter()
+                    .any(|c| !self.actual_path.coordinates.contains(c))
+        })
+    }
+
     // ── Keychain key views ──────────────────────────────────────────
 
     fn view_my_keychain_keys(&self) -> Element<Message> {
@@ -1202,9 +1227,12 @@ impl SelectKeySource {
                 Some(fp) => self.owner_placed_elsewhere(owner_id, fp),
                 None => true,
             };
+            // Disable a key that's already placed in this quorum so it
+            // can't be selected into a second slot.
+            let key_reused = candidate_fp.is_some_and(|fp| self.key_placed_elsewhere(fp));
             // W9 pre-check: reject keys that another Vault already claims.
             let used_elsewhere = rk.raw.used_by_vault;
-            let disabled = owner_blocked || used_elsewhere;
+            let disabled = owner_blocked || key_reused || used_elsewhere;
             let fp_short: String = rk.raw.fingerprint.chars().take(8).collect();
             let fingerprint = Some(format!("#{}", fp_short));
             let msg = if disabled {
@@ -1215,11 +1243,13 @@ impl SelectKeySource {
                     Self::route(SelectKeySourceMessage::SelectKeychainKey(rk_clone.clone()))
                 })
             };
-            // Surface the more specific reason when both apply: once a key
-            // is in another Vault, that's the blocking constraint even if
-            // the owner is also placed elsewhere in this build.
+            // Surface the most specific reason when several apply: a key
+            // claimed by another Vault reports that first, then an exact
+            // reuse in this quorum, then the owner being placed elsewhere.
             let warning = if used_elsewhere {
                 Some("Used by another Vault".to_string())
+            } else if key_reused {
+                Some("Already used in this Vault".to_string())
             } else if owner_blocked {
                 Some("Already selected".to_string())
             } else {
@@ -1292,8 +1322,10 @@ impl SelectKeySource {
                         Some(fp) => self.owner_placed_elsewhere(owner_id, fp),
                         None => true,
                     };
+                    let key_reused =
+                        candidate_fp.is_some_and(|fp| self.key_placed_elsewhere(fp));
                     let used_elsewhere = rk.raw.used_by_vault;
-                    let disabled = owner_blocked || used_elsewhere;
+                    let disabled = owner_blocked || key_reused || used_elsewhere;
                     let fp = &rk.raw.fingerprint;
                     let fingerprint = Some(format!("#{}", &fp[..fp.len().min(8)]));
                     let msg = if disabled {
@@ -1306,6 +1338,8 @@ impl SelectKeySource {
                     };
                     let warning = if used_elsewhere {
                         Some("Used by another Vault".to_string())
+                    } else if key_reused {
+                        Some("Already used in this Vault".to_string())
                     } else if owner_blocked {
                         Some("Already selected".to_string())
                     } else {

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -2009,10 +2009,12 @@ pub fn hw_list_view<'a>(
             }
             UnsupportedReason::Version {
                 minimal_supported_version,
+                note,
             } => hw::unsupported_version_hardware_wallet(
                 kind.to_string(),
                 version.as_ref(),
                 minimal_supported_version,
+                *note,
             ),
             _ => hw::unsupported_hardware_wallet(kind.to_string(), version.as_ref()),
         },

--- a/coincube-gui/src/loader.rs
+++ b/coincube-gui/src/loader.rs
@@ -647,6 +647,7 @@ pub async fn load_application(
         display_mode,
         node_bitcoind_sync_progress: None,
         node_bitcoind_ibd: None,
+        daemon_switch_in_progress: false,
         node_bitcoind_last_log: None,
         node_net_stats: None,
         connect_authenticated: false,

--- a/coincube-ui/src/component/form.rs
+++ b/coincube-ui/src/component/form.rs
@@ -177,6 +177,18 @@ where
         self
     }
 
+    /// Forces the input into its invalid (red) style regardless of the value's
+    /// own format validity — e.g. to flag insufficient funds on an otherwise
+    /// well-formed amount. Suppresses the format warning text, since the reason
+    /// is surfaced elsewhere (e.g. the disabled-action hint).
+    pub fn invalid(mut self, is_invalid: bool) -> Self {
+        if is_invalid {
+            self.valid = false;
+            self.warning = None;
+        }
+        self
+    }
+
     /// Sets the padding of the [`Form`].
     pub fn padding(mut self, units: u16) -> Self {
         self.input = self.input.padding(units);

--- a/coincube-ui/src/component/hw.rs
+++ b/coincube-ui/src/component/hw.rs
@@ -277,13 +277,19 @@ pub fn processing_hardware_wallet<'a, T: 'a, K: Display, V: Display, F: Display>
                     .push(version.map(|v| text::caption(v.to_string())))
                     .into(),
             ])
-            .into(), // No width - let column size naturally
+            // Fill so the "Processing…" prompt is pushed to the right edge
+            // rather than crowding the device name/fingerprint (matches the
+            // signed/selected rows).
+            .width(Length::Fill)
+            .into(),
             column(vec![
                 text::p1_regular("Processing...").into(),
                 text::p1_regular("Please check your device").into(),
             ])
+            .align_x(Alignment::End)
             .into(),
         ])
+        .spacing(10)
         .align_y(Alignment::Center),
     )
     .padding(10)

--- a/coincube-ui/src/component/hw.rs
+++ b/coincube-ui/src/component/hw.rs
@@ -476,12 +476,15 @@ pub fn unsupported_version_hardware_wallet<'a, T: 'static, K: Display, V: Displa
     kind: K,
     version: Option<V>,
     requested_version: S,
+    note: Option<&'static str>,
 ) -> Container<'a, T> {
     container(
         row(vec![
             column(vec![
                 text::p1_bold("Unsupported firmware version").into(),
                 text::p1_regular(format!("Install version {} or later", requested_version)).into(),
+                note.map(|n| text::p2_regular(n).style(theme::text::secondary).into())
+                    .unwrap_or_else(|| Row::new().into()),
                 Row::new()
                     .spacing(5)
                     .push(text::caption(kind.to_string()))

--- a/coincube-ui/src/component/hw.rs
+++ b/coincube-ui/src/component/hw.rs
@@ -450,6 +450,7 @@ pub fn unsupported_hardware_wallet<'a, T: 'static, K: Display, V: Display>(
                     .spacing(5)
                     .push(text::p1_bold("Connection error"))
                     .into(),
+                text::p1_regular("Please unlock your device and open the Bitcoin app.").into(),
                 Row::new()
                     .spacing(5)
                     .push(text::caption(kind.to_string()))

--- a/coincube-ui/src/component/transaction.rs
+++ b/coincube-ui/src/component/transaction.rs
@@ -138,6 +138,11 @@ impl<'a, T> TransactionListItem<'a, T> {
             info_column = info_column.push(text::p1_regular(label));
         }
 
+        // An unconfirmed payment has no timestamp, so surface its badge here —
+        // left-justified in the slot where the date normally sits — rather than
+        // over on the right next to the amount, which reads as more intuitive.
+        let has_unconfirmed = self.badges.contains(&TransactionBadge::Unconfirmed);
+
         if let Some(timestamp) = self.timestamp {
             info_column = info_column.push(
                 text::p2_regular(
@@ -155,6 +160,8 @@ impl<'a, T> TransactionListItem<'a, T> {
                 time_row = time_row.push(status);
             }
             info_column = info_column.push(time_row);
+        } else if has_unconfirmed {
+            info_column = info_column.push(badge::unconfirmed());
         }
 
         let mut left_side = Row::new().spacing(10).align_y(Alignment::Center);
@@ -180,7 +187,9 @@ impl<'a, T> TransactionListItem<'a, T> {
 
         for badge_type in self.badges {
             let badge_elem = match badge_type {
-                TransactionBadge::Unconfirmed => badge::unconfirmed(),
+                // Rendered left-justified in the info column above (where the
+                // date would be), not on the right by the amount.
+                TransactionBadge::Unconfirmed => continue,
                 TransactionBadge::Batch => badge::batch(),
                 TransactionBadge::Recovery => badge::recovery(),
             };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches PSBT signing, descriptor quorum key placement, and daemon backend switching—user-visible wallet flows—but changes are mostly UI/state mirroring with new validation guards rather than protocol or custody logic changes.
> 
> **Overview**
> Improves **hardware signing and key-picker flows** while tightening **node backend switching** and **send/spend** UI feedback.
> 
> **Node settings:** `daemon_switch_in_progress` is mirrored into `Cache` and wired through Node settings so switch actions stay disabled with a “Switching backend / Applying your node change…” card instead of clickable controls that only fail with “already in progress.” The duplicate-switch error copy is clearer when a local node may still be scanning.
> 
> **PSBT / HW signing:** Selecting a hardware wallet for signing no longer closes the modal; the signing card is wider and processing rows use an active (non-greyed) style so “Processing… / Please check your device” stays visible. PSBT status shows a **Partially signed** banner with signers when some signatures exist; incomplete txs use a **Remaining requirements** collapse header. `UnsupportedReason::Version` gains an optional `note` (e.g. Coldcard Edge guidance) across vault, installer, and shared HW widgets.
> 
> **Vault installer key picker:** Adds `key_placed_elsewhere` so the same fingerprint cannot occupy two quorum slots—rows disable with “Already used in this Vault,” submit validates before owner reuse, and unit tests cover the logic. Hardware wait UI uses a bordered card; detected-device lists align full width.
> 
> **Create spend:** On first non-recovery load, automatically fetches the Normal (~1h) feerate once; preset buttons highlight via `selected_feerate_target` and `feerate_preset_button`. Recipient amount fields can show invalid styling when coins are selected but the draft is still underfunded (`Form::invalid`).
> 
> **Misc:** Transaction list moves the unconfirmed badge into the date slot when there is no timestamp; connection-error HW copy nudges unlock + Bitcoin app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1627082bf1743bf9b781f20ed356b246cf3e9934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visible “switching backend” state with busy/disabled controls while transitioning to the local node.
  * Improved signing feedback during device signature requests by keeping the signing modal open.
  * Enhanced PSBT signature display to clearly show “partially signed” vs “not ready” with signed-by context.
  * Adjusted transaction rows so unconfirmed badges appear in the main info area when no timestamp is available.

* **Bug Fixes**
  * Prevented duplicate/invalid keychain key placements by enforcing stricter fingerprint checks and warning precedence.
  * Refined backend-switch messaging and ensured the UI state resets correctly after daemon restart.

* **Other**
  * Improved unsupported hardware wallet and Coldcard firmware guidance text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->