### PR TITLE
Fix/ci coincubed

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -125,12 +125,19 @@ jobs:
             chmod 754 electrs
             export ELECTRS_PATH=$PWD/electrs
           fi
-          curl -LO https://github.com/coincubetech/coincube/releases/download/v1.0.0/coincube-1.0.0-x86_64-unknown-linux-gnu.tar.gz
-          echo "9979f50c65991d2417b0c6c57701f00ebf91cdcd10b9583de0bcc9d898f0dc38 coincube-1.0.0-x86_64-unknown-linux-gnu.tar.gz" | sha256sum -c
-          tar -xzf coincube-1.0.0-x86_64-unknown-linux-gnu.tar.gz
-          # Find the binary
-          OLD_PATH=$(find $PWD -type f -name coincubed | head -n 1)
-          export OLD_COINCUBED_PATH="$OLD_PATH"
+          # The migration test (tests/test_misc.py::test_migration) needs a
+          # genuinely-old coincubed binary to build a legacy datadir. Upstream
+          # Liana shipped `lianad` in its release archive and pointed
+          # OLD_LIANAD_PATH straight at it; Coincube's releases ship only the
+          # `coincube` GUI (the v1.0.0 linux tarball contains coincube/LICENCE/
+          # README.md — no coincubed). The old `find $PWD -name coincubed`
+          # therefore matched nothing from a release and silently fell through
+          # to the freshly-built target/release/coincubed, turning the migration
+          # test into a meaningless new-vs-new comparison that passes only
+          # because the current daemon's version (0.9.0) happens to be in the
+          # accepted set. Leave OLD_COINCUBED_PATH unset so test_migration skips
+          # honestly. To restore real coverage, publish a coincubed binary as a
+          # release asset and point OLD_COINCUBED_PATH at it explicitly here.
           # Run the functional tests
           if [ "$USE_KNOTS" = "TRUE" ]; then
             # This leg exists to validate standard transaction relay under the

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -146,12 +146,16 @@ jobs:
             pytest tests/test_knots.py -vvv
           elif [ "$BITCOIN_BACKEND_TYPE" = "electrs" ]; then
             # Deep reorg indexing is I/O-heavy and can starve when eight
-            # bitcoind/electrs pairs run together. Keep the broad suite
-            # parallel, then exercise this reorg deterministically on its own.
+            # bitcoind/electrs pairs run together (the daemon stops answering
+            # RPC mid-rescan and the call times out). Keep the broad suite
+            # parallel, then exercise the reorg-heavy tests deterministically on
+            # their own with a higher timeout.
             pytest tests/ -vvv -n 8 \
-              --deselect tests/test_chain.py::test_reorg_exclusion
+              --deselect tests/test_chain.py::test_reorg_exclusion \
+              --deselect tests/test_chain.py::test_rescan_edge_cases
             TIMEOUT=240 pytest \
-              tests/test_chain.py::test_reorg_exclusion -vvv
+              tests/test_chain.py::test_reorg_exclusion \
+              tests/test_chain.py::test_rescan_edge_cases -vvv
           else
             pytest tests/ -vvv -n 8
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,6 +76,19 @@ jobs:
         with:
           persist-credentials: false
 
+      # The minimal-profile GUI build enables LTO (see env above), which spills
+      # large LLVM intermediates to disk; together with the restored target/
+      # cache this exhausts ubuntu-latest's ~14 GB of free space
+      # ("No space left on device"). Reclaim the big preinstalled toolchains we
+      # don't use, before the cache restore and build. Linux only — the macOS
+      # and Windows runners have more headroom and lack these paths.
+      - name: Free disk space (Linux)
+        if: matrix.platform == 'linux'
+        run: |
+          echo "Before:"; df -h /
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/hostedtoolcache/CodeQL
+          echo "After:"; df -h /
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/coincube-gui/src/app/view/global_home.rs
+++ b/coincube-gui/src/app/view/global_home.rs
@@ -1,6 +1,7 @@
 use breez_sdk_liquid::{bitcoin::Denomination, model::PreparePayOnchainResponse};
 use std::time::Duration;
 
+use coincube_ui::component::text::Text;
 use coincube_ui::{
     color,
     component::{amount::*, button, form, spinner, text::*},

--- a/coincube-gui/src/app/view/mod.rs
+++ b/coincube-gui/src/app/view/mod.rs
@@ -31,6 +31,7 @@ use iced::{
     Alignment, Length,
 };
 
+use coincube_ui::component::text::Text;
 use coincube_ui::{
     color,
     component::{button, text, text::*},

--- a/coincube-gui/src/app/view/p2p/components/order_filters.rs
+++ b/coincube-gui/src/app/view/p2p/components/order_filters.rs
@@ -217,7 +217,7 @@ pub fn order_filter_sidebar<'a>(state: OrderFilterState<'a>) -> Container<'a, vi
                 slider(0.0..=5.0_f32, state.min_rating, |v: f32| {
                     view::Message::P2P(P2PMessage::FilterMinRatingChanged(v))
                 })
-                .step(0.5),
+                .step(0.5_f32),
             ]
             .spacing(4),
             column![
@@ -230,7 +230,7 @@ pub fn order_filter_sidebar<'a>(state: OrderFilterState<'a>) -> Container<'a, vi
                 slider(0.0..=365.0_f32, state.min_days_active as f32, |v: f32| {
                     view::Message::P2P(P2PMessage::FilterMinDaysActiveChanged(v as u32))
                 })
-                .step(1.0),
+                .step(1.0_f32),
             ]
             .spacing(4),
             caption(description).style(theme::text::secondary),

--- a/coincube-gui/src/app/view/p2p/panel.rs
+++ b/coincube-gui/src/app/view/p2p/panel.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
 use std::sync::Arc;
 
+use coincube_ui::component::text::Text;
 use coincube_ui::{
     component::{button, card, form, text::*},
     icon, theme,
@@ -1528,7 +1529,7 @@ impl P2PPanel {
                 slider(slider_min..=slider_max, premium_val, |v: f32| {
                     view::Message::P2P(P2PMessage::PremiumEdited((v as i64).to_string()))
                 })
-                .step(1.0),
+                .step(1.0_f32),
             ]
             .spacing(8);
             if !self.create_premium.value.is_empty() {

--- a/coincube-gui/src/app/view/settings/mod.rs
+++ b/coincube-gui/src/app/view/settings/mod.rs
@@ -5,6 +5,7 @@ pub mod install_stats;
 pub mod local_signing;
 pub mod recovery_kit;
 
+use coincube_ui::component::text::Text;
 use coincube_ui::{component::text::*, widget::*};
 
 use crate::app::view::message::*;

--- a/coincube-gui/src/app/view/shared/picker.rs
+++ b/coincube-gui/src/app/view/shared/picker.rs
@@ -1,3 +1,4 @@
+use coincube_ui::component::text::Text;
 use coincube_ui::{color, component::text::*, icon, theme, widget::*};
 use iced::{
     widget::{button as iced_button, container, Column, Container, Row, Space},

--- a/coincube-gui/src/app/view/spark/last_tx.rs
+++ b/coincube-gui/src/app/view/spark/last_tx.rs
@@ -2,6 +2,7 @@
 //! panels. Produces the same row layout as the Spark Overview / Spark
 //! Transactions pages so users see a consistent list across the wallet.
 
+use coincube_ui::component::text::Text;
 use coincube_ui::{
     color,
     component::{

--- a/coincube-gui/src/app/view/spark/overview.rs
+++ b/coincube-gui/src/app/view/spark/overview.rs
@@ -12,6 +12,7 @@
 use coincube_core::miniscript::bitcoin::Amount;
 
 use crate::app::wallets::DomainPaymentStatus;
+use coincube_ui::component::text::Text;
 use coincube_ui::{
     color,
     component::{

--- a/coincube-gui/src/app/view/spark/transactions.rs
+++ b/coincube-gui/src/app/view/spark/transactions.rs
@@ -23,6 +23,7 @@ use iced::widget::image;
 use crate::app::wallets::DomainPaymentStatus;
 use crate::export::ImportExportMessage;
 use crate::utils::{format_timestamp, truncate_middle};
+use coincube_ui::component::text::Text;
 use coincube_ui::{
     component::{
         amount::{amount_with_size_and_unit, BitcoinDisplayUnit, DisplayAmount},

--- a/coincube-gui/src/installer/view/editor/mod.rs
+++ b/coincube-gui/src/installer/view/editor/mod.rs
@@ -380,6 +380,7 @@ pub fn edit_threshold_modal<'a>(threshold: (usize, usize)) -> Element<'a, Messag
 }
 
 mod threshsold_input {
+    use coincube_ui::component::text::Text;
     use coincube_ui::{component::text::*, icon, theme, widget::*};
     use iced::alignment::{self, Alignment};
     use iced::widget::{component, Component};

--- a/coincube-gui/src/loader.rs
+++ b/coincube-gui/src/loader.rs
@@ -1090,8 +1090,14 @@ mod tests {
         let tmp = TempDir::new();
         let internal_datadir = tmp.path().join("bitcoind/datadir");
         let cookie = internal_datadir.join(".cookie");
+        // Embed the path with a TOML *literal* string (single quotes): on
+        // Windows `cookie.display()` yields backslashes, which a basic
+        // (double-quoted) string treats as escape sequences (e.g. `\U`),
+        // making the config unparseable. Literal strings pass backslashes
+        // through verbatim — the same round-trip `toml::to_string_pretty`
+        // gives real configs.
         let backend = format!(
-            "[bitcoind_config]\ncookie_path = \"{}\"\naddr = \"127.0.0.1:8332\"",
+            "[bitcoind_config]\ncookie_path = '{}'\naddr = \"127.0.0.1:8332\"",
             cookie.display()
         );
         let config_path = write_daemon_toml(tmp.path(), &backend);

--- a/coincubed/src/jsonrpc/server/unix.rs
+++ b/coincubed/src/jsonrpc/server/unix.rs
@@ -195,7 +195,12 @@ fn bind(socket_path: &path::Path) -> Result<net::UnixListener, io::Error> {
 
 /// Bind to the UDS at `socket_path`
 pub fn rpcserver_setup(socket_path: &path::Path) -> Result<net::UnixListener, io::Error> {
-    log::debug!("Binding socket at {}", socket_path.display());
+    // info, not debug: the control-socket path (hashed into the temp dir since
+    // it must fit sun_path) is how clients — including the functional test
+    // harness — discover where to connect. Keep it at the same level as the
+    // "JSONRPC server started." line below so it's present whenever the server
+    // is reachable, not only under debug logging.
+    log::info!("Binding socket at {}", socket_path.display());
     // Create the socket with RW permissions only for the user
     let listener = bind(socket_path)?;
 

--- a/tests/test_framework/coincubed.py
+++ b/tests/test_framework/coincubed.py
@@ -146,12 +146,21 @@ class Coincubed(TailableProc):
         that bound at the legacy path don't emit this line, so keep the
         ``{data_directory}/coincubed_rpc`` path set in ``__init__`` as a
         fallback.
+
+        NB: ``TailableProc.tail`` stores each log line as ``str(bytes)`` — the
+        *repr* of the raw stdout bytes, e.g. ``b'... Binding socket at
+        /tmp/cc<hash>.sock'`` — so a bare ``(.+)`` capture would swallow the
+        trailing repr quote and connect to a bogus path. Anchor the capture on
+        the ``.sock`` suffix the daemon always uses (see
+        ``coincubed_rpc_socket_path`` in ``coincubed/src/datadir.rs``); this
+        ends the match before any trailing quote and works whether the stored
+        line is repr-wrapped or a plain decoded string.
         """
-        pattern = r"Binding socket at (.+)"
+        pattern = r"Binding socket at (.+\.sock)"
         line = self.is_in_log(pattern)
         if line is None:
             return
-        socket_path = re.search(pattern, line).group(1).strip()
+        socket_path = re.search(pattern, line).group(1)
         self.rpc = UnixDomainSocketRpc(socket_path)
 
     def stop(self, timeout=5):

--- a/tests/test_framework/coincubed.py
+++ b/tests/test_framework/coincubed.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import shutil
 
 from bip380.descriptors import Descriptor
@@ -128,6 +129,30 @@ class Coincubed(TailableProc):
                 "JSONRPC server started.",
             ]
         )
+        self._sync_rpc_socket_path()
+
+    def _sync_rpc_socket_path(self):
+        """Point the RPC client at the control socket the daemon actually bound.
+
+        Since coincubed 29f100ca the socket is no longer at
+        ``{data_directory}/coincubed_rpc``: to stay under the 104-byte
+        ``sun_path`` limit (notably on macOS) the daemon hashes the data
+        directory and binds at ``{tmpdir}/cc<hash>.sock`` (see
+        ``coincubed_rpc_socket_path`` in ``coincubed/src/datadir.rs``). Rather
+        than replicate Rust's hashing in Python, read the real path straight
+        from the daemon's own startup log — it logs ``Binding socket at
+        <path>`` (debug) immediately before the ``JSONRPC server started.``
+        line we just waited on, so the entry is already captured. Older daemons
+        that bound at the legacy path don't emit this line, so keep the
+        ``{data_directory}/coincubed_rpc`` path set in ``__init__`` as a
+        fallback.
+        """
+        pattern = r"Binding socket at (.+)"
+        line = self.is_in_log(pattern)
+        if line is None:
+            return
+        socket_path = re.search(pattern, line).group(1).strip()
+        self.rpc = UnixDomainSocketRpc(socket_path)
 
     def stop(self, timeout=5):
         try:

--- a/tests/test_framework/coincubed.py
+++ b/tests/test_framework/coincubed.py
@@ -42,8 +42,10 @@ class Coincubed(TailableProc):
         self.conf_file = os.path.join(datadir, "config.toml")
         self.cmd_line = [COINCUBED_PATH, "--conf", f"{self.conf_file}"]
         data_directory = os.path.join(datadir, "regtest")
-        socket_path = os.path.join(data_directory, "coincubed_rpc")
-        self.rpc = UnixDomainSocketRpc(socket_path)
+        # Legacy control-socket location, used by older daemons that don't log
+        # their bound path and as the reset target in _sync_rpc_socket_path.
+        self.legacy_socket_path = os.path.join(data_directory, "coincubed_rpc")
+        self.rpc = UnixDomainSocketRpc(self.legacy_socket_path)
         self.bitcoin_backend = bitcoin_backend
 
         with open(self.conf_file, "w") as f:
@@ -122,6 +124,12 @@ class Coincubed(TailableProc):
         )
 
     def start(self):
+        # Mark the current end of the captured log before the daemon starts.
+        # `self.logs` is never cleared, so after `restart_fresh` the history
+        # still holds earlier daemons' "Binding socket at" lines; the socket
+        # scan below must consider only the line *this* start produces, or it
+        # could latch onto a previous daemon's stale temp socket.
+        log_offset = len(self.logs)
         TailableProc.start(self)
         self.wait_for_logs(
             [
@@ -129,9 +137,9 @@ class Coincubed(TailableProc):
                 "JSONRPC server started.",
             ]
         )
-        self._sync_rpc_socket_path()
+        self._sync_rpc_socket_path(log_offset)
 
-    def _sync_rpc_socket_path(self):
+    def _sync_rpc_socket_path(self, search_from=0):
         """Point the RPC client at the control socket the daemon actually bound.
 
         Since coincubed 29f100ca the socket is no longer at
@@ -142,10 +150,16 @@ class Coincubed(TailableProc):
         than replicate Rust's hashing in Python, read the real path straight
         from the daemon's own startup log — it logs ``Binding socket at
         <path>`` (debug) immediately before the ``JSONRPC server started.``
-        line we just waited on, so the entry is already captured. Older daemons
-        that bound at the legacy path don't emit this line, so keep the
-        ``{data_directory}/coincubed_rpc`` path set in ``__init__`` as a
-        fallback.
+        line we just waited on, so the entry is already captured.
+
+        ``search_from`` is the log length captured just before this start (see
+        ``start``); the scan is restricted to lines from *this* daemon. This
+        matters across ``restart_fresh``: ``self.logs`` is never cleared, so an
+        earlier daemon's "Binding socket at" line lingers in the history and a
+        from-zero scan could bind a stale temp socket. When this start logged no
+        such line — an older daemon that binds the legacy
+        ``{data_directory}/coincubed_rpc`` path — reset to that legacy path
+        rather than keeping whatever a prior start pointed us at.
 
         NB: ``TailableProc.tail`` stores each log line as ``str(bytes)`` — the
         *repr* of the raw stdout bytes, e.g. ``b'... Binding socket at
@@ -157,8 +171,12 @@ class Coincubed(TailableProc):
         line is repr-wrapped or a plain decoded string.
         """
         pattern = r"Binding socket at (.+\.sock)"
-        line = self.is_in_log(pattern)
+        line = self.is_in_log(pattern, start=search_from)
         if line is None:
+            # This start logged no socket line — an older daemon binding the
+            # legacy path. Reset to it (a prior start on this object may have
+            # pointed us at a temp .sock).
+            self.rpc = UnixDomainSocketRpc(self.legacy_socket_path)
             return
         socket_path = re.search(pattern, line).group(1)
         self.rpc = UnixDomainSocketRpc(socket_path)

--- a/tests/test_framework/coincubed.py
+++ b/tests/test_framework/coincubed.py
@@ -149,8 +149,10 @@ class Coincubed(TailableProc):
         ``coincubed_rpc_socket_path`` in ``coincubed/src/datadir.rs``). Rather
         than replicate Rust's hashing in Python, read the real path straight
         from the daemon's own startup log — it logs ``Binding socket at
-        <path>`` (debug) immediately before the ``JSONRPC server started.``
-        line we just waited on, so the entry is already captured.
+        <path>`` at info (same level as, and immediately before, the ``JSONRPC
+        server started.`` line we just waited on), so the entry is present
+        whenever the server is reachable — not only under debug logging — and is
+        already captured by the time this runs.
 
         ``search_from`` is the log length captured just before this start (see
         ``start``); the scan is restricted to lines from *this* daemon. This

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1032,7 +1032,7 @@ def test_start_rescan(coincubed, bitcoind):
         # Only spend coins comfortably above spend_coins' flat per-input fee so
         # the output can't fall below the dust limit — this also skips the small
         # change coins that multi-input spends leave behind (matches upstream).
-        avail = list(c for c in unspent_coins() if c["amount"] > 1_000)
+        avail = [c for c in unspent_coins() if c["amount"] > 1_000]
         to_spend = random.sample(avail, random.randint(1, len(avail)))
         spend_coins(coincubed, bitcoind, to_spend)
         bitcoind.generate_block(random.randint(1, 5), wait_for_mempool=2)

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1797,14 +1797,14 @@ def test_rbfpsbt_insufficient_funds(coincubed, bitcoind):
     wait_for(lambda: len(coincubed.rpc.listcoins(["confirmed"])["coins"]) == 0)
     # Get another coin.
     deposit_txid_2 = bitcoind.rpc.sendtoaddress(
-        coincubed.rpc.getnewaddress()["address"], 5_200 / COIN
+        coincubed.rpc.getnewaddress()["address"], 700 / COIN
     )
     bitcoind.generate_block(1, wait_for_mempool=deposit_txid_2)
     wait_for(lambda: len(coincubed.rpc.listcoins(["confirmed"])["coins"]) == 1)
 
     # Create a spend that we will then attempt to cancel.
     destinations_2 = {
-        bitcoind.rpc.getnewaddress(): 5_000,
+        bitcoind.rpc.getnewaddress(): 500,
     }
     spend_res_2 = coincubed.rpc.createspend(destinations_2, [], 1)
     spend_psbt_2 = PSBT.from_base64(spend_res_2["psbt"])

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1017,7 +1017,12 @@ def test_start_rescan(coincubed, bitcoind):
     # First, get some coins
     for _ in range(10):
         addr = coincubed.rpc.getnewaddress()["address"]
-        amount = random.randint(1, COIN * 10) / COIN
+        # Floor the deposit so that spending a single one of these coins can't
+        # produce a sub-dust (< DUST_OUTPUT_SATS) output in spend_coins, which
+        # subtracts a flat fee and has no dust guard. Without a floor the
+        # unseeded randomness occasionally picks a ~600-sat coin and createspend
+        # rejects the resulting output ("Invalid output value").
+        amount = random.randint(10_000, COIN * 10) / COIN
         txid = bitcoind.rpc.sendtoaddress(addr, amount)
         bitcoind.generate_block(random.randint(1, 10), wait_for_mempool=txid)
     wait_for(lambda: len(list_coins()) == 10)
@@ -1027,7 +1032,12 @@ def test_start_rescan(coincubed, bitcoind):
     # without change, single or multiple inputs, sending externally or to self).
     for _ in range(5):
         addr = coincubed.rpc.getnewaddress()["address"]
-        amount = random.randint(1, COIN * 10) / COIN
+        # Floor the deposit so that spending a single one of these coins can't
+        # produce a sub-dust (< DUST_OUTPUT_SATS) output in spend_coins, which
+        # subtracts a flat fee and has no dust guard. Without a floor the
+        # unseeded randomness occasionally picks a ~600-sat coin and createspend
+        # rejects the resulting output ("Invalid output value").
+        amount = random.randint(10_000, COIN * 10) / COIN
         txid = bitcoind.rpc.sendtoaddress(addr, amount)
         avail = list(unspent_coins())
         to_spend = random.sample(avail, random.randint(1, len(avail)))

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1017,12 +1017,7 @@ def test_start_rescan(coincubed, bitcoind):
     # First, get some coins
     for _ in range(10):
         addr = coincubed.rpc.getnewaddress()["address"]
-        # Floor the deposit so that spending a single one of these coins can't
-        # produce a sub-dust (< DUST_OUTPUT_SATS) output in spend_coins, which
-        # subtracts a flat fee and has no dust guard. Without a floor the
-        # unseeded randomness occasionally picks a ~600-sat coin and createspend
-        # rejects the resulting output ("Invalid output value").
-        amount = random.randint(10_000, COIN * 10) / COIN
+        amount = random.randint(1, COIN * 10) / COIN
         txid = bitcoind.rpc.sendtoaddress(addr, amount)
         bitcoind.generate_block(random.randint(1, 10), wait_for_mempool=txid)
     wait_for(lambda: len(list_coins()) == 10)
@@ -1032,14 +1027,12 @@ def test_start_rescan(coincubed, bitcoind):
     # without change, single or multiple inputs, sending externally or to self).
     for _ in range(5):
         addr = coincubed.rpc.getnewaddress()["address"]
-        # Floor the deposit so that spending a single one of these coins can't
-        # produce a sub-dust (< DUST_OUTPUT_SATS) output in spend_coins, which
-        # subtracts a flat fee and has no dust guard. Without a floor the
-        # unseeded randomness occasionally picks a ~600-sat coin and createspend
-        # rejects the resulting output ("Invalid output value").
-        amount = random.randint(10_000, COIN * 10) / COIN
+        amount = random.randint(1, COIN * 10) / COIN
         txid = bitcoind.rpc.sendtoaddress(addr, amount)
-        avail = list(unspent_coins())
+        # Only spend coins comfortably above spend_coins' flat per-input fee so
+        # the output can't fall below the dust limit — this also skips the small
+        # change coins that multi-input spends leave behind (matches upstream).
+        avail = list(c for c in unspent_coins() if c["amount"] > 1_000)
         to_spend = random.sample(avail, random.randint(1, len(avail)))
         spend_coins(coincubed, bitcoind, to_spend)
         bitcoind.generate_block(random.randint(1, 5), wait_for_mempool=2)

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -131,17 +131,17 @@ def test_coin_marked_spent(coincubed, bitcoind):
         if deposit_b in c["outpoint"]
     )
     destinations = {
-        bitcoind.rpc.getnewaddress(): int(0.02 * COIN) - 1_000,
+        bitcoind.rpc.getnewaddress(): int(0.02 * COIN) - 500,
     }
     res = coincubed.rpc.createspend(destinations, [outpoint], 1)
     psbt = PSBT.from_base64(res["psbt"])
     sign_and_broadcast(psbt)
-    change_amount = 858 if USE_TAPROOT else 839
+    change_amount = 358 if USE_TAPROOT else 339
     assert len(psbt.o) == 1
     assert len(res["warnings"]) == 1
     assert (
         res["warnings"][0]
-        == "Dust UTXO. The minimal change output allowed by Coincube is 5000 sats. "
+        == "Dust UTXO. The minimal change output allowed by Coincube is 500 sats. "
         f"Instead of creating a change of {change_amount} sats, it was added to the "
         "transaction fee. Select a larger input to avoid this from happening."
     )
@@ -149,18 +149,18 @@ def test_coin_marked_spent(coincubed, bitcoind):
     # Spend the third coin to an address of ours, no change
     coins_c = [c for c in coincubed.rpc.listcoins()["coins"] if deposit_c in c["outpoint"]]
     destinations = {
-        coincubed.rpc.getnewaddress()["address"]: int(0.03 * COIN) - 1_000,
+        coincubed.rpc.getnewaddress()["address"]: int(0.03 * COIN) - 500,
     }
     outpoint_3 = [c["outpoint"] for c in coins_c if c["amount"] == 0.03 * COIN][0]
     res = coincubed.rpc.createspend(destinations, [outpoint_3], 1)
     psbt = PSBT.from_base64(res["psbt"])
     sign_and_broadcast(psbt)
-    change_amount = 846 if USE_TAPROOT else 827
+    change_amount = 346 if USE_TAPROOT else 327
     assert len(psbt.o) == 1
     assert len(res["warnings"]) == 1
     assert (
         res["warnings"][0]
-        == "Dust UTXO. The minimal change output allowed by Coincube is 5000 sats. "
+        == "Dust UTXO. The minimal change output allowed by Coincube is 500 sats. "
         f"Instead of creating a change of {change_amount} sats, it was added to the "
         "transaction fee. Select a larger input to avoid this from happening."
     )
@@ -289,7 +289,7 @@ def test_send_to_self(coincubed, bitcoind):
     # Create a new spend to the receive address with index 3.
     recv_addr = coincubed.rpc.listaddresses(3, 1)["addresses"][0]["receive"]
     res = coincubed.rpc.createspend(
-        {recv_addr: 11_965_000 if USE_TAPROOT else 11_955_000}, [], 2
+        {recv_addr: 11_967_600 if USE_TAPROOT else 11_959_200}, [], 2
     )
     assert "psbt" in res
     # Max(receive_index, change_index) is 3, so we return addresses 0, 1, 2, 3:

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -151,7 +151,7 @@ def test_coin_marked_spent(coincubed, bitcoind):
     destinations = {
         coincubed.rpc.getnewaddress()["address"]: int(0.03 * COIN) - 500,
     }
-    outpoint_3 = [c["outpoint"] for c in coins_c if c["amount"] == 0.03 * COIN][0]
+    outpoint_3 = next(c["outpoint"] for c in coins_c if c["amount"] == 0.03 * COIN)
     res = coincubed.rpc.createspend(destinations, [outpoint_3], 1)
     psbt = PSBT.from_base64(res["psbt"])
     sign_and_broadcast(psbt)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflows, functional-test plumbing, info-level logging, and compile/test expectation updates—no production auth, payment, or wallet logic paths are modified in this diff.
> 
> **Overview**
> **CI and test harness** fixes so integration and nightly jobs behave honestly under Coincube’s current release layout and daemon RPC changes.
> 
> **Functional tests (`integration.yml`)** stop downloading a Coincube GUI tarball to fake an “old” `coincubed` for migration: releases don’t ship `coincubed`, so `OLD_COINCUBED_PATH` is left unset and `test_migration` skips instead of comparing new-vs-new. On **electrs** legs, `test_rescan_edge_cases` is deselected from the parallel `-n 8` run and executed serially with `TIMEOUT=240` alongside `test_reorg_exclusion` to avoid RPC timeouts during heavy rescans.
> 
> **Test framework** points the RPC client at the daemon’s real Unix socket by parsing `Binding socket at …` from logs after each start (with log-offset handling across `restart_fresh`); **`coincubed`** logs that path at **info** so discovery works without debug logging.
> 
> **Nightly Linux** adds a step to remove large preinstalled toolchains before cache restore/build to avoid “no space left on device” with LTO + `target/` cache.
> 
> Smaller fixes: explicit `Text` imports and `f32` slider steps in the GUI, a Windows-safe TOML literal in a loader unit test, and refreshed spend/RBF/dust assertions in Python tests (500 sats minimal change messaging and amounts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca41e36b4a6bec346120f8f1a47ea3c5cdb9eb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability by syncing the RPC client to the actual Unix domain socket created at daemon startup.
  * Avoided accidental migration comparisons when no legacy binary is provided; improved Windows config parsing.
  * Updated transaction-related expectations (rescan deposits, RBF cancel, dust/minimal change, send-to-self).
* **Build & CI**
  * Nightly builds free disk space on Linux runners to reduce out-of-disk failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->