### PR TITLE
cleanup

### DIFF
--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -2252,6 +2252,19 @@ impl App {
             }
         }
 
+        // Keep the cross-network shift-status poll alive off the Spark Receive
+        // panel too: a swap settling while the user is elsewhere must still be
+        // observed promptly, or GlobalHome can't register the arrival before the
+        // deposit is auto-claimed and the flow hangs on "Bitcoin arriving". The
+        // poll stops itself once the shift is terminal, so this is idle outside
+        // the pre-settle window.
+        if !matches!(
+            self.panels.current,
+            Menu::Spark(crate::app::menu::SparkSubMenu::Receive)
+        ) {
+            subscriptions.push(self.panels.spark_receive.sideshift_poll_subscription());
+        }
+
         // Stream the pending internal bitcoind's debug.log for UpdateTip lines.
         if let Some(pending_cfg) = self
             .daemon

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -3901,9 +3901,9 @@ impl App {
             // than to the current panel. This is what lets a swap arrival reach
             // the flow while the user is on another screen; on the Receive screen
             // itself `spark_receive` is the current panel anyway, so it's the
-            // same target. Its status poll only ticks while that panel is current
-            // (subscriptions follow the current panel), so nothing fires here
-            // off-screen.
+            // same target. The flow's status poll is kept alive off-screen too
+            // (`sideshift_poll_subscription`), so its `PollStatus`/`StatusUpdated`
+            // messages land here regardless of which panel is current.
             msg @ Message::View(view::Message::SparkSideshiftReceive(_)) => {
                 return self
                     .panels

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -3883,6 +3883,20 @@ impl App {
                     .global_home
                     .update(self.daemon.clone(), &self.cache, msg);
             }
+            // The cross-network Receive flow lives in the (always-resident)
+            // `spark_receive` panel, so route its messages there directly rather
+            // than to the current panel. This is what lets a swap arrival reach
+            // the flow while the user is on another screen; on the Receive screen
+            // itself `spark_receive` is the current panel anyway, so it's the
+            // same target. Its status poll only ticks while that panel is current
+            // (subscriptions follow the current panel), so nothing fires here
+            // off-screen.
+            msg @ Message::View(view::Message::SparkSideshiftReceive(_)) => {
+                return self
+                    .panels
+                    .spark_receive
+                    .update(self.daemon.clone(), &self.cache, msg);
+            }
 
             Message::ShowReceivedCelebration {
                 context,
@@ -3900,8 +3914,22 @@ impl App {
                     coincube_ui::component::quote_display::random_quote(&context);
                 self.received_celebration_image =
                     coincube_ui::component::quote_display::image_handle_for_context(&context);
-                self.received_celebration_context = context;
+                self.received_celebration_context = context.clone();
                 self.show_received_celebration = true;
+                // A Spark swap's bitcoin just landed. Forward the arrival to the
+                // cross-network Receive flow so it advances from "Bitcoin
+                // arriving" to its arrived confirmation instead of sitting stale.
+                // Dispatched (not called inline) so it reaches the resident
+                // `spark_receive` panel even if the user is on another screen —
+                // arrival lands ~30 min after settle, by which point they've
+                // usually navigated away. The flow ignores it unless it's
+                // actually showing "Bitcoin arriving", so a plain (non-swap)
+                // Spark receive is unaffected.
+                if context == "spark-receive" {
+                    return Task::done(Message::View(view::Message::SparkSideshiftReceive(
+                        view::SparkSideshiftReceiveMessage::Arrived { amount_sat },
+                    )));
+                }
             }
 
             Message::SparkEvent(client_event) => {

--- a/coincube-gui/src/app/state/global_home.rs
+++ b/coincube-gui/src/app/state/global_home.rs
@@ -1771,11 +1771,35 @@ impl State for GlobalHome {
                             if !self.pending_spark_deposit_seen {
                                 return Task::none();
                             }
+                            // The deposit was claimed by someone other than our own
+                            // auto-claim below — the Spark SDK auto-claims static
+                            // deposits, and the user can claim from the Receive
+                            // panel — so `AutoClaimSparkResult` (which advances the
+                            // cross-network Receive flow off "Bitcoin arriving")
+                            // never ran. Nudge the flow to its arrived state here so
+                            // it doesn't hang. This is the *only* signal for an
+                            // SDK-silent claim; it's idempotent (the flow transitions
+                            // once and ignores it otherwise), so it can't double up
+                            // with a claim path that already fired. Non-swap
+                            // transfers (Vault/Liquid→Spark) don't touch it.
+                            let was_swap = self.pending_spark_incoming_is_swap;
+                            let amount_sat = self
+                                .pending_spark_incoming
+                                .as_ref()
+                                .map(|p| p.amount.to_sat())
+                                .unwrap_or(0);
                             self.pending_spark_incoming = None;
                             self.pending_spark_incoming_swap_id = None;
                             self.pending_spark_deposit_seen = false;
                             self.pending_spark_incoming_is_swap = false;
                             self.auto_claiming_spark_deposit = None;
+                            if was_swap {
+                                return Task::done(Message::View(
+                                    view::Message::SparkSideshiftReceive(
+                                        view::SparkSideshiftReceiveMessage::Arrived { amount_sat },
+                                    ),
+                                ));
+                            }
                             return Task::none();
                         }
                         // We've now observed at least one deposit in the list

--- a/coincube-gui/src/app/state/spark/receive.rs
+++ b/coincube-gui/src/app/state/spark/receive.rs
@@ -176,6 +176,22 @@ impl SparkReceive {
     pub fn phase(&self) -> &SparkReceivePhase {
         &self.phase
     }
+
+    /// The cross-network shift-status poll on its own, exposed so the app can
+    /// keep it alive while the user is on another panel. A swap settles and its
+    /// bitcoin is auto-claimed on a ~30-minute timeline; if the settle isn't
+    /// observed until the user happens back on this screen, the deposit can
+    /// already be claimed by then and the flow hangs on "Bitcoin arriving"
+    /// (GlobalHome can only register the arrival while the deposit is still
+    /// pending). Polling stops on its own once the shift is terminal, so this
+    /// only stays live through the pre-settle window. Returns `none` when there
+    /// is no active flow.
+    pub fn sideshift_poll_subscription(&self) -> Subscription<Message> {
+        self.sideshift_flow
+            .as_ref()
+            .map(|flow| flow.subscription())
+            .unwrap_or_else(Subscription::none)
+    }
 }
 
 impl State for SparkReceive {

--- a/coincube-gui/src/app/state/spark/receive.rs
+++ b/coincube-gui/src/app/state/spark/receive.rs
@@ -295,7 +295,9 @@ impl State for SparkReceive {
             };
             // `Back`/`Reset` from the flow's *entry* screen means "leave the
             // bridge", so tear it down and fall back to the ordinary receive
-            // form. The flow resets itself for any other phase.
+            // form. The arrived screen's "Done" button lands here too — once the
+            // bitcoin is in the wallet the swap is finished, so treat it the same
+            // way. The flow resets itself for any other phase.
             let leaving = matches!(
                 msg,
                 crate::app::view::SparkSideshiftReceiveMessage::Back
@@ -303,6 +305,7 @@ impl State for SparkReceive {
             ) && matches!(
                 flow.phase(),
                 super::sideshift_receive::SparkShiftPhase::Setup
+                    | super::sideshift_receive::SparkShiftPhase::Arrived
             );
             if leaving {
                 self.sideshift_flow = None;

--- a/coincube-gui/src/app/state/spark/receive.rs
+++ b/coincube-gui/src/app/state/spark/receive.rs
@@ -192,7 +192,7 @@ impl State for SparkReceive {
         let (sideshift_body, cross_network_selected) = match &self.sideshift_flow {
             Some(flow) => (
                 Some(
-                    crate::app::view::spark::spark_sideshift_receive_view(flow)
+                    crate::app::view::spark::spark_sideshift_receive_view(flow, cache.bitcoin_unit)
                         .map(crate::app::view::Message::SparkSideshiftReceive),
                 ),
                 Some(flow.selected()),

--- a/coincube-gui/src/app/state/spark/send.rs
+++ b/coincube-gui/src/app/state/spark/send.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use coincube_spark_protocol::{
     CrossChainAddress, CrossChainRoute, ParseInputKind, PrepareSendOk, SendPaymentOk,
 };
-use coincube_ui::component::amount::format_u64_as_string;
+use coincube_ui::component::amount::{format_u64_as_string, BitcoinDisplayUnit};
 use coincube_ui::widget::Element;
 use iced::Task;
 
@@ -370,7 +370,7 @@ impl SparkSend {
     /// Fetch (or re-fetch) a quote for the route the user selected. Shared by
     /// the first quote and the post-expiry re-quote — they differ only in what
     /// the user pressed, not in what has to happen.
-    fn quote_cross_chain(&mut self) -> Task<Message> {
+    fn quote_cross_chain(&mut self, bitcoin_unit: BitcoinDisplayUnit) -> Task<Message> {
         let Some(ctx) = &self.cross_chain else {
             return Task::none();
         };
@@ -389,14 +389,14 @@ impl SparkSend {
                 return Task::none();
             }
         };
-        let amount_sat = match self.amount_input.trim().parse::<u64>() {
+        let amount_sat = match parse_amount_to_sats(&self.amount_input, bitcoin_unit) {
             Ok(n) if n > 0 => n,
             _ => {
-                self.phase = SparkSendPhase::Error(
-                    "Enter the amount to send, in sats. Cross-chain sends are funded from your \
-                     Bitcoin balance and converted when they're paid."
-                        .to_string(),
-                );
+                self.phase = SparkSendPhase::Error(format!(
+                    "Enter the amount to send, in {}. Cross-chain sends are funded from your \
+                     Bitcoin balance and converted when they're paid.",
+                    amount_unit_word(bitcoin_unit),
+                ));
                 return Task::none();
             }
         };
@@ -609,12 +609,10 @@ impl State for SparkSend {
                 let amount_sat = if self.amount_input.trim().is_empty() {
                     None
                 } else {
-                    match self.amount_input.trim().parse::<u64>() {
+                    match parse_amount_to_sats(&self.amount_input, cache.bitcoin_unit) {
                         Ok(n) => Some(n),
-                        Err(_) => {
-                            self.phase = SparkSendPhase::Error(
-                                "Amount must be a whole number of sats.".to_string(),
-                            );
+                        Err(e) => {
+                            self.phase = SparkSendPhase::Error(e);
                             return Task::none();
                         }
                     }
@@ -736,7 +734,7 @@ impl State for SparkSend {
                 Task::none()
             }
             SparkSendMessage::CrossChainQuoteRequested | SparkSendMessage::ReQuoteRequested => {
-                self.quote_cross_chain()
+                self.quote_cross_chain(cache.bitcoin_unit)
             }
             SparkSendMessage::CrossChainRetryRequested => {
                 // A cross-chain retry re-sends the **same prepared quote**, not a
@@ -909,6 +907,33 @@ impl State for SparkSend {
     }
 }
 
+/// The word for the amount field's unit, for error messages.
+fn amount_unit_word(unit: BitcoinDisplayUnit) -> &'static str {
+    match unit {
+        BitcoinDisplayUnit::BTC => "BTC",
+        BitcoinDisplayUnit::Sats => "sats",
+    }
+}
+
+/// Parse the amount field — entered in the wallet's display unit — into sats.
+/// Mirrors the Vault send form: a sats wallet enters whole sats, a BTC wallet
+/// enters a decimal BTC value. The stored `amount_sat` the send path uses is
+/// always sats regardless.
+fn parse_amount_to_sats(input: &str, unit: BitcoinDisplayUnit) -> Result<u64, String> {
+    let trimmed = input.trim();
+    match unit {
+        BitcoinDisplayUnit::Sats => trimmed
+            .parse::<u64>()
+            .map_err(|_| "Amount must be a whole number of sats.".to_string()),
+        BitcoinDisplayUnit::BTC => coincube_core::miniscript::bitcoin::Amount::from_str_in(
+            trimmed,
+            coincube_core::miniscript::bitcoin::Denomination::Bitcoin,
+        )
+        .map(|a| a.to_sat())
+        .map_err(|_| "Amount must be a valid BTC value.".to_string()),
+    }
+}
+
 /// Phase 4e: classify the user-supplied destination via `parse_input`
 /// and dispatch to the right prepare RPC (`prepare_send` for
 /// BOLT11/on-chain/Other, `prepare_lnurl_pay` for LNURL/Lightning
@@ -1048,6 +1073,29 @@ fn fetch_balance_task(backend: Option<Arc<SparkBackend>>) -> Task<Message> {
 mod tests {
     use super::*;
     use crate::app::view::{Message as ViewMessage, SparkSendMessage};
+
+    #[test]
+    fn amount_parses_in_the_configured_unit() {
+        // Sats mode: whole integers only.
+        assert_eq!(
+            parse_amount_to_sats("30000", BitcoinDisplayUnit::Sats),
+            Ok(30_000)
+        );
+        assert!(parse_amount_to_sats("0.5", BitcoinDisplayUnit::Sats).is_err());
+
+        // BTC mode: decimals convert to sats.
+        assert_eq!(
+            parse_amount_to_sats("0.0003", BitcoinDisplayUnit::BTC),
+            Ok(30_000)
+        );
+        assert_eq!(
+            parse_amount_to_sats(" 1 ", BitcoinDisplayUnit::BTC),
+            Ok(100_000_000)
+        );
+        // More than 8 decimal places is sub-sat precision — rejected.
+        assert!(parse_amount_to_sats("0.000000001", BitcoinDisplayUnit::BTC).is_err());
+        assert!(parse_amount_to_sats("abc", BitcoinDisplayUnit::BTC).is_err());
+    }
 
     fn route() -> CrossChainRoute {
         CrossChainRoute {

--- a/coincube-gui/src/app/state/spark/sideshift_receive.rs
+++ b/coincube-gui/src/app/state/spark/sideshift_receive.rs
@@ -51,6 +51,12 @@ pub enum SparkShiftPhase {
     CreatingShift,
     /// Shift is live — deposit address on screen, polling status.
     Active,
+    /// The swap's bitcoin has landed in the Spark wallet and been claimed. A
+    /// terminal *success* state, distinct from `Active`+`Settled` ("Bitcoin
+    /// arriving"): SideShift's status can't report this — the arrival is an
+    /// on-chain claim on our side — so it's driven by the global "received"
+    /// event via [`Msg::Arrived`].
+    Arrived,
     /// Terminal failure before a shift existed.
     Failed,
 }
@@ -78,6 +84,9 @@ pub struct SparkSideshiftReceiveFlow {
     /// deposit is detected), not the create-time estimate. Shown next to the
     /// "Bitcoin arriving" status so the user sees how much is on the way.
     settle_amount_sat: Option<u64>,
+    /// The actual amount claimed into the wallet on arrival (post network fee),
+    /// in sats. Set when the flow reaches [`SparkShiftPhase::Arrived`].
+    arrived_amount_sat: Option<u64>,
     qr_data: Option<qr_code::Data>,
 
     loading: bool,
@@ -100,6 +109,7 @@ impl SparkSideshiftReceiveFlow {
             shift: None,
             shift_status: None,
             settle_amount_sat: None,
+            arrived_amount_sat: None,
             qr_data: None,
             loading: false,
             error: None,
@@ -140,6 +150,9 @@ impl SparkSideshiftReceiveFlow {
     pub fn settle_amount_sat(&self) -> Option<u64> {
         self.settle_amount_sat
     }
+    pub fn arrived_amount_sat(&self) -> Option<u64> {
+        self.arrived_amount_sat
+    }
     pub fn qr_data(&self) -> Option<&qr_code::Data> {
         self.qr_data.as_ref()
     }
@@ -161,6 +174,7 @@ impl SparkSideshiftReceiveFlow {
         self.shift = None;
         self.shift_status = None;
         self.settle_amount_sat = None;
+        self.arrived_amount_sat = None;
         self.qr_data = None;
         self.loading = false;
         self.error = None;
@@ -393,6 +407,31 @@ impl SparkSideshiftReceiveFlow {
                             ))),
                         ]);
                     }
+                }
+                Task::none()
+            }
+
+            Msg::Arrived { amount_sat } => {
+                // The global "bitcoin received" event fires for any Spark claim,
+                // so only take it as *this swap's* arrival once this shift has
+                // seen a deposit of its own (status past `Waiting`). That guards
+                // against an unrelated deposit — claimed while this flow is still
+                // waiting to be funded — hijacking the screen, while still
+                // catching the arrival if the user left the screen before the
+                // status poll reached `Settled` (the poll only ticks on-screen,
+                // so off-screen the status can lag behind the actual chain).
+                let deposit_seen = matches!(
+                    self.shift_status,
+                    Some(
+                        ShiftStatusKind::Pending
+                            | ShiftStatusKind::Processing
+                            | ShiftStatusKind::Settling
+                            | ShiftStatusKind::Settled
+                    )
+                );
+                if self.phase == SparkShiftPhase::Active && deposit_seen {
+                    self.arrived_amount_sat = Some(*amount_sat);
+                    self.phase = SparkShiftPhase::Arrived;
                 }
                 Task::none()
             }

--- a/coincube-gui/src/app/state/spark/sideshift_receive.rs
+++ b/coincube-gui/src/app/state/spark/sideshift_receive.rs
@@ -419,28 +419,7 @@ impl SparkSideshiftReceiveFlow {
             }
 
             Msg::Arrived { amount_sat } => {
-                // The global "bitcoin received" event fires for any Spark claim,
-                // so only take it as *this swap's* arrival once this shift has
-                // seen a deposit of its own (status past `Waiting`). That guards
-                // against an unrelated deposit — claimed while this flow is still
-                // waiting to be funded — hijacking the screen, while still
-                // catching the arrival if the user left the screen before the
-                // status poll reached `Settled` (the poll only ticks on-screen,
-                // so off-screen the status can lag behind the actual chain).
-                let deposit_seen = matches!(
-                    self.shift_status,
-                    Some(
-                        ShiftStatusKind::Pending
-                            | ShiftStatusKind::Processing
-                            | ShiftStatusKind::Settling
-                            | ShiftStatusKind::Settled
-                            // A review hold only happens after the deposit is
-                            // received, so a released hold that then arrives is
-                            // this swap's — catch it too.
-                            | ShiftStatusKind::Review
-                    )
-                );
-                if self.phase == SparkShiftPhase::Active && deposit_seen {
+                if arrival_belongs_to_this_shift(&self.phase, self.shift_status.as_ref()) {
                     self.arrived_amount_sat = Some(*amount_sat);
                     self.phase = SparkShiftPhase::Arrived;
                 }
@@ -495,6 +474,33 @@ impl SparkSideshiftReceiveFlow {
 /// The detail is passed through verbatim: the underlying errors already name
 /// the service that failed (Coincube, the Spark bridge, or SideShift), and
 /// re-prefixing them here is how they end up misattributed.
+/// Whether an `Arrived` signal — fired globally for *any* Spark claim — should
+/// be taken as this shift's bitcoin landing and move it to the terminal
+/// `Arrived` state.
+///
+/// True only when the swap is still live (`Active`) and has seen a deposit of
+/// its own (status past `Waiting`). The deposit-seen guard stops an unrelated
+/// claim, landing while this flow is still waiting to be funded, from hijacking
+/// the screen. It stays permissive across every post-deposit status — including
+/// `Review` (a hold only happens after the deposit is received) — so the arrival
+/// is still caught even if the shift status lags behind the actual chain.
+fn arrival_belongs_to_this_shift(
+    phase: &SparkShiftPhase,
+    status: Option<&ShiftStatusKind>,
+) -> bool {
+    *phase == SparkShiftPhase::Active
+        && matches!(
+            status,
+            Some(
+                ShiftStatusKind::Pending
+                    | ShiftStatusKind::Processing
+                    | ShiftStatusKind::Settling
+                    | ShiftStatusKind::Settled
+                    | ShiftStatusKind::Review
+            )
+        )
+}
+
 fn nothing_sent_yet(detail: &str) -> String {
     format!(
         "{}. Nothing has been sent — try again.",
@@ -543,6 +549,43 @@ mod tests {
                 ShiftStatusKind::from(s).is_terminal(),
                 "{} must stop polling — the shift will not advance on its own",
                 s
+            );
+        }
+    }
+
+    #[test]
+    fn an_arrival_only_lands_on_a_live_shift_that_has_seen_its_deposit() {
+        use ShiftStatusKind::*;
+
+        // Accept: the swap is Active and its status is past `Waiting`, so the
+        // claim that just fired is this shift's bitcoin landing.
+        for status in [Pending, Processing, Settling, Settled, Review] {
+            assert!(
+                arrival_belongs_to_this_shift(&SparkShiftPhase::Active, Some(&status)),
+                "Active + {status:?} should accept the arrival"
+            );
+        }
+
+        // Ignore: still waiting to be funded (or no status yet), so a claim
+        // firing now belongs to some other deposit, not this one.
+        assert!(!arrival_belongs_to_this_shift(
+            &SparkShiftPhase::Active,
+            Some(&Waiting)
+        ));
+        assert!(!arrival_belongs_to_this_shift(
+            &SparkShiftPhase::Active,
+            None
+        ));
+
+        // Ignore: not a live shift — nothing to advance.
+        for phase in [
+            SparkShiftPhase::Setup,
+            SparkShiftPhase::Arrived,
+            SparkShiftPhase::Failed,
+        ] {
+            assert!(
+                !arrival_belongs_to_this_shift(&phase, Some(&Settled)),
+                "{phase:?} must ignore the arrival even at Settled"
             );
         }
     }

--- a/coincube-gui/src/app/state/spark/sideshift_receive.rs
+++ b/coincube-gui/src/app/state/spark/sideshift_receive.rs
@@ -395,14 +395,17 @@ impl SparkSideshiftReceiveFlow {
                         //      the "bitcoin received" celebration when it lands.
                         // The amount is the swap's settle estimate, used only for
                         // the pending indicator; the celebration uses the actual
-                        // claimed amount.
+                        // claimed amount. Read the cached figure rather than this
+                        // poll's `settle_sat`: a settle response can omit
+                        // `settleAmount`, and the cache still holds the value an
+                        // earlier poll reported.
                         return Task::batch([
                             Task::done(Message::View(view::Message::SparkReceive(
                                 view::SparkReceiveMessage::DepositsChanged,
                             ))),
                             Task::done(Message::View(view::Message::Home(
                                 view::HomeMessage::SwapSettledAwaitingArrival {
-                                    amount_sat: settle_sat.unwrap_or(0),
+                                    amount_sat: self.settle_amount_sat.unwrap_or(0),
                                 },
                             ))),
                         ]);

--- a/coincube-gui/src/app/state/spark/sideshift_receive.rs
+++ b/coincube-gui/src/app/state/spark/sideshift_receive.rs
@@ -73,6 +73,11 @@ pub struct SparkSideshiftReceiveFlow {
     affiliate_id: Option<String>,
     shift: Option<ShiftResponse>,
     shift_status: Option<ShiftStatusKind>,
+    /// The BTC amount SideShift last reported as the settle output, in sats.
+    /// Sourced from the poll status (which carries the real figure once a
+    /// deposit is detected), not the create-time estimate. Shown next to the
+    /// "Bitcoin arriving" status so the user sees how much is on the way.
+    settle_amount_sat: Option<u64>,
     qr_data: Option<qr_code::Data>,
 
     loading: bool,
@@ -94,6 +99,7 @@ impl SparkSideshiftReceiveFlow {
             affiliate_id: None,
             shift: None,
             shift_status: None,
+            settle_amount_sat: None,
             qr_data: None,
             loading: false,
             error: None,
@@ -131,6 +137,9 @@ impl SparkSideshiftReceiveFlow {
     pub fn shift_status(&self) -> Option<&ShiftStatusKind> {
         self.shift_status.as_ref()
     }
+    pub fn settle_amount_sat(&self) -> Option<u64> {
+        self.settle_amount_sat
+    }
     pub fn qr_data(&self) -> Option<&qr_code::Data> {
         self.qr_data.as_ref()
     }
@@ -151,6 +160,7 @@ impl SparkSideshiftReceiveFlow {
         self.affiliate_id = None;
         self.shift = None;
         self.shift_status = None;
+        self.settle_amount_sat = None;
         self.qr_data = None;
         self.loading = false;
         self.error = None;
@@ -237,7 +247,7 @@ impl SparkSideshiftReceiveFlow {
     // ── View ────────────────────────────────────────────────────────────
 
     pub fn view<'a>(&'a self, menu: &'a Menu, cache: &'a Cache) -> Element<'a, view::Message> {
-        let body = view::spark::spark_sideshift_receive_view(self);
+        let body = view::spark::spark_sideshift_receive_view(self, cache.bitcoin_unit);
         view::dashboard(menu, cache, body.map(view::Message::SparkSideshiftReceive))
     }
 
@@ -347,6 +357,17 @@ impl SparkSideshiftReceiveFlow {
                     let settled = kind == ShiftStatusKind::Settled
                         && self.shift_status.as_ref() != Some(&ShiftStatusKind::Settled);
                     self.shift_status = Some(kind);
+                    // SideShift reports the settle output (BTC, as a decimal
+                    // string) once a deposit is detected. Keep the latest so the
+                    // view can show how much bitcoin is arriving.
+                    let settle_sat = status
+                        .settle_amount
+                        .as_deref()
+                        .and_then(|s| s.parse::<f64>().ok())
+                        .map(|btc| (btc * 100_000_000.0).round() as u64);
+                    if settle_sat.is_some() {
+                        self.settle_amount_sat = settle_sat;
+                    }
                     if settled {
                         // The bitcoin has landed at Spark's on-chain deposit
                         // address, which means it shows up as an *unclaimed
@@ -361,19 +382,13 @@ impl SparkSideshiftReceiveFlow {
                         // The amount is the swap's settle estimate, used only for
                         // the pending indicator; the celebration uses the actual
                         // claimed amount.
-                        let settle_sat = status
-                            .settle_amount
-                            .as_deref()
-                            .and_then(|s| s.parse::<f64>().ok())
-                            .map(|btc| (btc * 100_000_000.0).round() as u64)
-                            .unwrap_or(0);
                         return Task::batch([
                             Task::done(Message::View(view::Message::SparkReceive(
                                 view::SparkReceiveMessage::DepositsChanged,
                             ))),
                             Task::done(Message::View(view::Message::Home(
                                 view::HomeMessage::SwapSettledAwaitingArrival {
-                                    amount_sat: settle_sat,
+                                    amount_sat: settle_sat.unwrap_or(0),
                                 },
                             ))),
                         ]);

--- a/coincube-gui/src/app/state/spark/sideshift_receive.rs
+++ b/coincube-gui/src/app/state/spark/sideshift_receive.rs
@@ -562,7 +562,8 @@ mod tests {
         for status in [Pending, Processing, Settling, Settled, Review] {
             assert!(
                 arrival_belongs_to_this_shift(&SparkShiftPhase::Active, Some(&status)),
-                "Active + {status:?} should accept the arrival"
+                "Active + {:?} should accept the arrival",
+                status
             );
         }
 
@@ -585,7 +586,8 @@ mod tests {
         ] {
             assert!(
                 !arrival_belongs_to_this_shift(&phase, Some(&Settled)),
-                "{phase:?} must ignore the arrival even at Settled"
+                "{:?} must ignore the arrival even at Settled",
+                phase
             );
         }
     }

--- a/coincube-gui/src/app/state/spark/sideshift_receive.rs
+++ b/coincube-gui/src/app/state/spark/sideshift_receive.rs
@@ -373,12 +373,16 @@ impl SparkSideshiftReceiveFlow {
                     self.shift_status = Some(kind);
                     // SideShift reports the settle output (BTC, as a decimal
                     // string) once a deposit is detected. Keep the latest so the
-                    // view can show how much bitcoin is arriving.
-                    let settle_sat = status
-                        .settle_amount
-                        .as_deref()
-                        .and_then(|s| s.parse::<f64>().ok())
-                        .map(|btc| (btc * 100_000_000.0).round() as u64);
+                    // view can show how much bitcoin is arriving. Parse it exactly
+                    // (BTC → sats) rather than via f64, which rounds.
+                    let settle_sat = status.settle_amount.as_deref().and_then(|s| {
+                        coincube_core::miniscript::bitcoin::Amount::from_str_in(
+                            s.trim(),
+                            coincube_core::miniscript::bitcoin::Denomination::Bitcoin,
+                        )
+                        .ok()
+                        .map(|a| a.to_sat())
+                    });
                     if settle_sat.is_some() {
                         self.settle_amount_sat = settle_sat;
                     }
@@ -430,6 +434,10 @@ impl SparkSideshiftReceiveFlow {
                             | ShiftStatusKind::Processing
                             | ShiftStatusKind::Settling
                             | ShiftStatusKind::Settled
+                            // A review hold only happens after the deposit is
+                            // received, so a released hold that then arrives is
+                            // this swap's — catch it too.
+                            | ShiftStatusKind::Review
                     )
                 );
                 if self.phase == SparkShiftPhase::Active && deposit_seen {

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -700,6 +700,11 @@ pub enum SparkSideshiftReceiveMessage {
     ShiftCreated(Result<ShiftResponse, String>),
     PollStatus,
     StatusUpdated(Result<ShiftStatus, String>),
+    /// The swap's bitcoin has landed in the Spark wallet and been claimed —
+    /// forwarded from the global "bitcoin received" event so the inline flow
+    /// can advance from "Bitcoin arriving" to an arrived confirmation. Carries
+    /// the actual claimed amount (post network fee), in sats.
+    Arrived { amount_sat: u64 },
     /// Copy the deposit address.
     Copy,
     Back,

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -704,7 +704,9 @@ pub enum SparkSideshiftReceiveMessage {
     /// forwarded from the global "bitcoin received" event so the inline flow
     /// can advance from "Bitcoin arriving" to an arrived confirmation. Carries
     /// the actual claimed amount (post network fee), in sats.
-    Arrived { amount_sat: u64 },
+    Arrived {
+        amount_sat: u64,
+    },
     /// Copy the deposit address.
     Copy,
     Back,

--- a/coincube-gui/src/app/view/spark/send.rs
+++ b/coincube-gui/src/app/view/spark/send.rs
@@ -120,7 +120,11 @@ impl<'a> SparkSendView<'a> {
         // send form: label, placeholder, and the parse in state all switch on
         // it, so a BTC-configured wallet enters BTC and a sats one enters sats.
         let is_btc = matches!(self.bitcoin_unit, BitcoinDisplayUnit::BTC);
-        let amount_label = if is_btc { "Amount (BTC)" } else { "Amount (sats)" };
+        let amount_label = if is_btc {
+            "Amount (BTC)"
+        } else {
+            "Amount (sats)"
+        };
         let amount_placeholder = match (self.receive_target.is_stablecoin(), is_btc) {
             (true, true) => "Amount in BTC — funded from your Bitcoin balance",
             (true, false) => "Amount in sats — funded from your Bitcoin balance",

--- a/coincube-gui/src/app/view/spark/send.rs
+++ b/coincube-gui/src/app/view/spark/send.rs
@@ -116,10 +116,16 @@ impl<'a> SparkSendView<'a> {
         })
         .padding(10);
 
-        let amount_placeholder = if self.receive_target.is_stablecoin() {
-            "Amount in sats — funded from your Bitcoin balance"
-        } else {
-            "Amount in sats (optional for invoices with amount)"
+        // The amount field follows the wallet's display unit, like the Vault
+        // send form: label, placeholder, and the parse in state all switch on
+        // it, so a BTC-configured wallet enters BTC and a sats one enters sats.
+        let is_btc = matches!(self.bitcoin_unit, BitcoinDisplayUnit::BTC);
+        let amount_label = if is_btc { "Amount (BTC)" } else { "Amount (sats)" };
+        let amount_placeholder = match (self.receive_target.is_stablecoin(), is_btc) {
+            (true, true) => "Amount in BTC — funded from your Bitcoin balance",
+            (true, false) => "Amount in sats — funded from your Bitcoin balance",
+            (false, true) => "Amount in BTC (optional for invoices with amount)",
+            (false, false) => "Amount in sats (optional for invoices with amount)",
         };
         let amount = text_input(amount_placeholder, self.amount_input)
             .on_input(|v| {
@@ -133,7 +139,7 @@ impl<'a> SparkSendView<'a> {
                 .push(h4_bold("Destination"))
                 .push(destination)
                 .push(Space::new().height(Length::Fixed(8.0)))
-                .push(h4_bold("Amount"))
+                .push(h4_bold(amount_label))
                 .push(amount),
         )
         .padding(16)

--- a/coincube-gui/src/app/view/spark/sideshift_receive.rs
+++ b/coincube-gui/src/app/view/spark/sideshift_receive.rs
@@ -7,9 +7,14 @@
 //! **bitcoin arrives**, never "receive USDT". No standalone title / asset
 //! picker / Back button — navigation happens via the cards + THEY SEND modal.
 
+use coincube_core::miniscript::bitcoin::Amount;
 use coincube_ui::{
     color,
-    component::{button, text::*},
+    component::{
+        amount::{BitcoinDisplayUnit, DisplayAmount},
+        button,
+        text::*,
+    },
     icon::clipboard_icon,
     theme,
     widget::Element,
@@ -24,13 +29,16 @@ use crate::app::state::spark::sideshift_receive::{SparkShiftPhase, SparkSideshif
 use crate::app::view::SparkSideshiftReceiveMessage as Msg;
 use crate::services::sideshift::{ShiftResponse, ShiftStatusKind};
 
-pub fn spark_sideshift_receive_view(flow: &SparkSideshiftReceiveFlow) -> Element<'_, Msg> {
+pub fn spark_sideshift_receive_view(
+    flow: &SparkSideshiftReceiveFlow,
+    bitcoin_unit: BitcoinDisplayUnit,
+) -> Element<'_, Msg> {
     match flow.phase() {
         SparkShiftPhase::Setup => setup_body(flow),
         SparkShiftPhase::FetchingAffiliate | SparkShiftPhase::CreatingShift => {
             loading_body("Setting up your deposit address…")
         }
-        SparkShiftPhase::Active => active_body(flow),
+        SparkShiftPhase::Active => active_body(flow, bitcoin_unit),
         SparkShiftPhase::Failed => error_body(flow.error()),
     }
 }
@@ -112,7 +120,10 @@ fn setup_body(flow: &SparkSideshiftReceiveFlow) -> Element<'_, Msg> {
 
 // ── Active shift: deposit address + status ──────────────────────────────────
 
-fn active_body(flow: &SparkSideshiftReceiveFlow) -> Element<'_, Msg> {
+fn active_body(
+    flow: &SparkSideshiftReceiveFlow,
+    bitcoin_unit: BitcoinDisplayUnit,
+) -> Element<'_, Msg> {
     let Some(shift) = flow.shift() else {
         return error_body(Some("Shift data missing."));
     };
@@ -196,7 +207,7 @@ fn active_body(flow: &SparkSideshiftReceiveFlow) -> Element<'_, Msg> {
 
     let status_section: Element<Msg> = if let Some(status) = status {
         let (label, style_color) = status_badge(status);
-        Column::new()
+        let mut col = Column::new()
             .spacing(8)
             .align_x(Alignment::Center)
             .width(Length::Fill)
@@ -204,13 +215,34 @@ fn active_body(flow: &SparkSideshiftReceiveFlow) -> Element<'_, Msg> {
                 Container::new(text(label).size(P2_SIZE).color(style_color))
                     .padding([4, 10])
                     .style(theme::pill::simple),
-            )
-            .push(
-                text(spark_shift_guidance(status))
-                    .size(P2_SIZE)
-                    .style(theme::text::secondary),
-            )
-            .into()
+            );
+        // Once SideShift reports the settle output, show how much bitcoin is on
+        // the way — in whichever unit the user has chosen. Gated on `Settled`
+        // so it sits under the "Bitcoin arriving" badge, where the amount is
+        // finalised; earlier states can carry a moving estimate.
+        if matches!(status, ShiftStatusKind::Settled) {
+            if let Some(sats) = flow.settle_amount_sat() {
+                col = col.push(
+                    text(format!(
+                        "{} {}",
+                        Amount::from_sat(sats).to_formatted_string_with_unit(bitcoin_unit),
+                        if matches!(bitcoin_unit, BitcoinDisplayUnit::BTC) {
+                            "BTC"
+                        } else {
+                            "SATS"
+                        },
+                    ))
+                    .size(P1_SIZE)
+                    .bold(),
+                );
+            }
+        }
+        col.push(
+            text(spark_shift_guidance(status))
+                .size(P2_SIZE)
+                .style(theme::text::secondary),
+        )
+        .into()
     } else {
         Space::new().height(Length::Fixed(0.0)).into()
     };
@@ -241,7 +273,7 @@ fn spark_shift_guidance(status: &ShiftStatusKind) -> &'static str {
     match status {
         ShiftStatusKind::Settled => {
             "Converting complete. Your bitcoin is arriving on-chain and will be added to your \
-             wallet automatically after about 3 confirmations — usually a few minutes."
+             wallet automatically after about 3 confirmations — ~30 minutes."
         }
         other => other.guidance(),
     }

--- a/coincube-gui/src/app/view/spark/sideshift_receive.rs
+++ b/coincube-gui/src/app/view/spark/sideshift_receive.rs
@@ -39,6 +39,7 @@ pub fn spark_sideshift_receive_view(
             loading_body("Setting up your deposit address…")
         }
         SparkShiftPhase::Active => active_body(flow, bitcoin_unit),
+        SparkShiftPhase::Arrived => arrived_body(flow, bitcoin_unit),
         SparkShiftPhase::Failed => error_body(flow.error()),
     }
 }
@@ -217,14 +218,23 @@ fn active_body(
                     .style(theme::pill::simple),
             );
         // Once SideShift reports the settle output, show how much bitcoin is on
-        // the way — in whichever unit the user has chosen. Gated on `Settled`
-        // so it sits under the "Bitcoin arriving" badge, where the amount is
-        // finalised; earlier states can carry a moving estimate.
-        if matches!(status, ShiftStatusKind::Settled) {
+        // the way — in whichever unit the user has chosen. Shown from the moment
+        // a deposit is detected through settle; before settle it's SideShift's
+        // moving estimate, so it's labelled "≈", and it firms up as "arriving"
+        // under the "Bitcoin arriving" badge.
+        if matches!(
+            status,
+            ShiftStatusKind::Pending
+                | ShiftStatusKind::Processing
+                | ShiftStatusKind::Settling
+                | ShiftStatusKind::Settled
+        ) {
             if let Some(sats) = flow.settle_amount_sat() {
+                let settled = matches!(status, ShiftStatusKind::Settled);
                 col = col.push(
                     text(format!(
-                        "{} {}",
+                        "{}{} {}",
+                        if settled { "" } else { "≈ " },
                         Amount::from_sat(sats).to_formatted_string_with_unit(bitcoin_unit),
                         if matches!(bitcoin_unit, BitcoinDisplayUnit::BTC) {
                             "BTC"
@@ -259,6 +269,57 @@ fn active_body(
     )
     .padding(16)
     .width(Length::Fill)
+    .style(theme::card::simple)
+    .into()
+}
+
+// ── Arrived: the swap's bitcoin has landed and been claimed ──────────────────
+
+fn arrived_body(
+    flow: &SparkSideshiftReceiveFlow,
+    bitcoin_unit: BitcoinDisplayUnit,
+) -> Element<'_, Msg> {
+    let mut col = Column::new()
+        .spacing(12)
+        .align_x(Alignment::Center)
+        .width(Length::Fill)
+        .push(
+            Container::new(text("Bitcoin arrived").size(P2_SIZE).color(color::GREEN))
+                .padding([4, 10])
+                .style(theme::pill::simple),
+        );
+
+    if let Some(sats) = flow.arrived_amount_sat() {
+        col = col.push(
+            text(format!(
+                "{} {}",
+                Amount::from_sat(sats).to_formatted_string_with_unit(bitcoin_unit),
+                if matches!(bitcoin_unit, BitcoinDisplayUnit::BTC) {
+                    "BTC"
+                } else {
+                    "SATS"
+                },
+            ))
+            .size(H4_SIZE)
+            .bold(),
+        );
+    }
+
+    Container::new(
+        col.push(
+            text("Your bitcoin has been added to your Spark wallet.")
+                .size(P2_SIZE)
+                .style(theme::text::secondary),
+        )
+        .push(
+            button::primary(None, "Done")
+                .on_press(Msg::Reset)
+                .width(Length::Fixed(160.0)),
+        ),
+    )
+    .padding(24)
+    .width(Length::Fill)
+    .center_x(Length::Fill)
     .style(theme::card::simple)
     .into()
 }

--- a/coincube-gui/src/app/view/vault/psbt.rs
+++ b/coincube-gui/src/app/view/vault/psbt.rs
@@ -1292,9 +1292,13 @@ fn signing_key_row(row: &SigningKeyRow, color: iced::Color) -> Element<'static, 
         SigningKeyState::Disabled(reason) => p1_regular(reason.clone())
             .style(theme::text::secondary)
             .into(),
-        SigningKeyState::NeedsSignIn(reason) => Row::new()
-            .spacing(10)
-            .align_y(Alignment::Center)
+        // Stack the button *under* the reason rather than beside it: the sibling
+        // `info` column is `Fill`, so a side-by-side Row starves this slot and the
+        // button's label wraps into a cramped oval. A Column gives it a full line
+        // at its natural width.
+        SigningKeyState::NeedsSignIn(reason) => Column::new()
+            .spacing(6)
+            .align_x(Alignment::End)
             .push(p1_regular(reason.clone()).style(theme::text::secondary))
             .push(
                 // Bubbles straight to the tab (which opens/focuses the Home


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches global message routing, deposit watchers, and swap lifecycle timing; mistakes could advance the wrong flow or miss arrivals, but guards (`arrival_belongs_to_this_shift`, swap-only paths) limit blast radius.
> 
> **Overview**
> Fixes cross-network **SideShift → Spark** receive getting stuck on **“Bitcoin arriving”** when the user leaves the Receive screen before settle/claim (~30 minutes later).
> 
> **Background polling and routing:** SideShift status polling now stays subscribed whenever the user is not on Spark Receive (`sideshift_poll_subscription`), and `SparkSideshiftReceive` messages always update the resident `spark_receive` panel instead of the current screen.
> 
> **Arrival handling:** Adds terminal **`Arrived`** phase with a confirmation UI. `SparkSideshiftReceiveMessage::Arrived` is emitted from `GlobalHome` when a swap deposit disappears without auto-claim (SDK/user claim), and from `ShowReceivedCelebration` for `spark-receive` after auto-claim. **`Done`** on the arrived screen tears down the flow like **Back** on setup.
> 
> **Display and send UX:** Active shift shows SideShift’s settle output in the user’s **BTC/sats** unit (parsed without `f64`); settle copy notes **~30 minutes**. Spark **send** amount parsing and labels follow `cache.bitcoin_unit` (BTC decimals vs whole sats), with unit tests.
> 
> **Minor:** PSBT “Sign in to Connect” stacks vertically for layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fc3733f7f6945be3561ef78910dcad3d1248a38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * SideShift receive screens now display settle/arrived Bitcoin amounts in the user-selected BTC/sats unit (including an active-stage settle amount when available).
  * Updated settled guidance to “about 3 confirmations — ~30 minutes”.
  * Spark send amount input now respects the wallet display unit with clearer, unit-aware parsing/validation and labeling.
* **Behavior Updates**
  * Cross-network Spark receive updates route directly into the Spark receive panel.
  * SideShift receive polling remains active across the app except when viewing the Receive submenu.
  * “Bitcoin received” events advance the inline SideShift flow using the claimed amount (with improved phase handling).
* **UI**
  * PSBT key-row “Sign in” prompt layout adjusted for readability.
* **Tests**
  * Added regression coverage for amount parsing in both BTC and sats modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->