### PR TITLE
Default to Normal fee rate for Recovery

### DIFF
--- a/coincube-gui/src/app/state/vault/spend/mod.rs
+++ b/coincube-gui/src/app/state/vault/spend/mod.rs
@@ -237,8 +237,24 @@ impl State for CreateSpendPanel {
             // We still send this message to the current step below to update the values directly.
         }
 
+        // A recovery spend can't take the `reload` default (it opens on the
+        // path-selection step, which would drop the message). Instead fire the
+        // same "Normal" (~1h, 6-block target) default the first time we advance
+        // onto the DefineSpend step (index 1), so amounts/fees compute without
+        // the user first picking a feerate. The `initial_feerate_requested`
+        // guard keeps a later re-entry from clobbering a feerate they set.
+        let feerate_task =
+            if self.draft.is_recovery() && !self.initial_feerate_requested && self.current == 1 {
+                self.initial_feerate_requested = true;
+                Task::done(Message::View(view::Message::CreateSpend(
+                    view::CreateSpendMessage::FetchFeeEstimate(6),
+                )))
+            } else {
+                Task::none()
+            };
+
         if let Some(step) = self.steps.get_mut(self.current) {
-            return step.update(daemon, cache, message);
+            return Task::batch([feerate_task, step.update(daemon, cache, message)]);
         }
 
         Task::none()
@@ -319,7 +335,8 @@ impl State for CreateSpendPanel {
         ];
         // Default the feerate to "Normal" (~1h, 6-block target) the first time
         // this panel loads, so amounts/fees compute immediately. Recovery
-        // starts on the path-selection step, which wouldn't consume it.
+        // starts on the path-selection step, which wouldn't consume it, so it
+        // fires the same default from `update` on entering DefineSpend instead.
         if !self.initial_feerate_requested && !self.draft.is_recovery() {
             self.initial_feerate_requested = true;
             tasks.push(Task::done(Message::View(view::Message::CreateSpend(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI/state timing change in the vault spend wizard; no change to signing, coin selection, or broadcast logic.
> 
> **Overview**
> Recovery spends no longer rely on the **reload**-time default fee fetch (which ran on the path-selection step and was wasted). They now trigger the same **Normal** (~1h, **6-block**) `FetchFeeEstimate` the first time the user is on **DefineSpend** (step index 1), so amounts and fees can compute without manually picking a feerate first.
> 
> The existing **`initial_feerate_requested`** flag still ensures this only happens once, so going back and forward does not overwrite a feerate the user already chose. Non-recovery spends keep the reload-time behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c7c36972c84599234ef49a6412c0684163b9536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery spends now automatically request the standard fee estimate when you advance to the spend-definition step.
  * The fee default is applied once at the appropriate stage, ensuring recovery transactions display the expected fee information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->