### PR TITLE
feat(spark): validate cross-chain address + show conversion fee in sats

### DIFF
--- a/coincube-gui/src/app/state/spark/mod.rs
+++ b/coincube-gui/src/app/state/spark/mod.rs
@@ -83,15 +83,7 @@ pub(crate) fn unified_spark_balance_sats(
     stable: Option<&StableBalanceSnapshot>,
     cache: &Cache,
 ) -> u64 {
-    // `btc_usd_price` is only set when the user's fiat preference is USD; for
-    // other fiats fall back to the user-fiat converter's per-BTC price so the
-    // holding still shows (with a small FX-spread approximation) rather than
-    // collapsing to zero. Mirrors `global_home`'s SparkBalanceUpdated handler.
-    let reference_price = cache.btc_usd_price.or_else(|| {
-        let converter: Option<crate::app::view::FiatAmountConverter> =
-            cache.fiat_price.as_ref().and_then(|p| p.try_into().ok());
-        converter.map(|c| c.price_per_btc())
-    });
+    let reference_price = reference_btc_usd_price(cache);
     let usdb_as_sats = stable
         .map(|sb| {
             crate::app::breez_spark::assets::stable_token_as_sats(
@@ -102,4 +94,17 @@ pub(crate) fn unified_spark_balance_sats(
         })
         .unwrap_or(0);
     btc_sats.saturating_add(usdb_as_sats)
+}
+
+/// The BTC/USD price used to value USD-pegged tokens (USDB / USDT / USDC) in
+/// sats. `btc_usd_price` is only set when the user's fiat preference is USD; for
+/// other fiats fall back to the user-fiat converter's per-BTC price so a holding
+/// still shows (with a small FX-spread approximation) rather than collapsing to
+/// zero. `None` when no price is known. Mirrors `global_home`'s balance handler.
+pub(crate) fn reference_btc_usd_price(cache: &Cache) -> Option<f64> {
+    cache.btc_usd_price.or_else(|| {
+        let converter: Option<crate::app::view::FiatAmountConverter> =
+            cache.fiat_price.as_ref().and_then(|p| p.try_into().ok());
+        converter.map(|c| c.price_per_btc())
+    })
 }

--- a/coincube-gui/src/app/state/spark/mod.rs
+++ b/coincube-gui/src/app/state/spark/mod.rs
@@ -20,7 +20,6 @@ pub use send::{SparkSend, SparkSendPhase};
 pub use settings::SparkSettings;
 pub use transactions::SparkTransactions;
 
-use std::convert::TryInto;
 use std::sync::Arc;
 
 use coincube_spark_protocol::{PaymentSummary, StableBalanceSnapshot};
@@ -97,14 +96,12 @@ pub(crate) fn unified_spark_balance_sats(
 }
 
 /// The BTC/USD price used to value USD-pegged tokens (USDB / USDT / USDC) in
-/// sats. `btc_usd_price` is only set when the user's fiat preference is USD; for
-/// other fiats fall back to the user-fiat converter's per-BTC price so a holding
-/// still shows (with a small FX-spread approximation) rather than collapsing to
-/// zero. `None` when no price is known. Mirrors `global_home`'s balance handler.
+/// sats. The app always fetches a USD price for exactly this, regardless of the
+/// user's display fiat (see the `gui` loop's "Always fetch BTC/USD" path), so
+/// this just reads `cache.btc_usd_price`. `None` only in the brief window before
+/// that price lands (or if it fails); callers then show the token amount without
+/// a sats figure rather than valuing it at a non-USD rate — the user-fiat price
+/// (BTC/EUR, …) is *not* BTC/USD and would misprice a USD-pegged token.
 pub(crate) fn reference_btc_usd_price(cache: &Cache) -> Option<f64> {
-    cache.btc_usd_price.or_else(|| {
-        let converter: Option<crate::app::view::FiatAmountConverter> =
-            cache.fiat_price.as_ref().and_then(|p| p.try_into().ok());
-        converter.map(|c| c.price_per_btc())
-    })
+    cache.btc_usd_price
 }

--- a/coincube-gui/src/app/state/spark/send.rs
+++ b/coincube-gui/src/app/state/spark/send.rs
@@ -493,6 +493,7 @@ impl State for SparkSend {
                 recent_transactions: &self.recent_transactions,
                 balance_sats: self.balance_sats,
                 bitcoin_unit: cache.bitcoin_unit,
+                reference_btc_usd_price: super::reference_btc_usd_price(cache),
                 show_direction_badges: cache.show_direction_badges,
                 cross_chain_ctx: self.cross_chain.as_ref(),
                 slippage_input: &self.slippage_input,
@@ -951,6 +952,25 @@ async fn resolve_and_prepare(
         ));
     }
 
+    // A cross-chain (Solana / EVM / Tron) address parses as `Other` here — the
+    // SDK's Bitcoin parser drops it in the catch-all. Under a bitcoin rail
+    // that's a wrong-network paste, so probe the cross-chain parser and, if it
+    // recognises the address, reject with the chain named rather than letting
+    // it fail cryptically at prepare. A genuine `Other` (BOLT12) has no
+    // cross-chain address and falls through to the normal prepare below.
+    if matches!(parsed.kind, ParseInputKind::Other) {
+        if let Ok(routes) = backend.get_cross_chain_routes(input.clone()).await {
+            if let Some(addr) = routes.address {
+                return Err(format!(
+                    "This looks like {}, which can't receive bitcoin. Choose USDt or \
+                     USDC for what they receive to send there, or paste a Bitcoin \
+                     destination.",
+                    cross_chain_family_label(&addr.family),
+                ));
+            }
+        }
+    }
+
     match parsed.kind {
         ParseInputKind::LnurlPay | ParseInputKind::LightningAddress => {
             let amount = amount_sat.ok_or_else(|| {
@@ -982,6 +1002,17 @@ async fn resolve_and_prepare(
             .prepare_send(input, amount_sat)
             .await
             .map_err(|e| format!("prepare_send failed: {e}")),
+    }
+}
+
+/// Human label for a [`coincube_spark_protocol::CrossChainAddress`] family
+/// (`"evm"` / `"solana"` / `"tron"`), for the wrong-network error copy.
+fn cross_chain_family_label(family: &str) -> &'static str {
+    match family {
+        "solana" => "a Solana address",
+        "tron" => "a Tron address",
+        "evm" => "an EVM (Ethereum) address",
+        _ => "a cross-chain address",
     }
 }
 
@@ -1175,6 +1206,17 @@ mod tests {
         assert!(SparkSendTarget::Lightning.accepts_parsed(&K::Other));
         assert!(SparkSendTarget::OnChain.accepts_parsed(&K::Other));
         assert!(SparkSendTarget::Spark.accepts_parsed(&K::Other));
+    }
+
+    #[test]
+    fn cross_chain_family_label_names_the_chain() {
+        assert_eq!(cross_chain_family_label("solana"), "a Solana address");
+        assert_eq!(cross_chain_family_label("tron"), "a Tron address");
+        assert_eq!(cross_chain_family_label("evm"), "an EVM (Ethereum) address");
+        assert_eq!(
+            cross_chain_family_label("dogecoin"),
+            "a cross-chain address"
+        );
     }
 
     fn prepared_with_quote(expires_at: &str) -> PrepareSendOk {

--- a/coincube-gui/src/app/view/spark/send.rs
+++ b/coincube-gui/src/app/view/spark/send.rs
@@ -24,6 +24,7 @@ use iced::{
 
 use coincube_core::miniscript::bitcoin::{Amount, Network};
 
+use crate::app::breez_spark::assets::stable_token_as_sats;
 use crate::app::state::spark::cross_chain::{self, supported_on};
 use crate::app::state::spark::send::{CrossChainContext, SparkSendPhase, SparkSendTarget};
 use crate::app::view::shared::picker::picker_row;
@@ -43,6 +44,9 @@ pub struct SparkSendView<'a> {
     /// Unified balance (sats: BTC + Stable Balance), shown on the YOU SEND card.
     pub balance_sats: u64,
     pub bitcoin_unit: BitcoinDisplayUnit,
+    /// BTC/USD reference price for the cross-chain conversion-fee sats estimate.
+    /// `None` when no price is known — the fee then shows in the asset only.
+    pub reference_btc_usd_price: Option<f64>,
     pub show_direction_badges: bool,
     /// The "THEY RECEIVE" selection — drives the two-card selector and the
     /// destination placeholder.
@@ -143,6 +147,8 @@ impl<'a> SparkSendView<'a> {
             self.slippage_input,
             &self.advanced_open,
             self.quote_countdown.clone(),
+            self.reference_btc_usd_price,
+            self.bitcoin_unit,
         ));
 
         // ── Last transactions ─────────────────────────────────────────
@@ -164,6 +170,8 @@ fn phase_body<'a>(
     slippage_input: &str,
     advanced_open: &bool,
     quote_countdown: Option<cross_chain::QuoteCountdown>,
+    reference_btc_usd_price: Option<f64>,
+    bitcoin_unit: BitcoinDisplayUnit,
 ) -> Element<'a, Message> {
     use crate::app::view::SparkSendMessage;
     use coincube_ui::component::amount::format_u64_as_string;
@@ -350,13 +358,12 @@ fn phase_body<'a>(
                     ))
                     .push(kv_row(
                         "Conversion fee",
-                        format!(
-                            "{} {}",
-                            cross_chain::format_asset_amount(
-                                quote.fee_amount,
-                                quote.route.decimals
-                            ),
-                            quote.route.asset,
+                        conversion_fee_display(
+                            quote.fee_amount,
+                            quote.route.decimals,
+                            &quote.route.asset,
+                            reference_btc_usd_price,
+                            bitcoin_unit,
                         ),
                     ))
                     // Headline: the full sats debit from the wallet, fees
@@ -514,6 +521,43 @@ fn phase_body<'a>(
         .style(theme::card::simple)
         .into(),
     }
+}
+
+/// The cross-chain conversion fee for the preview: the fee in the destination
+/// asset, with a sats (or BTC) approximation alongside — the fee is quoted in
+/// USDT/USDC but the user spends bitcoin, so the sats figure is what compares
+/// against "Total you send". Asset-only when no BTC/USD price is available.
+fn conversion_fee_display(
+    fee_amount: u128,
+    decimals: u8,
+    asset: &str,
+    reference_btc_usd_price: Option<f64>,
+    bitcoin_unit: BitcoinDisplayUnit,
+) -> String {
+    let asset_part = format!(
+        "{} {}",
+        cross_chain::format_asset_amount(fee_amount, decimals),
+        asset,
+    );
+    // USDT/USDC are USD-pegged, so value the fee in sats the same way the wallet
+    // values its Stable Balance holding.
+    let sats = stable_token_as_sats(
+        fee_amount.min(u64::MAX as u128) as u64,
+        u32::from(decimals),
+        reference_btc_usd_price,
+    );
+    if sats == 0 {
+        return asset_part;
+    }
+    let unit = if matches!(bitcoin_unit, BitcoinDisplayUnit::BTC) {
+        "BTC"
+    } else {
+        "SATS"
+    };
+    format!(
+        "{asset_part} (≈ {} {unit})",
+        Amount::from_sat(sats).to_formatted_string_with_unit(bitcoin_unit),
+    )
 }
 
 fn kv_row<'a>(label: &'a str, value: String) -> Element<'a, Message> {
@@ -740,4 +784,22 @@ pub fn send_target_picker_modal<'a>(
         .push(text("THEY RECEIVE").size(16).bold())
         .push(list)
         .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conversion_fee_shows_a_sats_estimate_when_a_price_is_known() {
+        // 0.097921 USDT at $65,000/BTC ≈ 150 sats.
+        let s = conversion_fee_display(97_921, 6, "USDT", Some(65_000.0), BitcoinDisplayUnit::Sats);
+        assert_eq!(s, "0.097921 USDT (≈ 150 SATS)");
+    }
+
+    #[test]
+    fn conversion_fee_is_asset_only_without_a_price() {
+        let s = conversion_fee_display(97_921, 6, "USDT", None, BitcoinDisplayUnit::Sats);
+        assert_eq!(s, "0.097921 USDT");
+    }
 }

--- a/coincube-gui/src/app/view/spark/send.rs
+++ b/coincube-gui/src/app/view/spark/send.rs
@@ -539,16 +539,19 @@ fn conversion_fee_display(
         cross_chain::format_asset_amount(fee_amount, decimals),
         asset,
     );
-    // USDT/USDC are USD-pegged, so value the fee in sats the same way the wallet
-    // values its Stable Balance holding.
-    let sats = stable_token_as_sats(
-        fee_amount.min(u64::MAX as u128) as u64,
-        u32::from(decimals),
-        reference_btc_usd_price,
-    );
-    if sats == 0 {
+    // The sats hint needs a real BTC/USD price *and* a fee that fits the u64
+    // conversion input; without either, show the asset amount alone rather than
+    // a mispriced or clamped-and-understated estimate. (`sats == 0` alone can't
+    // gate this — it also means a sub-1-sat fee, which is still worth showing.)
+    let Some(price) = reference_btc_usd_price.filter(|p| *p > 0.0) else {
+        return asset_part;
+    };
+    if fee_amount > u64::MAX as u128 {
         return asset_part;
     }
+    // USDT/USDC are USD-pegged, so value the fee in sats the same way the wallet
+    // values its Stable Balance holding.
+    let sats = stable_token_as_sats(fee_amount as u64, u32::from(decimals), Some(price));
     let unit = if matches!(bitcoin_unit, BitcoinDisplayUnit::BTC) {
         "BTC"
     } else {
@@ -801,5 +804,31 @@ mod tests {
     fn conversion_fee_is_asset_only_without_a_price() {
         let s = conversion_fee_display(97_921, 6, "USDT", None, BitcoinDisplayUnit::Sats);
         assert_eq!(s, "0.097921 USDT");
+    }
+
+    #[test]
+    fn conversion_fee_shows_the_hint_for_a_sub_one_sat_fee_when_priced() {
+        // A tiny fee rounds to 0 sats, but with a price known the hint should
+        // still show — the old `sats == 0` gate wrongly suppressed it.
+        let s = conversion_fee_display(1, 6, "USDT", Some(65_000.0), BitcoinDisplayUnit::Sats);
+        assert_eq!(s, "0.000001 USDT (≈ 0 SATS)");
+    }
+
+    #[test]
+    fn conversion_fee_skips_the_hint_when_the_fee_overflows_u64() {
+        // A fee that doesn't fit u64 must not be clamped-and-understated — drop
+        // the sats hint rather than show a wrong figure.
+        let s = conversion_fee_display(
+            u128::MAX,
+            6,
+            "USDT",
+            Some(65_000.0),
+            BitcoinDisplayUnit::Sats,
+        );
+        assert!(
+            !s.contains('≈'),
+            "an overflowing fee must not show a clamped estimate: {}",
+            s
+        );
     }
 }


### PR DESCRIPTION
Two Spark Send follow-ups:

1. A cross-chain address (Solana / EVM / Tron) pasted under a bitcoin rail parses as Other and slipped past the rail check, then failed cryptically at prepare. resolve_and_prepare now probes get_cross_chain_routes for Other inputs and, if the address is recognised, rejects with the chain named ("This looks like a Solana address ... choose USDt or USDC ..."). Genuine Other inputs (BOLT12) have no cross-chain address and still prepare normally.

2. The cross-chain preview's conversion fee, quoted in USDT/USDC, now shows a sats (or BTC) approximation alongside — the user spends bitcoin, so the sats figure is what compares against "Total you send". Reuses stable_token_as_sats at the same BTC/USD reference price the balance uses, extracted into a shared reference_btc_usd_price helper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches send validation and how USD-pegged holdings/fees are valued in sats; wrong pricing or an extra routes probe could mislead users or add latency on ambiguous `Other` inputs.
> 
> **Overview**
> **Spark Send** gets clearer errors and fee preview when users mix rails.
> 
> On a **bitcoin** “they receive” rail, Solana/EVM/Tron addresses that parse as `Other` are now checked via `get_cross_chain_routes` before `prepare_send`, with copy that names the chain and points users to USDt/USDC.
> 
> The cross-chain **conversion fee** line shows the USDT/USDC amount plus an optional **≈ sats/BTC** estimate using the same `reference_btc_usd_price` (`cache.btc_usd_price`) as stable-balance valuation—asset-only when price is missing or the fee won’t fit `u64`.
> 
> `unified_spark_balance_sats` no longer falls back to the user’s fiat `price_per_btc` for token→sats conversion; it uses that shared BTC/USD reference only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c867bba8f7efc9158276ad4d41214fcdf224b06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an estimated BTC/sats equivalent to cross-chain conversion fees when a BTC/USD reference price is available.
  - Added clearer wrong-network guidance when a Bitcoin destination is entered for another supported chain.

- **Bug Fixes**
  - Improved conversion fee display when BTC/USD pricing is unavailable by showing the asset-only amount.
  - Centralized BTC/USD reference pricing with a fallback to fiat-based conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->