### PR TITLE
Debug Cube Recovery

### DIFF
--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -341,13 +341,16 @@ pub struct PendingLiquidToVaultTransfer {
 }
 
 impl CubeSettings {
-    /// Create a new `CubeSettings` with a caller-supplied UUID.
-    ///
-    /// The frontend should generate this UUID before initiating the creation
-    /// request so that retries reuse the same identifier (idempotent creation).
-    pub fn new_with_id(id: uuid::Uuid, name: String, network: Network) -> Self {
+    /// Create a new `CubeSettings` with a caller-supplied id string, taken
+    /// verbatim — no round-trip through `uuid::Uuid`, so the byte-exact value
+    /// is preserved. Used by Cube recovery, where the restored Cube's id must
+    /// string-match the server-side record for the idempotent `register_cube`
+    /// call to reactivate the original Cube instead of minting a duplicate
+    /// (parsing + re-formatting would normalize case; a malformed value would
+    /// force a lossy fallback).
+    pub fn new_with_raw_id(id: String, name: String, network: Network) -> Self {
         Self {
-            id: id.to_string(),
+            id,
             name,
             network,
             created_at: chrono::Utc::now().timestamp(),
@@ -370,6 +373,14 @@ impl CubeSettings {
             balance_masked: false,
             recovery_kit_last_backed_up_descriptor_fingerprint: None,
         }
+    }
+
+    /// Create a new `CubeSettings` with a caller-supplied UUID.
+    ///
+    /// The frontend should generate this UUID before initiating the creation
+    /// request so that retries reuse the same identifier (idempotent creation).
+    pub fn new_with_id(id: uuid::Uuid, name: String, network: Network) -> Self {
+        Self::new_with_raw_id(id.to_string(), name, network)
     }
 
     pub fn new(name: String, network: Network) -> Self {

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -1801,12 +1801,34 @@ async fn find_or_create_cube(
             // are its source of truth. The restore flow only overwrites
             // Cube-level credentials when we're actually minting a new
             // Cube for the restored wallet.
-            if let Some(existing_cube) = settings_data
+            if let Some(existing_idx) = settings_data
                 .cubes
                 .iter()
-                .find(|c| c.vault_wallet_id.as_ref() == Some(wallet_id))
+                .position(|c| c.vault_wallet_id.as_ref() == Some(wallet_id))
             {
-                return Ok(existing_cube.clone());
+                // On a Recovery-Kit restore we must reconcile identity *before*
+                // returning this match: if the wallet is attached to a cube with
+                // a **different** UUID than the one being restored, that's the
+                // old-bug duplicate (a prior buggy recovery minted a new Cube).
+                // Returning it here would leave the duplicate attached and the
+                // original still recoverable — the very bug this flow fixes. So
+                // detach it and fall through, letting the restore reconciliation
+                // below re-attach the wallet to the restored UUID (reused or
+                // minted). Identities agree (or no restore) → normal return.
+                match &restored_cube {
+                    Some(identity) if settings_data.cubes[existing_idx].id != identity.uuid => {
+                        info!(
+                            "Wallet {} was attached to duplicate cube '{}' ({}); detaching to \
+                             reconcile with restored UUID {}",
+                            wallet_id,
+                            settings_data.cubes[existing_idx].name,
+                            settings_data.cubes[existing_idx].id,
+                            identity.uuid,
+                        );
+                        settings_data.cubes[existing_idx].vault_wallet_id = None;
+                    }
+                    _ => return Ok(settings_data.cubes[existing_idx].clone()),
+                }
             }
 
             // Recovery-Kit restore: the restored Cube must carry the deleted
@@ -2395,5 +2417,66 @@ mod find_or_create_cube_tests {
         assert_ne!(cube.id, ORIG_UUID);
         assert_eq!(cube.name, "My Alias");
         assert_eq!(cube.vault_wallet_id.as_ref(), Some(&wid));
+    }
+
+    /// Upgrade path: a previous (buggy) recovery left the wallet attached to a
+    /// *duplicate* Cube with a different UUID, while the original Cube is still
+    /// recoverable. Re-running recovery must reconcile — move the wallet onto
+    /// the restored (original) UUID and detach the duplicate — rather than
+    /// returning the stale duplicate match and leaving the original recoverable.
+    #[tokio::test]
+    async fn restore_reconciles_wallet_off_a_duplicate_uuid() {
+        let nd = temp_network_dir("dup-uuid");
+        let wid = wallet_id();
+
+        // The exact state the old bug produced: a duplicate Cube (its own,
+        // different UUID) already holds the wallet.
+        let mut settings = app::settings::Settings::default();
+        let dup =
+            app::settings::CubeSettings::new("Duplicate".to_string(), bitcoin::Network::Bitcoin)
+                .with_vault(wid.clone());
+        let dup_id = dup.id.clone();
+        assert_ne!(
+            dup_id, ORIG_UUID,
+            "duplicate must not already carry the original UUID"
+        );
+        settings.cubes.push(dup);
+        update_settings_file(&nd, |_| Some(settings)).await.unwrap();
+
+        let cube = find_or_create_cube(
+            &nd,
+            &wid,
+            &None,
+            bitcoin::Network::Bitcoin,
+            None,
+            Some(RestoreCubeIdentity {
+                uuid: ORIG_UUID.to_string(),
+                name: "My Vault".to_string(),
+            }),
+            None,
+        )
+        .await
+        .expect("restore should succeed");
+
+        // The wallet now lives on the restored (original) UUID, not the duplicate.
+        assert_eq!(cube.id, ORIG_UUID, "wallet must move to the restored UUID");
+        assert_eq!(cube.vault_wallet_id.as_ref(), Some(&wid));
+
+        let reloaded = app::settings::Settings::from_file(&nd).unwrap();
+        let dup_after = reloaded
+            .cubes
+            .iter()
+            .find(|c| c.id == dup_id)
+            .expect("duplicate cube is kept, just detached");
+        assert_eq!(
+            dup_after.vault_wallet_id, None,
+            "the duplicate Cube must no longer be attached to the wallet"
+        );
+        let restored = reloaded
+            .cubes
+            .iter()
+            .find(|c| c.id == ORIG_UUID)
+            .expect("restored cube exists");
+        assert_eq!(restored.vault_wallet_id.as_ref(), Some(&wid));
     }
 }

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -2274,7 +2274,10 @@ mod find_or_create_cube_tests {
             cube.id, ORIG_UUID,
             "restored Cube must keep the original UUID"
         );
-        assert_eq!(cube.name, "My Vault", "restored Cube keeps the original name");
+        assert_eq!(
+            cube.name, "My Vault",
+            "restored Cube keeps the original name"
+        );
         assert_eq!(cube.vault_wallet_id.as_ref(), Some(&wid));
     }
 

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -1812,20 +1812,21 @@ async fn find_or_create_cube(
                 // old-bug duplicate (a prior buggy recovery minted a new Cube).
                 // Returning it here would leave the duplicate attached and the
                 // original still recoverable — the very bug this flow fixes. So
-                // detach it and fall through, letting the restore reconciliation
-                // below re-attach the wallet to the restored UUID (reused or
-                // minted). Identities agree (or no restore) → normal return.
+                // drop the spurious duplicate entirely and fall through, letting
+                // the restore reconciliation below re-attach the wallet to the
+                // restored UUID (reused or minted). Identities agree (or no
+                // restore) → normal return.
                 match &restored_cube {
                     Some(identity) if settings_data.cubes[existing_idx].id != identity.uuid => {
                         info!(
-                            "Wallet {} was attached to duplicate cube '{}' ({}); detaching to \
+                            "Wallet {} was attached to duplicate cube '{}' ({}); removing it to \
                              reconcile with restored UUID {}",
                             wallet_id,
                             settings_data.cubes[existing_idx].name,
                             settings_data.cubes[existing_idx].id,
                             identity.uuid,
                         );
-                        settings_data.cubes[existing_idx].vault_wallet_id = None;
+                        settings_data.cubes.remove(existing_idx);
                     }
                     _ => return Ok(settings_data.cubes[existing_idx].clone()),
                 }
@@ -2422,7 +2423,7 @@ mod find_or_create_cube_tests {
     /// Upgrade path: a previous (buggy) recovery left the wallet attached to a
     /// *duplicate* Cube with a different UUID, while the original Cube is still
     /// recoverable. Re-running recovery must reconcile — move the wallet onto
-    /// the restored (original) UUID and detach the duplicate — rather than
+    /// the restored (original) UUID and remove the duplicate — rather than
     /// returning the stale duplicate match and leaving the original recoverable.
     #[tokio::test]
     async fn restore_reconciles_wallet_off_a_duplicate_uuid() {
@@ -2463,14 +2464,14 @@ mod find_or_create_cube_tests {
         assert_eq!(cube.vault_wallet_id.as_ref(), Some(&wid));
 
         let reloaded = app::settings::Settings::from_file(&nd).unwrap();
-        let dup_after = reloaded
-            .cubes
-            .iter()
-            .find(|c| c.id == dup_id)
-            .expect("duplicate cube is kept, just detached");
+        assert!(
+            reloaded.cubes.iter().all(|c| c.id != dup_id),
+            "the spurious duplicate Cube must be removed outright"
+        );
         assert_eq!(
-            dup_after.vault_wallet_id, None,
-            "the duplicate Cube must no longer be attached to the wallet"
+            reloaded.cubes.len(),
+            1,
+            "only the restored Cube should remain"
         );
         let restored = reloaded
             .cubes

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -656,7 +656,11 @@ impl Tab {
                     // `context.cube_id` there is that existing Cube's identity —
                     // not a restore target — so we deliberately skip it.
                     let restored_cube = if i.cube_settings.is_none() {
-                        i.context.cube_id.clone().zip(i.context.cube_name.clone())
+                        i.context
+                            .cube_id
+                            .clone()
+                            .zip(i.context.cube_name.clone())
+                            .map(|(uuid, name)| RestoreCubeIdentity { uuid, name })
                     } else {
                         None
                     };
@@ -1728,17 +1732,31 @@ struct RestoreCubeSeed {
     master_signer_fingerprint: bitcoin::bip32::Fingerprint,
 }
 
+/// The deleted Cube's original identity, carried out of the decrypted
+/// kit/envelope by the restore steps (via `ctx.cube_id` / `ctx.cube_name`).
+/// Both fields are always present together: a restore either knows the full
+/// original identity or it isn't a seed restore at all — which is why
+/// `find_or_create_cube` takes `Option<RestoreCubeIdentity>` rather than a
+/// struct of `Option`s.
+struct RestoreCubeIdentity {
+    /// Original UUID, preserved verbatim (see `CubeSettings::new_with_raw_id`).
+    uuid: String,
+    /// Original display name, so the revived Cube doesn't inherit the
+    /// wallet-alias default.
+    name: String,
+}
+
 async fn find_or_create_cube(
     network_dir: &NetworkDirectory,
     wallet_id: &WalletId,
     wallet_alias: &Option<String>,
     network: bitcoin::Network,
     originating_cube_id: Option<String>,
-    // `(original_uuid, original_name)` for a Recovery-Kit *seed* restore. When
-    // present, the restored Cube reuses the deleted Cube's UUID so the Connect
+    // Original Cube identity for a Recovery-Kit *seed* restore. When present,
+    // the restored Cube reuses the deleted Cube's UUID so the Connect
     // `register_cube` call (idempotent on UUID) reactivates it rather than
     // creating a duplicate. `None` for every non-restore flow.
-    restored_cube: Option<(String, String)>,
+    restored_cube: Option<RestoreCubeIdentity>,
     restore_seed: Option<&RestoreCubeSeed>,
 ) -> Result<app::settings::CubeSettings, String> {
     // Helper: decorate a freshly-minted CubeSettings with
@@ -1756,17 +1774,16 @@ async fn find_or_create_cube(
         };
 
     // Base CubeSettings for a *brand-new* Cube. On the Recovery-Kit restore
-    // path we reuse the deleted Cube's original UUID + name; otherwise fall
-    // back to a fresh UUID + the wallet alias. The UUID is preserved verbatim
-    // (not round-tripped through `uuid::Uuid`) so the server-side UUID string
-    // match `register_cube` relies on stays exact.
+    // path we reuse the deleted Cube's original UUID + name (verbatim — see
+    // `new_with_raw_id`); otherwise fall back to a fresh UUID + the wallet
+    // alias.
     let new_cube_base = || -> app::settings::CubeSettings {
         match &restored_cube {
-            Some((uuid, name)) => {
-                let mut cube = app::settings::CubeSettings::new(name.clone(), network);
-                cube.id = uuid.clone();
-                cube
-            }
+            Some(identity) => app::settings::CubeSettings::new_with_raw_id(
+                identity.uuid.clone(),
+                identity.name.clone(),
+                network,
+            ),
             None => app::settings::CubeSettings::new(
                 wallet_alias
                     .clone()
@@ -1802,7 +1819,7 @@ async fn find_or_create_cube(
             // its own UUID) is exactly the duplicate we're trying to avoid. If
             // a local Cube already carries the original UUID (a re-run),
             // reuse it; otherwise mint one with that UUID.
-            if let Some((uuid, _)) = &restored_cube {
+            if let Some(RestoreCubeIdentity { uuid, .. }) = &restored_cube {
                 if let Some(idx) = settings_data.cubes.iter().position(|c| &c.id == uuid) {
                     if settings_data.cubes[idx].vault_wallet_id.is_some() {
                         return Err(format!(
@@ -2264,7 +2281,10 @@ mod find_or_create_cube_tests {
             &Some("Ignored Alias".to_string()),
             bitcoin::Network::Bitcoin,
             None, // originating_cube_id
-            Some((ORIG_UUID.to_string(), "My Vault".to_string())),
+            Some(RestoreCubeIdentity {
+                uuid: ORIG_UUID.to_string(),
+                name: "My Vault".to_string(),
+            }),
             None, // restore_seed
         )
         .await
@@ -2302,7 +2322,10 @@ mod find_or_create_cube_tests {
             &None,
             bitcoin::Network::Bitcoin,
             None,
-            Some((ORIG_UUID.to_string(), "My Vault".to_string())),
+            Some(RestoreCubeIdentity {
+                uuid: ORIG_UUID.to_string(),
+                name: "My Vault".to_string(),
+            }),
             None,
         )
         .await
@@ -2333,7 +2356,10 @@ mod find_or_create_cube_tests {
             &None,
             bitcoin::Network::Bitcoin,
             None,
-            Some((ORIG_UUID.to_string(), "My Vault".to_string())),
+            Some(RestoreCubeIdentity {
+                uuid: ORIG_UUID.to_string(),
+                name: "My Vault".to_string(),
+            }),
             None,
         )
         .await

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -642,6 +642,25 @@ impl Tab {
                     let network = i.network;
                     let originating_cube_id = i.cube_settings.as_ref().map(|c| c.id.clone());
 
+                    // Recovery-Kit *seed* restore: the deleted Cube's original
+                    // UUID + name, threaded through the context by
+                    // `RecoveryKitRestoreStep` from the decrypted kit.
+                    // `find_or_create_cube` re-mints the Cube with this UUID so
+                    // Connect re-registration reactivates the deleted Cube
+                    // instead of creating a duplicate. Gated on
+                    // `cube_settings.is_none()`: that's the wiped-install
+                    // recovery flow (launched from Home with no local Cube to
+                    // attach to). When a Cube shell already exists locally
+                    // (`cube_settings.is_some()`, e.g. AddWallet inside a Cube)
+                    // the `originating_cube_id` path owns that association, and
+                    // `context.cube_id` there is that existing Cube's identity —
+                    // not a restore target — so we deliberately skip it.
+                    let restored_cube = if i.cube_settings.is_none() {
+                        i.context.cube_id.clone().zip(i.context.cube_name.clone())
+                    } else {
+                        None
+                    };
+
                     // Capture restore-flow state up-front. Cloning the
                     // `Zeroizing<String>` here means the PIN copy
                     // carried into the Task is its own heap-zeroing
@@ -666,6 +685,7 @@ impl Tab {
                                 &wallet_alias,
                                 network,
                                 originating_cube_id,
+                                restored_cube,
                                 restore_seed.as_ref(),
                             )
                             .await?;
@@ -1714,11 +1734,16 @@ async fn find_or_create_cube(
     wallet_alias: &Option<String>,
     network: bitcoin::Network,
     originating_cube_id: Option<String>,
+    // `(original_uuid, original_name)` for a Recovery-Kit *seed* restore. When
+    // present, the restored Cube reuses the deleted Cube's UUID so the Connect
+    // `register_cube` call (idempotent on UUID) reactivates it rather than
+    // creating a duplicate. `None` for every non-restore flow.
+    restored_cube: Option<(String, String)>,
     restore_seed: Option<&RestoreCubeSeed>,
 ) -> Result<app::settings::CubeSettings, String> {
     // Helper: decorate a freshly-minted CubeSettings with
     // PIN + master-signer-fingerprint when we're on the restore path.
-    // Pulled out so the three "new cube" branches share one code path.
+    // Pulled out so the "new cube" branches share one code path.
     let decorate_new =
         |mut cube: app::settings::CubeSettings| -> Result<app::settings::CubeSettings, String> {
             if let Some(seed) = restore_seed {
@@ -1729,6 +1754,27 @@ async fn find_or_create_cube(
             }
             Ok(cube)
         };
+
+    // Base CubeSettings for a *brand-new* Cube. On the Recovery-Kit restore
+    // path we reuse the deleted Cube's original UUID + name; otherwise fall
+    // back to a fresh UUID + the wallet alias. The UUID is preserved verbatim
+    // (not round-tripped through `uuid::Uuid`) so the server-side UUID string
+    // match `register_cube` relies on stays exact.
+    let new_cube_base = || -> app::settings::CubeSettings {
+        match &restored_cube {
+            Some((uuid, name)) => {
+                let mut cube = app::settings::CubeSettings::new(name.clone(), network);
+                cube.id = uuid.clone();
+                cube
+            }
+            None => app::settings::CubeSettings::new(
+                wallet_alias
+                    .clone()
+                    .unwrap_or_else(|| format!("My {} Cube", network)),
+                network,
+            ),
+        }
+    };
 
     match app::settings::Settings::from_file(network_dir) {
         Ok(mut settings_data) => {
@@ -1744,6 +1790,48 @@ async fn find_or_create_cube(
                 .find(|c| c.vault_wallet_id.as_ref() == Some(wallet_id))
             {
                 return Ok(existing_cube.clone());
+            }
+
+            // Recovery-Kit restore: the restored Cube must carry the deleted
+            // Cube's *original* UUID so the Connect `register_cube` call
+            // (idempotent on UUID) reactivates it instead of minting a
+            // duplicate — the reported bug where recovery produced a new Cube
+            // and left the original still listed as recoverable. This is
+            // checked before the originating / empty-cube reuse below on
+            // purpose: attaching the wallet to a *different* local Cube (with
+            // its own UUID) is exactly the duplicate we're trying to avoid. If
+            // a local Cube already carries the original UUID (a re-run),
+            // reuse it; otherwise mint one with that UUID.
+            if let Some((uuid, _)) = &restored_cube {
+                if let Some(idx) = settings_data.cubes.iter().position(|c| &c.id == uuid) {
+                    if settings_data.cubes[idx].vault_wallet_id.is_some() {
+                        return Err(format!(
+                            "Cube '{}' has already been recovered on this device.",
+                            settings_data.cubes[idx].name
+                        ));
+                    }
+                    let mut cube = settings_data.cubes[idx].clone();
+                    cube.vault_wallet_id = Some(wallet_id.clone());
+                    let cube = decorate_new(cube)?;
+                    settings_data.cubes[idx] = cube.clone();
+
+                    info!(
+                        "Reactivating recovered cube '{}' ({}) with wallet {} on {} network",
+                        cube.name, uuid, wallet_id, network
+                    );
+
+                    return save_cube_settings(network_dir, cube, network, settings_data).await;
+                }
+
+                let cube = decorate_new(new_cube_base().with_vault(wallet_id.clone()))?;
+
+                info!(
+                    "Re-minting recovered cube '{}' ({}) for wallet {} on {} network",
+                    cube.name, uuid, wallet_id, network
+                );
+
+                settings_data.cubes.push(cube.clone());
+                return save_cube_settings(network_dir, cube, network, settings_data).await;
             }
 
             // Second, if we have an originating cube ID, validate and use it
@@ -1814,16 +1902,10 @@ async fn find_or_create_cube(
                 return save_cube_settings(network_dir, empty_cube, network, settings_data).await;
             }
 
-            // Third, create a new cube for this wallet
-            let cube = decorate_new(
-                app::settings::CubeSettings::new(
-                    wallet_alias
-                        .clone()
-                        .unwrap_or_else(|| format!("My {} Cube", network)),
-                    network,
-                )
-                .with_vault(wallet_id.clone()),
-            )?;
+            // Finally, create a new cube for this wallet. `restored_cube` is
+            // `None` here (the restore branch above returns early), so
+            // `new_cube_base` yields the alias-based fresh-UUID cube.
+            let cube = decorate_new(new_cube_base().with_vault(wallet_id.clone()))?;
             let cube_name = cube.name.clone();
 
             info!(
@@ -1835,16 +1917,9 @@ async fn find_or_create_cube(
             save_cube_settings(network_dir, cube, network, settings_data).await
         }
         Err(_) => {
-            // No settings file yet, create first cube
-            let cube = decorate_new(
-                app::settings::CubeSettings::new(
-                    wallet_alias
-                        .clone()
-                        .unwrap_or_else(|| format!("My {} Cube", network)),
-                    network,
-                )
-                .with_vault(wallet_id.clone()),
-            )?;
+            // No settings file yet, create first cube. On the restore path
+            // `new_cube_base` reuses the deleted Cube's original UUID + name.
+            let cube = decorate_new(new_cube_base().with_vault(wallet_id.clone()))?;
             let cube_name = cube.name.clone();
 
             info!(
@@ -2143,5 +2218,153 @@ mod duress_wipe_target_tests {
         );
 
         let _ = std::fs::remove_dir_all(&root);
+    }
+}
+
+#[cfg(test)]
+mod find_or_create_cube_tests {
+    //! Regression tests for the Recovery-Kit restore bug: recovering a
+    //! deleted Cube must reuse the deleted Cube's *original* UUID so the
+    //! Connect `register_cube` call (idempotent on UUID) reactivates it
+    //! rather than minting a brand-new Cube (which left the original still
+    //! listed as recoverable and let the flow be repeated indefinitely).
+    use super::*;
+
+    const ORIG_UUID: &str = "11111111-2222-3333-4444-555555555555";
+
+    fn temp_network_dir(tag: &str) -> NetworkDirectory {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let seq = SEQ.fetch_add(1, Ordering::SeqCst);
+        let path = std::env::temp_dir().join(format!(
+            "coincube-foc-{}-{}-{}",
+            tag,
+            std::process::id(),
+            seq
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).unwrap();
+        NetworkDirectory::new(path)
+    }
+
+    fn wallet_id() -> WalletId {
+        WalletId::new("abcd1234".to_string(), Some(1_700_000_000))
+    }
+
+    /// The reported scenario: recovery on a wiped install (no settings
+    /// file). The restored Cube must carry the original UUID + name, not a
+    /// freshly generated one.
+    #[tokio::test]
+    async fn restore_on_wiped_install_reuses_original_uuid() {
+        let nd = temp_network_dir("wiped");
+        let wid = wallet_id();
+        let cube = find_or_create_cube(
+            &nd,
+            &wid,
+            &Some("Ignored Alias".to_string()),
+            bitcoin::Network::Bitcoin,
+            None, // originating_cube_id
+            Some((ORIG_UUID.to_string(), "My Vault".to_string())),
+            None, // restore_seed
+        )
+        .await
+        .expect("restore should succeed");
+
+        assert_eq!(
+            cube.id, ORIG_UUID,
+            "restored Cube must keep the original UUID"
+        );
+        assert_eq!(cube.name, "My Vault", "restored Cube keeps the original name");
+        assert_eq!(cube.vault_wallet_id.as_ref(), Some(&wid));
+    }
+
+    /// Recovery on an install that already holds other, unrelated Cubes:
+    /// the restore must mint a *new* Cube carrying the original UUID, never
+    /// attach the restored wallet to an unrelated local Cube.
+    #[tokio::test]
+    async fn restore_with_other_cubes_mints_cube_with_original_uuid() {
+        let nd = temp_network_dir("others");
+        let mut settings = app::settings::Settings::default();
+        let other =
+            app::settings::CubeSettings::new("Other".to_string(), bitcoin::Network::Bitcoin)
+                .with_vault(WalletId::new("otherchk".to_string(), Some(1)));
+        let other_id = other.id.clone();
+        settings.cubes.push(other);
+        update_settings_file(&nd, |_| Some(settings)).await.unwrap();
+
+        let wid = wallet_id();
+        let cube = find_or_create_cube(
+            &nd,
+            &wid,
+            &None,
+            bitcoin::Network::Bitcoin,
+            None,
+            Some((ORIG_UUID.to_string(), "My Vault".to_string())),
+            None,
+        )
+        .await
+        .expect("restore should succeed");
+
+        assert_eq!(cube.id, ORIG_UUID);
+        assert_ne!(cube.id, other_id, "must not reuse the unrelated Cube");
+        let reloaded = app::settings::Settings::from_file(&nd).unwrap();
+        assert_eq!(reloaded.cubes.len(), 2, "unrelated Cube is preserved");
+    }
+
+    /// If a vault-less local Cube already carries the original UUID (e.g. a
+    /// partial earlier run), reactivate it in place — don't duplicate it.
+    #[tokio::test]
+    async fn restore_reactivates_existing_cube_with_original_uuid() {
+        let nd = temp_network_dir("reactivate");
+        let mut settings = app::settings::Settings::default();
+        let mut shell =
+            app::settings::CubeSettings::new("Shell".to_string(), bitcoin::Network::Bitcoin);
+        shell.id = ORIG_UUID.to_string();
+        settings.cubes.push(shell);
+        update_settings_file(&nd, |_| Some(settings)).await.unwrap();
+
+        let wid = wallet_id();
+        let cube = find_or_create_cube(
+            &nd,
+            &wid,
+            &None,
+            bitcoin::Network::Bitcoin,
+            None,
+            Some((ORIG_UUID.to_string(), "My Vault".to_string())),
+            None,
+        )
+        .await
+        .expect("restore should succeed");
+
+        assert_eq!(cube.id, ORIG_UUID);
+        assert_eq!(cube.vault_wallet_id.as_ref(), Some(&wid));
+        let reloaded = app::settings::Settings::from_file(&nd).unwrap();
+        assert_eq!(
+            reloaded.cubes.len(),
+            1,
+            "must reactivate in place, not create a duplicate"
+        );
+    }
+
+    /// Non-restore install is unchanged: a fresh UUID and the wallet alias.
+    #[tokio::test]
+    async fn non_restore_install_mints_fresh_uuid() {
+        let nd = temp_network_dir("fresh");
+        let wid = wallet_id();
+        let cube = find_or_create_cube(
+            &nd,
+            &wid,
+            &Some("My Alias".to_string()),
+            bitcoin::Network::Bitcoin,
+            None,
+            None, // no restored_cube
+            None,
+        )
+        .await
+        .expect("install should succeed");
+
+        assert_ne!(cube.id, ORIG_UUID);
+        assert_eq!(cube.name, "My Alias");
+        assert_eq!(cube.vault_wallet_id.as_ref(), Some(&wid));
     }
 }

--- a/coincube-gui/src/installer/step/inheritance_restore.rs
+++ b/coincube-gui/src/installer/step/inheritance_restore.rs
@@ -202,6 +202,19 @@ impl Step for InheritanceRestoreStep {
         if let Some(s) = staged.signer {
             ctx.recovered_signer = Some(Arc::new(s));
         }
+        // Carry the original Cube identity (UUID + name) out of the decrypted
+        // release so the post-install `find_or_create_cube` re-mints the same
+        // Cube. Reusing the UUID makes the Connect `register_cube` call
+        // (idempotent on UUID) reactivate the original Cube instead of creating
+        // a duplicate — the same duplicate-Cube bug the owner CRK restore had.
+        // Full scope only (a real Cube); Vault-only restores into an existing
+        // Cube with its own identity.
+        if matches!(self.scope, RestoreScope::Full) {
+            if let Some(seed) = seed {
+                ctx.cube_id = Some(seed.cube.uuid.clone());
+                ctx.cube_name = Some(seed.cube.name.clone());
+            }
+        }
         // Thread the heir's Connect session into the context so the downstream
         // `CoincubeConnectStep` skips a redundant re-auth and `Final` registers
         // the recovered Cube under the heir's account — mirrors the owner CRK
@@ -216,6 +229,10 @@ impl Step for InheritanceRestoreStep {
     fn revert(&self, ctx: &mut Context) {
         if matches!(self.scope, RestoreScope::Full) {
             ctx.recovered_signer = None;
+            // Drop the original Cube identity stamped in `apply` (Full scope
+            // only) so a later forward pass doesn't re-mint from stale values.
+            ctx.cube_id = None;
+            ctx.cube_name = None;
         }
         ctx.descriptor = None;
         ctx.connect_jwt = None;

--- a/coincube-gui/src/installer/step/owner_keychain_restore.rs
+++ b/coincube-gui/src/installer/step/owner_keychain_restore.rs
@@ -200,6 +200,19 @@ impl Step for OwnerKeychainRestoreStep {
         if let Some(s) = staged.signer {
             ctx.recovered_signer = Some(Arc::new(s));
         }
+        // Carry the original Cube identity (UUID + name) out of the decrypted
+        // envelope so the post-install `find_or_create_cube` re-mints the same
+        // Cube. Reusing the UUID makes the Connect `register_cube` call
+        // (idempotent on UUID) reactivate the original Cube instead of creating
+        // a duplicate — the same duplicate-Cube bug the owner CRK restore had.
+        // Full scope only (a real Cube); Vault-only restores into an existing
+        // Cube with its own identity.
+        if matches!(self.scope, RestoreScope::Full) {
+            if let Some(seed) = seed {
+                ctx.cube_id = Some(seed.cube.uuid.clone());
+                ctx.cube_name = Some(seed.cube.name.clone());
+            }
+        }
         // Thread the owner's Connect session into the context so the downstream
         // `CoincubeConnectStep` skips a redundant re-auth and `Final` re-registers
         // the recovered Cube under the owner's account — mirrors the owner CRK
@@ -214,6 +227,10 @@ impl Step for OwnerKeychainRestoreStep {
     fn revert(&self, ctx: &mut Context) {
         if matches!(self.scope, RestoreScope::Full) {
             ctx.recovered_signer = None;
+            // Drop the original Cube identity stamped in `apply` (Full scope
+            // only) so a later forward pass doesn't re-mint from stale values.
+            ctx.cube_id = None;
+            ctx.cube_name = None;
         }
         ctx.descriptor = None;
         ctx.connect_jwt = None;

--- a/coincube-gui/src/installer/step/recovery_kit_restore.rs
+++ b/coincube-gui/src/installer/step/recovery_kit_restore.rs
@@ -835,6 +835,25 @@ impl Step for RecoveryKitRestoreStep {
             ctx.recovered_signer = Some(Arc::new(s));
         }
 
+        // Carry the *original* Cube identity (UUID + name) out of the
+        // decrypted kit so the post-install `find_or_create_cube` re-mints
+        // the same Cube instead of a fresh one. Reusing the UUID makes the
+        // Connect `register_cube` call (idempotent on UUID) reactivate the
+        // deleted Cube rather than create a duplicate — without this, a
+        // Recovery-Kit restore spawned a brand-new Cube and left the
+        // original still listed as recoverable, so the flow could be
+        // repeated indefinitely.
+        //
+        // Full scope only: `DescriptorOnly` (W14/W15) restores into a Cube
+        // that already exists on disk with its own identity, so we must not
+        // overwrite `cube_id`/`cube_name` there.
+        if matches!(self.scope, RestoreScope::Full) {
+            if let Some(seed) = seed {
+                ctx.cube_id = Some(seed.cube.uuid.clone());
+                ctx.cube_name = Some(seed.cube.name.clone());
+            }
+        }
+
         // Thread the JWT we captured during the OTP step into the
         // context so the downstream `CoincubeConnectStep` can skip
         // re-authentication. Without this, the user has to type their
@@ -862,6 +881,11 @@ impl Step for RecoveryKitRestoreStep {
         // user can re-do the restore cleanly.
         if matches!(self.scope, RestoreScope::Full) {
             ctx.recovered_signer = None;
+            // Drop the original Cube identity we stamped in `apply` (Full
+            // scope only, matching where we set it) so a subsequent forward
+            // pass doesn't re-mint the restored Cube from stale values.
+            ctx.cube_id = None;
+            ctx.cube_name = None;
         }
         // Always clear descriptor — if the user navigates back from a
         // later step through this one, keeping a stale descriptor would


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes post-install cube association and Connect idempotent registration paths for several full restore flows; mistakes could attach wallets to the wrong cube or block recovery, but scope is localized and covered by new regression tests.
> 
> **Overview**
> Fixes recovery flows that were **minting a new Cube** instead of **reactivating the deleted one** on Connect, which left the original Cube still listed as recoverable.
> 
> **Identity threading:** Full-scope restores (Recovery Kit, heir inheritance, owner Keychain) now copy the decrypted kit’s **original UUID and display name** into installer context. After install, `find_or_create_cube` uses that identity when there’s no local Cube shell (wiped-install recovery); it’s skipped when adding a wallet inside an existing Cube.
> 
> **Local cube creation:** Adds `CubeSettings::new_with_raw_id` so the restored id string is stored **verbatim** (no UUID parse/format). Restore logic **reuses or re-mints** a cube with that UUID, **reactivates** vault-less shells that already match, **removes duplicate** cubes from the old bug when the wallet was on the wrong UUID, and errors if that UUID is already fully recovered.
> 
> **Tests:** Regression tests cover wiped install, coexistence with other cubes, in-place reactivation, non-restore behavior, and duplicate reconciliation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e127d288de849a8631b8ad9cadb317e0dd4f436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery Kit restores now preserve the original Cube identity and display name.
  * Restores reuse matching existing Cubes when appropriate, avoiding duplicate Cubes.
  * Vault-less Cubes with a matching identity are reactivated instead of recreated.
  * Non-restore installations continue generating fresh Cube identities.
  * Reverting a restore no longer leaves stale identity information behind.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->