### PR TITLE
Unified key picker

### DIFF
--- a/coincube-gui/src/app/state/global_home.rs
+++ b/coincube-gui/src/app/state/global_home.rs
@@ -2180,7 +2180,9 @@ impl State for GlobalHome {
 
                                     self.transfer_spend_tx = Some(spend_tx);
 
-                                    // Create the SignModal
+                                    // Create the SignModal. This send-to-self
+                                    // transfer signs locally only — no nested
+                                    // Keychain flow.
                                     let sign_modal = SignModal::new(
                                         std::collections::HashSet::new(),
                                         wallet,
@@ -2188,6 +2190,8 @@ impl State for GlobalHome {
                                         network,
                                         true,
                                         None,
+                                        None,
+                                        false,
                                     );
 
                                     self.modal = Modal::Sign(Box::new(sign_modal));

--- a/coincube-gui/src/app/state/vault/keychain_sign.rs
+++ b/coincube-gui/src/app/state/vault/keychain_sign.rs
@@ -128,6 +128,12 @@ pub struct PendingSession {
 /// and the create-session RPC completing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PendingSessionStatus {
+    /// Resolved as a keychain signer but no session requested yet. The
+    /// unified picker renders `Idle` rows as clickable "request signature"
+    /// entries; a session is only created once the user clicks the row (or
+    /// "Request from everyone"). Distinct from `Creating`, which means a
+    /// `CreateSigningSession` RPC is already in flight.
+    Idle,
     /// Waiting on `CreateSigningSession` to return.
     Creating,
     Pending,
@@ -173,10 +179,17 @@ impl PendingSessionStatus {
         }
     }
 
+    /// True for a signer that has been resolved but not yet requested. The
+    /// unified picker renders these as clickable rows rather than status text.
+    pub fn is_idle(&self) -> bool {
+        matches!(self, Self::Idle)
+    }
+
     pub fn label(&self) -> &'static str {
         match self {
-            Self::Creating => "Creating…",
-            Self::Pending => "Waiting for signer…",
+            Self::Idle => "",
+            Self::Creating => "Requesting…",
+            Self::Pending => "Requested…",
             Self::Delivered => "Delivered",
             Self::Viewed => "Viewed",
             Self::Approved => "Approved",
@@ -412,8 +425,40 @@ impl KeychainSignModal {
         matches!(self.phase, Phase::Loading | Phase::Resolving)
     }
 
+    /// True once `ResolveSigners` has returned (or the flow finished): the
+    /// `pending` list is now the authoritative set of keychain rows. Before
+    /// this, the unified picker falls back to descriptor-derived placeholder
+    /// rows so keychain signers are still visible while resolving.
+    pub fn is_resolved(&self) -> bool {
+        matches!(self.phase, Phase::Sessions | Phase::AllDone)
+    }
+
     pub fn is_done(&self) -> bool {
         matches!(self.phase, Phase::AllDone)
+    }
+
+    /// Banner text describing a degraded realtime stream while keychain
+    /// sessions are still in flight. `None` when the stream is healthy or no
+    /// session is pending. Surfaced by the unified picker (the standalone
+    /// keychain modal used to render this itself).
+    pub fn stream_health_banner(&self) -> Option<String> {
+        let has_pending_nonterminal = self.pending.iter().any(|p| !p.status.is_terminal());
+        if !has_pending_nonterminal {
+            return None;
+        }
+        match &self.stream_health {
+            crate::app::ConnectionStatus::Connecting => Some(
+                "Connection lost — reconnecting. Your signing requests are still active \
+                 server-side; updates will catch up once the connection comes back."
+                    .to_string(),
+            ),
+            crate::app::ConnectionStatus::Error(e) => Some(format!(
+                "Connection error ({}). Your signing requests are still active server-side; \
+                 reconnect to see updates.",
+                e,
+            )),
+            _ => None,
+        }
     }
 
     /// True when every pending session has both reached a
@@ -439,7 +484,12 @@ impl KeychainSignModal {
     /// `Cancelled` once their `SessionCancelled` reply lands. Dropping
     /// the modal before they drain orphans the sessions server-side.
     pub fn has_undrained_sessions(&self) -> bool {
-        self.pending.iter().any(|p| !p.status.is_terminal())
+        // Idle rows never started a session, so there is nothing to drain for
+        // them — only rows with an actual in-flight/awaiting-cancel session
+        // keep the dismissed modal mounted.
+        self.pending
+            .iter()
+            .any(|p| !p.status.is_terminal() && !p.status.is_idle())
     }
 
     /// Mark the modal dismissed-but-mounted. The view hides immediately
@@ -456,7 +506,10 @@ impl KeychainSignModal {
     fn close_if_dismissed_and_drained(&mut self) -> Task<Message> {
         if self.dismissed
             && !self.pending.is_empty()
-            && self.pending.iter().all(|p| p.status.is_terminal())
+            && self
+                .pending
+                .iter()
+                .all(|p| p.status.is_terminal() || p.status.is_idle())
         {
             self.phase = Phase::AllDone;
             return Task::done(Message::Updated(Ok(())));
@@ -602,12 +655,11 @@ impl KeychainSignModal {
                 required = %required_summary,
                 "No Keychain signers required for this transaction"
             );
+            // No keychain rows to show. In the unified picker this isn't an
+            // error — the user simply signs with the local signers listed
+            // alongside — so we leave `error` unset (the standalone modal used
+            // to surface a "use the Sign button" message here).
             self.phase = Phase::AllDone;
-            self.error = Some(
-                "No Keychain signers are required for this transaction. \
-                 Use the Sign button to sign locally."
-                    .to_string(),
-            );
             return Task::none();
         }
         tracing::info!(
@@ -682,18 +734,12 @@ impl KeychainSignModal {
         // classified signer so we can populate the label / fingerprint
         // on the pending row. Targets carry `key_fingerprint` so the
         // join is straightforward.
-        let mut tasks = Vec::new();
-        let psbt_bytes = self.psbt.serialize();
-        let vault_id = resp
-            .targets
-            .first()
-            .map(|_| self.vault_id.unwrap_or(0).to_string())
-            .unwrap_or_default();
-        let descriptor_id = self.descriptor_id.clone();
-        let tokens = self.tokens.clone();
-        let grpc_url = self.grpc_url.clone();
-        let desktop_device_id = self.desktop_device_id.clone();
-
+        //
+        // The rows start `Idle`: unlike the original fan-out flow we do NOT
+        // create a `SigningSession` here. Sessions are created on demand when
+        // the user clicks a row in the unified picker (`request_signer`) or
+        // presses "Request from everyone" (`request_from_everyone`).
+        //
         // Owned clone of the classification rows so the per-target
         // dispatch below can borrow without lifetime gymnastics.
         let by_fp: HashMap<String, RequiredSigner> = classified
@@ -735,50 +781,113 @@ impl KeychainSignModal {
                 fingerprint,
                 device_id: target.device_id.clone(),
                 label,
-                status: PendingSessionStatus::Creating,
+                status: PendingSessionStatus::Idle,
                 error: None,
                 cancel_requested: false,
                 signed_psbt_persisted: false,
                 signed_psbt_fetching: false,
             });
-
-            let req = CreateSigningSessionRequest {
-                request_id: uuid_v4(),
-                vault_id: vault_id.clone(),
-                descriptor_id: descriptor_id.clone(),
-                psbt: psbt_bytes.clone(),
-                targets: vec![target.clone()],
-                note: String::new(),
-                ttl: Some(prost_types::Duration {
-                    seconds: 24 * 60 * 60,
-                    nanos: 0,
-                }),
-                require_user_presence: false,
-                // Owner-branch signing; the heir recovery sweep sets this true.
-                is_recovery_spend: false,
-            };
-            let tokens = tokens.clone();
-            let grpc_url = grpc_url.clone();
-            let desktop_device_id = desktop_device_id.clone();
-            tasks.push(Task::perform(
-                async move {
-                    let channel = crate::services::connect::grpc::create_channel(&grpc_url)
-                        .await
-                        .map_err(|e| OpError::new(format!("gRPC channel: {}", e)))?;
-                    let access_token = tokens.read().await.access_token.clone();
-                    let mut client = GrpcSessionClient::new(
-                        channel,
-                        AuthInterceptor::with_device_id(&access_token, desktop_device_id),
-                    );
-                    client
-                        .create_signing_session(req)
-                        .await
-                        .map_err(OpError::from_status)
-                },
-                move |r| Message::KeychainSign(KeychainSignMessage::SessionCreated(fingerprint, r)),
-            ));
         }
 
+        Task::none()
+    }
+
+    /// Build the `CreateSigningSession` task for one already-populated pending
+    /// row, resetting its state to `Creating`. Shared by the on-demand request
+    /// paths (`request_signer`, `request_from_everyone`) and the failed-session
+    /// `retry_signer`. The caller is responsible for having gated on the row's
+    /// current status; this unconditionally (re)starts a session for it.
+    fn create_session_for(&mut self, index: usize) -> Task<Message> {
+        let Some(entry) = self.pending.get_mut(index) else {
+            return Task::none();
+        };
+        let fingerprint = entry.fingerprint;
+        let device_id = entry.device_id.clone();
+        let key_id = entry.key_id;
+        // Reset state to creating; clear any previous error and stale
+        // cancel intent (an explicit request overrides a prior cancel-all
+        // so the new session isn't auto-cancelled). A retried/re-requested
+        // session produces a fresh signature that must be fetched + persisted
+        // again before this row counts as done.
+        entry.status = PendingSessionStatus::Creating;
+        entry.session_id.clear();
+        entry.error = None;
+        entry.cancel_requested = false;
+        entry.signed_psbt_persisted = false;
+        entry.signed_psbt_fetching = false;
+
+        let psbt_bytes = self.psbt.serialize();
+        let vault_id = self.vault_id.unwrap_or(0).to_string();
+        let descriptor_id = self.descriptor_id.clone();
+        let tokens = self.tokens.clone();
+        let grpc_url = self.grpc_url.clone();
+        let desktop_device_id = self.desktop_device_id.clone();
+        Task::perform(
+            async move {
+                let channel = crate::services::connect::grpc::create_channel(&grpc_url)
+                    .await
+                    .map_err(|e| OpError::new(format!("gRPC channel: {}", e)))?;
+                let access_token = tokens.read().await.access_token.clone();
+                let mut client = GrpcSessionClient::new(
+                    channel,
+                    AuthInterceptor::with_device_id(&access_token, desktop_device_id),
+                );
+                let req = CreateSigningSessionRequest {
+                    request_id: uuid_v4(),
+                    vault_id,
+                    descriptor_id,
+                    psbt: psbt_bytes,
+                    targets: vec![crate::services::connect::grpc::connect_v1::SignerTarget {
+                        device_id,
+                        key_fingerprint: fingerprint_as_str(&fingerprint),
+                        key_id: key_id.to_string(),
+                    }],
+                    note: String::new(),
+                    ttl: Some(prost_types::Duration {
+                        seconds: 24 * 60 * 60,
+                        nanos: 0,
+                    }),
+                    require_user_presence: false,
+                    // Owner-branch signing; the heir recovery sweep sets this true.
+                    is_recovery_spend: false,
+                };
+                client
+                    .create_signing_session(req)
+                    .await
+                    .map_err(OpError::from_status)
+            },
+            move |r| Message::KeychainSign(KeychainSignMessage::SessionCreated(fingerprint, r)),
+        )
+    }
+
+    /// Request a signature from one specific idle keychain signer (the user
+    /// clicked its row in the unified picker). No-op unless the row is `Idle`.
+    pub fn request_signer(&mut self, fingerprint: Fingerprint) -> Task<Message> {
+        let Some(index) = self
+            .pending
+            .iter()
+            .position(|p| p.fingerprint == fingerprint && p.status.is_idle())
+        else {
+            return Task::none();
+        };
+        self.create_session_for(index)
+    }
+
+    /// Request a signature from every idle keychain signer at once — the
+    /// explicit "Request from everyone" affordance. Preserves the original
+    /// fan-out behaviour but triggered by the user rather than on launch.
+    pub fn request_from_everyone(&mut self) -> Task<Message> {
+        let idle: Vec<usize> = self
+            .pending
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| p.status.is_idle())
+            .map(|(i, _)| i)
+            .collect();
+        let tasks: Vec<Task<Message>> = idle
+            .into_iter()
+            .map(|i| self.create_session_for(i))
+            .collect();
         Task::batch(tasks)
     }
 
@@ -1270,7 +1379,7 @@ impl KeychainSignModal {
     /// `target_key_id`. The user must have manually addressed the
     /// underlying problem on the signer's device.
     pub fn retry_signer(&mut self, index: usize) -> Task<Message> {
-        let Some(entry) = self.pending.get_mut(index) else {
+        let Some(entry) = self.pending.get(index) else {
             return Task::none();
         };
         // Only the recoverable failure states are retryable. Anything
@@ -1285,63 +1394,7 @@ impl KeychainSignModal {
         ) {
             return Task::none();
         }
-        let fingerprint = entry.fingerprint;
-        let device_id = entry.device_id.clone();
-        let key_id = entry.key_id;
-        // Reset state to creating; clear any previous error and stale
-        // cancel intent (an explicit retry overrides a prior
-        // cancel-all so the new session isn't auto-cancelled).
-        entry.status = PendingSessionStatus::Creating;
-        entry.session_id.clear();
-        entry.error = None;
-        entry.cancel_requested = false;
-        // The retried session produces a fresh signature that must be
-        // fetched + persisted again before this row counts as done.
-        entry.signed_psbt_persisted = false;
-        entry.signed_psbt_fetching = false;
-
-        let psbt_bytes = self.psbt.serialize();
-        let vault_id = self.vault_id.unwrap_or(0).to_string();
-        let descriptor_id = self.descriptor_id.clone();
-        let tokens = self.tokens.clone();
-        let grpc_url = self.grpc_url.clone();
-        let desktop_device_id = self.desktop_device_id.clone();
-        Task::perform(
-            async move {
-                let channel = crate::services::connect::grpc::create_channel(&grpc_url)
-                    .await
-                    .map_err(|e| OpError::new(format!("gRPC channel: {}", e)))?;
-                let access_token = tokens.read().await.access_token.clone();
-                let mut client = GrpcSessionClient::new(
-                    channel,
-                    AuthInterceptor::with_device_id(&access_token, desktop_device_id),
-                );
-                let req = CreateSigningSessionRequest {
-                    request_id: uuid_v4(),
-                    vault_id,
-                    descriptor_id,
-                    psbt: psbt_bytes,
-                    targets: vec![crate::services::connect::grpc::connect_v1::SignerTarget {
-                        device_id,
-                        key_fingerprint: fingerprint_as_str(&fingerprint),
-                        key_id: key_id.to_string(),
-                    }],
-                    note: String::new(),
-                    ttl: Some(prost_types::Duration {
-                        seconds: 24 * 60 * 60,
-                        nanos: 0,
-                    }),
-                    require_user_presence: false,
-                    // Owner-branch signing; the heir recovery sweep sets this true.
-                    is_recovery_spend: false,
-                };
-                client
-                    .create_signing_session(req)
-                    .await
-                    .map_err(OpError::from_status)
-            },
-            move |r| Message::KeychainSign(KeychainSignMessage::SessionCreated(fingerprint, r)),
-        )
+        self.create_session_for(index)
     }
 }
 
@@ -1433,6 +1486,12 @@ impl KeychainSignModal {
             }
             Message::View(view::Message::Spend(SpendTxMessage::RetryKeychainSigner(idx))) => {
                 return self.retry_signer(idx);
+            }
+            Message::View(view::Message::Spend(SpendTxMessage::SelectKeychainSigner(fp))) => {
+                return self.request_signer(fp);
+            }
+            Message::View(view::Message::Spend(SpendTxMessage::RequestFromEveryone)) => {
+                return self.request_from_everyone();
             }
             _ => {}
         }

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -307,7 +307,25 @@ impl PsbtState {
                     }));
                     return Task::none();
                 }
-                // Ready: forward to the picker's nested Keychain flow.
+                // Connect is ready. If the picker was opened before Connect
+                // came up, its nested Keychain flow is still `None` — build and
+                // launch it now (checked without holding a mutable borrow so
+                // `build_keychain_if_ready` can read `self.wallet`/`self.tx`).
+                // This click just kicks off the resolve; the keychain rows
+                // become actionable once it returns.
+                let needs_init = matches!(
+                    &self.modal,
+                    Some(PsbtModal::Sign(sign)) if sign.keychain_needs_init()
+                );
+                if needs_init {
+                    let (keychain, launch) =
+                        build_keychain_if_ready(cache, &self.wallet, &self.tx.psbt);
+                    if let Some(PsbtModal::Sign(sign)) = self.modal.as_mut() {
+                        sign.set_keychain(keychain);
+                    }
+                    return launch;
+                }
+                // Ready and initialized: forward to the picker's nested flow.
                 if let Some(modal) = self.modal.as_mut() {
                     return modal.as_mut().update(daemon.clone(), message, &mut self.tx);
                 }
@@ -703,7 +721,10 @@ fn build_keychain_if_ready(
     cache: &Cache,
     wallet: &Arc<Wallet>,
     psbt: &Psbt,
-) -> (Option<super::keychain_sign::KeychainSignModal>, Task<Message>) {
+) -> (
+    Option<super::keychain_sign::KeychainSignModal>,
+    Task<Message>,
+) {
     if !keychain_connect_missing(cache).is_empty() {
         return (None, Task::none());
     }
@@ -993,9 +1014,10 @@ pub struct SignModal {
     /// Home send-to-self transfer), which suppresses keychain rows entirely
     /// regardless of Connect state.
     keychain_enabled: bool,
-    /// Recovery-path timelocks (sequences) the user has expanded. Inactive
-    /// spending-path cards default to collapsed; toggled via `ToggleSpendPath`.
-    expanded_paths: HashSet<u16>,
+    /// Spending-path identities the user has expanded, keyed the same way as
+    /// `ToggleSpendPath`: `None` = primary, `Some(seq)` = a recovery path.
+    /// Inactive cards default to collapsed.
+    expanded_paths: HashSet<Option<u16>>,
 }
 
 impl SignModal {
@@ -1059,6 +1081,19 @@ impl SignModal {
                 .is_none_or(|k| !k.has_undrained_sessions())
     }
 
+    /// True when this picker offers Keychain signing but the nested flow
+    /// hasn't been built yet — the picker was opened before Connect was ready.
+    /// Once Connect comes up, the panel builds + launches it on demand.
+    pub fn keychain_needs_init(&self) -> bool {
+        self.keychain_enabled && self.keychain.is_none()
+    }
+
+    /// Attach a freshly-built (and launched) nested Keychain flow. Called once
+    /// Connect becomes ready for a picker that opened without it.
+    pub fn set_keychain(&mut self, keychain: Option<super::keychain_sign::KeychainSignModal>) {
+        self.keychain = keychain;
+    }
+
     /// Best-effort cancel of any keychain sessions still in flight, used when
     /// the picker is about to close because the threshold was met so those
     /// sessions don't outlive it server-side.
@@ -1120,7 +1155,10 @@ impl SignModal {
             if matches!(state, SigningKeyState::Signed) {
                 collected += 1;
             }
-            if matches!(state, SigningKeyState::Available(SigningKeyAction::Keychain)) {
+            if matches!(
+                state,
+                SigningKeyState::Available(SigningKeyAction::Keychain)
+            ) {
                 idle_keychain += 1;
             }
             keys.push(SigningKeyRow {
@@ -1143,8 +1181,9 @@ impl SignModal {
             // i.e. more than one idle Keychain signer to request at once.
             can_request_all: active && self.keychain.is_some() && idle_keychain > 1,
             // Active path is always expanded; inactive paths start collapsed
-            // and expand only when the user toggles them.
-            expanded: active || sequence.is_some_and(|s| self.expanded_paths.contains(&s)),
+            // and expand only when the user toggles them (keyed by `sequence`:
+            // None = primary, Some(seq) = recovery).
+            expanded: active || self.expanded_paths.contains(&sequence),
         }
     }
 
@@ -1157,25 +1196,34 @@ impl SignModal {
         &self,
         fp: Fingerprint,
         active: bool,
-    ) -> (view::vault::psbt::SigningKeyKind, view::vault::psbt::SigningKeyState) {
+    ) -> (
+        view::vault::psbt::SigningKeyKind,
+        view::vault::psbt::SigningKeyState,
+    ) {
         use super::keychain_sign::PendingSessionStatus;
-        use view::vault::psbt::{SigningKeyAction as Act, SigningKeyKind as Kind, SigningKeyState as St};
+        use view::vault::psbt::{
+            SigningKeyAction as Act, SigningKeyKind as Kind, SigningKeyState as St,
+        };
 
         let master_fp = self.wallet.signer.as_ref().map(|s| s.fingerprint());
         // Keychain session for this key, only once the flow has resolved.
-        let kc = self.keychain.as_ref().filter(|k| k.is_resolved()).and_then(|k| {
-            k.pending()
-                .iter()
-                .enumerate()
-                .find(|(_, p)| p.fingerprint == fp)
-                .map(|(i, p)| {
-                    (
-                        i,
-                        p.status,
-                        p.status.is_terminal_success() && p.signed_psbt_persisted,
-                    )
-                })
-        });
+        let kc = self
+            .keychain
+            .as_ref()
+            .filter(|k| k.is_resolved())
+            .and_then(|k| {
+                k.pending()
+                    .iter()
+                    .enumerate()
+                    .find(|(_, p)| p.fingerprint == fp)
+                    .map(|(i, p)| {
+                        (
+                            i,
+                            p.status,
+                            p.status.is_terminal_success() && p.signed_psbt_persisted,
+                        )
+                    })
+            });
         let kind = self.signing_key_kind(fp, master_fp, kc.is_some());
 
         // Signature already collected (local or keychain).
@@ -1186,7 +1234,9 @@ impl SignModal {
         if !active {
             return (
                 kind,
-                St::Disabled("This spending path isn't available for this transaction.".to_string()),
+                St::Disabled(
+                    "This spending path isn't available for this transaction.".to_string(),
+                ),
             );
         }
         // Local device operation in flight.
@@ -1202,7 +1252,12 @@ impl SignModal {
             return (kind, St::Available(Act::BorderWallet));
         }
         // A currently-connected hardware wallet matching this key.
-        if let Some(i) = self.hws.list.iter().position(|hw| hw.fingerprint() == Some(fp)) {
+        if let Some(i) = self
+            .hws
+            .list
+            .iter()
+            .position(|hw| hw.fingerprint() == Some(fp))
+        {
             match &self.hws.list[i] {
                 HardwareWallet::Supported {
                     registered: Some(false),
@@ -1235,6 +1290,15 @@ impl SignModal {
                 other => (Kind::Keychain, St::InProgress(other.label().to_string())),
             };
         }
+        // Keychain flow launched but still resolving — we don't yet know which
+        // unidentified keys are Keychain signers, so show a neutral hint rather
+        // than a misleading "connect a device" message.
+        if self.keychain.as_ref().is_some_and(|k| k.is_loading()) {
+            return (
+                Kind::Unknown,
+                St::Disabled("Looking up Keychain signers…".to_string()),
+            );
+        }
         // Unidentified: an external key whose device isn't connected and which
         // Connect hasn't resolved. Shown disabled — never guessed as Keychain.
         // When Keychain is possible here but Connect is signed out, offer a
@@ -1243,7 +1307,7 @@ impl SignModal {
         if self.keychain_enabled && self.keychain.is_none() {
             return (
                 Kind::Unknown,
-                St::NeedsSignIn("Connect a device, or".to_string()),
+                St::NeedsSignIn("Connect a device to sign with this key.".to_string()),
             );
         }
         (
@@ -1311,7 +1375,6 @@ impl SignModal {
         notices
     }
 }
-
 
 /// Ensure any in-progress Border Wallet reconstruction state is dropped
 /// (triggering its own `Drop` zeroization) when the sign modal goes away.
@@ -1493,10 +1556,11 @@ impl Modal for SignModal {
                     return Task::done(Message::View(view::Message::ShowError(err_msg)));
                 }
             },
-            // Expand/collapse an inactive spending-path card.
-            Message::View(view::Message::Spend(view::SpendTxMessage::ToggleSpendPath(seq))) => {
-                if !self.expanded_paths.remove(&seq) {
-                    self.expanded_paths.insert(seq);
+            // Expand/collapse an inactive spending-path card (keyed by path:
+            // None = primary, Some(seq) = recovery).
+            Message::View(view::Message::Spend(view::SpendTxMessage::ToggleSpendPath(path))) => {
+                if !self.expanded_paths.remove(&path) {
+                    self.expanded_paths.insert(path);
                 }
             }
             // Forward all Keychain traffic to the nested modal: its own

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -64,15 +64,14 @@ pub trait Modal {
 
 pub enum PsbtModal {
     Save(SaveModal),
+    /// Unified signing picker. Owns local signers (HW, master, border) and
+    /// — nested inside `SignModal` — the multi-signer Keychain flow. Keychain
+    /// sessions run per-signer on demand; signatures returned by Keychain
+    /// signers are merged into the same SpendTx via the daemon's
+    /// `update_spend_tx`, so the picker can broadcast once every path
+    /// threshold is met regardless of which signer types contributed.
     Sign(SignModal),
-    /// Multi-signer Keychain signing flow. Coexists with `Sign` (local
-    /// signers) — the user picks which to open. Keychain sessions run
-    /// independently; signatures returned by Keychain signers are
-    /// merged into the same SpendTx via the daemon's `update_spend_tx`,
-    /// so the local-only "Sign" path can broadcast as today once every
-    /// path threshold is met.
-    KeychainSign(super::keychain_sign::KeychainSignModal),
-    /// Shown when "Sign via Keychain" is pressed but Connect isn't ready.
+    /// Shown when a Keychain signer is selected but Connect isn't ready.
     /// Offers Connect sign-in or local Wi-Fi pairing as ways forward,
     /// instead of dead-ending on a technical "missing field" toast.
     KeychainUnavailable(KeychainUnavailableModal),
@@ -86,7 +85,6 @@ impl<'a> AsRef<dyn Modal + 'a> for PsbtModal {
         match &self {
             Self::Save(a) => a,
             Self::Sign(a) => a,
-            Self::KeychainSign(a) => a,
             Self::KeychainUnavailable(a) => a,
             Self::Broadcast(a) => a,
             Self::Delete(a) => a,
@@ -100,7 +98,6 @@ impl<'a> AsMut<dyn Modal + 'a> for PsbtModal {
         match self {
             Self::Save(a) => a,
             Self::Sign(a) => a,
-            Self::KeychainSign(a) => a,
             Self::KeychainUnavailable(a) => a,
             Self::Broadcast(a) => a,
             Self::Delete(a) => a,
@@ -190,44 +187,37 @@ impl PsbtState {
                 }
             }
             Message::View(view::Message::Spend(view::SpendTxMessage::Cancel)) => {
-                if let Some(PsbtModal::Sign(SignModal {
-                    display_modal,
-                    signing,
-                    ..
-                })) = &mut self.modal
-                {
-                    if !signing.is_empty() {
-                        *display_modal = false;
+                // Dismissing the unified signing picker. A local
+                // hardware/master/border op in flight just hides the picker
+                // (keeping the device-confirmation state). Otherwise cancel
+                // any in-flight Keychain sessions server-side — otherwise
+                // signers keep seeing the request until its 24h TTL elapses.
+                // `cancel_all()` cancels sessions that already have an id;
+                // entries whose `CreateSigningSession` RPC is still in flight
+                // are cancelled later once their `SessionCreated` lands, which
+                // needs the picker to stay mounted. So when sessions are still
+                // undrained we keep the picker mounted-but-hidden — it
+                // self-closes via `Message::Updated(Ok)` once they all reach a
+                // terminal state (see `should_close_after_dismiss`).
+                if let Some(PsbtModal::Sign(sign)) = &mut self.modal {
+                    if sign.is_signing() {
+                        // A local device op is awaiting confirmation — just
+                        // hide the picker, keeping it mounted so the op's
+                        // result still lands. Any keychain sessions keep
+                        // running and are drained on the next close.
+                        sign.display_modal = false;
                         return Task::none();
                     }
+                    let (cancel, keep) = sign.begin_dismiss();
+                    if !keep {
+                        self.modal = None;
+                    }
+                    return cancel;
                 }
 
-                // Dismissing a Keychain-sign modal (blur or otherwise)
-                // must also terminate any in-flight signing sessions
-                // server-side, not just hide the UI — otherwise signers
-                // keep seeing the request until its 24h TTL elapses.
-                // `cancel_all()` cancels sessions that already have an
-                // id; entries whose `CreateSigningSession` RPC is still
-                // in flight are cancelled later by `on_session_created`,
-                // which only runs while the modal is still mounted to
-                // receive `SessionCreated`. So when sessions are still
-                // undrained, keep the modal mounted but hidden — it
-                // self-closes via `Message::Updated(Ok)` once they all
-                // reach a terminal state.
-                let (cancel, keep_modal) =
-                    if let Some(PsbtModal::KeychainSign(km)) = self.modal.as_mut() {
-                        let cancel = km.cancel_all();
-                        let keep = km.has_undrained_sessions();
-                        if keep {
-                            km.mark_dismissed();
-                        }
-                        (cancel, keep)
-                    } else {
-                        (Task::none(), false)
-                    };
-                if !keep_modal {
-                    self.modal = None;
-                }
+                // Any other modal (save / broadcast / export / keychain
+                // unavailable): dismissing just closes it.
+                self.modal = None;
                 // After a successful broadcast we keep the user on the
                 // PSBT detail page rather than reloading back to the
                 // list: the daemon derives `SpendStatus::Broadcast` from
@@ -240,7 +230,7 @@ impl PsbtState {
                 // runs `Wallet::apply_spend_tx_overrides` on every
                 // refresh to promote matching Pending entries to
                 // Broadcast.
-                return cancel;
+                return Task::none();
             }
             Message::View(view::Message::Spend(view::SpendTxMessage::KeychainConnectSignIn)) => {
                 // From the "Keychain needs Connect" modal: close it and
@@ -276,6 +266,13 @@ impl PsbtState {
                     return Task::none();
                 }
 
+                // Build (and launch) the nested Keychain flow up front when
+                // Connect is ready, so keychain rows populate with friendly
+                // labels by the time the user reads the picker. When Connect
+                // isn't ready this is `None` and the picker shows keychain
+                // rows derived from the descriptor, disabled with a hint.
+                let (keychain, kc_launch) =
+                    build_keychain_if_ready(cache, &self.wallet, &self.tx.psbt);
                 let modal = SignModal::new(
                     self.tx.signers(),
                     self.wallet.clone(),
@@ -283,86 +280,37 @@ impl PsbtState {
                     cache.network,
                     self.saved,
                     self.tx.recovery_timelock(),
+                    keychain,
+                    true,
                 );
                 let cmd = modal.load(daemon);
                 self.modal = Some(PsbtModal::Sign(modal));
-                return cmd;
+                return Task::batch([cmd, kc_launch]);
             }
-            Message::View(view::Message::Spend(view::SpendTxMessage::SignKeychain)) => {
-                // Idempotent: re-opening the modal while one is already
-                // attached just brings it back to the foreground.
-                if matches!(self.modal, Some(PsbtModal::KeychainSign(_))) {
-                    return Task::none();
-                }
-                // Don't clobber another in-progress modal — most
-                // importantly an in-flight local `SignModal`, whose
-                // hardware-signing state would be silently discarded.
-                // Require the user to finish/close it first.
-                if self.modal.is_some() {
-                    let msg = "Close the current signing dialog before \
-                               signing via Keychain."
-                        .to_string();
-                    return Task::done(Message::View(view::Message::ShowError(msg)));
-                }
-                let missing: Vec<&'static str> = [
-                    ("connect_grpc_url", cache.connect_grpc_url.is_none()),
-                    ("connect_tokens", cache.connect_tokens.is_none()),
-                    ("connect_device_id", cache.connect_device_id.is_none()),
-                    (
-                        "current_cube_server_id",
-                        cache.current_cube_server_id.is_none(),
-                    ),
-                ]
-                .iter()
-                .filter_map(|(name, is_missing)| is_missing.then_some(*name))
-                .collect();
+            Message::View(view::Message::Spend(
+                view::SpendTxMessage::SelectKeychainSigner(_)
+                | view::SpendTxMessage::RequestFromEveryone,
+            )) => {
+                // Connect-readiness check, moved here from the old
+                // button-press: only when the user actually selects a
+                // Keychain signer do we require Connect. If it isn't ready,
+                // surface the sign-in / pair-a-phone modal (replacing the
+                // picker) instead of dead-ending on a technical error.
+                let missing = keychain_connect_missing(cache);
                 if !missing.is_empty() {
-                    // Connect isn't ready. Rather than dead-end on a
-                    // technical "missing field" toast, open a modal that
-                    // explains the requirement and offers both ways
-                    // forward: sign in to Connect (relay signing) or pair
-                    // a phone over Wi-Fi (local signing, no Connect). The
-                    // technical detail still goes to the log for support.
                     tracing::info!(
-                        "Sign via Keychain unavailable: Connect not ready (missing {})",
+                        "Keychain signer selected but Connect not ready (missing {})",
                         missing.join(", ")
                     );
                     self.modal = Some(PsbtModal::KeychainUnavailable(KeychainUnavailableModal {
-                        // Reflect the real Connect account session, not the
-                        // stream-bootstrap fields (which stay unset until a
-                        // device is registered). When signed in, the modal
-                        // offers "Sign with Connect" (on-demand bootstrap)
-                        // rather than a sign-in that would no-op.
                         signed_in: connect_session_available(cache),
                     }));
                     return Task::none();
                 }
-                let grpc_url = cache.connect_grpc_url.clone().expect("checked above");
-                let tokens = cache.connect_tokens.clone().expect("checked above");
-                let device_id = cache.connect_device_id.clone().expect("checked above");
-                let cube_server_id = cache.current_cube_server_id.expect("checked above");
-                // The REST client's bearer is set asynchronously inside
-                // `KeychainSignModal::launch()`, which reads the shared
-                // `Arc<RwLock>` in an async context. Reading it here on
-                // the synchronous `update` path would require
-                // `blocking_read`, which panics inside a tokio runtime.
-                let coincube_client = crate::services::coincube::CoincubeClient::new();
-
-                let descriptor_id = self.wallet.main_descriptor.to_string();
-                let modal = super::keychain_sign::KeychainSignModal::new(
-                    self.wallet.clone(),
-                    coincube_client,
-                    tokens,
-                    grpc_url,
-                    device_id,
-                    cube_server_id,
-                    cache.cube_id.clone(),
-                    descriptor_id,
-                    self.tx.psbt.clone(),
-                );
-                let launch = modal.launch();
-                self.modal = Some(PsbtModal::KeychainSign(modal));
-                return launch;
+                // Ready: forward to the picker's nested Keychain flow.
+                if let Some(modal) = self.modal.as_mut() {
+                    return modal.as_mut().update(daemon.clone(), message, &mut self.tx);
+                }
             }
             Message::View(view::Message::Spend(view::SpendTxMessage::Broadcast)) => {
                 let outpoints: Vec<_> = self.tx.coins.keys().cloned().collect();
@@ -405,33 +353,42 @@ impl PsbtState {
                 self.saved = true;
                 if let Some(modal) = self.modal.as_mut() {
                     let cmd = modal.as_mut().update(daemon.clone(), message, &mut self.tx);
-                    // Decide modal-close intent before mutating
-                    // `self.modal` so the borrow checker stays happy.
-                    let close_sign = matches!(
-                        modal,
-                        PsbtModal::Sign(SignModal {
-                            display_modal: false,
-                            ..
-                        }),
-                    );
-                    let close_keychain = matches!(
-                        modal,
-                        PsbtModal::KeychainSign(km) if km.is_done(),
-                    );
-                    if close_sign || close_keychain {
-                        self.modal = None;
+                    // Recompute path_ready / sigs against the newly merged
+                    // PSBT so the close decision below — and the outer view's
+                    // Sign→Broadcast swap — reflect the just-added signature.
+                    // The signature may have come from a local device
+                    // (`SignModal`'s own Updated arm) or a Keychain session
+                    // (which re-emits `Updated(Ok)` through here after its
+                    // merge+persist), so recompute unconditionally.
+                    if let Ok(sigs) = self
+                        .wallet
+                        .main_descriptor
+                        .partial_spend_info(&self.tx.psbt)
+                    {
+                        self.tx.sigs = sigs;
                     }
-                    if close_keychain {
-                        // Recompute path_ready / sigs against the
-                        // newly merged PSBT so the outer view knows
-                        // to swap the Sign buttons for Broadcast.
-                        if let Ok(sigs) = self
-                            .wallet
-                            .main_descriptor
-                            .partial_spend_info(&self.tx.psbt)
-                        {
-                            self.tx.sigs = sigs;
+                    // Close the unified picker only when the spending path
+                    // threshold is met, or when it was dismissed mid-flight
+                    // and its Keychain sessions have finished draining. A
+                    // single local/keychain signature that doesn't meet the
+                    // threshold keeps the picker open so more signers can be
+                    // added.
+                    let close = match modal {
+                        PsbtModal::Sign(sign) => {
+                            self.tx.path_ready().is_some() || sign.should_close_after_dismiss()
                         }
+                        _ => false,
+                    };
+                    if close {
+                        // Best-effort: cancel any Keychain sessions still in
+                        // flight so they don't outlive the closed picker.
+                        let extra = if let PsbtModal::Sign(sign) = modal {
+                            sign.cancel_keychain_if_active()
+                        } else {
+                            Task::none()
+                        };
+                        self.modal = None;
+                        return Task::batch([cmd, extra]);
                     }
                     return cmd;
                 }
@@ -721,6 +678,59 @@ fn connect_session_available(cache: &Cache) -> bool {
         || (cache.connect_tokens.is_some() && cache.connect_email.is_some())
 }
 
+/// Connect-readiness fields required to open a Keychain signing session.
+/// Returns the names of any that are missing — empty means ready.
+fn keychain_connect_missing(cache: &Cache) -> Vec<&'static str> {
+    [
+        ("connect_grpc_url", cache.connect_grpc_url.is_none()),
+        ("connect_tokens", cache.connect_tokens.is_none()),
+        ("connect_device_id", cache.connect_device_id.is_none()),
+        (
+            "current_cube_server_id",
+            cache.current_cube_server_id.is_none(),
+        ),
+    ]
+    .iter()
+    .filter_map(|(name, is_missing)| is_missing.then_some(*name))
+    .collect()
+}
+
+/// Build and launch a nested `KeychainSignModal` when Connect is ready.
+/// Returns `(None, Task::none())` when Connect isn't ready — the unified
+/// picker still shows keychain rows (disabled, derived from the descriptor)
+/// so the user can be prompted to sign in when they click one.
+fn build_keychain_if_ready(
+    cache: &Cache,
+    wallet: &Arc<Wallet>,
+    psbt: &Psbt,
+) -> (Option<super::keychain_sign::KeychainSignModal>, Task<Message>) {
+    if !keychain_connect_missing(cache).is_empty() {
+        return (None, Task::none());
+    }
+    let grpc_url = cache.connect_grpc_url.clone().expect("checked above");
+    let tokens = cache.connect_tokens.clone().expect("checked above");
+    let device_id = cache.connect_device_id.clone().expect("checked above");
+    let cube_server_id = cache.current_cube_server_id.expect("checked above");
+    // The REST client's bearer is set asynchronously inside
+    // `KeychainSignModal::launch()` (an async context) rather than here on
+    // the synchronous `update` path, which can't `blocking_read` the token.
+    let coincube_client = crate::services::coincube::CoincubeClient::new();
+    let descriptor_id = wallet.main_descriptor.to_string();
+    let modal = super::keychain_sign::KeychainSignModal::new(
+        wallet.clone(),
+        coincube_client,
+        tokens,
+        grpc_url,
+        device_id,
+        cube_server_id,
+        cache.cube_id.clone(),
+        descriptor_id,
+        psbt.clone(),
+    );
+    let launch = modal.launch();
+    (Some(modal), launch)
+}
+
 impl Modal for KeychainUnavailableModal {
     fn view<'a>(&'a self, content: Element<'a, view::Message>) -> Element<'a, view::Message> {
         modal::Modal::new(
@@ -973,9 +983,23 @@ pub struct SignModal {
     display_modal: bool,
     recovery_timelock: Option<u16>,
     border_wallet_recon: Option<BorderWalletReconstructionState>,
+    /// Nested multi-signer Keychain flow. `Some` when Connect was ready at
+    /// picker-open time (built + launched then). `None` when Connect isn't
+    /// ready — keychain rows still render (disabled, derived from the
+    /// descriptor) so the user can be prompted to sign in on click.
+    keychain: Option<super::keychain_sign::KeychainSignModal>,
+    /// Whether this picker offers Keychain signing at all. `true` for the
+    /// vault PSBT flow; `false` for contexts that sign locally only (e.g. the
+    /// Home send-to-self transfer), which suppresses keychain rows entirely
+    /// regardless of Connect state.
+    keychain_enabled: bool,
+    /// Recovery-path timelocks (sequences) the user has expanded. Inactive
+    /// spending-path cards default to collapsed; toggled via `ToggleSpendPath`.
+    expanded_paths: HashSet<u16>,
 }
 
 impl SignModal {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         signed: HashSet<Fingerprint>,
         wallet: Arc<Wallet>,
@@ -983,6 +1007,8 @@ impl SignModal {
         network: Network,
         is_saved: bool,
         recovery_timelock: Option<u16>,
+        keychain: Option<super::keychain_sign::KeychainSignModal>,
+        keychain_enabled: bool,
     ) -> Self {
         Self {
             signing: HashSet::new(),
@@ -995,13 +1021,297 @@ impl SignModal {
             display_modal: true,
             recovery_timelock,
             border_wallet_recon: None,
+            keychain,
+            keychain_enabled,
+            expanded_paths: HashSet::new(),
         }
     }
 
     pub fn is_signing(&self) -> bool {
         !self.signing.is_empty()
     }
+
+    /// Begin dismissing the picker. Cancels any in-flight keychain sessions
+    /// server-side and reports whether the modal must stay mounted (hidden)
+    /// to drain deferred cancels — mirroring the old standalone keychain
+    /// modal's dismissal contract. When kept, the picker self-closes via
+    /// `Message::Updated(Ok)` once every session reaches a terminal state.
+    pub fn begin_dismiss(&mut self) -> (Task<Message>, bool) {
+        let Some(k) = self.keychain.as_mut() else {
+            return (Task::none(), false);
+        };
+        let cancel = k.cancel_all();
+        let keep = k.has_undrained_sessions();
+        if keep {
+            k.mark_dismissed();
+            self.display_modal = false;
+        }
+        (cancel, keep)
+    }
+
+    /// True once the picker was dismissed (hidden) and its keychain sessions
+    /// have all drained — the signal the panel uses to finally drop it.
+    pub fn should_close_after_dismiss(&self) -> bool {
+        !self.display_modal
+            && self
+                .keychain
+                .as_ref()
+                .is_none_or(|k| !k.has_undrained_sessions())
+    }
+
+    /// Best-effort cancel of any keychain sessions still in flight, used when
+    /// the picker is about to close because the threshold was met so those
+    /// sessions don't outlive it server-side.
+    pub fn cancel_keychain_if_active(&mut self) -> Task<Message> {
+        match self.keychain.as_mut() {
+            Some(k) if k.has_undrained_sessions() => k.cancel_all(),
+            _ => Task::none(),
+        }
+    }
+
+    /// Build the spending-path cards for the unified picker, mirroring the
+    /// vault-creation "Set keys" layout: one card per descriptor path (primary
+    /// + each recovery), each listing its keys with per-key signability.
+    fn signing_paths(&self) -> Vec<view::vault::psbt::SigningPath> {
+        let policy = self.wallet.main_descriptor.policy();
+        let mut paths = Vec::new();
+        // The transaction spends through exactly one path: the primary when it
+        // has no recovery timelock, else the recovery path matching that
+        // timelock. Keys in the other paths render disabled.
+        let primary_active = self.recovery_timelock.is_none();
+        paths.push(self.build_signing_path(
+            "Primary spending option:".to_string(),
+            true,
+            None,
+            primary_active,
+            policy.primary_path(),
+        ));
+        for (seq, info) in policy.recovery_paths() {
+            let active = self.recovery_timelock == Some(*seq);
+            paths.push(self.build_signing_path(
+                "Recovery spending option:".to_string(),
+                false,
+                Some(*seq),
+                active,
+                info,
+            ));
+        }
+        paths
+    }
+
+    fn build_signing_path(
+        &self,
+        title: String,
+        is_primary: bool,
+        sequence: Option<u16>,
+        active: bool,
+        path_info: &coincube_core::descriptors::PathInfo,
+    ) -> view::vault::psbt::SigningPath {
+        use view::vault::psbt::{SigningKeyAction, SigningKeyRow, SigningKeyState, SigningPath};
+        let (threshold, origins) = path_info.thresh_origins();
+        let mut fps: Vec<Fingerprint> = origins.into_keys().collect();
+        fps.sort();
+        let total = fps.len();
+        let mut collected = 0;
+        let mut idle_keychain = 0;
+        let mut keys = Vec::new();
+        for fp in fps {
+            let (kind, state) = self.classify_signing_key(fp, active);
+            if matches!(state, SigningKeyState::Signed) {
+                collected += 1;
+            }
+            if matches!(state, SigningKeyState::Available(SigningKeyAction::Keychain)) {
+                idle_keychain += 1;
+            }
+            keys.push(SigningKeyRow {
+                fingerprint: fp,
+                label: self.signing_key_label(fp),
+                kind,
+                state,
+            });
+        }
+        SigningPath {
+            title,
+            is_primary,
+            sequence,
+            active,
+            threshold,
+            total,
+            collected,
+            keys,
+            // Only worth offering the batch affordance when it saves clicks —
+            // i.e. more than one idle Keychain signer to request at once.
+            can_request_all: active && self.keychain.is_some() && idle_keychain > 1,
+            // Active path is always expanded; inactive paths start collapsed
+            // and expand only when the user toggles them.
+            expanded: active || sequence.is_some_and(|s| self.expanded_paths.contains(&s)),
+        }
+    }
+
+    /// Determine a descriptor key's display kind (for its icon) and signing
+    /// state (signed / in-progress / available / retry / disabled). Signability
+    /// is derived dynamically — a connected hardware wallet, the master signer,
+    /// a border wallet, or a Connect-resolved Keychain signer — so an
+    /// unidentified key is shown disabled rather than guessed as Keychain.
+    fn classify_signing_key(
+        &self,
+        fp: Fingerprint,
+        active: bool,
+    ) -> (view::vault::psbt::SigningKeyKind, view::vault::psbt::SigningKeyState) {
+        use super::keychain_sign::PendingSessionStatus;
+        use view::vault::psbt::{SigningKeyAction as Act, SigningKeyKind as Kind, SigningKeyState as St};
+
+        let master_fp = self.wallet.signer.as_ref().map(|s| s.fingerprint());
+        // Keychain session for this key, only once the flow has resolved.
+        let kc = self.keychain.as_ref().filter(|k| k.is_resolved()).and_then(|k| {
+            k.pending()
+                .iter()
+                .enumerate()
+                .find(|(_, p)| p.fingerprint == fp)
+                .map(|(i, p)| {
+                    (
+                        i,
+                        p.status,
+                        p.status.is_terminal_success() && p.signed_psbt_persisted,
+                    )
+                })
+        });
+        let kind = self.signing_key_kind(fp, master_fp, kc.is_some());
+
+        // Signature already collected (local or keychain).
+        if self.signed.contains(&fp) || kc.map(|(_, _, s)| s).unwrap_or(false) {
+            return (kind, St::Signed);
+        }
+        // Inactive spending path — nothing here can sign this transaction.
+        if !active {
+            return (
+                kind,
+                St::Disabled("This spending path isn't available for this transaction.".to_string()),
+            );
+        }
+        // Local device operation in flight.
+        if self.signing.contains(&fp) {
+            return (kind, St::InProgress("Signing…".to_string()));
+        }
+        // Master signer on this computer.
+        if master_fp == Some(fp) {
+            return (kind, St::Available(Act::Master));
+        }
+        // Border wallet key.
+        if self.wallet.border_wallet_fingerprints.contains(&fp) {
+            return (kind, St::Available(Act::BorderWallet));
+        }
+        // A currently-connected hardware wallet matching this key.
+        if let Some(i) = self.hws.list.iter().position(|hw| hw.fingerprint() == Some(fp)) {
+            match &self.hws.list[i] {
+                HardwareWallet::Supported {
+                    registered: Some(false),
+                    ..
+                } => {
+                    return (
+                        Kind::Hardware,
+                        St::Disabled("Register the wallet on this device to sign.".to_string()),
+                    );
+                }
+                HardwareWallet::Supported { .. } => {
+                    return (Kind::Hardware, St::Available(Act::Hardware(i)));
+                }
+                HardwareWallet::Locked { .. } => {
+                    return (
+                        Kind::Hardware,
+                        St::Disabled("Unlock this device to sign.".to_string()),
+                    );
+                }
+                _ => {}
+            }
+        }
+        // A Connect-resolved Keychain signer.
+        if let Some((idx, status, _)) = kc {
+            return match status {
+                PendingSessionStatus::Idle => (Kind::Keychain, St::Available(Act::Keychain)),
+                PendingSessionStatus::Rejected
+                | PendingSessionStatus::Expired
+                | PendingSessionStatus::Failed => (Kind::Keychain, St::Retry(idx)),
+                other => (Kind::Keychain, St::InProgress(other.label().to_string())),
+            };
+        }
+        // Unidentified: an external key whose device isn't connected and which
+        // Connect hasn't resolved. Shown disabled — never guessed as Keychain.
+        // When Keychain is possible here but Connect is signed out, offer a
+        // clickable "Sign in to Connect" so any Keychain signer among these
+        // rows can be resolved.
+        if self.keychain_enabled && self.keychain.is_none() {
+            return (
+                Kind::Unknown,
+                St::NeedsSignIn("Connect a device, or".to_string()),
+            );
+        }
+        (
+            Kind::Unknown,
+            St::Disabled("Connect this signing device to sign.".to_string()),
+        )
+    }
+
+    /// Icon kind for a descriptor key: master / border / connected-hardware /
+    /// resolved-keychain, else unknown.
+    fn signing_key_kind(
+        &self,
+        fp: Fingerprint,
+        master_fp: Option<Fingerprint>,
+        is_keychain: bool,
+    ) -> view::vault::psbt::SigningKeyKind {
+        use view::vault::psbt::SigningKeyKind as Kind;
+        if master_fp == Some(fp) {
+            Kind::Master
+        } else if self.wallet.border_wallet_fingerprints.contains(&fp) {
+            Kind::BorderWallet
+        } else if self.hws.list.iter().any(|hw| hw.fingerprint() == Some(fp)) {
+            Kind::Hardware
+        } else if is_keychain {
+            Kind::Keychain
+        } else {
+            Kind::Unknown
+        }
+    }
+
+    /// Display label for a descriptor key: user alias, else the resolved
+    /// Keychain signer's name, else the short fingerprint.
+    fn signing_key_label(&self, fp: Fingerprint) -> String {
+        if let Some(alias) = self.wallet.keys_aliases.get(&fp) {
+            return alias.clone();
+        }
+        if let Some(k) = self.keychain.as_ref().filter(|k| k.is_resolved()) {
+            if let Some(p) = k.pending().iter().find(|p| p.fingerprint == fp) {
+                return p.label.clone();
+            }
+        }
+        format!("#{}", fp)
+    }
+
+    /// Keychain-flow banners for the unified picker (errors, degraded stream,
+    /// unaddressable signers) — surfaced above the signer list. Empty when no
+    /// keychain flow is active or everything is healthy.
+    fn keychain_notices(&self) -> Vec<String> {
+        let Some(k) = self.keychain.as_ref() else {
+            return Vec::new();
+        };
+        let mut notices = Vec::new();
+        if let Some(err) = k.error() {
+            notices.push(format!("Couldn't start Keychain signing: {}", err));
+        }
+        if let Some(banner) = k.stream_health_banner() {
+            notices.push(banner);
+        }
+        for u in k.unresolved() {
+            notices.push(format!(
+                "Can't sign with {} — this signer has no registered device.",
+                u
+            ));
+        }
+        notices
+    }
 }
+
 
 /// Ensure any in-progress Border Wallet reconstruction state is dropped
 /// (triggering its own `Drop` zeroization) when the sign modal goes away.
@@ -1013,7 +1323,14 @@ impl Drop for SignModal {
 
 impl Modal for SignModal {
     fn subscription(&self) -> Subscription<Message> {
-        self.hws.refresh().map(Message::HardwareWallets)
+        // Local device refresh plus, when a Keychain flow is active, its
+        // poll-fallback subscription so missed realtime `SessionEvent`s still
+        // get picked up while the user can also sign locally.
+        let hws = self.hws.refresh().map(Message::HardwareWallets);
+        match self.keychain.as_ref() {
+            Some(k) => Subscription::batch([hws, k.subscription()]),
+            None => hws,
+        }
     }
 
     fn update(
@@ -1115,6 +1432,13 @@ impl Modal for SignModal {
                     }
                     Ok(psbt) => {
                         self.error = None;
+                        // Bring the picker back into view after a local sign
+                        // (the border-wallet path hides it during the async
+                        // reconstruction). The picker now closes only when the
+                        // threshold is met — decided by the panel's
+                        // `Message::Updated(Ok)` handler — so a sub-threshold
+                        // signature should leave it visible to add more.
+                        self.display_modal = true;
                         self.signed.insert(fingerprint);
                         let daemon = daemon.clone();
                         merge_signatures(&mut tx.psbt, &psbt);
@@ -1169,6 +1493,27 @@ impl Modal for SignModal {
                     return Task::done(Message::View(view::Message::ShowError(err_msg)));
                 }
             },
+            // Expand/collapse an inactive spending-path card.
+            Message::View(view::Message::Spend(view::SpendTxMessage::ToggleSpendPath(seq))) => {
+                if !self.expanded_paths.remove(&seq) {
+                    self.expanded_paths.insert(seq);
+                }
+            }
+            // Forward all Keychain traffic to the nested modal: its own
+            // async results (`KeychainSign(_)`) plus the per-row user actions
+            // routed through the unified picker. `KeychainSignModal::update`
+            // runs the merge+persist and the dismissed-drain choke point.
+            Message::KeychainSign(_)
+            | Message::View(view::Message::Spend(
+                view::SpendTxMessage::SelectKeychainSigner(_)
+                | view::SpendTxMessage::RequestFromEveryone
+                | view::SpendTxMessage::RetryKeychainSigner(_)
+                | view::SpendTxMessage::CancelKeychainSign,
+            )) => {
+                if let Some(k) = self.keychain.as_mut() {
+                    return k.update(daemon, message, tx);
+                }
+            }
             _ => {}
         }
 
@@ -1186,22 +1531,11 @@ impl Modal for SignModal {
                     )))
                     .into()
             } else {
+                let paths = self.signing_paths();
+                let keychain_notices = self.keychain_notices();
                 modal::Modal::new(
                     content,
-                    view::vault::psbt::sign_action(
-                        &self.hws.list,
-                        &self.wallet.main_descriptor,
-                        self.wallet.signer.as_ref().map(|s| s.fingerprint()),
-                        self.wallet
-                            .signer
-                            .as_ref()
-                            .and_then(|signer| self.wallet.keys_aliases.get(&signer.fingerprint)),
-                        &self.signed,
-                        &self.signing,
-                        self.recovery_timelock,
-                        &self.wallet.border_wallet_fingerprints,
-                        &self.wallet.keys_aliases,
-                    ),
+                    view::vault::psbt::sign_action(paths, keychain_notices),
                 )
                 .on_blur(Some(view::Message::Spend(view::SpendTxMessage::Cancel)))
                 .into()

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -280,10 +280,11 @@ pub enum SpendTxMessage {
     /// the explicit "fan out to everyone" affordance. Flips all idle
     /// keychain rows into the requested/waiting state.
     RequestFromEveryone,
-    /// Expand/collapse an unavailable spending-path card in the signing picker,
-    /// keyed by its recovery timelock (sequence). Inactive paths default to
-    /// collapsed (header only).
-    ToggleSpendPath(u16),
+    /// Expand/collapse an unavailable spending-path card in the signing picker.
+    /// Keyed by the path's recovery timelock: `None` is the primary path (which
+    /// is inactive during a recovery spend), `Some(seq)` a recovery path.
+    /// Inactive paths default to collapsed (header only).
+    ToggleSpendPath(Option<u16>),
     /// Cancel all non-terminal `SigningSession`s tracked by the open
     /// signing picker's nested `KeychainSignModal`. Discards any partial
     /// signatures already returned — those are not merged into the PSBT

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -270,16 +270,24 @@ pub enum ImportSpendMessage {
 pub enum SpendTxMessage {
     Delete,
     Sign,
-    /// Open the Keychain signing flow: contact-signers and self-signers
-    /// whose private keys live on a Connect-registered phone. Routed to
-    /// `KeychainSignModal` which fetches vault members, classifies the
-    /// required signers, and orchestrates `SigningSession` lifecycles
-    /// via gRPC.
-    SignKeychain,
+    /// Request a Keychain signature from one specific signer, chosen from
+    /// the unified signing picker. Carries the descriptor fingerprint of
+    /// the keychain signer to address. Creates just that signer's
+    /// `SigningSession` (see `KeychainSignModal::request_signer`) rather
+    /// than fanning out to everyone at once.
+    SelectKeychainSigner(Fingerprint),
+    /// Request a Keychain signature from every eligible signer at once —
+    /// the explicit "fan out to everyone" affordance. Flips all idle
+    /// keychain rows into the requested/waiting state.
+    RequestFromEveryone,
+    /// Expand/collapse an unavailable spending-path card in the signing picker,
+    /// keyed by its recovery timelock (sequence). Inactive paths default to
+    /// collapsed (header only).
+    ToggleSpendPath(u16),
     /// Cancel all non-terminal `SigningSession`s tracked by the open
-    /// `KeychainSignModal`. Discards any partial signatures already
-    /// returned — those are not merged into the PSBT until all signers
-    /// have responded.
+    /// signing picker's nested `KeychainSignModal`. Discards any partial
+    /// signatures already returned — those are not merged into the PSBT
+    /// until all signers have responded.
     CancelKeychainSign,
     /// Retry a single signer whose session expired or was rejected.
     /// Carries the per-signer position in `KeychainSignModal::pending`.

--- a/coincube-gui/src/app/view/vault/psbt.rs
+++ b/coincube-gui/src/app/view/vault/psbt.rs
@@ -1286,12 +1286,12 @@ fn signing_key_row(row: &SigningKeyRow, color: iced::Color) -> Element<'static, 
             .push(p1_regular("Signed").color(color::GREEN))
             .push(icon::check_icon().style(theme::text::success))
             .into(),
-        SigningKeyState::InProgress(status) => {
-            p1_regular(status.clone()).style(theme::text::secondary).into()
-        }
-        SigningKeyState::Disabled(reason) => {
-            p1_regular(reason.clone()).style(theme::text::secondary).into()
-        }
+        SigningKeyState::InProgress(status) => p1_regular(status.clone())
+            .style(theme::text::secondary)
+            .into(),
+        SigningKeyState::Disabled(reason) => p1_regular(reason.clone())
+            .style(theme::text::secondary)
+            .into(),
         SigningKeyState::NeedsSignIn(reason) => Row::new()
             .spacing(10)
             .align_y(Alignment::Center)
@@ -1300,8 +1300,7 @@ fn signing_key_row(row: &SigningKeyRow, color: iced::Color) -> Element<'static, 
                 // Bubbles straight to the tab (which opens/focuses the Home
                 // tab for sign-in) without routing through the PSBT panel, so
                 // the picker stays open behind the new tab.
-                button::secondary(None, "Sign in to Connect")
-                    .on_press(Message::OpenConnectSignIn),
+                button::secondary(None, "Sign in to Connect").on_press(Message::OpenConnectSignIn),
             )
             .into(),
         SigningKeyState::Retry(idx) => button::secondary(Some(icon::reload_icon()), "Retry")
@@ -1384,7 +1383,11 @@ fn signing_path_card(path: SigningPath) -> Element<'static, Message> {
         can_request_all,
         expanded,
     } = path;
-    let color = if is_primary { color::GREEN } else { color::BLUE };
+    let color = if is_primary {
+        color::GREEN
+    } else {
+        color::BLUE
+    };
     let subtitle_text = if is_primary {
         "Able to move the funds at any time.".to_string()
     } else {
@@ -1436,9 +1439,7 @@ fn signing_path_card(path: SigningPath) -> Element<'static, Message> {
         .padding(10)
         .width(Length::Fill)
         .style(theme::button::transparent_border)
-        .on_press(Message::Spend(SpendTxMessage::ToggleSpendPath(
-            sequence.unwrap_or(0),
-        )))
+        .on_press(Message::Spend(SpendTxMessage::ToggleSpendPath(sequence)))
         .into()
     };
 

--- a/coincube-gui/src/app/view/vault/psbt.rs
+++ b/coincube-gui/src/app/view/vault/psbt.rs
@@ -7,7 +7,6 @@ use iced::{
 };
 
 use coincube_core::border_wallet::{CellRef, WordGrid, PATTERN_LENGTH};
-use coincube_core::descriptors::CoincubeDescriptor;
 use coincube_core::{
     descriptors::{CoincubePolicy, PathInfo, PathSpendInfo},
     miniscript::bitcoin::{
@@ -24,7 +23,7 @@ use coincube_ui::{
         amount::*,
         badge, button, card,
         collapse::Collapse,
-        form, hw, separation,
+        form, separation,
         text::{self, *},
     },
     icon, theme,
@@ -36,7 +35,7 @@ use crate::{
         cache::Cache,
         menu::{Menu, VaultSubMenu},
         state::vault::psbt::{BorderWalletReconstructionState, ReconStep},
-        view::{dashboard, message::*, vault::hw::hw_list_view, vault::label},
+        view::{dashboard, message::*, vault::label},
     },
     daemon::model::{Coin, SpendStatus, SpendTx},
     hw::HardwareWallet,
@@ -513,27 +512,16 @@ pub fn spend_overview_view<'a>(
                 Row::new()
                     .push(Space::new().width(Length::Fill))
                     .push(if tx.path_ready().is_none() {
-                        // While the path threshold isn't met, expose
-                        // both Sign (local signers: HW, master, border)
-                        // and Sign via Keychain (Connect-registered
-                        // signers on contacts' phones). The Keychain
-                        // button stays enabled even when Connect isn't
-                        // ready — the modal shows a clean error in
-                        // that case, which is better than a confusing
-                        // disabled state with no hint about why.
+                        // A single "Sign" entry point opens the unified
+                        // picker, which lists every signer — local (HW,
+                        // master, border) and Keychain (contacts' phones) —
+                        // as its own row.
                         Some(
-                            Row::new()
-                                .spacing(10)
-                                .push(
-                                    button::secondary(None, "Sign via Keychain")
-                                        .on_press(Message::Spend(SpendTxMessage::SignKeychain))
-                                        .width(Length::Fixed(200.0)),
-                                )
-                                .push(
-                                    button::primary(None, "Sign")
-                                        .on_press(Message::Spend(SpendTxMessage::Sign))
-                                        .width(Length::Fixed(150.0)),
-                                ),
+                            Row::new().push(
+                                button::primary(None, "Sign")
+                                    .on_press(Message::Spend(SpendTxMessage::Sign))
+                                    .width(Length::Fixed(150.0)),
+                            ),
                         )
                     } else {
                         Some(
@@ -1165,92 +1153,340 @@ fn change_view(
         .into()
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn sign_action<'a>(
-    hws: &'a [HardwareWallet],
-    descriptor: &CoincubeDescriptor,
-    signer: Option<Fingerprint>,
-    signer_alias: Option<&'a String>,
-    signed: &HashSet<Fingerprint>,
-    signing: &HashSet<Fingerprint>,
-    recovery_timelock: Option<u16>,
-    border_wallet_fingerprints: &'a HashSet<Fingerprint>,
-    keys_aliases: &'a HashMap<Fingerprint, String>,
-) -> Element<'a, Message> {
-    let mut signers_col = Column::new()
-        .push(
-            text("Select signing device to sign with:")
-                .bold()
-                .width(Length::Fill),
-        )
-        .spacing(10)
-        .push(
-            hws.iter()
-                .enumerate()
-                .fold(Column::new().spacing(10), |col, (i, hw)| {
-                    let (signed, signing, can_sign) =
-                        hw.fingerprint().map_or((false, false, false), |f| {
-                            (
-                                signed.contains(&f),
-                                signing.contains(&f),
-                                descriptor.contains_fingerprint_in_path(f, recovery_timelock),
-                            )
-                        });
-                    col.push(hw_list_view(i, hw, signed, signing, can_sign))
-                }),
-        )
-        .push({
-            signer.map(|fingerprint| {
-                let can_sign =
-                    descriptor.contains_fingerprint_in_path(fingerprint, recovery_timelock);
-                let btn = Button::new(if signed.contains(&fingerprint) {
-                    hw::sign_success_master_signer(fingerprint, signer_alias)
-                } else {
-                    hw::master_signer(fingerprint, signer_alias, can_sign)
-                })
-                .padding(10)
-                .style(theme::button::secondary)
-                .width(Length::Fill);
-                if can_sign {
-                    btn.on_press(Message::Spend(SpendTxMessage::SelectMasterSigner))
-                } else {
-                    btn
-                }
-            })
-        })
-        .width(Length::Fill);
+/// A Keychain signer row for the unified signing picker. Built by
+/// `SignModal` from the nested Keychain flow once resolved, or derived from
+/// the descriptor before/without Connect. `status_label == None` means the
+/// signer is idle (clickable to request a signature); `Some` shows live
+/// session state.
+pub enum SigningKeyKind {
+    Master,
+    Hardware,
+    BorderWallet,
+    Keychain,
+    /// Not identifiable from local data — an external key whose device isn't
+    /// connected and which Connect hasn't resolved. Shown disabled rather than
+    /// guessed as hardware or keychain.
+    Unknown,
+}
 
-    // Add border wallet keys
-    for fg in border_wallet_fingerprints {
-        let can_sign = descriptor.contains_fingerprint_in_path(*fg, recovery_timelock);
-        let alias = keys_aliases.get(fg);
-        let btn = Button::new(if signed.contains(fg) {
-            hw::sign_success_border_wallet(*fg, alias)
-        } else {
-            hw::border_wallet_signer(*fg, alias, can_sign)
-        })
-        .padding(10)
-        .style(theme::button::secondary)
-        .width(Length::Fill);
-        signers_col = signers_col.push(if can_sign && !signed.contains(fg) {
-            btn.on_press(Message::Spend(SpendTxMessage::SelectBorderWallet(*fg)))
-        } else {
-            btn
-        });
+/// What clicking an available key row does.
+pub enum SigningKeyAction {
+    Master,
+    Hardware(usize),
+    BorderWallet,
+    Keychain,
+}
+
+pub enum SigningKeyState {
+    /// Signature already collected for this key.
+    Signed,
+    /// A signing operation is under way; carries status text.
+    InProgress(String),
+    /// Ready to sign — carries the action to fire.
+    Available(SigningKeyAction),
+    /// Failed keychain session; carries the `pending` index for retry.
+    Retry(usize),
+    /// Can't sign right now; carries the reason shown on the row.
+    Disabled(String),
+    /// Unidentified key while Connect is signed out: carries a reason and a
+    /// clickable "Sign in to Connect" affordance so the user can authenticate
+    /// (which then resolves any Keychain signers among these rows).
+    NeedsSignIn(String),
+}
+
+pub struct SigningKeyRow {
+    pub fingerprint: Fingerprint,
+    pub label: String,
+    pub kind: SigningKeyKind,
+    pub state: SigningKeyState,
+}
+
+/// One spending-path card in the signing picker, mirroring the vault-creation
+/// "Set keys" layout: a titled, colored card with a subtitle, per-key rows and
+/// a "k out of n" threshold badge.
+pub struct SigningPath {
+    pub title: String,
+    pub is_primary: bool,
+    /// Recovery timelock (in blocks) for the subtitle; `None` for the primary.
+    pub sequence: Option<u16>,
+    /// Whether this is the path the transaction actually spends through. Keys
+    /// in inactive paths render disabled.
+    pub active: bool,
+    pub threshold: usize,
+    pub total: usize,
+    pub collected: usize,
+    pub keys: Vec<SigningKeyRow>,
+    /// True when the active path has ≥1 idle keychain signer, enabling the
+    /// "Request from everyone" batch affordance.
+    pub can_request_all: bool,
+    /// Whether the card is expanded (keys shown). Active paths are always
+    /// expanded; inactive paths default to collapsed and toggle via
+    /// `ToggleSpendPath`.
+    pub expanded: bool,
+}
+
+/// Short human duration for a recovery timelock, e.g. "1y 2m". Mirrors the
+/// creation flow's `format_sequence_duration` without the cross-module dep.
+fn humanize_timelock(sequence: u16) -> String {
+    let mut n_minutes = sequence as u32 * 10;
+    let n_years = n_minutes / 525_960;
+    n_minutes -= n_years * 525_960;
+    let n_months = n_minutes / 43_830;
+    n_minutes -= n_months * 43_830;
+    let n_days = n_minutes / 1_440;
+    n_minutes -= n_days * 1_440;
+    let n_hours = n_minutes / 60;
+    n_minutes -= n_hours * 60;
+    [
+        (n_years, "y"),
+        (n_months, "m"),
+        (n_days, "d"),
+        (n_hours, "h"),
+        (n_minutes, "mn"),
+    ]
+    .iter()
+    .filter(|(n, _)| *n > 0)
+    .map(|(n, unit)| format!("{}{}", n, unit))
+    .collect::<Vec<_>>()
+    .join(" ")
+}
+
+fn signing_key_kind_caption(kind: &SigningKeyKind) -> Option<&'static str> {
+    match kind {
+        SigningKeyKind::Master => Some("This computer"),
+        SigningKeyKind::Hardware => Some("Hardware wallet"),
+        SigningKeyKind::BorderWallet => Some("Border Wallet"),
+        SigningKeyKind::Keychain => Some("Keychain"),
+        SigningKeyKind::Unknown => None,
+    }
+}
+
+/// Render one signer row inside a spending-path card. The key icon is colored
+/// with the path color, matching the creation "Set keys" look.
+fn signing_key_row(row: &SigningKeyRow, color: iced::Color) -> Element<'static, Message> {
+    let key_icon = match row.kind {
+        SigningKeyKind::Hardware => icon::usb_drive_icon(),
+        _ => icon::round_key_icon(),
+    }
+    .size(text::H3_SIZE)
+    .style(theme::text::adaptive(color));
+
+    let mut info = Column::new()
+        .spacing(2)
+        .width(Length::Fill)
+        .push(p1_bold(row.label.clone()));
+    if let Some(caption) = signing_key_kind_caption(&row.kind) {
+        info = info.push(text::caption(caption));
     }
 
+    let right: Element<Message> = match &row.state {
+        SigningKeyState::Signed => Row::new()
+            .spacing(5)
+            .align_y(Alignment::Center)
+            .push(p1_regular("Signed").color(color::GREEN))
+            .push(icon::check_icon().style(theme::text::success))
+            .into(),
+        SigningKeyState::InProgress(status) => {
+            p1_regular(status.clone()).style(theme::text::secondary).into()
+        }
+        SigningKeyState::Disabled(reason) => {
+            p1_regular(reason.clone()).style(theme::text::secondary).into()
+        }
+        SigningKeyState::NeedsSignIn(reason) => Row::new()
+            .spacing(10)
+            .align_y(Alignment::Center)
+            .push(p1_regular(reason.clone()).style(theme::text::secondary))
+            .push(
+                // Bubbles straight to the tab (which opens/focuses the Home
+                // tab for sign-in) without routing through the PSBT panel, so
+                // the picker stays open behind the new tab.
+                button::secondary(None, "Sign in to Connect")
+                    .on_press(Message::OpenConnectSignIn),
+            )
+            .into(),
+        SigningKeyState::Retry(idx) => button::secondary(Some(icon::reload_icon()), "Retry")
+            .on_press(Message::Spend(SpendTxMessage::RetryKeychainSigner(*idx)))
+            .into(),
+        SigningKeyState::Available(action) => {
+            let (msg, label) = match action {
+                SigningKeyAction::Master => {
+                    (Message::Spend(SpendTxMessage::SelectMasterSigner), "Sign")
+                }
+                SigningKeyAction::Hardware(i) => (Message::SelectHardwareWallet(*i), "Sign"),
+                SigningKeyAction::BorderWallet => (
+                    Message::Spend(SpendTxMessage::SelectBorderWallet(row.fingerprint)),
+                    "Sign",
+                ),
+                SigningKeyAction::Keychain => (
+                    Message::Spend(SpendTxMessage::SelectKeychainSigner(row.fingerprint)),
+                    "Request",
+                ),
+            };
+            button::primary(None, label).on_press(msg).into()
+        }
+    };
+
     card::simple(
-        Column::new()
-            .push(signers_col)
-            .spacing(20)
+        Row::new()
+            .spacing(10)
             .width(Length::Fill)
-            .align_x(Alignment::Center),
+            .align_y(Alignment::Center)
+            .push(key_icon)
+            .push(info)
+            .push(right),
     )
-    // Wider than the other action cards so long device names (e.g. "Ledger
-    // Nano S Plus #…") and the "Processing… / Please check your device"
-    // prompt don't crowd each other while signing.
-    .width(Length::Fixed(620.0))
     .into()
+}
+
+/// The "k out of n" badge with mini key icons, adapted to show collected
+/// signatures. Colored icons = signatures collected; text = collected / threshold.
+fn signing_threshold_badge<'a>(
+    color: iced::Color,
+    collected: usize,
+    threshold: usize,
+    total: usize,
+) -> Element<'a, Message> {
+    card::simple(
+        Row::new()
+            .spacing(10)
+            .align_y(Alignment::Center)
+            .push((0..total).fold(Row::new(), |row, i| {
+                if i < collected {
+                    row.push(icon::round_key_icon().style(theme::text::adaptive(color)))
+                } else {
+                    row.push(icon::round_key_icon())
+                }
+            }))
+            .push(text(format!(
+                "{} of {} signature{} collected",
+                collected,
+                threshold,
+                if threshold == 1 { "" } else { "s" }
+            ))),
+    )
+    .padding(10)
+    .into()
+}
+
+/// Render one spending-path card, mirroring the creation "Set keys" page. The
+/// active path is fully expanded; inactive paths default to a collapsed header
+/// (title + subtitle + note) with a caret, toggled via `ToggleSpendPath`.
+fn signing_path_card(path: SigningPath) -> Element<'static, Message> {
+    let SigningPath {
+        title,
+        is_primary,
+        sequence,
+        active,
+        threshold,
+        total,
+        collected,
+        keys,
+        can_request_all,
+        expanded,
+    } = path;
+    let color = if is_primary { color::GREEN } else { color::BLUE };
+    let subtitle_text = if is_primary {
+        "Able to move the funds at any time.".to_string()
+    } else {
+        format!(
+            "Available after inactivity of ~{}",
+            sequence.map(humanize_timelock).unwrap_or_default()
+        )
+    };
+
+    // Header. For an inactive path it's a toggle button (with a caret and the
+    // "not available" note); for the active path it's a plain title + subtitle.
+    let header: Element<Message> = if active {
+        Column::new()
+            .spacing(6)
+            .push(Row::new().push(Space::new().width(10)).push(p1_bold(title)))
+            .push(
+                Row::new()
+                    .padding(5)
+                    .push(p1_regular(subtitle_text).style(theme::text::secondary)),
+            )
+            .into()
+    } else {
+        let caret = if expanded {
+            icon::collapsed_icon()
+        } else {
+            icon::collapse_icon()
+        };
+        Button::new(
+            Column::new()
+                .spacing(6)
+                .push(
+                    Row::new()
+                        .align_y(Alignment::Center)
+                        .spacing(20)
+                        .push(
+                            Column::new()
+                                .spacing(2)
+                                .width(Length::Fill)
+                                .push(p1_bold(title))
+                                .push(p1_regular(subtitle_text).style(theme::text::secondary)),
+                        )
+                        .push(caret),
+                )
+                .push(
+                    p2_regular("This spending path isn't available for this transaction.")
+                        .style(theme::text::secondary),
+                ),
+        )
+        .padding(10)
+        .width(Length::Fill)
+        .style(theme::button::transparent_border)
+        .on_press(Message::Spend(SpendTxMessage::ToggleSpendPath(
+            sequence.unwrap_or(0),
+        )))
+        .into()
+    };
+
+    let mut col = Column::new().spacing(10).push(header);
+
+    if expanded {
+        let mut keys_col = Column::new().spacing(5);
+        for key in &keys {
+            keys_col = keys_col.push(signing_key_row(key, color));
+        }
+        col = col
+            .push(keys_col)
+            .push(signing_threshold_badge(color, collected, threshold, total));
+        if can_request_all {
+            col = col.push(
+                button::secondary(None, "Request from everyone")
+                    .on_press(Message::Spend(SpendTxMessage::RequestFromEveryone))
+                    .width(Length::Fill),
+            );
+        }
+    }
+
+    Container::new(col)
+        .padding(10)
+        .style(theme::card::border)
+        .into()
+}
+
+/// The unified signing picker: spending-path cards (primary + recovery), each
+/// listing its keys with per-key signability, mirroring the vault-creation
+/// "Set keys" layout.
+pub fn sign_action<'a>(
+    paths: Vec<SigningPath>,
+    keychain_notices: Vec<String>,
+) -> Element<'a, Message> {
+    let mut col = Column::new().spacing(15).width(Length::Fill);
+    for notice in &keychain_notices {
+        col = col.push(p1_regular(notice.clone()).style(theme::text::secondary));
+    }
+    for path in paths {
+        col = col.push(signing_path_card(path));
+    }
+    card::simple(scrollable(col.padding(5)))
+        // Wide enough that long device names, the per-path key rows and their
+        // "Sign in to Connect" affordances don't crowd each other.
+        .width(Length::Fixed(780.0))
+        .max_height(760.0)
+        .into()
 }
 
 /// Render the Border Wallet reconstruction wizard within the signing modal.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches PSBT signing, Keychain session creation/cancel/dismiss semantics, and Connect gating—user-visible flow changes with server-side session lifecycle implications, but logic largely refactors existing KeychainSignModal behavior.
> 
> **Overview**
> Replaces the split **Sign** / **Sign via Keychain** PSBT UX with a **single Sign button** that opens a unified picker. Local signers (hardware, master, border) and Keychain signers appear together on **spending-path cards** (primary vs recovery), styled like vault creation’s “Set keys” view.
> 
> **Keychain behavior changes:** resolving signers no longer auto-creates `SigningSession`s for everyone. Rows start in **`Idle`** until the user clicks **Request** on one signer or **Request from everyone**. Connect is required only when a Keychain action is taken (otherwise **Keychain unavailable** / sign-in prompts). `KeychainSignModal` is **nested inside `SignModal`**; the top-level `PsbtModal::KeychainSign` variant is removed.
> 
> **Lifecycle:** the picker stays open until the spend path threshold is met (not after each partial signature). Dismiss still cancels or drains in-flight Keychain sessions via hidden modal state. Home **send-to-self** uses `SignModal` with `keychain_enabled: false` (local only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42f605cba4432a8782c107ceda750d418487d4fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->