### PR TITLE
Dismiss celebration on click

### DIFF
--- a/coincube-ui/src/component/mod.rs
+++ b/coincube-ui/src/component/mod.rs
@@ -45,7 +45,7 @@ pub fn received_celebration_page<'a, M: Clone + 'a>(
 ) -> Element<'a, M> {
     use quote_display::{self as qd, QuoteDisplayProps};
 
-    Column::new()
+    let page = Column::new()
         .spacing(20)
         .width(Length::Fill)
         .align_x(iced::Alignment::Center)
@@ -75,13 +75,20 @@ pub fn received_celebration_page<'a, M: Clone + 'a>(
         .push(
             button::primary(None, "Back")
                 .width(Length::Fixed(150.0))
-                .on_press(on_dismiss),
+                .on_press(on_dismiss.clone()),
         )
         // Bottom breathing room below the Back button. Matches the
         // 30px internal padding `sent_celebration_page` gets from its
         // card wrapper — without it the button sits flush against the
         // scrollable area's bottom edge.
-        .push(iced::widget::Space::new().height(Length::Fixed(30.0)))
+        .push(iced::widget::Space::new().height(Length::Fixed(30.0)));
+
+    // The 480px artwork pushes the "Back" button off the bottom on short
+    // windows, where it can't be scrolled into reach — leaving the user
+    // stuck on the splash. Make the whole page a dismiss target so a click
+    // anywhere (including on the image) closes it, not just the button.
+    iced::widget::mouse_area(page)
+        .on_press(on_dismiss)
         .into()
 }
 
@@ -125,7 +132,7 @@ pub fn sent_celebration_page<'a, M: Clone + 'a>(
         .push(
             button::primary(None, "Back")
                 .width(Length::Fixed(150.0))
-                .on_press(on_dismiss),
+                .on_press(on_dismiss.clone()),
         );
 
     // The modal widget dims the underlying content with a translucent backdrop
@@ -142,9 +149,14 @@ pub fn sent_celebration_page<'a, M: Clone + 'a>(
     // dashboard's content column (visible bug on Liquid Send / Spark Send /
     // Vault PSBT full-page celebrations). The Modal widget centers its child
     // on its own, so this extra wrapper is a no-op in the modal use case.
-    Container::new(card)
+    let page = Container::new(card)
         .width(Length::Fill)
-        .align_x(iced::alignment::Horizontal::Center)
+        .align_x(iced::alignment::Horizontal::Center);
+
+    // Like the received page, the tall artwork can push "Back" out of reach on
+    // short windows, so make a click anywhere on the splash dismiss it too.
+    iced::widget::mouse_area(page)
+        .on_press(on_dismiss)
         .into()
 }
 

--- a/coincube-ui/src/component/mod.rs
+++ b/coincube-ui/src/component/mod.rs
@@ -87,9 +87,7 @@ pub fn received_celebration_page<'a, M: Clone + 'a>(
     // windows, where it can't be scrolled into reach — leaving the user
     // stuck on the splash. Make the whole page a dismiss target so a click
     // anywhere (including on the image) closes it, not just the button.
-    iced::widget::mouse_area(page)
-        .on_press(on_dismiss)
-        .into()
+    iced::widget::mouse_area(page).on_press(on_dismiss).into()
 }
 
 pub fn sent_celebration_page<'a, M: Clone + 'a>(
@@ -155,9 +153,7 @@ pub fn sent_celebration_page<'a, M: Clone + 'a>(
 
     // Like the received page, the tall artwork can push "Back" out of reach on
     // short windows, so make a click anywhere on the splash dismiss it too.
-    iced::widget::mouse_area(page)
-        .on_press(on_dismiss)
-        .into()
+    iced::widget::mouse_area(page).on_press(on_dismiss).into()
 }
 
 /// Empty-state placeholder card — centered icon + title + subtitle on a


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized Iced UI interaction change on celebration overlays with no auth, data, or payment logic touched.
> 
> **Overview**
> Fixes a UX bug where **payment received** and **transaction complete** celebration screens could trap users on short windows: the large artwork pushes the **Back** button below the visible area with no way to scroll to it.
> 
> Both `received_celebration_page` and `sent_celebration_page` now wrap their layout in a `mouse_area` so **any click** (including on the image) fires the same dismiss handler as **Back**. The dismiss callback is cloned for the button and consumed by the mouse area, which requires `M: Clone` on the message type (already satisfied by existing dismiss messages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5775a60816775b93abf162fa4ff203b35d6ac24a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Celebration pages can now be dismissed by clicking anywhere on the displayed content, including the image.
  * Updated the Back button dismissal behavior for consistent page closing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->