### PR TITLE
Adjustments to node resource settings

### DIFF
--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -182,6 +182,17 @@ impl BitcoindSettingsState {
         }
     }
 
+    /// Apply a one-click machine-profile preset (Small/Regular computer) to the
+    /// node-resources editor fields. Nothing is written until the user hits
+    /// "Restart node to apply".
+    fn apply_node_resource_preset(&mut self, r: NodeResources) {
+        crate::node::bitcoind::set_prune_form_value(&mut self.node_prune_mb, r.prune_mb.to_string());
+        crate::node::bitcoind::set_max_mempool_form_value(
+            &mut self.node_max_mempool_mb,
+            r.max_mempool_mb.map(|mb| mb.to_string()).unwrap_or_default(),
+        );
+    }
+
     /// Build an `EsploraConfig` carrying `jwt` and dispatch a `LoadDaemonConfig`
     /// task that flips the active backend to Connect. Shared by the post-OTP
     /// path and the App-level fast path that reuses an existing Connect
@@ -787,15 +798,10 @@ impl State for BitcoindSettingsState {
                         );
                     }
                     NodeSettingsMessage::NodeResourceSmallComputer => {
-                        let r = NodeResources::small_computer();
-                        crate::node::bitcoind::set_prune_form_value(
-                            &mut self.node_prune_mb,
-                            r.prune_mb.to_string(),
-                        );
-                        crate::node::bitcoind::set_max_mempool_form_value(
-                            &mut self.node_max_mempool_mb,
-                            r.max_mempool_mb.map(|mb| mb.to_string()).unwrap_or_default(),
-                        );
+                        self.apply_node_resource_preset(NodeResources::small_computer());
+                    }
+                    NodeSettingsMessage::NodeResourceRegularComputer => {
+                        self.apply_node_resource_preset(NodeResources::regular_computer());
                     }
                     NodeSettingsMessage::NodeResourceApply => {
                         // Validate the fields; bail (leaving them flagged) on bad

--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -186,10 +186,15 @@ impl BitcoindSettingsState {
     /// node-resources editor fields. Nothing is written until the user hits
     /// "Restart node to apply".
     fn apply_node_resource_preset(&mut self, r: NodeResources) {
-        crate::node::bitcoind::set_prune_form_value(&mut self.node_prune_mb, r.prune_mb.to_string());
+        crate::node::bitcoind::set_prune_form_value(
+            &mut self.node_prune_mb,
+            r.prune_mb.to_string(),
+        );
         crate::node::bitcoind::set_max_mempool_form_value(
             &mut self.node_max_mempool_mb,
-            r.max_mempool_mb.map(|mb| mb.to_string()).unwrap_or_default(),
+            r.max_mempool_mb
+                .map(|mb| mb.to_string())
+                .unwrap_or_default(),
         );
     }
 
@@ -1748,8 +1753,8 @@ mod tests {
     #[test]
     fn node_resources_apply_preserves_ports_and_rpcauth() {
         use std::fs;
-        let base = std::env::temp_dir()
-            .join(format!("coincube-settings-noderes-{}", std::process::id()));
+        let base =
+            std::env::temp_dir().join(format!("coincube-settings-noderes-{}", std::process::id()));
         let _ = fs::remove_dir_all(&base);
         let datadir = CoincubeDirectory::new(base.clone());
         let config_path = internal_bitcoind_config_path(&internal_bitcoind_datadir(&datadir));
@@ -1812,8 +1817,10 @@ mod tests {
     #[test]
     fn node_resources_default_mempool_clears_key() {
         use std::fs;
-        let base = std::env::temp_dir()
-            .join(format!("coincube-settings-noderes-def-{}", std::process::id()));
+        let base = std::env::temp_dir().join(format!(
+            "coincube-settings-noderes-def-{}",
+            std::process::id()
+        ));
         let _ = fs::remove_dir_all(&base);
         let datadir = CoincubeDirectory::new(base.clone());
         let config_path = internal_bitcoind_config_path(&internal_bitcoind_datadir(&datadir));

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -567,6 +567,8 @@ pub enum NodeSettingsMessage {
     NodeResourceMaxMempoolEdited(String),
     /// One-click "Small computer" preset: 550 MB prune + 100 MB mempool.
     NodeResourceSmallComputer,
+    /// One-click "Regular computer" preset: 15 GB prune + default mempool.
+    NodeResourceRegularComputer,
     /// Validate the fields and restart the managed node to apply the new prune
     /// target / mempool cap.
     NodeResourceApply,

--- a/coincube-gui/src/app/view/vault/settings/mod.rs
+++ b/coincube-gui/src/app/view/vault/settings/mod.rs
@@ -2046,6 +2046,7 @@ pub fn node_resources_section<'a>(
         NodeSettingsMessage::NodeResourcePruneEdited,
         NodeSettingsMessage::NodeResourceMaxMempoolEdited,
         NodeSettingsMessage::NodeResourceSmallComputer,
+        NodeSettingsMessage::NodeResourceRegularComputer,
     );
 
     let apply: Element<'_, NodeSettingsMessage> = if processing {

--- a/coincube-gui/src/installer/message.rs
+++ b/coincube-gui/src/installer/message.rs
@@ -434,6 +434,8 @@ pub enum InternalBitcoindMsg {
     MaxMempoolEdited(String),
     /// One-click "Small computer" preset: 550 MB prune + 100 MB mempool.
     SmallComputerPreset,
+    /// One-click "Regular computer" preset: 15 GB prune + default mempool.
+    RegularComputerPreset,
     DefineConfig,
     Download,
     DownloadProgressed(super::step::DownloadUpdate),

--- a/coincube-gui/src/installer/step/node/bitcoind.rs
+++ b/coincube-gui/src/installer/step/node/bitcoind.rs
@@ -991,6 +991,14 @@ impl InternalBitcoindStep {
         bitcoind::set_max_mempool_form_value(&mut self.max_mempool_mb, value);
     }
 
+    /// Apply a one-click machine-profile preset (Small/Regular computer) to both
+    /// resource fields, revealing the advanced disclosure so the change is seen.
+    fn apply_resource_preset(&mut self, r: NodeResources) {
+        self.set_prune_field(r.prune_mb.to_string());
+        self.set_max_mempool_field(r.max_mempool_mb.map(|mb| mb.to_string()).unwrap_or_default());
+        self.show_advanced = true;
+    }
+
     /// Validate both resource fields and return the chosen values, marking the
     /// offending field invalid on failure. Returns `None` so `DefineConfig` bails
     /// without writing.
@@ -1126,14 +1134,10 @@ impl Step for InternalBitcoindStep {
                     self.set_max_mempool_field(value);
                 }
                 message::InternalBitcoindMsg::SmallComputerPreset => {
-                    let r = NodeResources::small_computer();
-                    self.set_prune_field(r.prune_mb.to_string());
-                    self.set_max_mempool_field(
-                        r.max_mempool_mb.map(|mb| mb.to_string()).unwrap_or_default(),
-                    );
-                    // Reveal the controls if the preset was reachable some other
-                    // way; harmless when already open.
-                    self.show_advanced = true;
+                    self.apply_resource_preset(NodeResources::small_computer());
+                }
+                message::InternalBitcoindMsg::RegularComputerPreset => {
+                    self.apply_resource_preset(NodeResources::regular_computer());
                 }
                 message::InternalBitcoindMsg::DefineConfig => {
                     // Validate the node-resource choices before touching files, so

--- a/coincube-gui/src/installer/step/node/bitcoind.rs
+++ b/coincube-gui/src/installer/step/node/bitcoind.rs
@@ -995,7 +995,11 @@ impl InternalBitcoindStep {
     /// resource fields, revealing the advanced disclosure so the change is seen.
     fn apply_resource_preset(&mut self, r: NodeResources) {
         self.set_prune_field(r.prune_mb.to_string());
-        self.set_max_mempool_field(r.max_mempool_mb.map(|mb| mb.to_string()).unwrap_or_default());
+        self.set_max_mempool_field(
+            r.max_mempool_mb
+                .map(|mb| mb.to_string())
+                .unwrap_or_default(),
+        );
         self.show_advanced = true;
     }
 
@@ -1546,8 +1550,7 @@ mod tests {
         use std::fs;
 
         // Small-computer preset → 550 prune + 100 maxmempool.
-        let base =
-            std::env::temp_dir().join(format!("coincube-noderes-sc-{}", std::process::id()));
+        let base = std::env::temp_dir().join(format!("coincube-noderes-sc-{}", std::process::id()));
         let _ = fs::remove_dir_all(&base);
         let datadir = CoincubeDirectory::new(base.clone());
         let mut step = InternalBitcoindStep::new(&datadir);
@@ -1565,7 +1568,10 @@ mod tests {
         );
         assert_eq!(conf.max_mempool_mb, Some(100));
         // Emitted general section carries the standalone maxmempool key.
-        assert_eq!(conf.to_ini().general_section().get("maxmempool"), Some("100"));
+        assert_eq!(
+            conf.to_ini().general_section().get("maxmempool"),
+            Some("100")
+        );
         let _ = fs::remove_dir_all(&base);
 
         // Untouched default path → 15000 prune, no maxmempool key.

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -1194,6 +1194,7 @@ pub fn node_resources_controls<'a, M>(
     on_prune: impl Fn(String) -> M + Clone + 'static,
     on_mempool: impl Fn(String) -> M + Clone + 'static,
     small_computer: M,
+    regular_computer: M,
 ) -> Column<'a, M>
 where
     M: Clone + 'a,
@@ -1214,6 +1215,11 @@ where
             .parse::<u32>()
             .unwrap_or(MAX_MEMPOOL_DEFAULT_MB)
     };
+    // "Default" mempool is the blank (key-omitted) state; "Small" is exactly the
+    // 100 MB cap. Used to highlight both the mempool presets and the one-click
+    // machine-profile buttons.
+    let mem_is_default = max_mempool.value.is_empty();
+    let mem_is_small = max_mempool.value.parse::<u32>().ok() == Some(MAX_MEMPOOL_SMALL_MB);
 
     // Prune presets: highlight the one matching the current value.
     let prune_preset = |label: &'static str, val: u32, on: &dyn Fn() -> M| {
@@ -1243,8 +1249,6 @@ where
 
     // Mempool presets: "Default" writes an empty string (key omitted); highlight
     // it whenever the field is blank.
-    let mem_is_default = max_mempool.value.is_empty();
-    let mem_is_small = max_mempool.value.parse::<u32>().ok() == Some(MAX_MEMPOOL_SMALL_MB);
     let small_btn = if mem_is_small {
         button::primary(None, "Small (100 MB)")
     } else {
@@ -1312,10 +1316,30 @@ where
                 ),
         )
         .push(Space::new().height(Length::Fixed(8.0)))
+        // One-click machine profiles. "Small computer" = 550 MB prune + 100 MB
+        // mempool; "Regular computer" = the 15 GB / 300 MB defaults. Highlighted
+        // when the current values match. A future "Miner" preset joins this row.
         .push(
-            button::secondary(None, "Small computer")
-                .width(Length::Fixed(180.0))
-                .on_press(small_computer),
+            Row::new()
+                .spacing(10)
+                .push(
+                    if prune_mb == PRUNE_MINIMAL_MB && mem_is_small {
+                        button::primary(None, "Small computer")
+                    } else {
+                        button::secondary(None, "Small computer")
+                    }
+                    .width(Length::Fixed(180.0))
+                    .on_press(small_computer),
+                )
+                .push(
+                    if prune_mb == PRUNE_DEFAULT && mem_is_default {
+                        button::primary(None, "Regular computer")
+                    } else {
+                        button::secondary(None, "Regular computer")
+                    }
+                    .width(Length::Fixed(180.0))
+                    .on_press(regular_computer),
+                ),
         )
         .push(
             text(format!(
@@ -1790,6 +1814,7 @@ pub fn start_internal_bitcoind<'a>(
                 |v| Message::InternalBitcoind(message::InternalBitcoindMsg::PruneEdited(v)),
                 |v| Message::InternalBitcoind(message::InternalBitcoindMsg::MaxMempoolEdited(v)),
                 Message::InternalBitcoind(message::InternalBitcoindMsg::SmallComputerPreset),
+                Message::InternalBitcoind(message::InternalBitcoindMsg::RegularComputerPreset),
             )));
         }
         col = col.push(

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -1184,9 +1184,11 @@ pub fn define_coincube_connect<'a>(
 /// drift. Presets are a thin setter layer over the two custom MB fields:
 /// `on_prune`/`on_mempool` receive the raw MB string the widget produces (an
 /// empty mempool string means "leave blank" = bitcoind's 300 MB default =
-/// `max_mempool_mb: None`). `small_computer` is the one-click preset that sets
-/// both. The estimated-total line is honest about the unprunable chainstate
-/// floor — the prune choice only bounds block data.
+/// `max_mempool_mb: None`). `small_computer` and `regular_computer` are the
+/// one-click machine-profile presets that set both fields at once (550 MB prune
+/// + 100 MB mempool, and the 15 GB / 300 MB defaults respectively). The
+/// estimated-total line is honest about the unprunable chainstate floor — the
+/// prune choice only bounds block data.
 #[allow(clippy::too_many_arguments)]
 pub fn node_resources_controls<'a, M>(
     prune: &'a form::Value<String>,

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -1204,8 +1204,10 @@ where
         PRUNE_DEFAULT, PRUNE_MINIMAL_MB,
     };
 
-    // Current values back the honest disk/memory estimate. A blank/invalid field
-    // falls back to the default so the line is always meaningful.
+    // Current values back the honest disk/memory estimate, updating live as the
+    // user types. A blank or unparseable field falls back to the default so the
+    // line is always meaningful; a parseable-but-below-floor value (e.g. 100) is
+    // shown as-is here and caught by validation on apply.
     let prune_mb = prune.value.parse::<u32>().unwrap_or(PRUNE_DEFAULT);
     let mem_mb = if max_mempool.value.is_empty() {
         MAX_MEMPOOL_DEFAULT_MB
@@ -1804,9 +1806,11 @@ pub fn start_internal_bitcoind<'a>(
         let mut col = Column::new()
             .spacing(25)
             .push(node_flavor_selector(flavor, existing_flavor))
-            .push(button::transparent(None, adv_label).on_press(Message::InternalBitcoind(
-                message::InternalBitcoindMsg::ToggleAdvanced,
-            )));
+            .push(
+                button::transparent(None, adv_label).on_press(Message::InternalBitcoind(
+                    message::InternalBitcoindMsg::ToggleAdvanced,
+                )),
+            );
         if show_advanced {
             col = col.push(card::simple(node_resources_controls(
                 prune,

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -1185,8 +1185,8 @@ pub fn define_coincube_connect<'a>(
 /// `on_prune`/`on_mempool` receive the raw MB string the widget produces (an
 /// empty mempool string means "leave blank" = bitcoind's 300 MB default =
 /// `max_mempool_mb: None`). `small_computer` and `regular_computer` are the
-/// one-click machine-profile presets that set both fields at once (550 MB prune
-/// + 100 MB mempool, and the 15 GB / 300 MB defaults respectively). The
+/// one-click machine-profile presets that set both fields at once — 550 MB prune
+/// with a 100 MB mempool cap, and the 15 GB / 300 MB defaults respectively. The
 /// estimated-total line is honest about the unprunable chainstate floor — the
 /// prune choice only bounds block data.
 #[allow(clippy::too_many_arguments)]

--- a/coincube-gui/src/node/bitcoind.rs
+++ b/coincube-gui/src/node/bitcoind.rs
@@ -591,6 +591,17 @@ impl NodeResources {
             max_mempool_mb: Some(MAX_MEMPOOL_SMALL_MB),
         }
     }
+
+    /// The one-click "Regular computer" preset: the out-of-the-box profile —
+    /// bitcoind's 15 GB default prune and default 300 MB mempool (key omitted).
+    /// The inverse of [`Self::small_computer`], and the middle of the
+    /// machine-profile row a future "Miner" preset joins.
+    pub fn regular_computer() -> Self {
+        Self {
+            prune_mb: PRUNE_DEFAULT,
+            max_mempool_mb: None,
+        }
+    }
 }
 
 /// Validate and store a prune-target value in `field` (the text widget already
@@ -1807,6 +1818,12 @@ mod tests {
         // 550 MB of block data rounds to ~1 GB, plus the ~14 GB overhead.
         assert_eq!(estimated_total_disk_gb(PRUNE_MINIMAL_MB), 1 + CHAINSTATE_OVERHEAD_GB);
         assert_eq!(estimated_total_disk_gb(PRUNE_DEFAULT), 15 + CHAINSTATE_OVERHEAD_GB);
+
+        // "Regular computer" is the out-of-the-box default profile: 15 GB prune
+        // and the key-omitted (300 MB) mempool default — the inverse of Small.
+        let reg = NodeResources::regular_computer();
+        assert_eq!(reg.prune_mb, PRUNE_DEFAULT);
+        assert_eq!(reg.max_mempool_mb, None);
     }
 
     // When both flavours are installed, the launched binary must match the

--- a/coincube-gui/src/node/bitcoind.rs
+++ b/coincube-gui/src/node/bitcoind.rs
@@ -593,9 +593,10 @@ impl NodeResources {
     }
 
     /// The one-click "Regular computer" preset: the out-of-the-box profile —
-    /// bitcoind's 15 GB default prune and default 300 MB mempool (key omitted).
-    /// The inverse of [`Self::small_computer`], and the middle of the
-    /// machine-profile row a future "Miner" preset joins.
+    /// the managed-node default 15 GB prune target ([`PRUNE_DEFAULT`]) and
+    /// bitcoind's own default 300 MB mempool (key omitted). The inverse of
+    /// [`Self::small_computer`], and the middle of the machine-profile row a
+    /// future "Miner" preset joins.
     pub fn regular_computer() -> Self {
         Self {
             prune_mb: PRUNE_DEFAULT,
@@ -1816,8 +1817,14 @@ mod tests {
         assert_eq!(r.max_mempool_mb, Some(100));
         // The estimated total is honest about the unprunable chainstate floor:
         // 550 MB of block data rounds to ~1 GB, plus the ~14 GB overhead.
-        assert_eq!(estimated_total_disk_gb(PRUNE_MINIMAL_MB), 1 + CHAINSTATE_OVERHEAD_GB);
-        assert_eq!(estimated_total_disk_gb(PRUNE_DEFAULT), 15 + CHAINSTATE_OVERHEAD_GB);
+        assert_eq!(
+            estimated_total_disk_gb(PRUNE_MINIMAL_MB),
+            1 + CHAINSTATE_OVERHEAD_GB
+        );
+        assert_eq!(
+            estimated_total_disk_gb(PRUNE_DEFAULT),
+            15 + CHAINSTATE_OVERHEAD_GB
+        );
 
         // "Regular computer" is the out-of-the-box default profile: 15 GB prune
         // and the key-omitted (300 MB) mempool default — the inverse of Small.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI and form-preset wiring only; node restart and `bitcoin.conf` apply paths are unchanged aside from deduplicated preset setters.
> 
> **Overview**
> Adds a **Regular computer** one-click preset (15 GB prune, default 300 MB mempool) alongside the existing **Small computer** profile on the installer advanced node-resources UI and Vault node settings.
> 
> Shared `node_resources_controls` now shows both machine-profile buttons in a row and **highlights** each when the current prune + mempool values match that profile. Preset application is centralized in `apply_node_resource_preset` / `apply_resource_preset` so installer and settings stay aligned; the installer still opens the advanced section when a preset is chosen.
> 
> `NodeResources::regular_computer()` is the data model for the new preset, with a unit test asserting it mirrors the default managed-node profile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 079259c480d5236954b982b9b36a7dbf37df637b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Regular computer” node-resource preset.
  * The preset uses a 15 GB prune target and the default mempool allocation.
  * Added one-click controls across node setup and settings screens.
  * Preset selection now reflects both storage and mempool settings.

* **Bug Fixes**
  * Improved consistency when applying node-resource presets, including default mempool handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->