### PR TITLE
Replace user agent with device name in login activity display

### DIFF
--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -1463,7 +1463,7 @@ fn security_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccount
                 let status_color = if ok { color::ORANGE } else { color::RED };
 
                 let ip = a.ip_address.as_deref();
-                let ua = a.user_agent.as_deref();
+                let ua = a.device_name.as_deref();
                 let ip_and_ua = match (ip, ua) {
                     (Some(i), Some(u)) => {
                         let short_u = if u.chars().count() > 60 {

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -794,7 +794,7 @@ pub struct VerifiedDevice {
 pub struct LoginActivity {
     pub id: u32,
     pub ip_address: Option<String>,
-    pub user_agent: Option<String>,
+    pub device_name: Option<String>,
     pub created_at: String,
     pub success: Option<bool>,
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Security → Login Activity entries to display the device name instead of the user-agent string.
  * Preserved existing display formatting for IP addresses, status, messages, and timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->