### PR TITLE
Feature/recovery cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,13 @@ COINCUBE_LNURL_DOMAIN=
 # in the Create Cube form.
 COINCUBE_ENABLE_PASSKEY=0
 
+# Owner Keychain recovery ("protect with my phone"): seal the Cube's seed /
+# descriptor to an owner-self recovery key minted in the Keychain app, and
+# restore later via "Recover a Cube I own" by approving a Keychain decrypt.
+# Default: ON (the only feature flag that defaults on). Set to 0 / false / no
+# as a kill switch to dark-ship the picker and the launcher entry again.
+# COINCUBE_OWNER_KEYCHAIN_RECOVERY=0
+
 # --- Passkey Ceremony Configuration ---
 # URL of the hosted passkey ceremony page (WebAuthn + PRF). The non-macOS
 # webview fallback navigates here; macOS uses AuthenticationServices natively

--- a/coincube-gui/src/app/menu.rs
+++ b/coincube-gui/src/app/menu.rs
@@ -28,6 +28,10 @@ pub enum CubeSubMenu {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CubeSettingsOption {
     General,
+    /// Backup & recovery: local paper backup, the Connect Recovery Kit
+    /// (password / Keychain), and Vault Recovery Alerts. Split out of General
+    /// so each screen stays focused.
+    Recovery,
     About,
     Stats,
     /// Avatar questionnaire / generation / reveal / management. Renders

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1904,6 +1904,9 @@ impl App {
                     menu::CubeSettingsOption::General => {
                         Some(view::SettingsMessage::GeneralSection)
                     }
+                    menu::CubeSettingsOption::Recovery => {
+                        Some(view::SettingsMessage::RecoverySection)
+                    }
                     menu::CubeSettingsOption::About => Some(view::SettingsMessage::AboutSection),
                     menu::CubeSettingsOption::Stats => {
                         Some(view::SettingsMessage::InstallStatsSection)

--- a/coincube-gui/src/app/state/settings/general.rs
+++ b/coincube-gui/src/app/state/settings/general.rs
@@ -153,8 +153,21 @@ async fn update_unit_setting(
     }
 }
 
+/// Which face of the settings-content state to render. The General and Recovery
+/// sub-tabs share this one `State` type (they both own the local backup flow and
+/// flow through the same wrapper downcast); this discriminator selects the view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsSection {
+    /// App/display preferences (network, unit, display mode, badges, fiat).
+    General,
+    /// Backup & recovery: local paper backup + Recovery Kit + Vault alerts.
+    Recovery,
+}
+
 pub struct GeneralSettingsState {
     cube_id: String,
+    /// Which sub-tab's content this instance renders (General prefs vs Recovery).
+    section: SettingsSection,
     new_price_setting: PriceSetting,
     new_unit_setting: UnitSetting,
     currencies: Vec<Currency>,
@@ -182,6 +195,7 @@ impl From<GeneralSettingsState> for Box<dyn State> {
 impl GeneralSettingsState {
     pub fn new(
         cube_id: String,
+        section: SettingsSection,
         price_setting: PriceSetting,
         unit_setting: UnitSetting,
         datadir_path: &CoincubeDirectory,
@@ -191,6 +205,7 @@ impl GeneralSettingsState {
         let show_direction_badges = GlobalSettings::load_show_direction_badges(&global_path);
         Self {
             cube_id,
+            section,
             new_price_setting: price_setting,
             new_unit_setting: unit_setting,
             currencies: Vec::new(),
@@ -537,7 +552,8 @@ impl GeneralSettingsState {
         rk: &'a super::recovery_kit::RecoveryKit,
         ra: &'a super::recovery_alerts::RecoveryAlerts,
     ) -> Element<'a, view::Message> {
-        crate::app::view::settings::general::general_section(
+        crate::app::view::settings::general::settings_content_section(
+            self.section,
             menu,
             cache,
             &self.new_price_setting,
@@ -559,7 +575,8 @@ impl State for GeneralSettingsState {
     }
 
     fn view<'a>(&'a self, menu: &'a Menu, cache: &'a Cache) -> Element<'a, view::Message> {
-        crate::app::view::settings::general::general_section(
+        crate::app::view::settings::general::settings_content_section(
+            self.section,
             menu,
             cache,
             &self.new_price_setting,

--- a/coincube-gui/src/app/state/settings/mod.rs
+++ b/coincube-gui/src/app/state/settings/mod.rs
@@ -12,7 +12,7 @@ use iced::Task;
 use coincube_ui::widget::Element;
 
 use about::AboutSettingsState;
-use general::GeneralSettingsState;
+use general::{GeneralSettingsState, SettingsSection};
 use install_stats::InstallStatsState;
 
 use crate::{
@@ -74,6 +74,25 @@ impl State for SettingsState {
                 self.setting = Some(
                     GeneralSettingsState::new(
                         self.cube_id.clone(),
+                        SettingsSection::General,
+                        self.current_price_setting.clone(),
+                        self.current_unit_setting.clone(),
+                        &cache.datadir_path,
+                    )
+                    .into(),
+                );
+                self.setting
+                    .as_mut()
+                    .map(|s| s.reload(daemon, None))
+                    .unwrap_or_else(Task::none)
+            }
+            Message::View(view::Message::Settings(view::SettingsMessage::RecoverySection)) => {
+                // Same content state, Recovery face — it hosts the local backup
+                // flow plus the Recovery-Kit and Vault-Alerts cards.
+                self.setting = Some(
+                    GeneralSettingsState::new(
+                        self.cube_id.clone(),
+                        SettingsSection::Recovery,
                         self.current_price_setting.clone(),
                         self.current_unit_setting.clone(),
                         &cache.datadir_path,
@@ -85,10 +104,10 @@ impl State for SettingsState {
                     .as_mut()
                     .map(|s| s.reload(daemon, None))
                     .unwrap_or_else(Task::none);
-                // Kick the Recovery-Kit status fetch so the card has
-                // fresh copy by the time the user looks at it. The
-                // handler is App-level (it needs the authenticated
-                // client); we just drop a message onto the queue.
+                // Kick the Recovery-Kit status fetch so the card has a fresh
+                // copy by the time the user looks at it. The handler is
+                // App-level (it needs the authenticated client); we just drop a
+                // message onto the queue.
                 let load_status = Task::done(Message::View(view::Message::Settings(
                     view::SettingsMessage::RecoveryKit(view::RecoveryKitMessage::LoadStatus),
                 )));
@@ -154,6 +173,7 @@ impl State for SettingsState {
             if let Some(wizard) = crate::app::view::settings::recovery_kit::dispatch(
                 &self.recovery_kit.flow,
                 &self.recovery_kit.pin,
+                self.recovery_kit.status.as_ref(),
             ) {
                 return crate::app::view::dashboard(
                     menu,

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -25,7 +25,8 @@ use crate::app::message::Message;
 use crate::app::settings::{self, update_settings_file};
 use crate::app::view;
 use crate::app::view::{
-    RecoveryKitMessage, RecoveryKitMode, RecoveryKitUploadOutcome, RecoveryProtectionMode,
+    PhoneKeyOutcome, RecoveryKitMessage, RecoveryKitMode, RecoveryKitUploadOutcome,
+    RecoveryProtectionMode,
 };
 use crate::app::wallet::Wallet;
 use crate::feature_flags;
@@ -34,7 +35,9 @@ use crate::services::coincube::{
     CoincubeClient, CoincubeError, RecoveryKit as ApiRecoveryKit, RecoveryKitStatus,
     RECOVERY_KIT_SCHEME_AES_256_GCM,
 };
-use crate::services::inheritance::{find_owner_self_recipient, seal_and_upload_owner_self};
+use crate::services::inheritance::{
+    find_owner_self_recipient, seal_and_upload_owner_self, OwnerSelfError,
+};
 use crate::services::recovery::{
     self, DescriptorBlob, DescriptorBlobCube, DescriptorBlobSigner, DescriptorBlobVault, KdfParams,
     SeedBlob, SeedBlobCube, SeedBlobMnemonic, BLOB_VERSION, MIN_PASSWORD_LEN,
@@ -81,6 +84,26 @@ impl std::fmt::Debug for PasswordEntryPending {
     }
 }
 
+/// Auto-detection status of the owner's `owner-self` Keychain recovery key,
+/// shown on the protection-choice screen. The check runs automatically on
+/// entry (and via the "Check again" link); its result gates the phone options —
+/// "Use my phone" / "Use both" are only selectable while `Present`. Registration
+/// is phone-initiated (COIN-390): the desktop only *detects* whether the
+/// Keychain app has minted + registered the key yet.
+#[derive(Debug, Clone)]
+pub enum PhoneKey {
+    /// Detection request in flight.
+    Checking,
+    /// A registered `owner-self` key exists — phone options are enabled.
+    Present,
+    /// No key registered yet — phone options disabled, with guidance to create
+    /// one in the Keychain app under the same Connect account.
+    Absent,
+    /// Detection failed (network / auth / not signed in). Shown inline; the
+    /// "Check again" link lets the user retry.
+    Error(String),
+}
+
 /// The actual UI state of the wizard. `None` = card view; any other
 /// variant = wizard is taking over the settings page.
 ///
@@ -104,8 +127,12 @@ pub enum RecoveryKitState {
     ProtectionChoice {
         mode: RecoveryKitMode,
         mnemonic: Option<Zeroizing<Vec<String>>>,
-        /// Set while the mint+register provisioning task is in flight.
-        provisioning: bool,
+        /// Auto-detection status of the owner's phone (`owner-self`) key. Gates
+        /// whether the phone/both options are selectable.
+        phone: PhoneKey,
+        /// Seal-preflight error (e.g. a settings read failing after the user
+        /// picks Phone/Both). Distinct from a `PhoneKey::Error` detection
+        /// failure — this is a later-stage error surfaced inline.
         error: Option<String>,
     },
     /// In-flight phone seal+upload (PR 2). Reached from `ProtectionChoice` (phone
@@ -154,13 +181,13 @@ impl std::fmt::Debug for RecoveryKitState {
             Self::ProtectionChoice {
                 mode,
                 mnemonic,
-                provisioning,
+                phone,
                 error,
             } => f
                 .debug_struct("ProtectionChoice")
                 .field("mode", mode)
                 .field("mnemonic", &mnemonic.as_ref().map(|_| "<redacted>"))
-                .field("provisioning", provisioning)
+                .field("phone", phone)
                 .field("error", error)
                 .finish(),
             Self::PhoneSealing { mode } => {
@@ -302,6 +329,7 @@ pub fn update(
                         encryption_scheme: String::new(),
                         created_at: None,
                         updated_at: None,
+                        owner_self: None,
                     });
                 }
                 Err(e) => {
@@ -349,7 +377,7 @@ pub fn update(
                 StartGuard::NotSignedIn => {
                     rk.flow = RecoveryKitState::Error {
                         message: "Sign in to Connect to back up your Recovery Kit. \
-                                  You can sign in from Settings → Connect."
+                                  You can sign in from Home → Sign In."
                             .to_string(),
                     };
                     return Task::none();
@@ -380,9 +408,10 @@ pub fn update(
                         return Task::none();
                     }
                     // Passkey cubes have no on-device seed, so there's no PIN
-                    // gate; offer the protection-mode choice (flag on) or jump
-                    // straight to the password entry (flag off).
-                    rk.flow = next_after_seed_unlock(mode, None);
+                    // gate; offer the protection-mode choice (flag on, with the
+                    // phone key auto-detected on entry) or jump straight to the
+                    // password entry (flag off).
+                    return enter_after_seed_unlock(rk, mode, None, client, server_cube_id);
                 }
             }
             Task::none()
@@ -418,18 +447,19 @@ pub fn update(
                     // already happened at the async boundary in
                     // `verify_pin`'s task. Just move it into state. When the
                     // owner-keychain flag is on, the seed is now unlocked so we
-                    // offer the protection-mode choice (PR 2); otherwise go
-                    // straight to the password entry as before.
-                    rk.flow = next_after_seed_unlock(mode, Some(words));
+                    // offer the protection-mode choice (PR 2), auto-detecting the
+                    // phone key on entry; otherwise go straight to the password
+                    // entry as before.
+                    enter_after_seed_unlock(rk, mode, Some(words), client, server_cube_id)
                 }
                 Err(e) => {
                     rk.flow = RecoveryKitState::PinEntry {
                         mode,
                         error: Some(e),
                     };
+                    Task::none()
                 }
             }
-            Task::none()
         }
 
         RecoveryKitMessage::PasswordChanged(value) => {
@@ -500,51 +530,24 @@ pub fn update(
         }
 
         RecoveryKitMessage::ProvisionPhone => {
+            // Re-run detection (the "Check again" link). No-op off the choice
+            // screen. `begin_phone_detection` sets `PhoneKey::Checking` and
+            // handles the not-signed-in / unregistered cases inline.
             if !matches!(rk.flow, RecoveryKitState::ProtectionChoice { .. }) {
                 return Task::none();
             }
-            let Some(client) = client else {
-                set_protection_error(rk, "Sign in to Connect to set up phone recovery.");
-                return Task::none();
-            };
-            let Some(cube_id) = server_cube_id else {
-                set_protection_error(rk, "This Cube isn't registered with Connect yet.");
-                return Task::none();
-            };
-            if let RecoveryKitState::ProtectionChoice {
-                provisioning,
-                error,
-                ..
-            } = &mut rk.flow
-            {
-                *provisioning = true;
-                *error = None;
-            }
-            Task::perform(
-                async move { detect_owner_self_recipient(client, cube_id).await },
-                |res| {
-                    Message::View(view::Message::Settings(view::SettingsMessage::RecoveryKit(
-                        RecoveryKitMessage::ProvisionResult(res),
-                    )))
-                },
-            )
+            begin_phone_detection(rk, client, server_cube_id)
         }
 
-        RecoveryKitMessage::ProvisionResult(res) => {
-            if let RecoveryKitState::ProtectionChoice {
-                provisioning,
-                error,
-                ..
-            } = &mut rk.flow
-            {
-                *provisioning = false;
-                match res {
-                    // The `owner-self` recipient now exists; the user can pick a
-                    // phone protection mode, which will seal to it.
-                    Ok(()) => *error = None,
-                    Err(e) => *error = Some(e),
-                }
-            }
+        RecoveryKitMessage::ProvisionResult(outcome) => {
+            let status = match outcome {
+                // The `owner-self` recipient exists; the phone/both options unlock.
+                PhoneKeyOutcome::Present => PhoneKey::Present,
+                // No key yet — show guidance rather than an error.
+                PhoneKeyOutcome::Absent => PhoneKey::Absent,
+                PhoneKeyOutcome::Failed(e) => PhoneKey::Error(e),
+            };
+            set_phone_detection(rk, status);
             Task::none()
         }
 
@@ -960,11 +963,74 @@ fn next_after_seed_unlock(
         RecoveryKitState::ProtectionChoice {
             mode,
             mnemonic,
-            provisioning: false,
+            // Detection is kicked off immediately on entry (see
+            // `enter_after_seed_unlock`), so start in `Checking` rather than
+            // showing the phone options in an indeterminate state.
+            phone: PhoneKey::Checking,
             error: None,
         }
     } else {
         password_entry(mode, mnemonic)
+    }
+}
+
+/// Move into the post-seed-unlock state and, when that's the protection-choice
+/// screen, immediately kick off the owner-self phone-key detection so the phone
+/// options reflect reality without the user having to click anything. With the
+/// flag off (`password_entry`) there's nothing to detect.
+fn enter_after_seed_unlock(
+    rk: &mut RecoveryKit,
+    mode: RecoveryKitMode,
+    mnemonic: Option<Zeroizing<Vec<String>>>,
+    client: Option<CoincubeClient>,
+    server_cube_id: Option<u64>,
+) -> Task<Message> {
+    rk.flow = next_after_seed_unlock(mode, mnemonic);
+    if matches!(rk.flow, RecoveryKitState::ProtectionChoice { .. }) {
+        begin_phone_detection(rk, client, server_cube_id)
+    } else {
+        Task::none()
+    }
+}
+
+/// Set `PhoneKey::Checking` and spawn the detection task. Shared by the auto-run
+/// on entry and the "Check again" link. On a missing client / cube id, records
+/// the reason as a `PhoneKey::Error` inline (retryable) rather than spawning.
+fn begin_phone_detection(
+    rk: &mut RecoveryKit,
+    client: Option<CoincubeClient>,
+    server_cube_id: Option<u64>,
+) -> Task<Message> {
+    let Some(client) = client else {
+        set_phone_detection(
+            rk,
+            PhoneKey::Error("Sign in to Connect to check for your phone key.".to_string()),
+        );
+        return Task::none();
+    };
+    let Some(cube_id) = server_cube_id else {
+        set_phone_detection(
+            rk,
+            PhoneKey::Error("This Cube isn't registered with Connect yet.".to_string()),
+        );
+        return Task::none();
+    };
+    set_phone_detection(rk, PhoneKey::Checking);
+    Task::perform(
+        async move { detect_owner_self_recipient(client, cube_id).await },
+        |res| {
+            Message::View(view::Message::Settings(view::SettingsMessage::RecoveryKit(
+                RecoveryKitMessage::ProvisionResult(res),
+            )))
+        },
+    )
+}
+
+/// Update the phone-key detection status on the choice screen. No-op off it
+/// (e.g. a stale detection result arriving after the user navigated away).
+fn set_phone_detection(rk: &mut RecoveryKit, status: PhoneKey) {
+    if let RecoveryKitState::ProtectionChoice { phone, .. } = &mut rk.flow {
+        *phone = status;
     }
 }
 
@@ -1133,14 +1199,16 @@ async fn seal_phone(
 /// Provisioning is phone-initiated (COIN-390): the Keychain app mints + attaches
 /// the key and registers the recipient (tier `full_cube`). The desktop never
 /// mints or registers — it polls the recipients list and reports whether the
-/// `owner-self` row exists yet. `Ok(())` once it does (the user can then seal via
-/// "My phone" / "Both"); `Err(..)` with the [`OwnerSelfError::NoRecipient`]
-/// "set this up on your phone first" copy until they create it on their phone.
-async fn detect_owner_self_recipient(client: CoincubeClient, cube_id: u64) -> Result<(), String> {
-    find_owner_self_recipient(&client, cube_id)
-        .await
-        .map(|_| ())
-        .map_err(|e| e.to_string())
+/// `owner-self` row exists yet. Maps the absent case
+/// ([`OwnerSelfError::NoRecipient`]) to [`PhoneKeyOutcome::Absent`] — a normal
+/// "not set up yet" state that drives guidance copy, *not* an error — and any
+/// other failure to [`PhoneKeyOutcome::Failed`].
+async fn detect_owner_self_recipient(client: CoincubeClient, cube_id: u64) -> PhoneKeyOutcome {
+    match find_owner_self_recipient(&client, cube_id).await {
+        Ok(_) => PhoneKeyOutcome::Present,
+        Err(OwnerSelfError::NoRecipient) => PhoneKeyOutcome::Absent,
+        Err(e) => PhoneKeyOutcome::Failed(e.to_string()),
+    }
 }
 
 /// Network string used inside `SeedBlob`/`DescriptorBlob`. Routed
@@ -1484,6 +1552,7 @@ mod tests {
             encryption_scheme: "aes-256-gcm".into(),
             created_at: Some("2026-04-23T00:00:00Z".into()),
             updated_at: Some("2026-04-23T00:00:00Z".into()),
+            owner_self: None,
         }
     }
 
@@ -1495,6 +1564,7 @@ mod tests {
             encryption_scheme: "aes-256-gcm".into(),
             created_at: Some("2026-04-23T00:00:00Z".into()),
             updated_at: Some("2026-04-23T00:00:00Z".into()),
+            owner_self: None,
         }
     }
 
@@ -1506,6 +1576,7 @@ mod tests {
             encryption_scheme: String::new(),
             created_at: None,
             updated_at: None,
+            owner_self: None,
         }
     }
 
@@ -1693,7 +1764,7 @@ mod tests {
         rk.flow = RecoveryKitState::ProtectionChoice {
             mode: RecoveryKitMode::Create,
             mnemonic: None,
-            provisioning: false,
+            phone: PhoneKey::Absent,
             error: None,
         };
         set_protection_error(&mut rk, "Sign in to Connect to back up to your phone.");
@@ -1733,7 +1804,7 @@ mod tests {
         rk.flow = RecoveryKitState::ProtectionChoice {
             mode: RecoveryKitMode::Create,
             mnemonic: None,
-            provisioning: false,
+            phone: PhoneKey::Absent,
             error: None,
         };
         let mnemonic = Some(Zeroizing::new(vec!["word".to_string(); 12]));

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -530,13 +530,26 @@ pub fn update(
         }
 
         RecoveryKitMessage::ProvisionPhone => {
-            // Re-run detection (the "Check again" link). No-op off the choice
-            // screen. `begin_phone_detection` sets `PhoneKey::Checking` and
-            // handles the not-signed-in / unregistered cases inline.
-            if !matches!(rk.flow, RecoveryKitState::ProtectionChoice { .. }) {
-                return Task::none();
+            // Re-run detection (the "Check again" link). Two guards:
+            //   * Off the choice screen → no-op.
+            //   * Already `Checking` → no-op. Dropping a duplicate request
+            //     (e.g. a double-click) keeps a single detection outstanding,
+            //     so a late `ProvisionResult` can't be a stale duplicate that
+            //     clobbers a newer one. Results that arrive after the user has
+            //     left the choice screen are already discarded by
+            //     `set_phone_detection` (the same flow guard `PhoneSealResult`
+            //     uses). `begin_phone_detection` sets `PhoneKey::Checking` and
+            //     handles the not-signed-in / unregistered cases inline.
+            match &rk.flow {
+                RecoveryKitState::ProtectionChoice {
+                    phone: PhoneKey::Checking,
+                    ..
+                } => Task::none(),
+                RecoveryKitState::ProtectionChoice { .. } => {
+                    begin_phone_detection(rk, client, server_cube_id)
+                }
+                _ => Task::none(),
             }
-            begin_phone_detection(rk, client, server_cube_id)
         }
 
         RecoveryKitMessage::ProvisionResult(outcome) => {

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -374,6 +374,8 @@ pub enum SettingsMessage {
     WalletAliasEdited(String),
     Save,
     GeneralSection,
+    /// Install the Recovery settings section (backup + Recovery Kit + alerts).
+    RecoverySection,
     DisplayUnitChanged(BitcoinDisplayUnit),
     Fiat(FiatMessage),
     NodeSettings(NodeSettingsMessage),
@@ -1088,6 +1090,22 @@ pub enum RecoveryProtectionMode {
     Both,
 }
 
+/// Result of the owner-self phone-key detection that runs automatically on
+/// entering the protection-choice screen (and via the "Check again" link).
+/// Distinguishes the expected "not registered yet" case (`Absent` — show
+/// guidance) from a genuine failure (`Failed` — show the error + retry), so the
+/// UI can gate the phone options without treating a missing key as an error.
+#[derive(Debug, Clone)]
+pub enum PhoneKeyOutcome {
+    /// A registered `owner-self` recovery key was found — phone options enable.
+    Present,
+    /// No `owner-self` recipient registered yet (the Keychain app must mint one
+    /// first, COIN-390). Phone options stay disabled with guidance copy.
+    Absent,
+    /// Detection failed (network / auth / not signed in). Display-safe message.
+    Failed(String),
+}
+
 /// Messages driving the Cube Recovery Kit flow. Mirrors the shape of
 /// `BackupWalletMessage` — a Debug impl below redacts every variant
 /// that carries key material (mnemonic, password, ciphertext) so the
@@ -1138,15 +1156,16 @@ pub enum RecoveryKitMessage {
     /// User picked a protection mode on the choice screen (PR 2). Routes to the
     /// password path (`Password`/`Both`) or runs the phone seal (`Phone`).
     SelectProtectionMode(RecoveryProtectionMode),
-    /// User clicked "Check for my phone key" on the choice screen (PR 1).
+    /// Re-run the owner-self phone-key detection on the choice screen. Fired
+    /// automatically on entering the screen, and by the "Check again" link.
     /// Provisioning is phone-initiated (COIN-390): the Keychain app mints +
     /// registers the `owner-self` recovery recipient. This action only *detects*
-    /// it — polls the recipients list until the row appears.
+    /// it — polls the recipients list to see whether the row exists yet.
     ProvisionPhone,
-    /// Async result of [`Self::ProvisionPhone`] (the detect): `Ok(())` once the
-    /// `owner-self` recipient exists; `Err` carries the "set this up on your
-    /// phone first" copy.
-    ProvisionResult(Result<(), String>),
+    /// Async result of [`Self::ProvisionPhone`] (the detect). Carries the
+    /// three-way [`PhoneKeyOutcome`] so the choice screen can enable the phone
+    /// options (`Present`), show guidance (`Absent`), or surface an error.
+    ProvisionResult(PhoneKeyOutcome),
     /// Async result of the phone seal+upload (PR 2). `Ok(())` on success; the
     /// error string is display-safe.
     PhoneSealResult(Result<(), String>),

--- a/coincube-gui/src/app/view/mod.rs
+++ b/coincube-gui/src/app/view/mod.rs
@@ -83,7 +83,7 @@ pub fn backup_warning_banner<'a>() -> Element<'a, Message> {
                 .width(Length::Fixed(140.0))
                 .on_press(Message::Menu(Menu::Cube(
                     crate::app::menu::CubeSubMenu::Settings(
-                        crate::app::menu::CubeSettingsOption::General,
+                        crate::app::menu::CubeSettingsOption::Recovery,
                     ),
                 ))),
             iced::widget::Button::new(

--- a/coincube-gui/src/app/view/nav/tertiary.rs
+++ b/coincube-gui/src/app/view/nav/tertiary.rs
@@ -20,8 +20,8 @@ use crate::app::{
 use coincube_ui::{
     icon::{
         bitcoin_icon, chat_icon, coins_outline_icon, graph_icon, home_icon, lightning_outline_icon,
-        person_icon, phone_icon, plus_icon, receipt_icon, settings_icon, tooltip_icon, wallet_icon,
-        wrench_icon,
+        person_icon, phone_icon, plus_icon, receipt_icon, recovery_icon, settings_icon,
+        tooltip_icon, wallet_icon, wrench_icon,
     },
     theme,
     widget::{Column, Element},
@@ -78,13 +78,13 @@ fn cube_settings_items() -> Vec<SubItem> {
             },
         ),
         SubItem::new(
-            "About",
-            tooltip_icon,
-            Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::About)),
+            "Recovery",
+            recovery_icon,
+            Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::Recovery)),
             |m| {
                 matches!(
                     m,
-                    Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::About))
+                    Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::Recovery))
                 )
             },
         ),
@@ -109,6 +109,18 @@ fn cube_settings_items() -> Vec<SubItem> {
                 matches!(
                     m,
                     Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::Avatar))
+                )
+            },
+        ),
+        // About sits at the bottom — reference info below the actionable tabs.
+        SubItem::new(
+            "About",
+            tooltip_icon,
+            Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::About)),
+            |m| {
+                matches!(
+                    m,
+                    Menu::Cube(CubeSubMenu::Settings(CubeSettingsOption::About))
                 )
             },
         ),

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -481,18 +481,6 @@ fn backup_master_seed_card<'a>(backed_up: bool) -> Element<'a, Message> {
     .into()
 }
 
-/// Cube Recovery Kit card — rendered below the local paper-phrase
-/// backup card. Shows copy + a primary action that drives the
-/// `RecoveryKitMessage` flow. States mirror the plan §6.3 matrix.
-///
-/// - `is_passkey`: when true, the seed is unextractable on-device and
-///   only the descriptor can be backed up; the card has a reduced
-///   two-state variant and is suppressed entirely on passkey cubes
-///   without a Vault (nothing to back up).
-/// - `has_vault`: gates the "complete" copy on mnemonic cubes — a
-///   seed-only kit on a vaultless cube is already "complete" from the
-///   user's perspective, so the CTA becomes "Update" rather than
-///   "Add Wallet Descriptor".
 /// Small rounded "pill" badge naming a Recovery-Kit backup method in use
 /// (e.g. "Password", "Keychain"). Subtle translucent-orange fill + orange
 /// border, but the label uses the **theme's primary text colour** (not orange)
@@ -543,6 +531,18 @@ fn format_backup_time(raw: &str) -> String {
         .unwrap_or_else(|_| raw.to_string())
 }
 
+/// Cube Recovery Kit card — rendered below the local paper-phrase
+/// backup card. Shows copy + a primary action that drives the
+/// `RecoveryKitMessage` flow. States mirror the plan §6.3 matrix.
+///
+/// - `is_passkey`: when true, the seed is unextractable on-device and
+///   only the descriptor can be backed up; the card has a reduced
+///   two-state variant and is suppressed entirely on passkey cubes
+///   without a Vault (nothing to back up).
+/// - `has_vault`: gates the "complete" copy on mnemonic cubes — a
+///   seed-only kit on a vaultless cube is already "complete" from the
+///   user's perspective, so the CTA becomes "Update" rather than
+///   "Add Wallet Descriptor".
 fn recovery_kit_card<'a>(
     is_passkey: bool,
     has_vault: bool,

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -114,30 +114,40 @@ fn recovery_section<'a>(
     // wrapper invoked `view_with_recovery_kit`. Falling back to no-card when
     // `None` keeps the trait-based `view` callers harmless.
     if let Some(rk) = recovery_kit {
-        // W12 drift: compute on the fly by comparing the cached live
-        // fingerprint (refreshed every App tick) with the last-backed-up
-        // fingerprint (persisted on `CubeSettings`). Only meaningful when a
-        // descriptor has actually been backed up — otherwise the card's
-        // "incomplete" copy already prompts the user.
-        let server_has_descriptor = rk
-            .status
-            .as_ref()
-            .map(|s| s.has_encrypted_wallet_descriptor)
-            .unwrap_or(false);
-        let drift = descriptor_drift(
-            server_has_descriptor,
-            cache.current_descriptor_fingerprint.as_deref(),
-            cache
-                .recovery_kit_last_backed_up_descriptor_fingerprint
-                .as_deref(),
-        );
-        col = col.push(recovery_kit_card(
-            cache.current_cube_is_passkey,
-            cache.has_vault,
-            rk.status.as_ref(),
-            rk.status_loading,
-            drift,
-        ));
+        if !cache.connect_authenticated {
+            // The Recovery Kit lives in the Connect account, so it needs sign-in
+            // first. Reuse the shared Connect sign-in prompt (same card + "Sign
+            // In" → `OpenConnectSignIn` button used by Avatar / Members) rather
+            // than a "Create Recovery Kit" CTA that would only dead-end.
+            col = col.push(crate::app::view::connect::sign_in_prompt::sign_in_prompt(
+                "back up your Cube Recovery Kit",
+            ));
+        } else {
+            // W12 drift: compute on the fly by comparing the cached live
+            // fingerprint (refreshed every App tick) with the last-backed-up
+            // fingerprint (persisted on `CubeSettings`). Only meaningful when a
+            // descriptor has actually been backed up — otherwise the card's
+            // "incomplete" copy already prompts the user.
+            let server_has_descriptor = rk
+                .status
+                .as_ref()
+                .map(|s| s.has_encrypted_wallet_descriptor)
+                .unwrap_or(false);
+            let drift = descriptor_drift(
+                server_has_descriptor,
+                cache.current_descriptor_fingerprint.as_deref(),
+                cache
+                    .recovery_kit_last_backed_up_descriptor_fingerprint
+                    .as_deref(),
+            );
+            col = col.push(recovery_kit_card(
+                cache.current_cube_is_passkey,
+                cache.has_vault,
+                rk.status.as_ref(),
+                rk.status_loading,
+                drift,
+            ));
+        }
     }
 
     // Vault Recovery Alerts card (Estate Notifications — PR 2). Same threading

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -13,6 +13,7 @@ use crate::app::menu::Menu;
 use crate::app::settings::display::DisplayMode;
 use crate::app::settings::fiat::PriceSetting;
 use crate::app::settings::unit::{BitcoinDisplayUnit, UnitSetting};
+use crate::app::state::settings::general::SettingsSection;
 use crate::app::state::settings::recovery_alerts::RecoveryAlerts;
 use crate::app::state::settings::recovery_kit::RecoveryKit;
 use crate::app::view::dashboard;
@@ -21,8 +22,11 @@ use crate::services::coincube::{KeyholderDownloadPolicy, RecoveryKitStatus};
 use crate::services::fiat::{Currency, ALL_PRICE_SOURCES};
 use crate::services::inheritance::EscrowTier;
 
+/// Render whichever settings sub-tab is active. The General and Recovery tabs
+/// share `GeneralSettingsState`; this dispatches on the section discriminator.
 #[allow(clippy::too_many_arguments)]
-pub fn general_section<'a>(
+pub fn settings_content_section<'a>(
+    section: SettingsSection,
     menu: &'a Menu,
     cache: &'a cache::Cache,
     new_price_setting: &'a PriceSetting,
@@ -35,39 +39,86 @@ pub fn general_section<'a>(
     recovery_kit: Option<&'a RecoveryKit>,
     recovery_alerts: Option<&'a RecoveryAlerts>,
 ) -> Element<'a, Message> {
-    use crate::app::state::settings::general::BackupSeedState;
-
-    // When the backup flow is active, take over the entire settings page
-    // with the wizard view. This matches the UX the old Liquid Settings
-    // backup used and keeps the multi-step flow focused.
-    if !matches!(backup_state, BackupSeedState::None) {
-        if let Some(wizard) = super::backup::dispatch(backup_state, backup_pin, backup_mnemonic) {
-            return dashboard(menu, cache, Column::new().spacing(20).push(wizard));
-        }
+    match section {
+        SettingsSection::General => general_section(
+            menu,
+            cache,
+            new_price_setting,
+            new_unit_setting,
+            currencies_list,
+            show_direction_badges,
+        ),
+        SettingsSection::Recovery => recovery_section(
+            menu,
+            cache,
+            backup_state,
+            backup_pin,
+            backup_mnemonic,
+            recovery_kit,
+            recovery_alerts,
+        ),
     }
+}
 
-    // Normal settings rendering.
-    let mut col = Column::new()
+/// General tab: app/display preferences only.
+fn general_section<'a>(
+    menu: &'a Menu,
+    cache: &'a cache::Cache,
+    new_price_setting: &'a PriceSetting,
+    new_unit_setting: &'a UnitSetting,
+    currencies_list: &'a [Currency],
+    show_direction_badges: bool,
+) -> Element<'a, Message> {
+    let col = Column::new()
         .spacing(20)
         .push(super::header("General", SettingsMessage::GeneralSection))
         .push(network_row(cache.network))
         .push(bitcoin_display_unit(new_unit_setting))
         .push(display_mode_toggle(cache.display_mode))
         .push(direction_badges_toggle(show_direction_badges))
-        .push(fiat_price(new_price_setting, currencies_list))
+        .push(fiat_price(new_price_setting, currencies_list));
+
+    dashboard(menu, cache, col)
+}
+
+/// Recovery tab: local paper backup + Connect Recovery Kit + Vault Recovery
+/// Alerts. Hosts the local-backup wizard page takeover (unchanged from when it
+/// lived on General).
+#[allow(clippy::too_many_arguments)]
+fn recovery_section<'a>(
+    menu: &'a Menu,
+    cache: &'a cache::Cache,
+    backup_state: &'a crate::app::state::settings::general::BackupSeedState,
+    backup_pin: &'a crate::pin_input::PinInput,
+    backup_mnemonic: Option<&'a [String]>,
+    recovery_kit: Option<&'a RecoveryKit>,
+    recovery_alerts: Option<&'a RecoveryAlerts>,
+) -> Element<'a, Message> {
+    use crate::app::state::settings::general::BackupSeedState;
+
+    // When the local backup flow is active, take over the entire settings page
+    // with the wizard view. This keeps the multi-step PIN → reveal flow focused.
+    if !matches!(backup_state, BackupSeedState::None) {
+        if let Some(wizard) = super::backup::dispatch(backup_state, backup_pin, backup_mnemonic) {
+            return dashboard(menu, cache, Column::new().spacing(20).push(wizard));
+        }
+    }
+
+    let mut col = Column::new()
+        .spacing(20)
+        .push(super::header("Recovery", SettingsMessage::RecoverySection))
         .push(backup_master_seed_card(cache.current_cube_backed_up));
 
     // Connect-hosted Recovery Kit card. Render only when the outer
-    // SettingsState had a `RecoveryKit` on hand — i.e. when the
-    // downcasting wrapper invoked `view_with_recovery_kit`. Falling
-    // back to no-card when `None` keeps the trait-based `view`
-    // callers harmless.
+    // SettingsState had a `RecoveryKit` on hand — i.e. when the downcasting
+    // wrapper invoked `view_with_recovery_kit`. Falling back to no-card when
+    // `None` keeps the trait-based `view` callers harmless.
     if let Some(rk) = recovery_kit {
         // W12 drift: compute on the fly by comparing the cached live
         // fingerprint (refreshed every App tick) with the last-backed-up
-        // fingerprint (persisted on `CubeSettings`). Only meaningful
-        // when a descriptor has actually been backed up — otherwise
-        // the card's "incomplete" copy already prompts the user.
+        // fingerprint (persisted on `CubeSettings`). Only meaningful when a
+        // descriptor has actually been backed up — otherwise the card's
+        // "incomplete" copy already prompts the user.
         let server_has_descriptor = rk
             .status
             .as_ref()
@@ -89,8 +140,8 @@ pub fn general_section<'a>(
         ));
     }
 
-    // Vault Recovery Alerts card (Estate Notifications — PR 2). Same
-    // threading discipline as the Recovery Kit card above.
+    // Vault Recovery Alerts card (Estate Notifications — PR 2). Same threading
+    // discipline as the Recovery Kit card above.
     if let Some(ra) = recovery_alerts {
         col = col.push(recovery_alerts_card(ra));
     }
@@ -394,7 +445,7 @@ fn backup_master_seed_card<'a>(backed_up: bool) -> Element<'a, Message> {
     } else {
         (
             "Backup Master Seed Phrase",
-            "Write down your 12-word recovery phrase as a backup. This is the only way to recover your Cube if you forget your PIN.",
+            "Write down your 12-word recovery phrase as a backup. This is the only way to recover your Cube if you forget your PIN and do not have a Recovery Kit.",
             "Start Backup",
         )
     };
@@ -432,6 +483,56 @@ fn backup_master_seed_card<'a>(backed_up: bool) -> Element<'a, Message> {
 ///   seed-only kit on a vaultless cube is already "complete" from the
 ///   user's perspective, so the CTA becomes "Update" rather than
 ///   "Add Wallet Descriptor".
+/// Small rounded "pill" badge naming a Recovery-Kit backup method in use
+/// (e.g. "Password", "Keychain"). Subtle translucent-orange fill + orange
+/// border, but the label uses the **theme's primary text colour** (not orange)
+/// so it stays high-contrast in both dark and light mode — orange-on-orange was
+/// unreadable, especially on the light warm-paper background.
+pub(crate) fn backup_pill<'a>(label: &'static str) -> Element<'a, Message> {
+    iced::widget::container(text(label).size(12).bold())
+        .padding([3, 10])
+        .style(|t: &theme::Theme| iced::widget::container::Style {
+            text_color: Some(t.colors.text.primary),
+            background: Some(iced::Background::Color(color::TRANSPARENT_ORANGE)),
+            border: iced::Border {
+                radius: 10.0.into(),
+                width: 1.0,
+                color: color::ORANGE,
+            },
+            ..Default::default()
+        })
+        .into()
+}
+
+/// Which Recovery-Kit backup methods are actually in place, from the status.
+/// Returns `(password_present, keychain_present)`. Password = ciphertext on the
+/// password kit; Keychain = recovery material actually sealed to the owner's
+/// phone key (envelope uploaded, not merely a recipient registered). Shared by
+/// the Settings card and the protection-choice wizard screen.
+pub(crate) fn backup_methods_present(status: Option<&RecoveryKitStatus>) -> (bool, bool) {
+    let password = status
+        .map(|s| s.has_encrypted_seed || s.has_encrypted_wallet_descriptor)
+        .unwrap_or(false);
+    let keychain = status
+        .and_then(|s| s.owner_self.as_ref())
+        .map(|o| o.has_envelope())
+        .unwrap_or(false);
+    (password, keychain)
+}
+
+/// Format an RFC 3339 timestamp as the API returns it (e.g.
+/// `2026-05-08T14:36:50Z`) into a friendlier `8 May 2026, 14:36 UTC`. Falls
+/// back to the raw string if it can't be parsed.
+fn format_backup_time(raw: &str) -> String {
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .map(|dt| {
+            dt.with_timezone(&chrono::Utc)
+                .format("%-d %b %Y, %H:%M UTC")
+                .to_string()
+        })
+        .unwrap_or_else(|_| raw.to_string())
+}
+
 fn recovery_kit_card<'a>(
     is_passkey: bool,
     has_vault: bool,
@@ -463,7 +564,13 @@ fn recovery_kit_card<'a>(
         match status {
             Some(s) if s.has_encrypted_wallet_descriptor => (
                 "Wallet Descriptor backed up",
-                format!("Last updated {}.", s.updated_at.as_deref().unwrap_or("—")),
+                format!(
+                    "Last updated {}.",
+                    s.updated_at
+                        .as_deref()
+                        .map(format_backup_time)
+                        .unwrap_or_else(|| "—".to_string())
+                ),
                 "Update",
                 RecoveryKitMode::Rotate,
             ),
@@ -503,7 +610,13 @@ fn recovery_kit_card<'a>(
             ),
             Some(s) => (
                 "Recovery Kit backed up",
-                format!("Last updated {}.", s.updated_at.as_deref().unwrap_or("—")),
+                format!(
+                    "Last updated {}.",
+                    s.updated_at
+                        .as_deref()
+                        .map(format_backup_time)
+                        .unwrap_or_else(|| "—".to_string())
+                ),
                 "Update",
                 RecoveryKitMode::Rotate,
             ),
@@ -549,11 +662,26 @@ fn recovery_kit_card<'a>(
         );
     }
 
+    // Which backup methods are actually in place — drives the method pills.
+    let (password_present, keychain_present) = backup_methods_present(status);
+
     let mut body = Column::new()
         .spacing(4)
         .width(Length::Fill)
         .push(text(title).bold())
         .push(text(subtitle).size(14));
+    if password_present || keychain_present {
+        let mut pills = Row::new().spacing(6).align_y(Alignment::Center);
+        if password_present {
+            pills = pills.push(backup_pill("Password"));
+        }
+        if keychain_present {
+            pills = pills.push(backup_pill("Keychain"));
+        }
+        body = body
+            .push(Space::new().height(Length::Fixed(2.0)))
+            .push(pills);
+    }
     if drift {
         body = body.push(
             text("⚠ Descriptor out of sync with your Connect backup.")

--- a/coincube-gui/src/app/view/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/view/settings/recovery_kit.rs
@@ -18,12 +18,15 @@ use coincube_ui::{
 use iced::widget::{progress_bar, Column, Row, Space};
 use iced::{Alignment, Length};
 
-use crate::app::state::settings::recovery_kit::RecoveryKitState;
+use crate::app::state::settings::recovery_kit::{PhoneKey, RecoveryKitState};
 use crate::app::view::message::{
     Message, RecoveryKitMessage, RecoveryProtectionMode, SettingsMessage,
 };
 use crate::pin_input::PinInput;
+use crate::services::coincube::RecoveryKitStatus;
 use crate::services::recovery::{score_password, MIN_PASSWORD_LEN};
+
+use super::general::{backup_methods_present, backup_pill};
 use zeroize::Zeroizing;
 
 fn wrap(msg: RecoveryKitMessage) -> Message {
@@ -322,8 +325,10 @@ pub fn password_entry_view<'a>(
 /// password / phone / both — plus a one-time "set up phone protection"
 /// provisioning action (PR 1). Only reached when `OWNER_KEYCHAIN_RECOVERY_ENABLED`.
 pub fn protection_choice_view<'a>(
-    provisioning: bool,
+    phone: &'a PhoneKey,
     error: Option<&'a str>,
+    password_backed: bool,
+    keychain_backed: bool,
 ) -> Element<'a, Message> {
     let intro = Container::new(
         text(
@@ -369,14 +374,43 @@ pub fn protection_choice_view<'a>(
         )
         .push(Space::new().height(Length::Fixed(8.0)));
 
-    for (label, mode, primary) in [
+    // Show what's already backed up (Update mode). Nothing in Create mode, so
+    // the row is omitted entirely.
+    if password_backed || keychain_backed {
+        let mut pills = Row::new()
+            .spacing(6)
+            .align_y(Alignment::Center)
+            .push(text("Already backed up:").size(13));
+        if password_backed {
+            pills = pills.push(backup_pill("Password"));
+        }
+        if keychain_backed {
+            pills = pills.push(backup_pill("Keychain"));
+        }
+        col = col
+            .push(
+                Row::new()
+                    .width(Length::Fill)
+                    .push(Space::new().width(Length::Fill))
+                    .push(pills)
+                    .push(Space::new().width(Length::Fill)),
+            )
+            .push(Space::new().height(Length::Fixed(8.0)));
+    }
+
+    // The phone options are only selectable once a registered `owner-self` key
+    // has been detected. Registration is phone-initiated (COIN-390); the desktop
+    // auto-detects on entry (see `enter_after_seed_unlock`).
+    let phone_ready = matches!(phone, PhoneKey::Present);
+    for (label, mode, primary, needs_phone) in [
         (
             "Use a recovery password",
             RecoveryProtectionMode::Password,
             true,
+            false,
         ),
-        ("Use my phone", RecoveryProtectionMode::Phone, false),
-        ("Use both", RecoveryProtectionMode::Both, false),
+        ("Use my phone", RecoveryProtectionMode::Phone, false, true),
+        ("Use both", RecoveryProtectionMode::Both, false, true),
     ] {
         let base = if primary {
             ui_button::primary(None, label)
@@ -385,15 +419,12 @@ pub fn protection_choice_view<'a>(
         }
         .padding([12, 16])
         .width(Length::Fixed(380.0));
-        // Gate the choice on provisioning being idle: dispatching
-        // `SelectProtectionMode` while the owner-self provisioning task is in
-        // flight would advance the flow out of `ProtectionChoice` — abandoning
-        // provisioning (its `ProvisionResult` then no-ops) and, for phone/both,
-        // racing the recipient registration. Mirrors the `provision_btn` gating.
-        let btn = if provisioning {
-            base
-        } else {
+        // Password never needs the phone key; phone/both stay disabled (no
+        // `on_press` → greyed out) until detection reports `Present`.
+        let btn = if !needs_phone || phone_ready {
             base.on_press(wrap(RecoveryKitMessage::SelectProtectionMode(mode)))
+        } else {
+            base
         };
         col = col.push(
             Row::new()
@@ -404,49 +435,48 @@ pub fn protection_choice_view<'a>(
         );
     }
 
-    // Detect action (PR 1) — provisioning is phone-initiated (COIN-390); the
-    // desktop only checks whether the Keychain app has registered the key yet.
-    let provision_label = if provisioning {
-        "Checking your phone…"
-    } else {
-        "Check for my phone key"
-    };
-    let provision_btn = {
-        let b = ui_button::secondary(None, provision_label)
-            .padding([8, 16])
-            .width(Length::Fixed(380.0));
-        if provisioning {
-            b
-        } else {
-            b.on_press(wrap(RecoveryKitMessage::ProvisionPhone))
-        }
-    };
-    col = col
-        .push(Space::new().height(Length::Fixed(8.0)))
-        .push(
-            Row::new()
-                .width(Length::Fill)
-                .push(Space::new().width(Length::Fill))
-                .push(provision_btn)
-                .push(Space::new().width(Length::Fill)),
+    // Detection status for the phone options, plus a "Check again" link so a
+    // user who just registered the key in their Keychain can re-detect without
+    // leaving the screen. `Checking` shows a spinner-ish line and no link.
+    let status_line: Element<'a, Message> = match phone {
+        PhoneKey::Checking => text("Checking for your phone key…").size(14).into(),
+        PhoneKey::Present => text(
+            "Phone key found. Choose “Use my phone” or “Use both” — you'll restore \
+             by approving on your Keychain.",
         )
-        .push(
+        .size(13)
+        .into(),
+        PhoneKey::Absent => text(
+            "No phone key yet. Create a recovery key in your Keychain app — signed in to \
+             this same Connect account — to enable phone recovery. You'll need this phone \
+             (or its recovery phrase) to restore.",
+        )
+        .size(13)
+        .into(),
+        PhoneKey::Error(e) => text(e).size(14).color(color::RED).into(),
+    };
+    col = col.push(Space::new().height(Length::Fixed(8.0))).push(
+        Row::new()
+            .width(Length::Fill)
+            .push(Space::new().width(Length::Fill))
+            .push(Container::new(status_line).width(Length::Fixed(600.0)))
+            .push(Space::new().width(Length::Fill)),
+    );
+
+    // Only offer a retry when there's a reason to — no key yet (`Absent`) or a
+    // failed check (`Error`). Once a key is `Present` (or while `Checking`)
+    // there's nothing to re-check.
+    if matches!(phone, PhoneKey::Absent | PhoneKey::Error(_)) {
+        let recheck =
+            ui_button::link(None, "Check again").on_press(wrap(RecoveryKitMessage::ProvisionPhone));
+        col = col.push(
             Row::new()
                 .width(Length::Fill)
                 .push(Space::new().width(Length::Fill))
-                .push(
-                    Container::new(
-                        text(
-                            "First time? Create a recovery key in your Keychain app, then \
-                             “Check for my phone key” and choose “Use my phone”. You'll need \
-                             this phone (or its recovery phrase) to restore.",
-                        )
-                        .size(12),
-                    )
-                    .width(Length::Fixed(600.0)),
-                )
+                .push(recheck)
                 .push(Space::new().width(Length::Fill)),
         );
+    }
 
     if let Some(err) = error {
         col = col.push(
@@ -585,15 +615,22 @@ pub fn error_view(message: &str) -> Element<'static, Message> {
 pub fn dispatch<'a>(
     state: &'a RecoveryKitState,
     pin: &'a PinInput,
+    status: Option<&'a RecoveryKitStatus>,
 ) -> Option<Element<'a, Message>> {
     match state {
         RecoveryKitState::None => None,
         RecoveryKitState::PinEntry { error, .. } => Some(pin_entry_view(pin, error.as_deref())),
-        RecoveryKitState::ProtectionChoice {
-            provisioning,
-            error,
-            ..
-        } => Some(protection_choice_view(*provisioning, error.as_deref())),
+        RecoveryKitState::ProtectionChoice { phone, error, .. } => {
+            // Surface what's already backed up so the user knows what an Update
+            // will re-encrypt / add to (empty in Create mode → no pills).
+            let (password_backed, keychain_backed) = backup_methods_present(status);
+            Some(protection_choice_view(
+                phone,
+                error.as_deref(),
+                password_backed,
+                keychain_backed,
+            ))
+        }
         RecoveryKitState::PhoneSealing { .. } => Some(phone_sealing_view()),
         RecoveryKitState::PasswordEntry {
             password,

--- a/coincube-gui/src/feature_flags.rs
+++ b/coincube-gui/src/feature_flags.rs
@@ -48,14 +48,16 @@ pub const RECOVER_VAULT_ENABLED: bool = is_truthy(option_env!("COINCUBE_ENABLE_R
 /// by approving a Keychain decrypt — no recovery password.
 ///
 /// Controlled by the `COINCUBE_OWNER_KEYCHAIN_RECOVERY` env var at build time.
-/// Defaults to `false`: the feature depends on net-new `coincube-api`
-/// (`recovery-kit/recipients`, `recovery-kit/envelope`) and `keychain-app`
-/// (owner-self key mint) surfaces, so it stays **Beta**/dark until those ship.
-/// When `false`, the wizard's protection-mode picker hides the phone branches and
+/// Defaults to `true` now that the feature's dependencies have shipped: the
+/// net-new `coincube-api` (`recovery-kit/recipients`, `recovery-kit/envelope`)
+/// surfaces and the `keychain-app` owner-self key mint (COIN-390). This is the
+/// one flag that defaults **on** — set `COINCUBE_OWNER_KEYCHAIN_RECOVERY=0`
+/// (or `false`/`no`) at build time as a kill switch to dark-ship it again. When
+/// disabled, the wizard's protection-mode picker hides the phone branches and
 /// the "Recover a Cube I own" entry is hidden; the code still compiles but is
 /// unreachable via UI.
 pub const OWNER_KEYCHAIN_RECOVERY_ENABLED: bool =
-    is_truthy(option_env!("COINCUBE_OWNER_KEYCHAIN_RECOVERY"));
+    !is_falsy(option_env!("COINCUBE_OWNER_KEYCHAIN_RECOVERY"));
 
 /// `const`-compatible truthy check: accepts `"1"`, `"true"`, `"yes"`
 /// (case-insensitive for the latter two). Anything else, including `None`,
@@ -69,6 +71,18 @@ const fn is_truthy(val: Option<&str>) -> bool {
     };
     let b = s.as_bytes();
     bytes_eq_ci(b, b"1") || bytes_eq_ci(b, b"true") || bytes_eq_ci(b, b"yes")
+}
+
+/// `const`-compatible falsy check: accepts `"0"`, `"false"`, `"no"`
+/// (case-insensitive for the latter two). Anything else, including `None`, is
+/// `false` (i.e. "not explicitly disabled"). Used to make a flag default **on**
+/// while keeping a build-time kill switch: `!is_falsy(option_env!(...))`.
+const fn is_falsy(val: Option<&str>) -> bool {
+    let Some(s) = val else {
+        return false;
+    };
+    let b = s.as_bytes();
+    bytes_eq_ci(b, b"0") || bytes_eq_ci(b, b"false") || bytes_eq_ci(b, b"no")
 }
 
 /// Case-insensitive byte-slice equality, const-stable.
@@ -123,5 +137,29 @@ mod tests {
         assert!(!is_truthy(Some("on")));
         assert!(!is_truthy(Some("off")));
         assert!(!is_truthy(Some("2")));
+    }
+
+    #[test]
+    fn is_falsy_accepts_disabling_values() {
+        assert!(is_falsy(Some("0")));
+        assert!(is_falsy(Some("false")));
+        assert!(is_falsy(Some("FALSE")));
+        assert!(is_falsy(Some("False")));
+        assert!(is_falsy(Some("no")));
+        assert!(is_falsy(Some("NO")));
+    }
+
+    #[test]
+    fn is_falsy_rejects_everything_else() {
+        // `None` / unset must NOT be falsy — that's what makes the flag
+        // default-on. Unknown strings likewise leave the feature enabled.
+        assert!(!is_falsy(None));
+        assert!(!is_falsy(Some("")));
+        assert!(!is_falsy(Some("1")));
+        assert!(!is_falsy(Some("true")));
+        assert!(!is_falsy(Some("yes")));
+        assert!(!is_falsy(Some("on")));
+        assert!(!is_falsy(Some("off")));
+        assert!(!is_falsy(Some("2")));
     }
 }

--- a/coincube-gui/src/installer/step/recovery_kit_restore.rs
+++ b/coincube-gui/src/installer/step/recovery_kit_restore.rs
@@ -258,6 +258,7 @@ impl RecoveryKitRestoreStep {
                             encryption_scheme: String::new(),
                             created_at: None,
                             updated_at: None,
+                            owner_self: None,
                         },
                         Err(e) => {
                             return Err(format!(
@@ -931,6 +932,7 @@ mod tests {
                 encryption_scheme: "aes-256-gcm".to_string(),
                 created_at: None,
                 updated_at: None,
+                owner_self: None,
             },
         }
     }
@@ -952,6 +954,7 @@ mod tests {
                 encryption_scheme: "aes-256-gcm".to_string(),
                 created_at: None,
                 updated_at: None,
+                owner_self: None,
             },
         }
     }

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -1402,6 +1402,37 @@ pub struct RecoveryKitStatus {
     pub created_at: Option<String>,
     #[serde(default)]
     pub updated_at: Option<String>,
+    /// Owner-keychain ("phone") recovery summary, folded into the same
+    /// `/recovery-kit/status` response by the API (presence/tier only, no
+    /// ciphertext). `None` when the Cube has never used the envelope path.
+    #[serde(default)]
+    pub owner_self: Option<OwnerSelfRecoverySummary>,
+}
+
+/// Presence/tier summary of the owner-keychain recovery mode, mirrored from the
+/// API's `ownerSelf` block on `/recovery-kit/status`. Carries no ciphertext.
+/// A registered recipient (`has_recipient`) means a phone key exists; a
+/// non-empty `envelope_kinds` means recovery material has actually been sealed
+/// and uploaded to it — the signal that drives the "Keychain" backup pill.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OwnerSelfRecoverySummary {
+    #[serde(default)]
+    pub has_recipient: bool,
+    #[serde(default)]
+    pub tier: String,
+    /// Distinct artifact kinds escrowed to the phone key (`"descriptor"`,
+    /// `"seed"`). Empty when a recipient is registered but nothing sealed yet.
+    #[serde(default)]
+    pub envelope_kinds: Vec<String>,
+}
+
+impl OwnerSelfRecoverySummary {
+    /// Whether recovery material has actually been sealed to the phone key
+    /// (not merely a recipient registered). Drives the "Keychain" backup pill.
+    pub fn has_envelope(&self) -> bool {
+        !self.envelope_kinds.is_empty()
+    }
 }
 
 /// Deserialize a field that may arrive as:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Recovery Kit backup/restore flows and changes a feature flag default to on, which exposes phone/Keychain recovery UI broadly; changes are mostly UI routing and detection logic rather than crypto.
> 
> **Overview**
> **Cube → Settings** now has a separate **Recovery** tab (local paper backup, Connect Recovery Kit, Vault Recovery Alerts); **General** keeps display/network/fiat prefs only. The master-seed **“Back Up Now”** banner and settings tertiary rail route there instead of General.
> 
> **Recovery Kit** changes: when not signed in to Connect, the Recovery tab shows the shared sign-in prompt instead of a dead-end CTA. The status card shows **Password** / **Keychain** pills from API `owner_self` envelope data, friendlier “last updated” timestamps, and updated copy on the local backup card.
> 
> On the protection-choice wizard, **phone key detection runs automatically** on entry (replacing the old provisioning flow). Phone / Both stay disabled until a registered `owner-self` key is found; **Absent** vs **Failed** outcomes drive guidance vs errors, with **Check again** to retry. The choice screen can show what’s already backed up.
> 
> **`COINCUBE_OWNER_KEYCHAIN_RECOVERY`** now **defaults on** (explicit `0`/`false`/`no` is the kill switch), documented in `.env.example`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb1dfd337278aecb7c1e84b47e7eeae627a7f9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Recovery** section in Cube Settings (including navigation and direct access from backups).
  * Recovery Kit now displays available backup methods (Password/Keychain) and shows friendlier “last updated” timestamps.
  * Improved phone-key based owner self recovery flow with clear detection status (including retry) and “already backed up” indicators.
  * Owner keychain recovery is enabled by default; can be disabled via `COINCUBE_OWNER_KEYCHAIN_RECOVERY` configuration.
* **Bug Fixes**
  * “Back Up Now” now opens the **Recovery** section directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->