### PR TITLE
Added more test coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,9 @@ on:
       - "**/*.rs"
       - "**/Cargo.toml"
       - "Cargo.lock"
+      - "coincube-spark-bridge/Cargo.lock"
       - "contrib/coverage.sh"
+      - "contrib/coverage-bridge.sh"
       - ".github/workflows/coverage.yml"
   workflow_dispatch:
 
@@ -18,6 +20,10 @@ jobs:
       BREEZ_API_KEY: DUMMY_BREEZ_API_KEY
       CARGO_TOOLCHAIN: nightly-2026-06-17
       COVERAGE_DOCTESTS: 1
+      # Current full-workspace baseline is ~26.8%. Keep the gate non-breaking
+      # while focused tests ratchet this toward COVERAGE_TARGET_LINES.
+      COVERAGE_TARGET_LINES: 50
+      FAIL_UNDER_LINES: 26
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -48,3 +54,43 @@ jobs:
           path: |
             target/coverage/lcov.info
             target/coverage/summary.json
+
+  spark-bridge-coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CARGO_TOOLCHAIN: nightly-2026-06-17
+      # Current bridge baseline is ~10.9%. The bridge is covered separately
+      # because it is intentionally not part of the root Cargo workspace.
+      COVERAGE_TARGET_LINES: 50
+      FAIL_UNDER_LINES: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
+        with:
+          toolchain: nightly-2026-06-17
+          components: llvm-tools-preview
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config protobuf-compiler
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@528e28158500e8adf409c61ac0eaa6bdd47f49ca # cargo-llvm-cov
+
+      - name: Generate Spark bridge coverage
+        run: ./contrib/coverage-bridge.sh
+
+      - name: Upload Spark bridge coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: spark-bridge-coverage
+          path: |
+            target/coverage/bridge-lcov.info
+            target/coverage/bridge-summary.json

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -147,14 +147,18 @@ jobs:
           elif [ "$BITCOIN_BACKEND_TYPE" = "electrs" ]; then
             # Deep reorg indexing is I/O-heavy and can starve when eight
             # bitcoind/electrs pairs run together (the daemon stops answering
-            # RPC mid-rescan and the call times out). Keep the broad suite
-            # parallel, then exercise the reorg-heavy tests deterministically on
-            # their own with a higher timeout.
+            # RPC mid-reorg and the call times out). Keep the broad suite
+            # parallel, then exercise every simple_reorg-driven test
+            # deterministically on its own with a higher timeout.
             pytest tests/ -vvv -n 8 \
+              --deselect tests/test_chain.py::test_reorg_detection \
               --deselect tests/test_chain.py::test_reorg_exclusion \
+              --deselect tests/test_chain.py::test_reorg_status_recovery \
               --deselect tests/test_chain.py::test_rescan_edge_cases
             TIMEOUT=240 pytest \
+              tests/test_chain.py::test_reorg_detection \
               tests/test_chain.py::test_reorg_exclusion \
+              tests/test_chain.py::test_reorg_status_recovery \
               tests/test_chain.py::test_rescan_edge_cases -vvv
           else
             pytest tests/ -vvv -n 8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,10 @@ jobs:
   unit_tests:
     needs: linter
     strategy:
+      # Don't cancel the whole matrix when one leg fails: a flaky Windows job
+      # was masking otherwise-green macOS/ubuntu results and forcing full
+      # re-runs to see them.
+      fail-fast: false
       matrix:
         toolchain:
           - stable
@@ -46,6 +50,20 @@ jobs:
         run: |
           rustup update ${{ matrix.toolchain }}
           rustup default ${{ matrix.toolchain }}
+      # Windows Defender's real-time scanning briefly locks files the tests
+      # have just written under %TEMP%, so a follow-up read/enumerate can miss
+      # them and surface as os error 2/3/5. Exclude the temp/work dirs (and drop
+      # real-time monitoring as a fallback) so the filesystem-heavy tests aren't
+      # racing an antivirus scan. Best-effort: ignore failures if a cmdlet is
+      # blocked, since the code paths are also hardened with bounded retries.
+      - name: Reduce Defender interference (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          Add-MpPreference -ExclusionPath $env:TEMP -ErrorAction SilentlyContinue
+          Add-MpPreference -ExclusionPath $env:RUNNER_TEMP -ErrorAction SilentlyContinue
+          Add-MpPreference -ExclusionPath $env:GITHUB_WORKSPACE -ErrorAction SilentlyContinue
+          Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
       - name: Test on Rust ${{ matrix.toolchain }} (Windows)
         if: matrix.os == 'windows-latest'
         run: |

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -4890,3 +4890,273 @@ fn restart_daemon_blocking(
     }
     DaemonRestart::Started(daemon)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::{
+        fs,
+        io::ErrorKind,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use coincube_core::miniscript::bitcoin::Network;
+
+    use crate::{
+        app::settings::{CubeSettings, Settings, SETTINGS_FILE_NAME},
+        services::duress::DuressLocalState,
+    };
+
+    struct TempRoot(PathBuf);
+
+    impl TempRoot {
+        fn new(label: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after unix epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "coincube-app-{label}-{}-{unique}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).expect("create test root");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempRoot {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn write_settings_dir(root: &Path, name: &str, settings: Settings) -> PathBuf {
+        let dir = root.join(name);
+        fs::create_dir_all(&dir).expect("create network dir");
+        let bytes = serde_json::to_vec_pretty(&settings).expect("serialize settings");
+        fs::write(dir.join(SETTINGS_FILE_NAME), bytes).expect("write settings");
+        dir
+    }
+
+    fn cube(id: &str, name: &str, network: Network) -> CubeSettings {
+        CubeSettings::new_with_raw_id(id.to_string(), name.to_string(), network)
+    }
+
+    #[test]
+    fn connection_status_visibility_and_tooltips_are_stable() {
+        assert!(!ConnectionStatus::Inactive.is_visible());
+        assert_eq!(ConnectionStatus::Inactive.tooltip(), "Connect inactive");
+
+        assert!(ConnectionStatus::Connecting.is_visible());
+        assert!(ConnectionStatus::Connecting
+            .tooltip()
+            .starts_with("Connecting to Coincube Connect"));
+
+        assert!(ConnectionStatus::Connected.is_visible());
+        assert_eq!(ConnectionStatus::Connected.tooltip(), "Connected");
+
+        let err = ConnectionStatus::Error("socket closed".to_string());
+        assert!(err.is_visible());
+        assert_eq!(err.tooltip(), "Connection error: socket closed");
+    }
+
+    #[test]
+    fn daemon_unreachable_detection_is_limited_to_transport_failures() {
+        assert!(is_daemon_unreachable(&Error::Daemon(
+            DaemonError::DaemonStopped
+        )));
+        assert!(is_daemon_unreachable(&Error::Daemon(DaemonError::NoAnswer)));
+        assert!(is_daemon_unreachable(&Error::Daemon(
+            DaemonError::RpcSocket(Some(ErrorKind::ConnectionRefused), "refused".to_string())
+        )));
+
+        assert!(!is_daemon_unreachable(&Error::Daemon(DaemonError::Rpc(
+            -1,
+            "application error".to_string()
+        ))));
+        assert!(!is_daemon_unreachable(&Error::Daemon(DaemonError::Http(
+            Some(500),
+            "server error".to_string()
+        ))));
+        assert!(!is_daemon_unreachable(&Error::Unexpected(
+            "not a daemon error".to_string()
+        )));
+    }
+
+    #[test]
+    fn duress_enroll_network_dirs_only_includes_settings_directories() {
+        let root = TempRoot::new("duress-dirs");
+        write_settings_dir(root.path(), "bitcoin", Settings::default());
+        write_settings_dir(root.path(), "regtest", Settings::default());
+
+        fs::create_dir_all(root.path().join("testnet")).expect("create ignored network dir");
+        fs::write(root.path().join("settings.json"), "{}").expect("write root-level file");
+        fs::write(root.path().join("loose-file"), "").expect("write ignored file");
+
+        let mut names = duress_enroll_network_dirs(root.path())
+            .into_iter()
+            .map(|dir| {
+                dir.path()
+                    .file_name()
+                    .expect("network dir has name")
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect::<Vec<_>>();
+        names.sort();
+
+        assert_eq!(names, vec!["bitcoin".to_string(), "regtest".to_string()]);
+    }
+
+    #[test]
+    fn duress_pin_collision_check_rejects_empty_and_real_cube_pin() {
+        let root = TempRoot::new("duress-collision");
+        assert_eq!(
+            duress_pin_collision_check(root.path(), "1234").unwrap_err(),
+            DURESS_NO_CUBES_MSG
+        );
+
+        let protected_cube = cube("cube-a", "Primary", Network::Bitcoin)
+            .with_pin("1234")
+            .expect("pin hash");
+        let secondary_cube = cube("cube-b", "Secondary", Network::Regtest)
+            .with_pin("9999")
+            .expect("pin hash");
+
+        write_settings_dir(
+            root.path(),
+            "bitcoin",
+            Settings {
+                cubes: vec![protected_cube],
+                ..Settings::default()
+            },
+        );
+        write_settings_dir(
+            root.path(),
+            "regtest",
+            Settings {
+                cubes: vec![secondary_cube],
+                ..Settings::default()
+            },
+        );
+
+        assert_eq!(
+            duress_pin_collision_check(root.path(), "1234").unwrap_err(),
+            DURESS_PIN_COLLIDES_MSG
+        );
+        assert!(duress_pin_collision_check(root.path(), "5555").is_ok());
+    }
+
+    #[test]
+    fn verify_regular_cube_pin_accepts_real_pin_and_rejects_duress_pin() {
+        let root = TempRoot::new("regular-pin");
+        let cube = cube("cube-a", "Primary", Network::Bitcoin)
+            .with_pin("1234")
+            .expect("pin hash")
+            .with_duress_pin("8765")
+            .expect("duress hash");
+
+        write_settings_dir(
+            root.path(),
+            "bitcoin",
+            Settings {
+                cubes: vec![cube],
+                ..Settings::default()
+            },
+        );
+
+        assert_eq!(
+            verify_regular_cube_pin(root.path(), "").unwrap_err(),
+            "Enter your Cube unlock PIN to continue."
+        );
+        assert!(verify_regular_cube_pin(root.path(), "1234").is_ok());
+        assert_eq!(
+            verify_regular_cube_pin(root.path(), "8765").unwrap_err(),
+            DURESS_STEP_UP_BAD_PIN_MSG
+        );
+    }
+
+    #[test]
+    fn verify_regular_cube_pin_allows_when_cubes_have_no_regular_pin() {
+        let root = TempRoot::new("regular-pinless");
+        write_settings_dir(
+            root.path(),
+            "bitcoin",
+            Settings {
+                cubes: vec![cube("cube-a", "Pinless", Network::Bitcoin)],
+                ..Settings::default()
+            },
+        );
+
+        assert!(verify_regular_cube_pin(root.path(), "any pin").is_ok());
+    }
+
+    #[test]
+    fn any_cube_duress_armed_scans_all_network_settings() {
+        let root = TempRoot::new("duress-armed");
+        write_settings_dir(
+            root.path(),
+            "bitcoin",
+            Settings {
+                cubes: vec![cube("cube-a", "Plain", Network::Bitcoin)],
+                ..Settings::default()
+            },
+        );
+        assert!(!any_cube_duress_armed(root.path()).expect("scan plain cube"));
+
+        let mut armed_cube = cube("cube-b", "Armed", Network::Regtest);
+        armed_cube.duress_pin_hash = Some("stored-duress-hash".to_string());
+        write_settings_dir(
+            root.path(),
+            "regtest",
+            Settings {
+                cubes: vec![armed_cube],
+                ..Settings::default()
+            },
+        );
+
+        assert!(any_cube_duress_armed(root.path()).expect("scan armed cube"));
+    }
+
+    #[tokio::test]
+    async fn clear_duress_enrollment_clears_cube_hashes_and_local_state() {
+        let root = TempRoot::new("duress-clear");
+        let mut armed_cube = cube("cube-a", "Armed", Network::Bitcoin);
+        armed_cube.duress_pin_hash = Some("stored-duress-hash".to_string());
+        let network_dir = write_settings_dir(
+            root.path(),
+            "bitcoin",
+            Settings {
+                cubes: vec![armed_cube],
+                ..Settings::default()
+            },
+        );
+        DuressLocalState {
+            enrolled: true,
+            active: true,
+            account_id: Some("acct-1".to_string()),
+            duress_code: Some("ciphertext".to_string()),
+            ..DuressLocalState::default()
+        }
+        .save(root.path())
+        .expect("save local state");
+
+        clear_duress_enrollment(CoincubeDirectory::new(root.path().to_path_buf()))
+            .await
+            .expect("clear duress");
+
+        let settings =
+            Settings::from_file(&crate::dir::NetworkDirectory::new(network_dir)).unwrap();
+        assert!(settings.cubes.iter().all(|cube| !cube.has_duress_pin()));
+        assert_eq!(
+            DuressLocalState::load(root.path()).expect("load cleared state"),
+            DuressLocalState::default()
+        );
+    }
+}

--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -47,16 +47,33 @@ impl Settings {
         let mut path = network_dir.path().to_path_buf();
         path.push(SETTINGS_FILE_NAME);
 
-        std::fs::read(path)
-            .map_err(|e| match e.kind() {
-                std::io::ErrorKind::NotFound => SettingsError::NotFound,
-                _ => SettingsError::ReadingFile(format!("Reading settings file: {}", e)),
-            })
-            .and_then(|file_content| {
-                serde_json::from_slice::<Settings>(&file_content).map_err(|e| {
-                    SettingsError::ReadingFile(format!("Parsing settings file: {}", e))
-                })
-            })
+        // Retry the transient sharing/permission failure Windows raises when a
+        // virus scanner or search indexer briefly holds settings.json (or a
+        // just-written file's lock hasn't been released yet): ERROR_ACCESS_DENIED
+        // ("os error 5"). A genuinely absent file is ErrorKind::NotFound, which
+        // is never retried and maps to SettingsError::NotFound as before.
+        let mut attempt = 0u32;
+        let file_content = loop {
+            match std::fs::read(&path) {
+                Ok(bytes) => break bytes,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    return Err(SettingsError::NotFound)
+                }
+                Err(e) if attempt < 5 && e.kind() == std::io::ErrorKind::PermissionDenied => {
+                    attempt += 1;
+                    std::thread::sleep(std::time::Duration::from_millis(20 * u64::from(attempt)));
+                }
+                Err(e) => {
+                    return Err(SettingsError::ReadingFile(format!(
+                        "Reading settings file: {}",
+                        e
+                    )))
+                }
+            }
+        };
+
+        serde_json::from_slice::<Settings>(&file_content)
+            .map_err(|e| SettingsError::ReadingFile(format!("Parsing settings file: {}", e)))
     }
 }
 

--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -68,49 +68,73 @@ where
     F: FnOnce(Settings) -> Option<Settings>,
 {
     let path = network_dir.path().join(SETTINGS_FILE_NAME);
-    // Ensure the network directory exists before opening with create(true).
-    // OpenOptions creates the file but never its parent directories, so a
-    // missing network dir surfaces as ERROR_PATH_NOT_FOUND ("os error 3" on
-    // Windows) instead of writing the settings file. Doing the create_dir_all
-    // in this async context, immediately before the open, also settles a
-    // Windows filesystem race where a just-created temp dir isn't yet visible
-    // to the following tokio::fs open. create_dir_all is idempotent, so this is
-    // a no-op when the dir already exists.
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|e| SettingsError::WritingFile(format!("Creating settings dir: {}", e)))?;
-    }
-    let file_exists = tokio::fs::try_exists(&path).await.unwrap_or(false);
 
-    let mut file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(&path)
-        .await
-        .map_err(|e| SettingsError::ReadingFile(format!("Opening file: {}", e)))?
+    // Open the settings file, retrying briefly on the transient failures
+    // Windows surfaces for freshly-created files. OpenOptions creates the file
+    // but never its parent directories, so we (re)create the network dir each
+    // attempt; and on Windows a virus scanner or search indexer momentarily
+    // holds a new file (or its just-created parent), so create(true) can return
+    // ERROR_PATH_NOT_FOUND ("os error 3") or a sharing/permission error even
+    // though the path is valid. Both map to NotFound / PermissionDenied — retry
+    // those with a short backoff; surface anything else immediately. This also
+    // hardens the real app, where AV software locks settings.json in the same way.
+    let raw_file = {
+        let mut attempt = 0u32;
+        loop {
+            if let Some(parent) = path.parent() {
+                tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                    SettingsError::WritingFile(format!("Creating settings dir: {}", e))
+                })?;
+            }
+            match OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&path)
+                .await
+            {
+                Ok(f) => break f,
+                Err(e)
+                    if attempt < 5
+                        && matches!(
+                            e.kind(),
+                            std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied
+                        ) =>
+                {
+                    attempt += 1;
+                    tokio::time::sleep(std::time::Duration::from_millis(20 * u64::from(attempt)))
+                        .await;
+                }
+                Err(e) => return Err(SettingsError::ReadingFile(format!("Opening file: {}", e))),
+            }
+        }
+    };
+
+    let mut file = raw_file
         .lock_write()
         .await
         .map_err(|e| SettingsError::ReadingFile(format!("Locking file: {:?}", e)))?;
 
-    let settings = if file_exists {
-        let mut file_content = Vec::new();
-        file.read_to_end(&mut file_content)
-            .await
-            .map_err(|e| SettingsError::ReadingFile(format!("Reading file content: {}", e)))?;
-
+    // Read the current contents. A file we just created is empty, and an empty
+    // file is treated as "no prior settings" rather than a parse error.
+    let mut file_content = Vec::new();
+    file.read_to_end(&mut file_content)
+        .await
+        .map_err(|e| SettingsError::ReadingFile(format!("Reading file content: {}", e)))?;
+    let settings = if file_content.is_empty() {
+        Settings::default()
+    } else {
         serde_json::from_slice::<Settings>(&file_content)
             .map_err(|e| SettingsError::ReadingFile(e.to_string()))?
-    } else {
-        Settings::default()
     };
 
     let settings = updater(settings);
 
-    // If updater returns None, delete the file
+    // If updater returns None, delete the file. Drop the locked handle first so
+    // the file isn't held open when we unlink it (required on Windows).
     let Some(settings) = settings else {
+        drop(file);
         tokio::fs::remove_file(&path)
             .await
             .map_err(|e| SettingsError::DeletingFile(e.to_string()))?;
@@ -133,6 +157,20 @@ where
         .set_len(content.len() as u64)
         .await
         .map_err(|e| SettingsError::WritingFile(format!("Failed to truncate file: {}", e)))?;
+
+    // Flush and fsync so the bytes are durably on disk, then drop the handle to
+    // release the lock — all before returning. Without this a subsequent reader
+    // (Settings::from_file takes no lock) can observe stale/empty content on
+    // Windows, where dropping an async handle does not guarantee the write has
+    // landed yet.
+    file.flush()
+        .await
+        .map_err(|e| SettingsError::WritingFile(format!("Failed to flush settings: {}", e)))?;
+    file.inner_mut()
+        .sync_all()
+        .await
+        .map_err(|e| SettingsError::WritingFile(format!("Failed to sync settings: {}", e)))?;
+    drop(file);
 
     Ok(())
 }

--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -486,9 +486,16 @@ impl CubeSettings {
         // Generate a random salt
         let salt = SaltString::generate(&mut OsRng);
 
-        // Configure Argon2id with reasonable parameters
-        // m_cost: 19456 KiB (19 MiB), t_cost: 2 iterations, p_cost: 1 thread
+        // Configure Argon2id. Production uses ~19 MiB of memory (m_cost 19456
+        // KiB, t_cost 2, p_cost 1) to make a PIN hash costly to brute-force.
+        // Test builds drop to the argon2 minimum: the suite hashes/verifies PINs
+        // hundreds of times, and paying 19 MiB per op starves CI enough to make
+        // PIN-verify tests flake under parallel load. Verification reads m/t/p
+        // from the stored PHC string, so a hash made at either cost round-trips.
+        #[cfg(not(test))]
         let params = Params::new(19456, 2, 1, None)?;
+        #[cfg(test)]
+        let params = Params::new(8, 1, 1, None)?;
         let argon2 = Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
 
         // Hash the PIN

--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -68,6 +68,19 @@ where
     F: FnOnce(Settings) -> Option<Settings>,
 {
     let path = network_dir.path().join(SETTINGS_FILE_NAME);
+    // Ensure the network directory exists before opening with create(true).
+    // OpenOptions creates the file but never its parent directories, so a
+    // missing network dir surfaces as ERROR_PATH_NOT_FOUND ("os error 3" on
+    // Windows) instead of writing the settings file. Doing the create_dir_all
+    // in this async context, immediately before the open, also settles a
+    // Windows filesystem race where a just-created temp dir isn't yet visible
+    // to the following tokio::fs open. create_dir_all is idempotent, so this is
+    // a no-op when the dir already exists.
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| SettingsError::WritingFile(format!("Creating settings dir: {}", e)))?;
+    }
     let file_exists = tokio::fs::try_exists(&path).await.unwrap_or(false);
 
     let mut file = OpenOptions::new()

--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -69,6 +69,13 @@ where
 {
     let path = network_dir.path().join(SETTINGS_FILE_NAME);
 
+    // Whether settings.json already existed before we touch anything. Only a
+    // brand-new file is safe to treat as "no prior settings"; a pre-existing
+    // file that reads back empty is corrupt/truncated and must NOT be silently
+    // replaced with defaults (that would drop the stored cube configuration),
+    // so it falls through to a parse error below. Checked before the create.
+    let file_existed = tokio::fs::try_exists(&path).await.unwrap_or(false);
+
     // Open the settings file, retrying briefly on the transient failures
     // Windows surfaces for freshly-created files. OpenOptions creates the file
     // but never its parent directories, so we (re)create the network dir each
@@ -116,17 +123,19 @@ where
         .await
         .map_err(|e| SettingsError::ReadingFile(format!("Locking file: {:?}", e)))?;
 
-    // Read the current contents. A file we just created is empty, and an empty
-    // file is treated as "no prior settings" rather than a parse error.
-    let mut file_content = Vec::new();
-    file.read_to_end(&mut file_content)
-        .await
-        .map_err(|e| SettingsError::ReadingFile(format!("Reading file content: {}", e)))?;
-    let settings = if file_content.is_empty() {
-        Settings::default()
-    } else {
+    // A file we created in this call starts empty and means "no prior
+    // settings". A file that already existed is parsed — including when it reads
+    // back empty, which surfaces as a parse error rather than silently
+    // discarding the previous contents.
+    let settings = if file_existed {
+        let mut file_content = Vec::new();
+        file.read_to_end(&mut file_content)
+            .await
+            .map_err(|e| SettingsError::ReadingFile(format!("Reading file content: {}", e)))?;
         serde_json::from_slice::<Settings>(&file_content)
             .map_err(|e| SettingsError::ReadingFile(e.to_string()))?
+    } else {
+        Settings::default()
     };
 
     let settings = updater(settings);

--- a/coincube-gui/src/app/state/buysell.rs
+++ b/coincube-gui/src/app/state/buysell.rs
@@ -765,3 +765,471 @@ impl State for BuySellPanel {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coincube_core::{descriptors::CoincubeDescriptor, miniscript::bitcoin::Network};
+    use std::{str::FromStr, sync::Arc};
+
+    const DESC: &str = "wsh(or_d(multi(2,[ffd63c8d/48'/1'/0'/2']tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N/<0;1>/*,[de6eb005/48'/1'/0'/2']tpubDFGuYfS2JwiUSEXiQuNGdT3R7WTDhbaE6jbUhgYSSdhmfQcSx7ZntMPPv7nrkvAqjpj3jX9wbhSGMeKVao4qAzhbNyBi7iQmv5xxQk6H6jz/<0;1>/*),and_v(v:pkh([ffd63c8d/48'/1'/0'/2']tpubDExA3EC3iAsPxPhFn4j6gMiVup6V2eH3qKyk69RcTc9TTNRfFYVPad8bJD5FCHVQxyBT4izKsvr7Btd2R4xmQ1hZkvsqGBaeE82J71uTK4N/<2;3>/*),older(3))))#p9ax3xxp";
+
+    fn wallet() -> Arc<crate::app::wallet::Wallet> {
+        Arc::new(crate::app::wallet::Wallet::new(
+            CoincubeDescriptor::from_str(DESC).unwrap(),
+        ))
+    }
+
+    fn panel() -> BuySellPanel {
+        BuySellPanel::new(
+            Network::Bitcoin,
+            wallet(),
+            Arc::new(crate::app::breez_liquid::BreezClient::disconnected(
+                Network::Bitcoin,
+            )),
+        )
+    }
+
+    fn country(code: &str) -> &'static Country {
+        crate::services::coincube::get_countries()
+            .iter()
+            .find(|country| country.code == code)
+            .unwrap()
+    }
+
+    fn login() -> LoginResponse {
+        LoginResponse {
+            requires_2fa: false,
+            token: "token".to_string(),
+            refresh_token: "refresh-token".to_string(),
+            user: User {
+                id: 7,
+                email: "user@example.com".to_string(),
+                email_verified: Some(true),
+            },
+        }
+    }
+
+    fn buysell_msg(msg: view::BuySellMessage) -> Message {
+        Message::View(view::Message::BuySell(msg))
+    }
+
+    #[test]
+    fn reset_widget_without_country_prompts_manual_location() {
+        let mut panel = panel();
+        panel.step = BuySellFlowState::ModeSelect { buy_or_sell: None };
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::ResetWidget),
+        );
+
+        assert!(matches!(
+            panel.step,
+            BuySellFlowState::DetectingLocation(true)
+        ));
+    }
+
+    #[test]
+    fn reset_widget_with_login_and_country_returns_to_mode_select() {
+        let mut panel = panel();
+        panel.detected_country = Some(country("US"));
+        panel.login = Some(login());
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::ResetWidget),
+        );
+
+        assert!(matches!(
+            panel.step,
+            BuySellFlowState::ModeSelect { buy_or_sell: None }
+        ));
+    }
+
+    #[test]
+    fn mode_select_toggles_buy_and_sell_choices() {
+        let mut panel = panel();
+        panel.step = BuySellFlowState::ModeSelect { buy_or_sell: None };
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::SelectBuyOrSell(BuyOrSell::Sell)),
+        );
+        assert!(matches!(
+            panel.step,
+            BuySellFlowState::ModeSelect {
+                buy_or_sell: Some(BuyOrSell::Sell)
+            }
+        ));
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::SelectBuyOrSell(BuyOrSell::Sell)),
+        );
+        assert!(matches!(
+            panel.step,
+            BuySellFlowState::ModeSelect { buy_or_sell: None }
+        ));
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::SelectBuyOrSell(BuyOrSell::Buy)),
+        );
+        assert!(matches!(
+            panel.step,
+            BuySellFlowState::ModeSelect {
+                buy_or_sell: Some(BuyOrSell::Buy)
+            }
+        ));
+    }
+
+    #[test]
+    fn country_detection_success_and_failure_update_location_state() {
+        let mut panel = panel();
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::CountryDetected(Ok(country("ZA")))),
+        );
+        assert_eq!(
+            panel.detected_country.map(|country| country.code),
+            Some("ZA")
+        );
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::CountryDetected(Err(
+                "geo lookup failed".to_string(),
+            ))),
+        );
+        assert!(panel.detected_country.is_none());
+        assert!(matches!(
+            panel.step,
+            BuySellFlowState::DetectingLocation(true)
+        ));
+    }
+
+    #[test]
+    fn login_and_registration_forms_advance_to_otp_verification() {
+        let mut panel = panel();
+        panel.step = BuySellFlowState::Login {
+            email: String::new(),
+            loading: false,
+        };
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::EmailChanged(
+                "login@example.com".to_string(),
+            )),
+        );
+        assert!(matches!(
+            &panel.step,
+            BuySellFlowState::Login { email, loading: false } if email == "login@example.com"
+        ));
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::SubmitLogin),
+        );
+        assert!(matches!(
+            panel.step,
+            BuySellFlowState::Login { loading: true, .. }
+        ));
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::SendOtp),
+        );
+        assert!(matches!(
+            &panel.step,
+            BuySellFlowState::OtpVerification {
+                email,
+                otp,
+                sending: false,
+                is_signup: false,
+                cooldown: 30
+            } if email == "login@example.com" && otp.is_empty()
+        ));
+
+        panel.step = BuySellFlowState::Login {
+            email: "old@example.com".to_string(),
+            loading: false,
+        };
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::CreateNewAccount),
+        );
+        assert!(matches!(
+            panel.step,
+            BuySellFlowState::Register { loading: false, .. }
+        ));
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::EmailChanged(
+                "signup@example.com".to_string(),
+            )),
+        );
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::SubmitRegistration),
+        );
+        assert!(matches!(
+            panel.step,
+            BuySellFlowState::Register { loading: true, .. }
+        ));
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::RegistrationSuccess),
+        );
+        assert!(matches!(
+            &panel.step,
+            BuySellFlowState::OtpVerification {
+                email,
+                is_signup: true,
+                cooldown: 30,
+                ..
+            } if email == "signup@example.com"
+        ));
+    }
+
+    #[test]
+    fn otp_state_edits_cooldown_and_verify_in_flight() {
+        let mut panel = panel();
+        panel.step = BuySellFlowState::OtpVerification {
+            email: "user@example.com".to_string(),
+            otp: String::new(),
+            sending: false,
+            is_signup: false,
+            cooldown: 1,
+        };
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::OtpCooldownTick),
+        );
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::OtpCooldownTick),
+        );
+        assert!(matches!(
+            panel.step,
+            BuySellFlowState::OtpVerification { cooldown: 0, .. }
+        ));
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::OtpChanged("123456".to_string())),
+        );
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::VerifyOtp),
+        );
+        assert!(matches!(
+            &panel.step,
+            BuySellFlowState::OtpVerification {
+                otp,
+                sending: true,
+                ..
+            } if otp == "123456"
+        ));
+    }
+
+    #[test]
+    fn start_session_initializes_mavapay_sell_for_supported_country() {
+        let mut panel = panel();
+        panel.detected_country = Some(country("KE"));
+        panel.step = BuySellFlowState::ModeSelect {
+            buy_or_sell: Some(BuyOrSell::Sell),
+        };
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::StartSession),
+        );
+
+        let BuySellFlowState::Mavapay(state) = &panel.step else {
+            panic!("expected Mavapay state");
+        };
+        assert_eq!(state.buy_or_sell, BuyOrSell::Sell);
+        assert_eq!(state.country.code, "KE");
+        assert!(matches!(
+            state.steps.last(),
+            Some(MavapayFlowStep::SellInputForm {
+                beneficiary: Beneficiary::KES(KenyanBeneficiary::PayToPhone {
+                    phone_number,
+                    ..
+                }),
+                sending_quote: false,
+                liquid_balance: None,
+                ..
+            }) if phone_number == "+254700000000"
+        ));
+    }
+
+    #[test]
+    fn start_session_initializes_mavapay_buy_for_supported_country() {
+        let mut panel = panel();
+        panel.detected_country = Some(country("NG"));
+        panel.step = BuySellFlowState::ModeSelect {
+            buy_or_sell: Some(BuyOrSell::Buy),
+        };
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::StartSession),
+        );
+
+        let BuySellFlowState::Mavapay(state) = &panel.step else {
+            panic!("expected Mavapay state");
+        };
+        assert_eq!(state.buy_or_sell, BuyOrSell::Buy);
+        assert!(matches!(
+            state.steps.last(),
+            Some(MavapayFlowStep::BuyInputFrom {
+                getting_invoice: false,
+                sending_quote: false,
+                ln_invoice: None
+            })
+        ));
+    }
+
+    #[test]
+    fn view_history_uses_mavapay_history_for_supported_country() {
+        let mut panel = panel();
+        panel.detected_country = Some(country("ZA"));
+        panel.step = BuySellFlowState::ModeSelect { buy_or_sell: None };
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::ViewHistory),
+        );
+
+        assert!(matches!(
+            &panel.step,
+            BuySellFlowState::Mavapay(state)
+                if matches!(
+                    state.steps.last(),
+                    Some(MavapayFlowStep::History {
+                        loading: true,
+                        transactions: None
+                    })
+                )
+        ));
+    }
+
+    #[test]
+    fn session_error_unblocks_loading_flags() {
+        let mut panel = panel();
+        panel.step = BuySellFlowState::Login {
+            email: "user@example.com".to_string(),
+            loading: true,
+        };
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::SessionError(
+                "failed",
+                "network".to_string(),
+            )),
+        );
+        assert!(matches!(
+            panel.step,
+            BuySellFlowState::Login { loading: false, .. }
+        ));
+
+        panel.step = BuySellFlowState::Register {
+            email: "user@example.com".to_string(),
+            loading: true,
+        };
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::SessionError(
+                "failed",
+                "network".to_string(),
+            )),
+        );
+        assert!(matches!(
+            panel.step,
+            BuySellFlowState::Register { loading: false, .. }
+        ));
+
+        panel.step = BuySellFlowState::OtpVerification {
+            email: "user@example.com".to_string(),
+            otp: "123456".to_string(),
+            sending: true,
+            is_signup: false,
+            cooldown: 0,
+        };
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::SessionError(
+                "failed",
+                "network".to_string(),
+            )),
+        );
+        assert!(matches!(
+            panel.step,
+            BuySellFlowState::OtpVerification { sending: false, .. }
+        ));
+
+        panel.step = BuySellFlowState::Mavapay(MavapayState::new(
+            BuyOrSell::Buy,
+            MavapayFlowStep::BuyInputFrom {
+                ln_invoice: None,
+                getting_invoice: true,
+                sending_quote: true,
+            },
+            country("NG"),
+            Arc::new(crate::app::breez_liquid::BreezClient::disconnected(
+                Network::Bitcoin,
+            )),
+        ));
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            buysell_msg(view::BuySellMessage::SessionError(
+                "failed",
+                "network".to_string(),
+            )),
+        );
+        assert!(matches!(
+            &panel.step,
+            BuySellFlowState::Mavapay(state)
+                if matches!(
+                    state.steps.last(),
+                    Some(MavapayFlowStep::BuyInputFrom {
+                        getting_invoice: false,
+                        sending_quote: false,
+                        ..
+                    })
+                )
+        ));
+    }
+}

--- a/coincube-gui/src/app/state/connect/cube.rs
+++ b/coincube-gui/src/app/state/connect/cube.rs
@@ -1452,3 +1452,510 @@ fn validate_ln_username(username: &str) -> Option<String> {
     }
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use coincube_spark_protocol::LightningAddressInfo;
+
+    use crate::{
+        app::view::AvatarMessage,
+        services::coincube::{
+            AvatarAccentMotif, AvatarAgeFeel, AvatarArmorStyle, AvatarDemeanor,
+            AvatarDerivedTraits, AvatarGender, AvatarGenerateData, AvatarIdentity,
+            AvatarResolvedDirectives, AvatarSelectData, AvatarVariant, CubeResponse, GetAvatarData,
+            RegenerationData,
+        },
+    };
+
+    fn panel() -> ConnectCubePanel {
+        ConnectCubePanel::new(
+            None,
+            "cube-uuid".to_string(),
+            "Family Vault".to_string(),
+            "bitcoin".to_string(),
+            false,
+        )
+    }
+
+    fn lightning(address: &str) -> LightningAddress {
+        LightningAddress {
+            lightning_address: Some(address.to_string()),
+        }
+    }
+
+    fn lightning_info(address: &str) -> LightningAddressInfo {
+        let username = address.split('@').next().unwrap_or(address).to_string();
+        LightningAddressInfo {
+            lightning_address: address.to_string(),
+            username: username.clone(),
+            description: Some("Coincube".to_string()),
+            lnurl_url: format!("https://example.com/.well-known/lnurlp/{username}"),
+            lnurl_bech32: "lnurl1test".to_string(),
+        }
+    }
+
+    fn cube_response(lightning_address: Option<&str>) -> CubeResponse {
+        CubeResponse {
+            id: 42,
+            uuid: "cube-uuid".to_string(),
+            name: "Family Vault".to_string(),
+            network: "bitcoin".to_string(),
+            lightning_address: lightning_address.map(str::to_string),
+            status: "active".to_string(),
+            has_recovery_kit: false,
+            has_vault: Some(true),
+            members: Vec::new(),
+            pending_invites: Vec::new(),
+            vault: None,
+        }
+    }
+
+    fn avatar_variant(id: u64) -> AvatarVariant {
+        AvatarVariant {
+            id,
+            index: id as u32,
+            image_url: format!("https://cdn.example/avatar/{id}.png"),
+        }
+    }
+
+    fn avatar_data(has_avatar: bool, active_id: Option<u64>) -> GetAvatarData {
+        GetAvatarData {
+            has_avatar,
+            active_avatar_url: active_id.map(|id| format!("https://cdn.example/avatar/{id}.png")),
+            identity: None,
+            variants: vec![avatar_variant(7), avatar_variant(8)],
+            regenerations_remaining: 3,
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    fn identity() -> AvatarIdentity {
+        AvatarIdentity {
+            version: 1,
+            seed_version: 1,
+            seed_hash: "seed-hash".to_string(),
+            lightning_address: "founder@example.com".to_string(),
+            archetype: "ronin".to_string(),
+            user_traits: AvatarUserTraits {
+                gender: AvatarGender::Woman,
+                archetype: crate::services::coincube::AvatarArchetype::Shogun,
+                age_feel: AvatarAgeFeel::Elder,
+                demeanor: AvatarDemeanor::Fierce,
+                armor_style: AvatarArmorStyle::Heavy,
+                accent_motif: AvatarAccentMotif::OrangeSun,
+                laser_eyes: true,
+            },
+            derived_traits: AvatarDerivedTraits {
+                pose: "front".to_string(),
+                crop_style: "portrait".to_string(),
+                hat_style: "none".to_string(),
+                face_visibility: "visible".to_string(),
+                eye_visibility: "visible".to_string(),
+                weapon_mode: "none".to_string(),
+                shoulder_profile: "square".to_string(),
+                cloak_presence: "none".to_string(),
+                armor_wear: "clean".to_string(),
+                enso_style: "brush".to_string(),
+                ink_density: "medium".to_string(),
+                brush_texture: "dry".to_string(),
+                splash_intensity: "low".to_string(),
+                orange_placement: "accent".to_string(),
+                ornament_level: "simple".to_string(),
+            },
+            resolved_directives: AvatarResolvedDirectives {
+                composition: "composition".to_string(),
+                silhouette: "silhouette".to_string(),
+                face_treatment: "face".to_string(),
+                armor_treatment: "armor".to_string(),
+                mood: "mood".to_string(),
+                orange_treatment: "orange".to_string(),
+                ink_treatment: "ink".to_string(),
+                eyes_treatment: "eyes".to_string(),
+                background: "background".to_string(),
+                archetype_flavor: "flavor".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn lightning_username_validation_covers_client_side_rules() {
+        assert_eq!(
+            validate_ln_username("").as_deref(),
+            Some("Username is required")
+        );
+        assert_eq!(
+            validate_ln_username("ab").as_deref(),
+            Some("Username must be at least 3 characters")
+        );
+        assert_eq!(
+            validate_ln_username(&"a".repeat(65)).as_deref(),
+            Some("Username must be at most 64 characters")
+        );
+        assert_eq!(
+            validate_ln_username("-abc").as_deref(),
+            Some("Must start with a letter or number")
+        );
+        assert_eq!(
+            validate_ln_username("abc_").as_deref(),
+            Some("Must end with a letter or number")
+        );
+        assert_eq!(
+            validate_ln_username("ab$c").as_deref(),
+            Some("Invalid character: '$'")
+        );
+        assert_eq!(
+            validate_ln_username("ab..c").as_deref(),
+            Some("No consecutive special characters allowed")
+        );
+        assert!(validate_ln_username("abc-123_def.xyz").is_none());
+    }
+
+    #[test]
+    fn registration_client_and_avatar_helpers_reset_session_state() {
+        let mut panel = panel();
+        assert!(panel.api_cube_id().is_none());
+        assert!(panel.load_avatar_if_needed().is_none());
+        let (_, handle) = panel.register_cube().abortable();
+        handle.abort();
+
+        panel.set_client(CoincubeClient::new());
+        panel.server_cube_id = Some(42);
+        assert_eq!(panel.api_cube_id().as_deref(), Some("42"));
+        assert!(panel.load_avatar_if_needed().is_some());
+        let (_, handle) = panel.register_cube().abortable();
+        handle.abort();
+        let _ = panel.report_vault_created();
+        assert!(panel.cube_has_vault);
+
+        panel.avatar_data = Some(avatar_data(true, Some(7)));
+        panel.avatar_image_cache.insert(
+            7,
+            (
+                vec![137, 80, 78, 71],
+                iced::widget::image::Handle::from_bytes(vec![137, 80, 78, 71]),
+            ),
+        );
+        assert!(panel.get_active_avatar_handle().is_some());
+        if let Some(data) = panel.avatar_data.as_mut() {
+            data.active_avatar_url = Some("https://cdn.example/avatar/70.png".to_string());
+        }
+        assert!(panel.get_active_avatar_handle().is_none());
+
+        panel.ln_username_input = "founder".to_string();
+        panel.ln_username_available = Some(true);
+        panel.ln_username_error = Some("old".to_string());
+        panel.ln_claim_error = Some("old".to_string());
+        panel.lightning_address = Some(lightning("founder@example.com"));
+        panel.ln_reconcile_needs_reregister = Some("retry".to_string());
+        panel.avatar_error = Some("old".to_string());
+        panel.clear_client();
+
+        assert!(panel.client.is_none());
+        assert!(panel.server_cube_id.is_none());
+        assert!(panel.lightning_address.is_none());
+        assert!(panel.ln_username_input.is_empty());
+        assert!(panel.ln_username_available.is_none());
+        assert!(panel.ln_username_error.is_none());
+        assert!(panel.ln_claim_error.is_none());
+        assert!(panel.ln_reconcile_needs_reregister.is_none());
+        assert!(panel.avatar_data.is_none());
+        assert!(panel.avatar_image_cache.is_empty());
+    }
+
+    #[test]
+    fn lightning_address_state_machine_handles_non_network_branches() {
+        let mut panel = panel();
+
+        let _ = panel.update_message(ConnectCubeMessage::CubeRegistered(Ok(cube_response(Some(
+            "founder@example.com",
+        )))));
+        assert_eq!(panel.server_cube_id, Some(42));
+        assert_eq!(
+            panel
+                .lightning_address
+                .as_ref()
+                .and_then(|a| a.lightning_address.as_deref()),
+            Some("founder@example.com")
+        );
+
+        let _ = panel.update_message(ConnectCubeMessage::CubeRegistered(Err(
+            "register failed".to_string()
+        )));
+        assert_eq!(panel.registration_error.as_deref(), Some("register failed"));
+
+        let _ = panel.update_message(ConnectCubeMessage::LnUsernameChanged("Bad$".to_string()));
+        assert_eq!(panel.ln_username_input, "bad$");
+        assert!(panel.ln_username_error.is_some());
+        assert!(!panel.ln_checking);
+
+        let _ = panel.update_message(ConnectCubeMessage::LnUsernameChanged(
+            "Fresh_Name".to_string(),
+        ));
+        assert_eq!(panel.ln_username_input, "fresh_name");
+        assert!(panel.ln_username_error.is_none());
+        assert!(!panel.ln_checking);
+
+        let stale_version = panel.ln_check_version + 1;
+        let _ = panel.update_message(ConnectCubeMessage::LnUsernameChecked {
+            available: false,
+            error_message: Some("taken".to_string()),
+            version: stale_version,
+        });
+        assert!(panel.ln_username_available.is_none());
+
+        let _ = panel.update_message(ConnectCubeMessage::LnUsernameChecked {
+            available: false,
+            error_message: None,
+            version: panel.ln_check_version,
+        });
+        assert_eq!(panel.ln_username_available, Some(false));
+        assert_eq!(
+            panel.ln_username_error.as_deref(),
+            Some("Username is taken")
+        );
+
+        let _ = panel.update_message(ConnectCubeMessage::ClaimLightningAddress);
+        assert!(!panel.ln_claiming);
+
+        panel.set_client(CoincubeClient::new());
+        let _ = panel.update_message(ConnectCubeMessage::ClaimLightningAddress);
+        assert_eq!(
+            panel.ln_claim_error.as_deref(),
+            Some("Spark wallet is not available on this cube")
+        );
+
+        let _ = panel.update_message(ConnectCubeMessage::BeginEditLightningAddress);
+        assert!(panel.ln_editing);
+        panel.ln_username_input = "newname".to_string();
+        panel.ln_username_available = Some(true);
+        panel.ln_username_error = None;
+        let _ = panel.update_message(ConnectCubeMessage::RequestChangeLightningAddress);
+        assert_eq!(panel.ln_change_confirm_pending.as_deref(), Some("newname"));
+        let _ = panel.update_message(ConnectCubeMessage::DismissChangeConfirmation);
+        assert!(panel.ln_change_confirm_pending.is_none());
+        let _ = panel.update_message(ConnectCubeMessage::CancelEditLightningAddress);
+        assert!(!panel.ln_editing);
+        assert!(panel.ln_username_input.is_empty());
+
+        let _ = panel.update_message(ConnectCubeMessage::LightningAddressUpdated(
+            LightningAddressChangeOutcome::ServerError("conflict".to_string()),
+        ));
+        assert_eq!(panel.ln_claim_error.as_deref(), Some("conflict"));
+
+        let _ = panel.update_message(ConnectCubeMessage::LightningAddressUpdated(
+            LightningAddressChangeOutcome::SdkSyncFailed {
+                addr: lightning("new@example.com"),
+                message: "sdk failed".to_string(),
+            },
+        ));
+        assert_eq!(
+            panel.ln_reconcile_needs_reregister.as_deref(),
+            Some("sdk failed")
+        );
+
+        let _ = panel.update_message(ConnectCubeMessage::LightningAddressUpdated(
+            LightningAddressChangeOutcome::Ok(lightning("ok@example.com")),
+        ));
+        assert!(panel.ln_reconcile_needs_reregister.is_none());
+        assert!(!panel.ln_editing);
+    }
+
+    #[test]
+    fn reconciliation_messages_update_prompt_state_without_spark() {
+        let mut panel = panel();
+        panel.lightning_address = Some(lightning("founder@example.com"));
+
+        let _ = panel.update_message(ConnectCubeMessage::SparkLightningAddressChanged(Some(
+            lightning_info("founder@example.com"),
+        )));
+        assert!(panel.ln_reconcile_needs_reregister.is_none());
+
+        let _ = panel.update_message(ConnectCubeMessage::LightningAddressReconciled(
+            ReconcileOutcome::AlreadyBound(lightning_info("founder@example.com")),
+        ));
+        assert!(panel.ln_reconcile_needs_reregister.is_none());
+
+        let _ = panel.update_message(ConnectCubeMessage::LightningAddressReconciled(
+            ReconcileOutcome::ReRegistered(lightning_info("founder@example.com")),
+        ));
+        assert!(panel.ln_reconcile_needs_reregister.is_none());
+
+        let _ = panel.update_message(ConnectCubeMessage::LightningAddressReconciled(
+            ReconcileOutcome::QueryFailed("offline".to_string()),
+        ));
+        assert!(panel.ln_reconcile_needs_reregister.is_none());
+
+        let _ = panel.update_message(ConnectCubeMessage::LightningAddressReconciled(
+            ReconcileOutcome::NeedsReRegistration("needs retry".to_string()),
+        ));
+        assert_eq!(
+            panel.ln_reconcile_needs_reregister.as_deref(),
+            Some("needs retry")
+        );
+
+        let _ = panel.update_message(ConnectCubeMessage::LightningAddressReregistered(Ok(
+            lightning_info("founder@example.com"),
+        )));
+        assert!(panel.ln_reconcile_needs_reregister.is_none());
+
+        let _ = panel.update_message(ConnectCubeMessage::LightningAddressReregistered(Ok(
+            lightning_info("wrong@example.com"),
+        )));
+        assert!(panel.ln_reconcile_needs_reregister.is_some());
+
+        let _ = panel.update_message(ConnectCubeMessage::LightningAddressReregistered(Err(
+            "still down".to_string(),
+        )));
+        assert_eq!(
+            panel.ln_reconcile_needs_reregister.as_deref(),
+            Some("still down")
+        );
+    }
+
+    #[test]
+    fn avatar_state_machine_handles_local_transitions_and_results() {
+        let mut panel = panel();
+
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::Enter));
+        assert_eq!(panel.avatar_error.as_deref(), Some("Not signed in"));
+
+        panel.set_client(CoincubeClient::new());
+        panel.registration_error = Some("registration pending".to_string());
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::Enter));
+        assert_eq!(panel.avatar_error.as_deref(), Some("registration pending"));
+
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::Loaded(Ok(
+            avatar_data(false, None),
+        ))));
+        assert!(matches!(panel.avatar_step, AvatarFlowStep::Questionnaire));
+
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::Loaded(Ok(
+            avatar_data(true, Some(7)),
+        ))));
+        assert!(matches!(panel.avatar_step, AvatarFlowStep::Settings));
+
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::Loaded(Err(
+            "load failed".to_string(),
+        ))));
+        assert_eq!(panel.avatar_error.as_deref(), Some("load failed"));
+
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::SetStep(
+            AvatarFlowStep::Reveal,
+        )));
+        assert!(matches!(panel.avatar_step, AvatarFlowStep::Reveal));
+
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::GenderChanged(
+            AvatarGender::Woman,
+        )));
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::AgeFeelChanged(
+            AvatarAgeFeel::Young,
+        )));
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::DemeanorChanged(
+            AvatarDemeanor::Calm,
+        )));
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(
+            AvatarMessage::ArmorStyleChanged(AvatarArmorStyle::Standard),
+        ));
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(
+            AvatarMessage::AccentMotifChanged(AvatarAccentMotif::Seal),
+        ));
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::LaserEyesToggled(
+            true,
+        )));
+        assert_eq!(panel.avatar_draft.gender, AvatarGender::Woman);
+        assert_eq!(panel.avatar_draft.age_feel, AvatarAgeFeel::Young);
+        assert!(panel.avatar_draft.laser_eyes);
+
+        panel.avatar_generating = true;
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::Generate));
+        assert!(panel.avatar_generating);
+
+        panel.avatar_generating = false;
+        panel.client = None;
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::Generate));
+        assert_eq!(panel.avatar_error.as_deref(), Some("Not signed in"));
+
+        panel.set_client(CoincubeClient::new());
+        panel.server_cube_id = None;
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::Generate));
+        assert_eq!(panel.avatar_error.as_deref(), Some("registration pending"));
+
+        let generated = AvatarGenerateData {
+            identity: identity(),
+            variant: avatar_variant(9),
+        };
+        panel.avatar_data = Some(avatar_data(true, Some(7)));
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::GenerateComplete(
+            Ok(generated),
+        )));
+        assert!(matches!(panel.avatar_step, AvatarFlowStep::Reveal));
+        assert_eq!(panel.avatar_draft.gender, AvatarGender::Woman);
+        assert_eq!(
+            panel.avatar_data.as_ref().unwrap().regenerations_remaining,
+            2
+        );
+
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::GenerateComplete(
+            Err("generation failed".to_string()),
+        )));
+        assert_eq!(panel.avatar_error.as_deref(), Some("generation failed"));
+        assert!(matches!(panel.avatar_step, AvatarFlowStep::Questionnaire));
+
+        panel.client = None;
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::SelectVariant(8)));
+        assert_eq!(panel.avatar_error.as_deref(), Some("Not signed in"));
+
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::VariantSelected(
+            Ok(AvatarSelectData {
+                active_avatar_url: "https://cdn.example/avatar/8.png".to_string(),
+                variant_id: 8,
+            }),
+        )));
+        assert_eq!(
+            panel
+                .avatar_data
+                .as_ref()
+                .unwrap()
+                .active_avatar_url
+                .as_deref(),
+            Some("https://cdn.example/avatar/8.png")
+        );
+
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::VariantSelected(
+            Err("select failed".to_string()),
+        )));
+        assert_eq!(panel.avatar_error.as_deref(), Some("select failed"));
+
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(
+            AvatarMessage::RegenerationsLoaded(Ok(RegenerationData {
+                total_allowed: 5,
+                used: 4,
+                remaining: 1,
+            })),
+        ));
+        assert_eq!(
+            panel.avatar_data.as_ref().unwrap().regenerations_remaining,
+            1
+        );
+
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::ImageLoaded {
+            variant_id: 8,
+            result: Ok(vec![137, 80, 78, 71]),
+        }));
+        assert!(panel.avatar_image_cache.contains_key(&8));
+
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::SaveError(
+            "disk full".to_string(),
+        )));
+        assert_eq!(panel.avatar_error.as_deref(), Some("disk full"));
+
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::Retry));
+        assert!(panel.avatar_error.is_none());
+        assert!(matches!(panel.avatar_step, AvatarFlowStep::Questionnaire));
+
+        let _ = panel.update_message(ConnectCubeMessage::Avatar(AvatarMessage::Noop));
+    }
+}

--- a/coincube-gui/src/app/state/connect/mod.rs
+++ b/coincube-gui/src/app/state/connect/mod.rs
@@ -331,3 +331,65 @@ impl State for ConnectPanel {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ConnectPanel;
+
+    #[test]
+    fn new_propagates_active_cube_context_to_both_panels() {
+        let panel = ConnectPanel::new(
+            None,
+            "cube-uuid".to_string(),
+            "Family Vault".to_string(),
+            "bitcoin".to_string(),
+            true,
+        );
+
+        assert_eq!(panel.cube.cube_uuid, "cube-uuid");
+        assert_eq!(panel.cube.cube_name, "Family Vault");
+        assert_eq!(panel.cube.cube_network, "bitcoin");
+        assert!(panel.cube.cube_has_vault);
+        assert_eq!(
+            panel.account.contacts_state.active_network.as_deref(),
+            Some("bitcoin")
+        );
+    }
+
+    #[test]
+    fn sync_active_cube_server_id_mirrors_registration_id() {
+        let mut panel = ConnectPanel::new(
+            None,
+            "cube-uuid".to_string(),
+            "Family Vault".to_string(),
+            "regtest".to_string(),
+            false,
+        );
+
+        assert_eq!(panel.account.contacts_state.active_cube_server_id, None);
+        panel.cube.server_cube_id = Some(42);
+        panel.sync_active_cube_server_id();
+        assert_eq!(panel.account.contacts_state.active_cube_server_id, Some(42));
+
+        panel.cube.server_cube_id = None;
+        panel.sync_active_cube_server_id();
+        assert_eq!(panel.account.contacts_state.active_cube_server_id, None);
+    }
+
+    #[test]
+    fn report_vault_created_sets_local_flag_and_invalidates_duress_cache() {
+        let mut panel = ConnectPanel::new(
+            None,
+            "cube-uuid".to_string(),
+            "Family Vault".to_string(),
+            "bitcoin".to_string(),
+            false,
+        );
+        panel.account.duress_cubes = Some(Vec::new());
+
+        let _ = panel.report_vault_created();
+
+        assert!(panel.cube.cube_has_vault);
+        assert!(panel.account.duress_cubes.is_none());
+    }
+}

--- a/coincube-gui/src/app/state/global_home.rs
+++ b/coincube-gui/src/app/state/global_home.rs
@@ -2976,6 +2976,127 @@ impl GlobalHome {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use coincube_core::miniscript::bitcoin::{OutPoint, Txid};
+    use std::str::FromStr;
+
+    const MAINNET_ADDR: &str = "bc1qvrl2849aggm6qry9ea7xqp2kk39j8vaa8r3cwg";
+
+    fn address() -> Address {
+        Address::from_str(MAINNET_ADDR).unwrap().assume_checked()
+    }
+
+    fn outpoint(n: u32) -> OutPoint {
+        OutPoint::new(Txid::from_str(&format!("{n:064x}")).unwrap(), n)
+    }
+
+    fn coin(
+        n: u32,
+        sats: u64,
+        block_height: Option<i32>,
+        is_from_self: bool,
+        spent: bool,
+    ) -> crate::daemon::model::Coin {
+        crate::daemon::model::Coin {
+            amount: Amount::from_sat(sats),
+            outpoint: outpoint(n),
+            address: address(),
+            block_height,
+            derivation_index: ChildNumber::from(n),
+            spend_info: spent.then(|| coincubed::commands::LCSpendInfo {
+                txid: Txid::from_str(&format!("{:064x}", n + 100)).unwrap(),
+                height: None,
+            }),
+            is_immature: false,
+            is_change: false,
+            is_from_self,
+        }
+    }
+
+    fn liquid_bitcoin_payment(payment_type: PaymentType) -> breez_sdk_liquid::prelude::Payment {
+        breez_sdk_liquid::prelude::Payment {
+            destination: Some("destination".to_string()),
+            tx_id: Some("txid".to_string()),
+            unblinding_data: Some("unblind".to_string()),
+            timestamp: 1_722_000_000,
+            amount_sat: 25_000,
+            fees_sat: 125,
+            swapper_fees_sat: Some(50),
+            payment_type,
+            status: breez_sdk_liquid::model::PaymentState::Pending,
+            details: PaymentDetails::Bitcoin {
+                swap_id: "swap-id".to_string(),
+                bitcoin_address: MAINNET_ADDR.to_string(),
+                description: "chain swap".to_string(),
+                auto_accepted_fees: true,
+                liquid_expiration_blockheight: 123,
+                bitcoin_expiration_blockheight: 456,
+                lockup_tx_id: Some("lockup".to_string()),
+                claim_tx_id: Some("claim".to_string()),
+                refund_tx_id: Some("refund".to_string()),
+                refund_tx_amount_sat: Some(900),
+            },
+        }
+    }
+
+    #[test]
+    fn default_transfer_feerate_is_valid_and_unwarned() {
+        let feerate = default_transfer_feerate();
+
+        assert_eq!(feerate.value, DEFAULT_TRANSFER_FEERATE_SATS_VB);
+        assert!(feerate.valid);
+        assert_eq!(feerate.warning, None);
+    }
+
+    #[test]
+    fn cache_vault_pending_receive_counts_only_external_unconfirmed_unspent_coins() {
+        let mut cache = Cache::default();
+        cache.daemon_cache.coins = vec![
+            coin(1, 5_000, None, false, false),
+            coin(2, 7_000, None, false, false),
+            coin(3, 11_000, Some(100), false, false),
+            coin(4, 13_000, None, true, false),
+            coin(5, 17_000, None, false, true),
+        ];
+
+        assert_eq!(cache_vault_pending_receive_sats(&cache), 12_000);
+    }
+
+    #[test]
+    fn receive_address_info_exposes_address_label_target_and_mutable_labels() {
+        let mut info = ReceiveAddressInfo {
+            address: address(),
+            index: ChildNumber::from(7),
+            labels: HashMap::new(),
+        };
+        let address_key = info.address.to_string();
+
+        assert_eq!(
+            info.labelled(),
+            vec![LabelItem::Address(info.address.clone())]
+        );
+
+        info.labels()
+            .insert(address_key.clone(), "deposit address".to_string());
+
+        assert_eq!(
+            info.labels.get(&address_key).map(String::as_str),
+            Some("deposit address")
+        );
+    }
+
+    #[test]
+    fn bitcoin_send_swap_id_only_returns_ids_for_sent_bitcoin_payments() {
+        let send = liquid_bitcoin_payment(PaymentType::Send);
+        let receive = liquid_bitcoin_payment(PaymentType::Receive);
+
+        assert_eq!(bitcoin_send_swap_id(&send).as_deref(), Some("swap-id"));
+        assert_eq!(bitcoin_send_swap_id(&receive), None);
+    }
+
+    #[test]
+    fn modal_default_debug_is_stable() {
+        assert_eq!(format!("{:?}", Modal::default()), "None");
+    }
 
     /// Breez-involving legs compose `MIN_TRANSFER_SATS` with the SDK's own
     /// minimum. Whichever is larger wins.

--- a/coincube-gui/src/app/state/settings/general.rs
+++ b/coincube-gui/src/app/state/settings/general.rs
@@ -111,6 +111,519 @@ async fn update_price_setting(
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::fiat::{
+        api::{ListCurrenciesResult, PriceApiError},
+        PriceSource,
+    };
+    use coincube_ui::component::amount::BitcoinDisplayUnit;
+
+    fn state() -> GeneralSettingsState {
+        GeneralSettingsState::new(
+            "cube-1".to_string(),
+            SettingsSection::General,
+            PriceSetting::default(),
+            UnitSetting::default(),
+            &CoincubeDirectory::new(std::path::PathBuf::new()),
+        )
+    }
+
+    fn backup_msg(msg: view::BackupWalletMessage) -> Message {
+        Message::View(view::Message::Settings(
+            view::SettingsMessage::BackupMasterSeed(msg),
+        ))
+    }
+
+    fn words() -> Vec<String> {
+        [
+            "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel", "india",
+            "juliet", "kilo", "lima",
+        ]
+        .iter()
+        .map(|word| (*word).to_string())
+        .collect()
+    }
+
+    #[test]
+    fn random_word_indices_require_three_unique_in_range_values() {
+        assert!(generate_random_word_indices(2).is_none());
+
+        let indices = generate_random_word_indices(12).unwrap();
+        assert!(indices.iter().all(|index| (1..=12).contains(index)));
+        assert_ne!(indices[0], indices[1]);
+        assert_ne!(indices[0], indices[2]);
+        assert_ne!(indices[1], indices[2]);
+    }
+
+    #[test]
+    fn backup_start_prompts_for_pin_when_cube_is_not_passkey() {
+        let mut state = state();
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::Start),
+        );
+
+        assert!(matches!(
+            state.backup_state,
+            BackupSeedState::PinEntry { error: None }
+        ));
+        assert!(state.backup_mnemonic.is_none());
+    }
+
+    #[test]
+    fn verify_pin_requires_pin_entry_and_all_digits() {
+        let mut state = state();
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::VerifyPin),
+        );
+        assert_eq!(state.backup_state, BackupSeedState::None);
+
+        state.backup_state = BackupSeedState::PinEntry { error: None };
+        state.backup_pin.digits = [
+            "1".to_string(),
+            "2".to_string(),
+            String::new(),
+            "4".to_string(),
+        ];
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::VerifyPin),
+        );
+
+        assert!(matches!(
+            &state.backup_state,
+            BackupSeedState::PinEntry { error: Some(error) }
+                if error == "Please enter all 4 PIN digits"
+        ));
+    }
+
+    #[test]
+    fn pin_verified_success_stores_words_and_clears_pin() {
+        let mut state = state();
+        state.backup_state = BackupSeedState::PinEntry { error: None };
+        state.backup_pin.digits = [
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+        ];
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::PinVerified(Ok(words()))),
+        );
+
+        assert_eq!(state.backup_pin.value(), "");
+        assert!(matches!(state.backup_state, BackupSeedState::Intro(false)));
+        assert_eq!(
+            state.backup_mnemonic.as_ref().map(|words| words.len()),
+            Some(12)
+        );
+    }
+
+    #[test]
+    fn pin_verified_error_returns_to_pin_entry_and_clears_pin() {
+        let mut state = state();
+        state.backup_state = BackupSeedState::PinEntry { error: None };
+        state.backup_pin.digits = [
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+        ];
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::PinVerified(Err(
+                "Incorrect PIN".to_string()
+            ))),
+        );
+
+        assert_eq!(state.backup_pin.value(), "");
+        assert!(matches!(
+            &state.backup_state,
+            BackupSeedState::PinEntry { error: Some(error) } if error == "Incorrect PIN"
+        ));
+    }
+
+    #[test]
+    fn intro_and_previous_step_transitions_clear_sensitive_state() {
+        let mut state = state();
+        state.backup_mnemonic = Some(Zeroizing::new(words()));
+        state.backup_state = BackupSeedState::Intro(false);
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::ToggleBackupIntroCheck),
+        );
+        assert_eq!(state.backup_state, BackupSeedState::Intro(true));
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::NextStep),
+        );
+        assert_eq!(state.backup_state, BackupSeedState::RecoveryPhrase);
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::PreviousStep),
+        );
+        assert_eq!(state.backup_state, BackupSeedState::Intro(false));
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::PreviousStep),
+        );
+        assert_eq!(state.backup_state, BackupSeedState::None);
+        assert!(state.backup_mnemonic.is_none());
+    }
+
+    #[test]
+    fn recovery_phrase_advances_to_verification_only_with_loaded_words() {
+        let mut state = state();
+        state.backup_state = BackupSeedState::RecoveryPhrase;
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::NextStep),
+        );
+        assert_eq!(state.backup_state, BackupSeedState::RecoveryPhrase);
+
+        state.backup_mnemonic = Some(Zeroizing::new(words()));
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::NextStep),
+        );
+
+        assert!(matches!(
+            &state.backup_state,
+            BackupSeedState::Verification {
+                word_indices,
+                word_inputs,
+                error: None,
+                saving: false
+            } if word_indices.iter().all(|index| (1..=12).contains(index))
+                && word_inputs.iter().all(String::is_empty)
+        ));
+    }
+
+    #[test]
+    fn word_input_updates_matching_prompt_and_ignores_edits_while_saving() {
+        let mut state = state();
+        state.backup_state = BackupSeedState::Verification {
+            word_indices: [1, 3, 5],
+            word_inputs: [String::new(), String::new(), String::new()],
+            error: Some("old error".to_string()),
+            saving: false,
+        };
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::WordInput {
+                index: 3,
+                input: "charlie".to_string(),
+            }),
+        );
+
+        assert!(matches!(
+            &state.backup_state,
+            BackupSeedState::Verification {
+                word_inputs,
+                error: Some(error),
+                saving: false,
+                ..
+            } if word_inputs[1] == "charlie" && error == "old error"
+        ));
+
+        state.backup_state = BackupSeedState::Verification {
+            word_indices: [1, 3, 5],
+            word_inputs: [
+                "alpha".to_string(),
+                "charlie".to_string(),
+                "echo".to_string(),
+            ],
+            error: None,
+            saving: true,
+        };
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::WordInput {
+                index: 1,
+                input: "changed".to_string(),
+            }),
+        );
+        assert!(matches!(
+            &state.backup_state,
+            BackupSeedState::Verification {
+                word_inputs,
+                saving: true,
+                ..
+            } if word_inputs[0] == "alpha"
+        ));
+    }
+
+    #[test]
+    fn verify_phrase_sets_inline_error_for_mismatched_words() {
+        let mut state = state();
+        state.backup_mnemonic = Some(Zeroizing::new(words()));
+        state.backup_state = BackupSeedState::Verification {
+            word_indices: [1, 2, 3],
+            word_inputs: [
+                "alpha".to_string(),
+                "wrong".to_string(),
+                "charlie".to_string(),
+            ],
+            error: None,
+            saving: false,
+        };
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::VerifyPhrase),
+        );
+
+        assert!(matches!(
+            &state.backup_state,
+            BackupSeedState::Verification {
+                error: Some(error),
+                saving: false,
+                ..
+            } if error == "The words you entered don't match. Please try again."
+        ));
+    }
+
+    #[test]
+    fn verify_phrase_marks_saving_for_correct_words() {
+        let mut state = state();
+        state.backup_mnemonic = Some(Zeroizing::new(words()));
+        state.backup_state = BackupSeedState::Verification {
+            word_indices: [1, 2, 3],
+            word_inputs: [
+                "alpha".to_string(),
+                "bravo".to_string(),
+                "charlie".to_string(),
+            ],
+            error: Some("old error".to_string()),
+            saving: false,
+        };
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::VerifyPhrase),
+        );
+
+        assert!(matches!(
+            &state.backup_state,
+            BackupSeedState::Verification {
+                error: None,
+                saving: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn backup_save_failure_restores_verification_error() {
+        let mut state = state();
+        state.backup_state = BackupSeedState::Verification {
+            word_indices: [1, 2, 3],
+            word_inputs: [
+                "alpha".to_string(),
+                "bravo".to_string(),
+                "charlie".to_string(),
+            ],
+            error: None,
+            saving: true,
+        };
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::BackupSaveResult(Err(
+                "disk full".to_string(),
+            ))),
+        );
+
+        assert!(matches!(
+            &state.backup_state,
+            BackupSeedState::Verification {
+                error: Some(error),
+                saving: false,
+                ..
+            } if error == "Failed to save backup status: disk full"
+        ));
+    }
+
+    #[test]
+    fn backup_completed_message_clears_pin_and_mnemonic() {
+        let mut state = state();
+        state.backup_pin.digits = [
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+        ];
+        state.backup_mnemonic = Some(Zeroizing::new(words()));
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            Message::View(view::Message::Settings(
+                view::SettingsMessage::BackupMasterSeedUpdated,
+            )),
+        );
+
+        assert_eq!(state.backup_state, BackupSeedState::Completed);
+        assert_eq!(state.backup_pin.value(), "");
+        assert!(state.backup_mnemonic.is_none());
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            backup_msg(view::BackupWalletMessage::Complete),
+        );
+        assert_eq!(state.backup_state, BackupSeedState::None);
+    }
+
+    #[test]
+    fn fiat_currency_results_ignore_stale_source_and_store_matching_result() {
+        let mut state = state();
+        state.new_price_setting.source = PriceSource::Coincube;
+        state.error = Some(Error::Unexpected("old".to_string()));
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            Message::Fiat(FiatMessage::ListCurrenciesResult(
+                PriceSource::CoinGecko,
+                Ok(ListCurrenciesResult {
+                    currencies: vec![Currency::EUR],
+                }),
+            )),
+        );
+        assert!(state.currencies.is_empty());
+        assert!(state.error.is_some());
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            Message::Fiat(FiatMessage::ListCurrenciesResult(
+                PriceSource::Coincube,
+                Ok(ListCurrenciesResult {
+                    currencies: vec![Currency::USD, Currency::EUR],
+                }),
+            )),
+        );
+        assert_eq!(state.currencies, vec![Currency::USD, Currency::EUR]);
+        assert!(state.error.is_none());
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            Message::Fiat(FiatMessage::ListCurrenciesResult(
+                PriceSource::Coincube,
+                Err(PriceApiError::RequestFailed("timeout".to_string())),
+            )),
+        );
+        assert!(state.error.is_some());
+    }
+
+    #[test]
+    fn fiat_validation_falls_back_or_errors_when_currency_unavailable() {
+        let mut state = state();
+        state.new_price_setting.currency = Currency::EUR;
+        state.currencies = vec![Currency::USD, Currency::GBP];
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            Message::Fiat(FiatMessage::ValidateCurrencySetting),
+        );
+        assert_eq!(state.new_price_setting.currency, Currency::USD);
+
+        state.new_price_setting.currency = Currency::EUR;
+        state.currencies.clear();
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            Message::Fiat(FiatMessage::ValidateCurrencySetting),
+        );
+        assert!(matches!(state.error, Some(Error::Unexpected(_))));
+    }
+
+    #[test]
+    fn fiat_and_display_preference_messages_update_draft_state() {
+        let mut state = state();
+        state.new_price_setting.is_enabled = false;
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            Message::View(view::Message::Settings(view::SettingsMessage::Fiat(
+                view::FiatMessage::Enable(true),
+            ))),
+        );
+        assert!(state.new_price_setting.is_enabled);
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            Message::View(view::Message::Settings(view::SettingsMessage::Fiat(
+                view::FiatMessage::SourceEdited(PriceSource::CoinGecko),
+            ))),
+        );
+        assert_eq!(state.new_price_setting.source, PriceSource::CoinGecko);
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            Message::View(view::Message::Settings(view::SettingsMessage::Fiat(
+                view::FiatMessage::CurrencyEdited(Currency::GBP),
+            ))),
+        );
+        assert_eq!(state.new_price_setting.currency, Currency::GBP);
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            Message::View(view::Message::Settings(
+                view::SettingsMessage::DisplayUnitChanged(BitcoinDisplayUnit::BTC),
+            )),
+        );
+        assert_eq!(state.new_unit_setting.display_unit, BitcoinDisplayUnit::BTC);
+
+        let _ = state.update(
+            None,
+            &Cache::default(),
+            Message::View(view::Message::Settings(
+                view::SettingsMessage::ToggleDirectionBadges(false),
+            )),
+        );
+        assert!(!state.show_direction_badges);
+    }
+}
+
 async fn update_unit_setting(
     data_dir: CoincubeDirectory,
     network: Network,

--- a/coincube-gui/src/app/state/spark/receive.rs
+++ b/coincube-gui/src/app/state/spark/receive.rs
@@ -836,3 +836,462 @@ fn fetch_deposits_task(backend: Option<Arc<SparkBackend>>) -> Task<Message> {
         },
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::message::Message as AppMessage;
+    use crate::app::state::State;
+    use crate::app::view::{Message as ViewMessage, SparkReceiveMessage};
+
+    fn receive_ok(payment_request: &str) -> ReceivePaymentOk {
+        ReceivePaymentOk {
+            payment_request: payment_request.to_string(),
+            fee_sat: 7,
+        }
+    }
+
+    fn deposit(txid: &str, vout: u32, is_mature: bool) -> DepositInfo {
+        DepositInfo {
+            txid: txid.to_string(),
+            vout,
+            amount_sat: 12_345,
+            is_mature,
+            claim_error: None,
+        }
+    }
+
+    fn update(panel: &mut SparkReceive, msg: SparkReceiveMessage) {
+        let _task = State::update(
+            panel,
+            None,
+            &Cache::default(),
+            AppMessage::View(ViewMessage::SparkReceive(msg)),
+        );
+    }
+
+    #[test]
+    fn receive_method_labels_are_stable() {
+        assert_eq!(SparkReceiveMethod::Bolt11.label(), "Lightning (BOLT11)");
+        assert_eq!(
+            SparkReceiveMethod::OnchainBitcoin.label(),
+            "On-chain Bitcoin"
+        );
+        assert_eq!(SparkReceiveMethod::Spark.label(), "Spark");
+    }
+
+    #[test]
+    fn new_panel_starts_in_bolt11_idle_state() {
+        let panel = SparkReceive::new(None);
+
+        assert!(panel.backend.is_none());
+        assert_eq!(panel.balance_sats, 0);
+        assert_eq!(panel.method, SparkReceiveMethod::Bolt11);
+        assert!(!panel.sender_picker_open);
+        assert!(matches!(panel.phase(), SparkReceivePhase::Idle));
+        assert!(panel.qr_data.is_none());
+        assert!(panel.displayed_invoice.is_none());
+        assert!(panel.pending_deposits.is_empty());
+        assert!(panel.recent_transactions.is_empty());
+    }
+
+    #[test]
+    fn generate_without_backend_surfaces_actionable_error() {
+        let mut panel = SparkReceive::new(None);
+
+        update(&mut panel, SparkReceiveMessage::GenerateRequested);
+
+        assert!(matches!(
+            panel.phase(),
+            SparkReceivePhase::Error(msg) if msg == "Spark backend is not available."
+        ));
+    }
+
+    #[test]
+    fn input_edits_reset_generated_payment_state() {
+        let mut panel = SparkReceive::new(None);
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::GenerateSucceeded(receive_ok("lnbc1invoice")),
+        );
+        assert!(matches!(panel.phase(), SparkReceivePhase::Generated(_)));
+        assert!(panel.qr_data.is_some());
+        assert_eq!(panel.displayed_invoice.as_deref(), Some("lnbc1invoice"));
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::AmountInputChanged("2500".to_string()),
+        );
+
+        assert_eq!(panel.amount_input, "2500");
+        assert!(matches!(panel.phase(), SparkReceivePhase::Idle));
+        assert!(panel.qr_data.is_none());
+        assert!(panel.displayed_invoice.is_none());
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::GenerateSucceeded(receive_ok("lnbc1invoice2")),
+        );
+        update(
+            &mut panel,
+            SparkReceiveMessage::DescriptionInputChanged("for coffee".to_string()),
+        );
+
+        assert_eq!(panel.description_input, "for coffee");
+        assert!(matches!(panel.phase(), SparkReceivePhase::Idle));
+        assert!(panel.qr_data.is_none());
+        assert!(panel.displayed_invoice.is_none());
+    }
+
+    #[test]
+    fn generated_bolt11_payment_captures_invoice_for_correlation() {
+        let mut panel = SparkReceive::new(None);
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::GenerateSucceeded(receive_ok("lnbc1invoice")),
+        );
+
+        assert!(matches!(panel.phase(), SparkReceivePhase::Generated(_)));
+        assert_eq!(panel.displayed_invoice.as_deref(), Some("lnbc1invoice"));
+        assert!(panel.qr_data.is_some());
+    }
+
+    #[test]
+    fn generated_onchain_payment_does_not_capture_invoice() {
+        let mut panel = SparkReceive::new(None);
+        panel.method = SparkReceiveMethod::OnchainBitcoin;
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::GenerateSucceeded(receive_ok("bc1qaddress")),
+        );
+
+        assert!(matches!(panel.phase(), SparkReceivePhase::Generated(_)));
+        assert!(panel.displayed_invoice.is_none());
+        assert!(panel.qr_data.is_some());
+    }
+
+    #[test]
+    fn failed_generation_clears_qr_and_invoice_state() {
+        let mut panel = SparkReceive::new(None);
+        update(
+            &mut panel,
+            SparkReceiveMessage::GenerateSucceeded(receive_ok("lnbc1invoice")),
+        );
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::GenerateFailed("bridge down".to_string()),
+        );
+
+        assert!(matches!(
+            panel.phase(),
+            SparkReceivePhase::Error(msg) if msg == "bridge down"
+        ));
+        assert!(panel.qr_data.is_none());
+        assert!(panel.displayed_invoice.is_none());
+    }
+
+    #[test]
+    fn payment_received_ignores_idle_outgoing_and_unrelated_events() {
+        let mut panel = SparkReceive::new(None);
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::PaymentReceived {
+                amount_sat: 100,
+                bolt11: None,
+            },
+        );
+        assert!(matches!(panel.phase(), SparkReceivePhase::Idle));
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::GenerateSucceeded(receive_ok("lnbc1invoice")),
+        );
+        update(
+            &mut panel,
+            SparkReceiveMessage::PaymentReceived {
+                amount_sat: -100,
+                bolt11: Some("lnbc1invoice".to_string()),
+            },
+        );
+        assert!(matches!(panel.phase(), SparkReceivePhase::Generated(_)));
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::PaymentReceived {
+                amount_sat: 100,
+                bolt11: Some("lnbc1other".to_string()),
+            },
+        );
+        assert!(matches!(panel.phase(), SparkReceivePhase::Generated(_)));
+    }
+
+    #[test]
+    fn payment_received_matches_bolt11_case_insensitively() {
+        let mut panel = SparkReceive::new(None);
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::GenerateSucceeded(receive_ok("LNBC1Invoice")),
+        );
+        update(
+            &mut panel,
+            SparkReceiveMessage::PaymentReceived {
+                amount_sat: 321,
+                bolt11: Some("lnbc1invoice".to_string()),
+            },
+        );
+
+        assert!(matches!(
+            panel.phase(),
+            SparkReceivePhase::Received {
+                amount_sat: 321,
+                count: 1
+            }
+        ));
+        assert_eq!(panel.received_amount_display, "+321 sats");
+        assert_eq!(panel.received_celebration_context, "lightning-receive");
+        assert!(panel.qr_data.is_none());
+        assert!(panel.displayed_invoice.is_none());
+    }
+
+    #[test]
+    fn onchain_receive_events_accumulate_while_celebrating() {
+        let mut panel = SparkReceive::new(None);
+        panel.method = SparkReceiveMethod::OnchainBitcoin;
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::GenerateSucceeded(receive_ok("bc1qaddress")),
+        );
+        update(
+            &mut panel,
+            SparkReceiveMessage::PaymentReceived {
+                amount_sat: 100,
+                bolt11: None,
+            },
+        );
+        update(
+            &mut panel,
+            SparkReceiveMessage::PaymentReceived {
+                amount_sat: 50,
+                bolt11: None,
+            },
+        );
+
+        assert!(matches!(
+            panel.phase(),
+            SparkReceivePhase::Received {
+                amount_sat: 150,
+                count: 2
+            }
+        ));
+        assert_eq!(panel.received_amount_display, "+150 sats (2 deposits)");
+        assert_eq!(panel.received_celebration_context, "spark-receive");
+    }
+
+    #[test]
+    fn reset_returns_to_idle_and_clears_generated_artifacts() {
+        let mut panel = SparkReceive::new(None);
+        update(
+            &mut panel,
+            SparkReceiveMessage::GenerateSucceeded(receive_ok("lnbc1invoice")),
+        );
+
+        update(&mut panel, SparkReceiveMessage::Reset);
+
+        assert!(matches!(panel.phase(), SparkReceivePhase::Idle));
+        assert!(panel.qr_data.is_none());
+        assert!(panel.displayed_invoice.is_none());
+    }
+
+    #[test]
+    fn sender_picker_opens_closes_and_rail_selection_resets_receive_state() {
+        let mut panel = SparkReceive::new(None);
+        update(
+            &mut panel,
+            SparkReceiveMessage::GenerateSucceeded(receive_ok("lnbc1invoice")),
+        );
+
+        update(&mut panel, SparkReceiveMessage::OpenSenderPicker);
+        assert!(panel.sender_picker_open);
+
+        update(&mut panel, SparkReceiveMessage::CloseSenderPicker);
+        assert!(!panel.sender_picker_open);
+
+        update(&mut panel, SparkReceiveMessage::OpenSenderPicker);
+        update(
+            &mut panel,
+            SparkReceiveMessage::SelectSenderRail(SparkReceiveMethod::Spark),
+        );
+
+        assert!(!panel.sender_picker_open);
+        assert_eq!(panel.method, SparkReceiveMethod::Spark);
+        assert!(panel.sideshift_flow.is_none());
+        assert!(matches!(panel.phase(), SparkReceivePhase::Idle));
+        assert!(panel.qr_data.is_none());
+        assert!(panel.displayed_invoice.is_none());
+    }
+
+    #[test]
+    fn pending_deposits_reload_prunes_stale_confirmations_and_clears_error() {
+        let mut panel = SparkReceive::new(None);
+        panel.claim_error = Some("old claim error".to_string());
+        panel
+            .pending_deposit_confirmations
+            .insert(("kept".to_string(), 0), 2);
+        panel
+            .pending_deposit_confirmations
+            .insert(("stale".to_string(), 1), 6);
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::PendingDepositsLoaded(vec![deposit("kept", 0, false)]),
+        );
+
+        assert_eq!(panel.pending_deposits.len(), 1);
+        assert_eq!(panel.pending_deposits[0].txid, "kept");
+        assert!(panel.claim_error.is_none());
+        assert_eq!(
+            panel
+                .pending_deposit_confirmations
+                .get(&("kept".to_string(), 0)),
+            Some(&2)
+        );
+        assert!(!panel
+            .pending_deposit_confirmations
+            .contains_key(&("stale".to_string(), 1)));
+    }
+
+    #[test]
+    fn pending_deposit_failures_clear_list_and_confirmation_cache() {
+        let mut panel = SparkReceive::new(None);
+        panel.pending_deposits = vec![deposit("tx", 0, false)];
+        panel
+            .pending_deposit_confirmations
+            .insert(("tx".to_string(), 0), 1);
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::PendingDepositsFailed("timeout".to_string()),
+        );
+
+        assert!(panel.pending_deposits.is_empty());
+        assert!(panel.pending_deposit_confirmations.is_empty());
+    }
+
+    #[test]
+    fn confirmation_updates_merge_and_can_move_backward() {
+        let mut panel = SparkReceive::new(None);
+        panel
+            .pending_deposit_confirmations
+            .insert(("a".to_string(), 0), 6);
+        panel
+            .pending_deposit_confirmations
+            .insert(("b".to_string(), 1), 1);
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::DepositConfirmationsUpdated(HashMap::from([
+                (("a".to_string(), 0), 3),
+                (("c".to_string(), 2), 0),
+            ])),
+        );
+
+        assert_eq!(
+            panel
+                .pending_deposit_confirmations
+                .get(&("a".to_string(), 0)),
+            Some(&3)
+        );
+        assert_eq!(
+            panel
+                .pending_deposit_confirmations
+                .get(&("b".to_string(), 1)),
+            Some(&1)
+        );
+        assert_eq!(
+            panel
+                .pending_deposit_confirmations
+                .get(&("c".to_string(), 2)),
+            Some(&0)
+        );
+    }
+
+    #[test]
+    fn claim_result_messages_update_claim_error_state() {
+        let mut panel = SparkReceive::new(None);
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::ClaimDepositRequested {
+                txid: "tx".to_string(),
+                vout: 0,
+            },
+        );
+        assert!(panel.claiming.is_none());
+
+        panel.claiming = Some(("tx".to_string(), 0));
+        update(
+            &mut panel,
+            SparkReceiveMessage::ClaimDepositFailed("claim failed".to_string()),
+        );
+        assert!(panel.claiming.is_none());
+        assert_eq!(panel.claim_error.as_deref(), Some("claim failed"));
+
+        panel.claiming = Some(("tx".to_string(), 0));
+        panel.claim_error = Some("old".to_string());
+        update(
+            &mut panel,
+            SparkReceiveMessage::ClaimDepositSucceeded(coincube_spark_protocol::ClaimDepositOk {
+                payment_id: "payment".to_string(),
+                amount_sat: 5_000,
+            }),
+        );
+        assert!(panel.claiming.is_none());
+        assert!(panel.claim_error.is_none());
+    }
+
+    #[test]
+    fn balance_loaded_updates_only_when_value_is_present() {
+        let mut panel = SparkReceive::new(None);
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::BalanceLoaded(Some((123, None))),
+        );
+        assert_eq!(panel.balance_sats, 123);
+
+        update(&mut panel, SparkReceiveMessage::BalanceLoaded(None));
+        assert_eq!(panel.balance_sats, 123);
+    }
+
+    #[test]
+    fn payments_failed_clears_recent_transactions() {
+        let mut panel = SparkReceive::new(None);
+        panel.recent_transactions.push(SparkRecentTransaction {
+            id: "id".to_string(),
+            description: "test payment".to_string(),
+            time_ago: "just now".to_string(),
+            timestamp: 1,
+            amount: coincube_core::miniscript::bitcoin::Amount::from_sat(1),
+            fees_sat: coincube_core::miniscript::bitcoin::Amount::from_sat(0),
+            fiat_amount: None,
+            is_incoming: true,
+            status: crate::app::wallets::DomainPaymentStatus::Complete,
+            method: crate::app::view::spark::SparkPaymentMethod::Spark,
+            token_display: None,
+        });
+
+        update(
+            &mut panel,
+            SparkReceiveMessage::PaymentsFailed("bridge down".to_string()),
+        );
+
+        assert!(panel.recent_transactions.is_empty());
+    }
+}

--- a/coincube-gui/src/app/state/vault/keychain_sign.rs
+++ b/coincube-gui/src/app/state/vault/keychain_sign.rs
@@ -1956,31 +1956,12 @@ fn event_type_from_i32(v: i32) -> crate::services::connect::grpc::connect_v1::Ev
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::state::vault::test_support::{empty_psbt, tokens};
     use std::str::FromStr;
 
     // Primary signer `f5acc2fd`; recovery signer `8a64f2a9` behind a CSV.
     // Same fixture used by the `signers` classification tests.
     const RECOVERY_DESC: &str = "wsh(or_d(pk([f5acc2fd]tpubD6NzVbkrYhZ4YgUx2ZLNt2rLYAMTdYysCRzKoLu2BeSHKvzqPaBDvf17GeBPnExUVPkuBpx4kniP964e2MxyzzazcXLptxLXModSVCVEV1T/<0;1>/*),and_v(v:pkh([8a64f2a9]tpubD6NzVbkrYhZ4WmzFjvQrp7sDa4ECUxTi9oby8K4FZkd3XCBtEdKwUiQyYJaxiJo5y42gyDWEczrFpozEjeLxMPxjf2WtkfcbpUdfvNnozWF/<0;1>/*),older(10))))#d72le4dr";
-
-    fn empty_psbt() -> Psbt {
-        use coincube_core::miniscript::bitcoin::{absolute, transaction, Transaction};
-
-        Psbt::from_unsigned_tx(Transaction {
-            version: transaction::Version::TWO,
-            lock_time: absolute::LockTime::Blocks(absolute::Height::ZERO),
-            input: vec![],
-            output: vec![],
-        })
-        .expect("empty unsigned tx is psbt-compatible")
-    }
-
-    fn tokens() -> Arc<RwLock<AccessTokenResponse>> {
-        Arc::new(RwLock::new(AccessTokenResponse {
-            access_token: "access".to_string(),
-            refresh_token: "refresh".to_string(),
-            expires_at: i64::MAX,
-        }))
-    }
 
     fn modal() -> KeychainSignModal {
         let wallet = Arc::new(Wallet::new(

--- a/coincube-gui/src/app/state/vault/keychain_sign.rs
+++ b/coincube-gui/src/app/state/vault/keychain_sign.rs
@@ -1962,6 +1962,58 @@ mod tests {
     // Same fixture used by the `signers` classification tests.
     const RECOVERY_DESC: &str = "wsh(or_d(pk([f5acc2fd]tpubD6NzVbkrYhZ4YgUx2ZLNt2rLYAMTdYysCRzKoLu2BeSHKvzqPaBDvf17GeBPnExUVPkuBpx4kniP964e2MxyzzazcXLptxLXModSVCVEV1T/<0;1>/*),and_v(v:pkh([8a64f2a9]tpubD6NzVbkrYhZ4WmzFjvQrp7sDa4ECUxTi9oby8K4FZkd3XCBtEdKwUiQyYJaxiJo5y42gyDWEczrFpozEjeLxMPxjf2WtkfcbpUdfvNnozWF/<0;1>/*),older(10))))#d72le4dr";
 
+    fn empty_psbt() -> Psbt {
+        use coincube_core::miniscript::bitcoin::{absolute, transaction, Transaction};
+
+        Psbt::from_unsigned_tx(Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::Blocks(absolute::Height::ZERO),
+            input: vec![],
+            output: vec![],
+        })
+        .expect("empty unsigned tx is psbt-compatible")
+    }
+
+    fn tokens() -> Arc<RwLock<AccessTokenResponse>> {
+        Arc::new(RwLock::new(AccessTokenResponse {
+            access_token: "access".to_string(),
+            refresh_token: "refresh".to_string(),
+            expires_at: i64::MAX,
+        }))
+    }
+
+    fn modal() -> KeychainSignModal {
+        let wallet = Arc::new(Wallet::new(
+            CoincubeDescriptor::from_str(RECOVERY_DESC).unwrap(),
+        ));
+        KeychainSignModal::new(
+            wallet,
+            CoincubeClient::new(),
+            tokens(),
+            "https://grpc.example.test".to_string(),
+            "desktop-device".to_string(),
+            42,
+            "cube-local".to_string(),
+            RECOVERY_DESC.to_string(),
+            empty_psbt(),
+        )
+    }
+
+    fn pending(status: PendingSessionStatus) -> PendingSession {
+        PendingSession {
+            session_id: "session-1".to_string(),
+            key_id: 7,
+            fingerprint: Fingerprint::from_str("f5acc2fd").unwrap(),
+            device_id: "phone-1".to_string(),
+            label: "Phone (you)".to_string(),
+            status,
+            error: None,
+            cancel_requested: false,
+            signed_psbt_persisted: false,
+            signed_psbt_fetching: false,
+        }
+    }
+
     #[test]
     fn descriptor_fingerprints_covers_primary_and_recovery() {
         let desc = CoincubeDescriptor::from_str(RECOVERY_DESC).unwrap();
@@ -1972,5 +2024,191 @@ mod tests {
         assert!(fps.contains(&Fingerprint::from_str("f5acc2fd").unwrap()));
         assert!(fps.contains(&Fingerprint::from_str("8a64f2a9").unwrap()));
         assert_eq!(fps.len(), 2);
+    }
+
+    #[test]
+    fn pending_session_status_labels_and_terminal_flags_are_stable() {
+        let cases = [
+            (PendingSessionStatus::Idle, "", false, false),
+            (PendingSessionStatus::Creating, "Requesting…", false, false),
+            (PendingSessionStatus::Pending, "Requested…", false, false),
+            (PendingSessionStatus::Delivered, "Delivered", false, false),
+            (PendingSessionStatus::Viewed, "Viewed", false, false),
+            (PendingSessionStatus::Approved, "Approved", false, false),
+            (
+                PendingSessionStatus::PartiallySigned,
+                "Signing…",
+                false,
+                false,
+            ),
+            (PendingSessionStatus::Completed, "Signed", true, true),
+            (PendingSessionStatus::Rejected, "Rejected", true, false),
+            (PendingSessionStatus::Cancelled, "Cancelled", true, false),
+            (PendingSessionStatus::Expired, "Expired", true, false),
+            (PendingSessionStatus::Failed, "Failed", true, false),
+        ];
+
+        for (status, label, terminal, success) in cases {
+            assert_eq!(status.label(), label);
+            assert_eq!(status.is_terminal(), terminal);
+            assert_eq!(status.is_terminal_success(), success);
+        }
+        assert!(PendingSessionStatus::Idle.is_idle());
+        assert!(!PendingSessionStatus::Pending.is_idle());
+    }
+
+    #[test]
+    fn modal_phase_helpers_track_loading_resolution_and_done_states() {
+        let mut modal = modal();
+        assert!(modal.is_loading());
+        assert!(!modal.is_resolved());
+        assert!(!modal.is_done());
+
+        modal.phase = Phase::Resolving;
+        assert!(modal.is_loading());
+        assert!(!modal.is_resolved());
+
+        modal.phase = Phase::Sessions;
+        assert!(!modal.is_loading());
+        assert!(modal.is_resolved());
+        assert!(!modal.is_done());
+
+        modal.phase = Phase::AllDone;
+        assert!(modal.is_resolved());
+        assert!(modal.is_done());
+    }
+
+    #[test]
+    fn stream_health_banner_only_shows_for_degraded_pending_sessions() {
+        let mut modal = modal();
+        assert!(modal.stream_health_banner().is_none());
+
+        modal.pending.push(pending(PendingSessionStatus::Pending));
+        assert!(modal.stream_health_banner().is_none());
+
+        modal.stream_health = crate::app::ConnectionStatus::Connecting;
+        assert!(modal
+            .stream_health_banner()
+            .is_some_and(|b| b.contains("reconnecting")));
+
+        modal.stream_health = crate::app::ConnectionStatus::Error("socket closed".to_string());
+        assert!(modal
+            .stream_health_banner()
+            .is_some_and(|b| b.contains("socket closed")));
+
+        modal.pending[0].status = PendingSessionStatus::Completed;
+        assert!(modal.stream_health_banner().is_none());
+    }
+
+    #[test]
+    fn done_and_dismissed_drain_helpers_ignore_idle_but_wait_for_active_sessions() {
+        let mut modal = modal();
+        assert!(!modal.check_all_done());
+        assert!(!modal.has_undrained_sessions());
+
+        modal.pending.push(pending(PendingSessionStatus::Idle));
+        assert!(!modal.check_all_done());
+        assert!(!modal.has_undrained_sessions());
+
+        modal.pending[0].status = PendingSessionStatus::Creating;
+        assert!(modal.has_undrained_sessions());
+        modal.mark_dismissed();
+        let _ = modal.close_if_dismissed_and_drained();
+        assert!(!matches!(modal.phase, Phase::AllDone));
+
+        modal.pending[0].status = PendingSessionStatus::Completed;
+        assert!(!modal.has_undrained_sessions());
+        assert!(!modal.check_all_done());
+
+        modal.pending[0].signed_psbt_persisted = true;
+        assert!(modal.check_all_done());
+
+        modal.pending[0].status = PendingSessionStatus::Cancelled;
+        modal.pending[0].signed_psbt_persisted = false;
+        let _ = modal.close_if_dismissed_and_drained();
+        assert!(matches!(modal.phase, Phase::AllDone));
+    }
+
+    #[test]
+    fn proto_status_mapping_handles_known_and_unknown_values() {
+        use ProtoSessionStatus::*;
+
+        let cases = [
+            (Pending, PendingSessionStatus::Pending),
+            (Delivered, PendingSessionStatus::Delivered),
+            (Viewed, PendingSessionStatus::Viewed),
+            (Approved, PendingSessionStatus::Approved),
+            (PartiallySigned, PendingSessionStatus::PartiallySigned),
+            (Completed, PendingSessionStatus::Completed),
+            (Rejected, PendingSessionStatus::Rejected),
+            (Cancelled, PendingSessionStatus::Cancelled),
+            (Expired, PendingSessionStatus::Expired),
+            (Failed, PendingSessionStatus::Failed),
+            (Unspecified, PendingSessionStatus::Pending),
+        ];
+
+        for (proto, status) in cases {
+            assert_eq!(PendingSessionStatus::from_proto(proto), status);
+        }
+
+        assert_eq!(session_status_from_i32(1), Pending);
+        assert_eq!(session_status_from_i32(6), Completed);
+        assert_eq!(session_status_from_i32(10), Failed);
+        assert_eq!(session_status_from_i32(999), Unspecified);
+    }
+
+    #[test]
+    fn event_type_mapping_handles_known_and_unknown_values() {
+        use crate::services::connect::grpc::connect_v1::EventType;
+
+        assert_eq!(event_type_from_i32(1), EventType::SessionCreated);
+        assert_eq!(event_type_from_i32(6), EventType::SignatureSubmitted);
+        assert_eq!(event_type_from_i32(12), EventType::DeviceOffline);
+        assert_eq!(event_type_from_i32(-1), EventType::Unspecified);
+    }
+
+    #[test]
+    fn auth_failure_detectors_classify_rest_and_grpc_errors() {
+        assert!(is_rest_auth_failure("HTTP 401 Unauthorized"));
+        assert!(is_rest_auth_failure("jwt expired"));
+        assert!(is_rest_auth_failure("invalid token"));
+        assert!(is_rest_auth_failure("403 forbidden"));
+        assert!(!is_rest_auth_failure("temporary network failure"));
+
+        let unauth = OpError::from_status(tonic::Status::unauthenticated("JWT expired"));
+        assert!(unauth.auth);
+        assert_eq!(
+            unauth.message,
+            "Your Connect session has expired. Please sign in again."
+        );
+
+        let denied = friendly_grpc_error(tonic::Status::permission_denied("nope"));
+        assert!(denied.1);
+        assert!(denied.0.contains("don't have permission"));
+
+        let unavailable = friendly_grpc_error(tonic::Status::unavailable("offline"));
+        assert!(!unavailable.1);
+        assert!(unavailable.0.contains("temporarily unreachable"));
+
+        let timed_out = friendly_grpc_error(tonic::Status::deadline_exceeded("slow"));
+        assert!(!timed_out.1);
+        assert!(timed_out.0.contains("timed out"));
+
+        let other = friendly_grpc_error(tonic::Status::internal("boom"));
+        assert_eq!(other, ("boom".to_string(), false));
+    }
+
+    #[test]
+    fn generated_ids_and_fingerprint_strings_have_expected_wire_shape() {
+        let id = uuid_v4();
+        assert_eq!(id.len(), 36);
+        assert_eq!(id.as_bytes()[14], b'4');
+        assert!(matches!(id.as_bytes()[19], b'8' | b'9' | b'a' | b'b'));
+        assert_eq!(id.matches('-').count(), 4);
+
+        let fp = Fingerprint::from_str("f5acc2fd").unwrap();
+        assert_eq!(fingerprint_as_str(&fp), "f5acc2fd");
+        assert_eq!(OpError::new("plain").message, "plain");
+        assert!(!OpError::new("plain").auth);
     }
 }

--- a/coincube-gui/src/app/state/vault/mod.rs
+++ b/coincube-gui/src/app/state/vault/mod.rs
@@ -9,4 +9,6 @@ pub mod receive;
 pub mod settings;
 pub mod signers;
 pub mod spend;
+#[cfg(test)]
+pub mod test_support;
 pub mod transactions;

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -1704,7 +1704,7 @@ async fn sign_psbt(
 mod tests {
     use super::*;
     use crate::{
-        app::{cache::Cache, state::PsbtsPanel},
+        app::{cache::Cache, state::PsbtsPanel, state::vault::test_support::{empty_psbt, tokens}},
         daemon::client::{Coincubed, Request},
         utils::{mock::Daemon, sandbox::Sandbox},
     };
@@ -1723,29 +1723,6 @@ mod tests {
 
     fn wallet() -> Wallet {
         Wallet::new(CoincubeDescriptor::from_str(DESC).unwrap())
-    }
-
-    fn empty_psbt() -> Psbt {
-        use coincube_core::miniscript::bitcoin::{absolute, transaction, Transaction};
-
-        Psbt::from_unsigned_tx(Transaction {
-            version: transaction::Version::TWO,
-            lock_time: absolute::LockTime::Blocks(absolute::Height::ZERO),
-            input: vec![],
-            output: vec![],
-        })
-        .expect("empty unsigned tx is psbt-compatible")
-    }
-
-    fn tokens(
-    ) -> Arc<tokio::sync::RwLock<crate::services::connect::client::auth::AccessTokenResponse>> {
-        Arc::new(tokio::sync::RwLock::new(
-            crate::services::connect::client::auth::AccessTokenResponse {
-                access_token: "access".to_string(),
-                refresh_token: "refresh".to_string(),
-                expires_at: i64::MAX,
-            },
-        ))
     }
 
     fn enter_phrase_words(state: &mut BorderWalletReconstructionState, phrase: &str) {

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -1704,7 +1704,11 @@ async fn sign_psbt(
 mod tests {
     use super::*;
     use crate::{
-        app::{cache::Cache, state::PsbtsPanel, state::vault::test_support::{empty_psbt, tokens}},
+        app::{
+            cache::Cache,
+            state::vault::test_support::{empty_psbt, tokens},
+            state::PsbtsPanel,
+        },
         daemon::client::{Coincubed, Request},
         utils::{mock::Daemon, sandbox::Sandbox},
     };

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -1711,25 +1711,331 @@ mod tests {
 
     use coincube_core::descriptors::CoincubeDescriptor;
     use serde_json::json;
-    use std::str::FromStr;
+    use std::{path::PathBuf, str::FromStr};
 
     const DESC: &str = "wsh(or_d(multi(2,[f714c228/48'/1'/0'/2']tpubDEwJnTwfKoMvu8AXXBPydBVWDpzNP5tatjjZ56q4TQioGL7iL9xzTbMoCCQ3tfGihtff7vtR4xsjcRuhZ7HWARVAkGZ1HZcpBhVdou76k7j/<0;1>/*,[2522f23c/48'/1'/0'/2']tpubDEoTU4bDW1EXN1rnLXnRfue1a7DeqjJcs39PkEeLcVXhVKzCnFo9yQX2EeeXJ6kh4hgbz5o9v7YAc1EE97AEJpJbKNmDxE3ZQo4msGPSp2J/<0;1>/*),and_v(v:thresh(1,pkh([f714c228/48'/1'/0'/2']tpubDEwJnTwfKoMvu8AXXBPydBVWDpzNP5tatjjZ56q4TQioGL7iL9xzTbMoCCQ3tfGihtff7vtR4xsjcRuhZ7HWARVAkGZ1HZcpBhVdou76k7j/<2;3>/*),a:pkh([2522f23c/48'/1'/0'/2']tpubDEoTU4bDW1EXN1rnLXnRfue1a7DeqjJcs39PkEeLcVXhVKzCnFo9yQX2EeeXJ6kh4hgbz5o9v7YAc1EE97AEJpJbKNmDxE3ZQo4msGPSp2J/<2;3>/*)),older(65535))))#9s8ekrce";
+    const GRID_PHRASE: &str =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    fn fingerprint(hex: &str) -> Fingerprint {
+        Fingerprint::from_str(hex).expect("fingerprint")
+    }
+
+    fn wallet() -> Wallet {
+        Wallet::new(CoincubeDescriptor::from_str(DESC).unwrap())
+    }
+
+    fn empty_psbt() -> Psbt {
+        use coincube_core::miniscript::bitcoin::{absolute, transaction, Transaction};
+
+        Psbt::from_unsigned_tx(Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::Blocks(absolute::Height::ZERO),
+            input: vec![],
+            output: vec![],
+        })
+        .expect("empty unsigned tx is psbt-compatible")
+    }
+
+    fn tokens(
+    ) -> Arc<tokio::sync::RwLock<crate::services::connect::client::auth::AccessTokenResponse>> {
+        Arc::new(tokio::sync::RwLock::new(
+            crate::services::connect::client::auth::AccessTokenResponse {
+                access_token: "access".to_string(),
+                refresh_token: "refresh".to_string(),
+                expires_at: i64::MAX,
+            },
+        ))
+    }
+
+    fn enter_phrase_words(state: &mut BorderWalletReconstructionState, phrase: &str) {
+        for (i, word) in phrase.split_whitespace().enumerate() {
+            state.update(BorderWalletReconMessage::PhraseWordEdited(
+                i,
+                word.to_string(),
+            ));
+        }
+    }
 
     #[test]
     fn persisted_connect_identity_counts_as_available_session() {
         let cache = Cache {
             connect_email: Some("alice@example.com".to_string()),
-            connect_tokens: Some(Arc::new(tokio::sync::RwLock::new(
-                crate::services::connect::client::auth::AccessTokenResponse {
-                    access_token: "access".to_string(),
-                    refresh_token: "refresh".to_string(),
-                    expires_at: i64::MAX,
-                },
-            ))),
+            connect_tokens: Some(tokens()),
             ..Cache::default()
         };
 
         assert!(connect_session_available(&cache));
+    }
+
+    #[test]
+    fn connect_session_available_accepts_live_or_persisted_session_markers() {
+        assert!(!connect_session_available(&Cache::default()));
+
+        assert!(connect_session_available(&Cache {
+            connect_authenticated: true,
+            ..Cache::default()
+        }));
+        assert!(connect_session_available(&Cache {
+            has_connect_session: true,
+            ..Cache::default()
+        }));
+        assert!(connect_session_available(&Cache {
+            connect_email: Some("alice@example.com".to_string()),
+            connect_tokens: Some(tokens()),
+            ..Cache::default()
+        }));
+
+        assert!(!connect_session_available(&Cache {
+            connect_email: Some("alice@example.com".to_string()),
+            ..Cache::default()
+        }));
+        assert!(!connect_session_available(&Cache {
+            connect_tokens: Some(tokens()),
+            ..Cache::default()
+        }));
+    }
+
+    #[test]
+    fn keychain_connect_missing_reports_each_required_field() {
+        assert_eq!(
+            keychain_connect_missing(&Cache::default()),
+            vec![
+                "connect_grpc_url",
+                "connect_tokens",
+                "connect_device_id",
+                "current_cube_server_id",
+            ]
+        );
+
+        let ready = Cache {
+            connect_grpc_url: Some("https://grpc.example.test".to_string()),
+            connect_tokens: Some(tokens()),
+            connect_device_id: Some("device-1".to_string()),
+            current_cube_server_id: Some(42),
+            ..Cache::default()
+        };
+        assert!(keychain_connect_missing(&ready).is_empty());
+    }
+
+    #[test]
+    fn build_keychain_if_ready_requires_connect_fields() {
+        let wallet = Arc::new(wallet());
+        let psbt = empty_psbt();
+
+        let (modal, _task) = build_keychain_if_ready(&Cache::default(), &wallet, &psbt);
+        assert!(modal.is_none());
+
+        let ready = Cache {
+            connect_grpc_url: Some("https://grpc.example.test".to_string()),
+            connect_tokens: Some(tokens()),
+            connect_device_id: Some("device-1".to_string()),
+            current_cube_server_id: Some(42),
+            cube_id: "cube-local".to_string(),
+            ..Cache::default()
+        };
+        let (modal, _task) = build_keychain_if_ready(&ready, &wallet, &psbt);
+        assert!(modal.is_some());
+    }
+
+    #[tokio::test]
+    async fn master_signer_reports_error_when_not_loaded() {
+        let (fingerprint, result) =
+            sign_psbt_with_master_signer(Arc::new(wallet()), empty_psbt()).await;
+
+        assert_eq!(fingerprint, Fingerprint::default());
+        assert!(matches!(
+            result,
+            Err(Error::Wallet(WalletError::MasterSigner(_)))
+        ));
+    }
+
+    #[test]
+    fn border_wallet_reconstruction_rejects_bad_phrase_and_moves_to_grid_on_valid_phrase() {
+        let mut state =
+            BorderWalletReconstructionState::new(fingerprint("f714c228"), Network::Bitcoin);
+
+        enter_phrase_words(
+            &mut state,
+            "not a valid mnemonic with twelve words total surely now extra words",
+        );
+        assert!(state.phrase_valid);
+        assert!(state.update(BorderWalletReconMessage::Next).is_none());
+        assert_eq!(state.step, ReconStep::RecoveryPhrase);
+        assert!(state
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("Invalid recovery phrase")));
+
+        let mut state =
+            BorderWalletReconstructionState::new(fingerprint("f714c228"), Network::Bitcoin);
+        enter_phrase_words(&mut state, GRID_PHRASE);
+        assert!(state.phrase_valid);
+        assert!(state.update(BorderWalletReconMessage::Next).is_none());
+        assert_eq!(state.step, ReconStep::Grid);
+        assert!(state.grid.is_some());
+        assert!(state.pattern.is_empty());
+        assert!(state.error.is_none());
+    }
+
+    #[test]
+    fn border_wallet_pattern_messages_update_checksum_and_errors() {
+        let mut state =
+            BorderWalletReconstructionState::new(fingerprint("f714c228"), Network::Bitcoin);
+        enter_phrase_words(&mut state, GRID_PHRASE);
+        state.update(BorderWalletReconMessage::Next);
+
+        state.update(BorderWalletReconMessage::Next);
+        assert!(state
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("Please select exactly")));
+
+        state.update(BorderWalletReconMessage::ToggleCell(0, 0));
+        assert_eq!(state.pattern.len(), 1);
+        assert!(state.error.is_none());
+        assert!(state.checksum_word.is_none());
+
+        state.update(BorderWalletReconMessage::ToggleCell(0, 0));
+        assert!(state.pattern.is_empty());
+        assert!(state.checksum_word.is_none());
+
+        for row in 0..PATTERN_LENGTH as u16 {
+            state.update(BorderWalletReconMessage::ToggleCell(row, 0));
+        }
+        assert!(state.pattern.is_complete());
+        assert!(state.checksum_word.is_some());
+
+        state.update(BorderWalletReconMessage::UndoLastCell);
+        assert_eq!(state.pattern.len(), PATTERN_LENGTH - 1);
+        assert!(state.checksum_word.is_none());
+
+        state.update(BorderWalletReconMessage::ClearPattern);
+        assert!(state.pattern.is_empty());
+
+        state.update(BorderWalletReconMessage::Previous);
+        assert_eq!(state.step, ReconStep::RecoveryPhrase);
+    }
+
+    #[test]
+    fn signing_paths_classify_active_signed_border_and_inactive_keys() {
+        use view::vault::psbt::{SigningKeyAction, SigningKeyKind, SigningKeyState};
+
+        let primary_fp = fingerprint("f714c228");
+        let border_fp = fingerprint("2522f23c");
+        let mut wallet = wallet();
+        wallet
+            .keys_aliases
+            .insert(primary_fp, "Primary alias".to_string());
+        wallet.border_wallet_fingerprints.insert(border_fp);
+
+        let modal = SignModal::new(
+            HashSet::from([primary_fp]),
+            Arc::new(wallet),
+            CoincubeDirectory::new(PathBuf::new()),
+            Network::Signet,
+            false,
+            None,
+            None,
+            true,
+        );
+
+        let paths = modal.signing_paths();
+        assert_eq!(paths.len(), 2);
+
+        let primary = paths.iter().find(|p| p.is_primary).unwrap();
+        assert!(primary.active);
+        assert!(primary.expanded);
+        assert_eq!(primary.threshold, 2);
+        assert_eq!(primary.total, 2);
+        assert_eq!(primary.collected, 1);
+
+        let primary_row = primary
+            .keys
+            .iter()
+            .find(|row| row.fingerprint == primary_fp)
+            .unwrap();
+        assert_eq!(primary_row.label, "Primary alias");
+        assert!(matches!(&primary_row.state, SigningKeyState::Signed));
+
+        let border_row = primary
+            .keys
+            .iter()
+            .find(|row| row.fingerprint == border_fp)
+            .unwrap();
+        assert!(matches!(&border_row.kind, SigningKeyKind::BorderWallet));
+        assert!(matches!(
+            &border_row.state,
+            SigningKeyState::Available(SigningKeyAction::BorderWallet)
+        ));
+
+        let recovery = paths.iter().find(|p| !p.is_primary).unwrap();
+        assert!(!recovery.active);
+        assert!(!recovery.expanded);
+        assert_eq!(recovery.sequence, Some(65535));
+        let signed_recovery_row = recovery
+            .keys
+            .iter()
+            .find(|row| row.fingerprint == primary_fp)
+            .unwrap();
+        assert!(matches!(
+            &signed_recovery_row.state,
+            SigningKeyState::Signed
+        ));
+        let unsigned_recovery_row = recovery
+            .keys
+            .iter()
+            .find(|row| row.fingerprint == border_fp)
+            .unwrap();
+        assert!(matches!(
+            &unsigned_recovery_row.state,
+            SigningKeyState::Disabled(reason) if reason.contains("isn't available")
+        ));
+    }
+
+    #[test]
+    fn signing_paths_prompt_unknown_keys_to_sign_in_only_when_keychain_is_enabled() {
+        use view::vault::psbt::SigningKeyState;
+
+        let keychain_enabled = SignModal::new(
+            HashSet::new(),
+            Arc::new(wallet()),
+            CoincubeDirectory::new(PathBuf::new()),
+            Network::Signet,
+            false,
+            None,
+            None,
+            true,
+        );
+        let primary = keychain_enabled
+            .signing_paths()
+            .into_iter()
+            .find(|p| p.is_primary)
+            .unwrap();
+        assert!(primary.keys.iter().all(|row| matches!(
+            &row.state,
+            SigningKeyState::NeedsSignIn(reason) if reason.contains("Connect a device")
+        )));
+
+        let local_only = SignModal::new(
+            HashSet::new(),
+            Arc::new(wallet()),
+            CoincubeDirectory::new(PathBuf::new()),
+            Network::Signet,
+            false,
+            None,
+            None,
+            false,
+        );
+        let primary = local_only
+            .signing_paths()
+            .into_iter()
+            .find(|p| p.is_primary)
+            .unwrap();
+        assert!(primary.keys.iter().all(|row| matches!(
+            &row.state,
+            SigningKeyState::Disabled(reason) if reason.contains("Connect this signing device")
+        )));
     }
 
     #[tokio::test]

--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -1744,7 +1744,585 @@ const SIGNET_GENESIS_BLOCK_TIMESTAMP: i64 = 1598918400;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::daemon::{DaemonBackend, DaemonError};
     use crate::node::bitcoind::RpcAuth;
+    use coincube_core::{
+        descriptors::CoincubeDescriptor,
+        miniscript::bitcoin::{address, bip32::ChildNumber, psbt::Psbt, Address, OutPoint, Txid},
+    };
+    use coincubed::{
+        bip329::Labels,
+        commands::{CoinStatus, LabelItem, UpdateDerivIndexesResult},
+        datadir::DataDirectory,
+    };
+    use std::collections::{HashMap, HashSet};
+
+    const DESC: &str = "wsh(or_d(pk([f5acc2fd]tpubD6NzVbkrYhZ4YgUx2ZLNt2rLYAMTdYysCRzKoLu2BeSHKvzqPaBDvf17GeBPnExUVPkuBpx4kniP964e2MxyzzazcXLptxLXModSVCVEV1T/<0;1>/*),and_v(v:pkh([8a64f2a9]tpubD6NzVbkrYhZ4WmzFjvQrp7sDa4ECUxTi9oby8K4FZkd3XCBtEdKwUiQyYJaxiJo5y42gyDWEczrFpozEjeLxMPxjf2WtkfcbpUdfvNnozWF/<0;1>/*),older(10))))#d72le4dr";
+
+    #[derive(Debug)]
+    struct TestDaemon {
+        config: Option<Config>,
+    }
+
+    #[async_trait::async_trait]
+    impl Daemon for TestDaemon {
+        fn backend(&self) -> DaemonBackend {
+            DaemonBackend::EmbeddedCoincubed(Some(NodeType::Bitcoind))
+        }
+
+        fn config(&self) -> Option<&Config> {
+            self.config.as_ref()
+        }
+
+        async fn is_alive(
+            &self,
+            _datadir: &CoincubeDirectory,
+            _network: Network,
+        ) -> Result<(), DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn stop(&self) -> Result<(), DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn get_info(&self) -> Result<crate::daemon::model::GetInfoResult, DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn request_sync(&self) -> Result<(), DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn get_new_address(
+            &self,
+        ) -> Result<crate::daemon::model::GetAddressResult, DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn list_revealed_addresses(
+            &self,
+            _is_change: bool,
+            _exclude_used: bool,
+            _limit: usize,
+            _start_index: Option<ChildNumber>,
+        ) -> Result<crate::daemon::model::ListRevealedAddressesResult, DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn update_deriv_indexes(
+            &self,
+            _receive: Option<u32>,
+            _change: Option<u32>,
+        ) -> Result<UpdateDerivIndexesResult, DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn list_coins(
+            &self,
+            _statuses: &[CoinStatus],
+            _outpoints: &[OutPoint],
+        ) -> Result<crate::daemon::model::ListCoinsResult, DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn list_spend_txs(
+            &self,
+        ) -> Result<crate::daemon::model::ListSpendResult, DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn create_spend_tx(
+            &self,
+            _coins_outpoints: &[OutPoint],
+            _destinations: &HashMap<Address<address::NetworkUnchecked>, u64>,
+            _feerate_vb: u64,
+            _change_address: Option<Address<address::NetworkUnchecked>>,
+        ) -> Result<crate::daemon::model::CreateSpendResult, DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn rbf_psbt(
+            &self,
+            _txid: &Txid,
+            _is_cancel: bool,
+            _feerate_vb: Option<u64>,
+        ) -> Result<crate::daemon::model::CreateSpendResult, DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn update_spend_tx(&self, _psbt: &Psbt) -> Result<(), DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn delete_spend_tx(&self, _txid: &Txid) -> Result<(), DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn broadcast_spend_tx(&self, _txid: &Txid) -> Result<(), DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn start_rescan(&self, _t: u32) -> Result<(), DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn list_confirmed_txs(
+            &self,
+            _start: u32,
+            _end: u32,
+            _limit: u64,
+        ) -> Result<crate::daemon::model::ListTransactionsResult, DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn create_recovery(
+            &self,
+            _address: Address<address::NetworkUnchecked>,
+            _coins_outpoints: &[OutPoint],
+            _feerate_vb: u64,
+            _sequence: Option<u16>,
+        ) -> Result<Psbt, DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn list_txs(
+            &self,
+            _txid: &[Txid],
+        ) -> Result<crate::daemon::model::ListTransactionsResult, DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn get_labels(
+            &self,
+            _labels: &HashSet<LabelItem>,
+        ) -> Result<HashMap<String, String>, DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn update_labels(
+            &self,
+            _labels: &HashMap<LabelItem, Option<String>>,
+        ) -> Result<(), DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+
+        async fn get_labels_bip329(
+            &self,
+            _offset: u32,
+            _limit: u32,
+        ) -> Result<Labels, DaemonError> {
+            unreachable!("test daemon should not be queried")
+        }
+    }
+
+    fn daemon(config: Option<Config>) -> Arc<dyn Daemon + Sync + Send> {
+        Arc::new(TestDaemon { config })
+    }
+
+    fn bitcoin_config(network: Network) -> BitcoinConfig {
+        BitcoinConfig {
+            network,
+            poll_interval_secs: std::time::Duration::from_secs(
+                coincubed::config::LOCAL_BACKEND_POLL_INTERVAL_SECS,
+            ),
+        }
+    }
+
+    fn bitcoind_config(rpc_auth: BitcoindRpcAuth) -> BitcoindConfig {
+        BitcoindConfig {
+            rpc_auth,
+            addr: "127.0.0.1:8332".parse().unwrap(),
+        }
+    }
+
+    fn electrum_config() -> ElectrumConfig {
+        ElectrumConfig {
+            addr: "ssl://electrum.example:50002".to_string(),
+            validate_domain: true,
+        }
+    }
+
+    fn esplora_config() -> coincubed::config::EsploraConfig {
+        coincubed::config::EsploraConfig {
+            addr: "https://example.com/api".to_string(),
+            token: None,
+            fallback_addr: None,
+            fallback_token: None,
+            secondary_fallback_addr: None,
+            secondary_fallback_token: None,
+        }
+    }
+
+    fn config_with_backend(backend: Option<BitcoinBackend>) -> Config {
+        Config::new(
+            bitcoin_config(Network::Bitcoin),
+            backend,
+            log::LevelFilter::Info,
+            CoincubeDescriptor::from_str(DESC).unwrap(),
+            DataDirectory::new(std::env::temp_dir().join("coincube-settings-state-test")),
+        )
+    }
+
+    fn edit_message(message: view::SettingsEditMessage) -> Message {
+        Message::View(view::Message::Settings(
+            view::SettingsMessage::BitcoindSettings(message),
+        ))
+    }
+
+    fn node_message(message: view::NodeSettingsMessage) -> Message {
+        Message::View(view::Message::Settings(
+            view::SettingsMessage::NodeSettings(message),
+        ))
+    }
+
+    #[test]
+    fn bitcoind_settings_new_hydrates_cookie_and_userpass_forms() {
+        let cookie = BitcoindSettings::new(
+            Some(NodeType::Bitcoind),
+            bitcoin_config(Network::Bitcoin),
+            bitcoind_config(BitcoindRpcAuth::CookieFile(PathBuf::from(
+                "/tmp/bitcoin/.cookie",
+            ))),
+            false,
+            false,
+        );
+
+        assert_eq!(cookie.selected_auth_type, RpcAuthType::CookieFile);
+        assert_eq!(cookie.addr.value, "127.0.0.1:8332");
+        assert_eq!(
+            cookie.rpc_auth_vals.cookie_path.value,
+            "/tmp/bitcoin/.cookie"
+        );
+        assert!(cookie.rpc_auth_vals.cookie_path.valid);
+        assert!(!cookie.edit);
+        assert!(!cookie.processing);
+
+        let userpass = BitcoindSettings::new(
+            Some(NodeType::Electrum),
+            bitcoin_config(Network::Testnet),
+            bitcoind_config(BitcoindRpcAuth::UserPass(
+                "rpcuser".to_string(),
+                "secret".to_string(),
+            )),
+            true,
+            false,
+        );
+
+        assert_eq!(userpass.selected_auth_type, RpcAuthType::UserPass);
+        assert_eq!(userpass.addr.value, "");
+        assert_eq!(userpass.rpc_auth_vals.user.value, "rpcuser");
+        assert_eq!(userpass.rpc_auth_vals.password.value, "secret");
+        assert!(userpass.daemon_is_external);
+    }
+
+    #[test]
+    fn edit_substates_toggle_editing_and_keep_processing_changes_guarded() {
+        let cache = Cache::default();
+        let daemon = daemon(None);
+        let mut bitcoind = BitcoindSettings::new(
+            Some(NodeType::Bitcoind),
+            bitcoin_config(Network::Bitcoin),
+            bitcoind_config(BitcoindRpcAuth::CookieFile(PathBuf::from(
+                "/tmp/bitcoin/.cookie",
+            ))),
+            false,
+            false,
+        );
+
+        let _ = bitcoind.update(daemon.clone(), &cache, view::SettingsEditMessage::Select);
+        assert!(bitcoind.edit);
+        let _ = bitcoind.update(
+            daemon.clone(),
+            &cache,
+            view::SettingsEditMessage::FieldEdited("socket_address", "bad".to_string()),
+        );
+        let _ = bitcoind.update(daemon.clone(), &cache, view::SettingsEditMessage::Confirm);
+        assert!(!bitcoind.addr.valid);
+        assert!(!bitcoind.processing);
+        let _ = bitcoind.update(daemon.clone(), &cache, view::SettingsEditMessage::Cancel);
+        assert!(!bitcoind.edit);
+
+        bitcoind.processing = true;
+        let previous = bitcoind.addr.value.clone();
+        let _ = bitcoind.update(
+            daemon.clone(),
+            &cache,
+            view::SettingsEditMessage::FieldEdited("socket_address", "127.0.0.1:9999".to_string()),
+        );
+        assert_eq!(bitcoind.addr.value, previous);
+
+        bitcoind.edited(false);
+        assert!(!bitcoind.processing);
+        bitcoind.edit = true;
+        bitcoind.processing = true;
+        bitcoind.edited(true);
+        assert!(!bitcoind.edit);
+        assert!(!bitcoind.processing);
+
+        let mut electrum = ElectrumSettings::new(
+            Some(NodeType::Electrum),
+            bitcoin_config(Network::Bitcoin),
+            electrum_config(),
+            false,
+        );
+        let _ = electrum.update(daemon.clone(), &cache, view::SettingsEditMessage::Select);
+        assert!(electrum.edit);
+        let _ = electrum.update(
+            daemon.clone(),
+            &cache,
+            view::SettingsEditMessage::ValidateDomainEdited(false),
+        );
+        assert!(!electrum.electrum_config.validate_domain);
+        let _ = electrum.update(
+            daemon,
+            &cache,
+            view::SettingsEditMessage::FieldEdited("address", "".to_string()),
+        );
+        assert!(!electrum.addr.valid);
+        electrum.edited(true);
+        assert!(!electrum.edit);
+        assert!(!electrum.processing);
+    }
+
+    #[test]
+    fn rescan_setting_validates_inputs_without_starting_daemon_on_bad_dates() {
+        let cache = Cache::default();
+        let daemon = daemon(None);
+        let mut rescan = RescanSetting::new(Some(0.5));
+        assert!(rescan.processing);
+
+        rescan.edited(false);
+        assert!(!rescan.processing);
+        assert!(!rescan.success);
+
+        let _ = rescan.update(
+            daemon.clone(),
+            &cache,
+            view::SettingsEditMessage::FieldEdited("rescan_year", "2024".to_string()),
+        );
+        let _ = rescan.update(
+            daemon.clone(),
+            &cache,
+            view::SettingsEditMessage::FieldEdited("rescan_month", "2".to_string()),
+        );
+        let _ = rescan.update(
+            daemon.clone(),
+            &cache,
+            view::SettingsEditMessage::FieldEdited("rescan_day", "31".to_string()),
+        );
+        let _ = rescan.update(
+            daemon.clone(),
+            &cache,
+            view::SettingsEditMessage::FieldEdited("rescan_year", "abcd".to_string()),
+        );
+        assert_eq!(rescan.year.value, "2024");
+
+        let _ = rescan.update(daemon.clone(), &cache, view::SettingsEditMessage::Confirm);
+        assert!(rescan.invalid_date);
+        assert!(!rescan.processing);
+
+        let _ = rescan.update(
+            daemon.clone(),
+            &cache,
+            view::SettingsEditMessage::FieldEdited("rescan_year", "2999".to_string()),
+        );
+        let _ = rescan.update(
+            daemon.clone(),
+            &cache,
+            view::SettingsEditMessage::FieldEdited("rescan_month", "1".to_string()),
+        );
+        let _ = rescan.update(
+            daemon.clone(),
+            &cache,
+            view::SettingsEditMessage::FieldEdited("rescan_day", "1".to_string()),
+        );
+        let _ = rescan.update(daemon, &cache, view::SettingsEditMessage::Confirm);
+        assert!(rescan.future_date);
+        assert!(!rescan.processing);
+    }
+
+    #[test]
+    fn state_new_selects_backend_substates_and_resource_defaults() {
+        let cache = Cache::default();
+        let bitcoind_state = BitcoindSettingsState::new(
+            Some(config_with_backend(Some(BitcoinBackend::Bitcoind(
+                bitcoind_config(BitcoindRpcAuth::CookieFile(PathBuf::from(
+                    "/tmp/bitcoin/.cookie",
+                ))),
+            )))),
+            &cache,
+            false,
+            false,
+        );
+        assert!(bitcoind_state.bitcoind_settings.is_some());
+        assert!(bitcoind_state.electrum_settings.is_none());
+        assert_eq!(
+            bitcoind_state.node_prune_mb.value,
+            PRUNE_DEFAULT.to_string()
+        );
+        assert_eq!(bitcoind_state.node_max_mempool_mb.value, "");
+
+        let electrum_state = BitcoindSettingsState::new(
+            Some(config_with_backend(Some(BitcoinBackend::Electrum(
+                electrum_config(),
+            )))),
+            &cache,
+            true,
+            false,
+        );
+        assert!(electrum_state.bitcoind_settings.is_none());
+        assert!(electrum_state.electrum_settings.is_some());
+
+        let empty_state = BitcoindSettingsState::new(None, &cache, false, false);
+        assert!(empty_state.bitcoind_settings.is_none());
+        assert!(empty_state.electrum_settings.is_none());
+    }
+
+    #[test]
+    fn state_update_tracks_setup_forms_flavor_confirmation_and_resource_presets() {
+        let cache = Cache::default();
+        let daemon = daemon(Some(config_with_backend(Some(BitcoinBackend::Esplora(
+            esplora_config(),
+        )))));
+        let mut state = BitcoindSettingsState::new(
+            Some(config_with_backend(Some(BitcoinBackend::Esplora(
+                esplora_config(),
+            )))),
+            &cache,
+            false,
+            false,
+        );
+
+        let _ = state.update(
+            Some(daemon.clone()),
+            &cache,
+            node_message(view::NodeSettingsMessage::SetupLocalNode),
+        );
+        assert!(matches!(
+            state.pending_node_setup.as_ref().map(|s| s.mode),
+            Some(None)
+        ));
+
+        let _ = state.update(
+            Some(daemon.clone()),
+            &cache,
+            node_message(view::NodeSettingsMessage::SetupLocalNodeModeSelected(false)),
+        );
+        let _ = state.update(
+            Some(daemon.clone()),
+            &cache,
+            node_message(view::NodeSettingsMessage::SetupLocalNodeAddrChanged(
+                "bad".to_string(),
+            )),
+        );
+        let _ = state.update(
+            Some(daemon.clone()),
+            &cache,
+            node_message(view::NodeSettingsMessage::SetupLocalNodeConfirm),
+        );
+        assert_eq!(state.pending_node_setup.as_ref().unwrap().mode, Some(false));
+        assert!(!state.pending_node_setup.as_ref().unwrap().addr.valid);
+
+        let _ = state.update(
+            Some(daemon.clone()),
+            &cache,
+            node_message(view::NodeSettingsMessage::SetupLocalNodeAuthTypeSelected(
+                RpcAuthType::UserPass,
+            )),
+        );
+        let _ = state.update(
+            Some(daemon.clone()),
+            &cache,
+            node_message(view::NodeSettingsMessage::SetupLocalNodeAddrChanged(
+                "127.0.0.1:8332".to_string(),
+            )),
+        );
+        let _ = state.update(
+            Some(daemon.clone()),
+            &cache,
+            node_message(view::NodeSettingsMessage::SetupLocalNodeFieldEdited(
+                "password",
+                "secret".to_string(),
+            )),
+        );
+        let _ = state.update(
+            Some(daemon.clone()),
+            &cache,
+            node_message(view::NodeSettingsMessage::SetupLocalNodeConfirm),
+        );
+        assert!(
+            !state
+                .pending_node_setup
+                .as_ref()
+                .unwrap()
+                .rpc_auth_vals
+                .user
+                .valid
+        );
+
+        let _ = state.update(
+            Some(daemon.clone()),
+            &cache,
+            node_message(view::NodeSettingsMessage::SetupLocalNodeCancel),
+        );
+        assert!(state.pending_node_setup.is_none());
+
+        state.bitcoind_settings = Some(BitcoindSettings::new(
+            Some(NodeType::Bitcoind),
+            bitcoin_config(Network::Bitcoin),
+            bitcoind_config(BitcoindRpcAuth::CookieFile(PathBuf::from(
+                "/tmp/bitcoin/.cookie",
+            ))),
+            false,
+            false,
+        ));
+        state.bitcoind_settings.as_mut().unwrap().managed_flavor = Some(NodeFlavor::Core);
+
+        let _ = state.update(
+            Some(daemon.clone()),
+            &cache,
+            edit_message(view::SettingsEditMessage::SwitchManagedFlavor(
+                NodeFlavor::Knots,
+            )),
+        );
+        assert_eq!(state.pending_flavor_switch, Some(NodeFlavor::Knots));
+        let _ = state.update(
+            Some(daemon.clone()),
+            &cache,
+            node_message(view::NodeSettingsMessage::CancelFlavorSwitch),
+        );
+        assert_eq!(state.pending_flavor_switch, None);
+
+        let _ = state.update(
+            Some(daemon.clone()),
+            &cache,
+            node_message(view::NodeSettingsMessage::NodeResourceSmallComputer),
+        );
+        assert_eq!(
+            state.node_prune_mb.value,
+            NodeResources::small_computer().prune_mb.to_string()
+        );
+        assert_eq!(state.node_max_mempool_mb.value, "100");
+        let _ = state.update(
+            Some(daemon.clone()),
+            &cache,
+            node_message(view::NodeSettingsMessage::NodeResourceRegularComputer),
+        );
+        assert_eq!(
+            state.node_prune_mb.value,
+            NodeResources::regular_computer().prune_mb.to_string()
+        );
+        assert_eq!(state.node_max_mempool_mb.value, "");
+        let _ = state.update(
+            Some(daemon),
+            &cache,
+            node_message(view::NodeSettingsMessage::NodeResourcePruneEdited(
+                "100".to_string(),
+            )),
+        );
+        assert!(!state.node_prune_mb.valid);
+    }
 
     // A node-resources apply on a pre-existing datadir must overwrite prune and
     // the mempool cap while preserving the network section's ports and rpc_auth

--- a/coincube-gui/src/app/state/vault/spend/step.rs
+++ b/coincube-gui/src/app/state/vault/spend/step.rs
@@ -1619,3 +1619,374 @@ fn recovery_paths(wallet: &Wallet, coins: &[Coin], tip_height: i32) -> Vec<Recov
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coincube_core::descriptors::CoincubeDescriptor;
+    use coincube_core::miniscript::bitcoin::{bip32::ChildNumber, Txid};
+    use std::str::FromStr;
+
+    const DESC: &str = "wsh(or_d(pk([f5acc2fd]tpubD6NzVbkrYhZ4YgUx2ZLNt2rLYAMTdYysCRzKoLu2BeSHKvzqPaBDvf17GeBPnExUVPkuBpx4kniP964e2MxyzzazcXLptxLXModSVCVEV1T/<0;1>/*),and_v(v:pkh([8a64f2a9]tpubD6NzVbkrYhZ4WmzFjvQrp7sDa4ECUxTi9oby8K4FZkd3XCBtEdKwUiQyYJaxiJo5y42gyDWEczrFpozEjeLxMPxjf2WtkfcbpUdfvNnozWF/<0;1>/*),older(10))))#d72le4dr";
+    const MAINNET_ADDR: &str = "bc1qvrl2849aggm6qry9ea7xqp2kk39j8vaa8r3cwg";
+
+    fn wallet() -> Arc<Wallet> {
+        Arc::new(Wallet::new(CoincubeDescriptor::from_str(DESC).unwrap()))
+    }
+
+    fn outpoint(n: u32) -> OutPoint {
+        OutPoint::new(Txid::from_str(&format!("{n:064x}")).unwrap(), n)
+    }
+
+    fn address() -> Address {
+        Address::from_str(MAINNET_ADDR).unwrap().assume_checked()
+    }
+
+    fn coin(n: u32, sats: u64, block_height: Option<i32>) -> Coin {
+        Coin {
+            amount: Amount::from_sat(sats),
+            outpoint: outpoint(n),
+            address: address(),
+            block_height,
+            derivation_index: ChildNumber::from(n),
+            spend_info: None,
+            is_immature: false,
+            is_change: false,
+            is_from_self: false,
+        }
+    }
+
+    #[test]
+    fn filter_coins_excludes_unspendable_and_sets_default_selection_by_path() {
+        let mut spent = coin(2, 20_000, Some(90));
+        spent.spend_info = Some(coincubed::commands::LCSpendInfo {
+            txid: Txid::from_str(&format!("{:064x}", 99)).unwrap(),
+            height: None,
+        });
+        let mut immature = coin(3, 30_000, Some(90));
+        immature.is_immature = true;
+        let unconfirmed = coin(4, 40_000, None);
+        let mature = coin(1, 10_000, Some(90));
+        let too_young = coin(5, 50_000, Some(96));
+        let coins = vec![
+            mature.clone(),
+            spent,
+            immature,
+            unconfirmed.clone(),
+            too_young.clone(),
+        ];
+
+        let primary = filter_coins(&coins, None, 100, None);
+        assert_eq!(primary.len(), 3);
+        assert!(primary.iter().all(|(_, selected)| !*selected));
+        assert!(primary
+            .iter()
+            .any(|(coin, _)| coin.outpoint == unconfirmed.outpoint));
+
+        let recovery = filter_coins(&coins, Some(10), 100, None);
+        assert_eq!(recovery.len(), 1);
+        assert_eq!(recovery[0].0.outpoint, mature.outpoint);
+        assert!(recovery[0].1);
+
+        let selected = HashSet::from_iter([too_young.outpoint]);
+        let later_recovery = filter_coins(&coins, Some(10), 105, Some(selected));
+        assert_eq!(later_recovery.len(), 2);
+        assert_eq!(
+            later_recovery
+                .iter()
+                .find(|(coin, _)| coin.outpoint == mature.outpoint)
+                .map(|(_, selected)| *selected),
+            Some(false)
+        );
+        assert_eq!(
+            later_recovery
+                .iter()
+                .find(|(coin, _)| coin.outpoint == too_young.outpoint)
+                .map(|(_, selected)| *selected),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn define_spend_initializes_primary_recovery_and_self_send_modes() {
+        let wallet = wallet();
+        let coins = vec![coin(1, 10_000, Some(90)), coin(2, 20_000, Some(91))];
+
+        let primary = DefineSpend::new(
+            Network::Bitcoin,
+            wallet.clone(),
+            &coins,
+            100,
+            None,
+            true,
+            Amount::from_sat(30_000),
+            Amount::ZERO,
+            SyncStatus::Synced,
+            BitcoinDisplayUnit::Sats,
+        )
+        .with_preselected_coins(&[coins[1].outpoint])
+        .with_coins_sorted(100);
+        assert_eq!(primary.recipients.len(), 1);
+        assert_eq!(primary.send_max_to_recipient, None);
+        assert!(primary.coins[0].1);
+        assert_eq!(primary.coins[0].0.outpoint, coins[1].outpoint);
+        assert_eq!(
+            primary.timelock(),
+            wallet.main_descriptor.first_timelock_value()
+        );
+
+        let recovery = DefineSpend::new(
+            Network::Bitcoin,
+            wallet.clone(),
+            &coins,
+            100,
+            Some(10),
+            false,
+            Amount::from_sat(30_000),
+            Amount::ZERO,
+            SyncStatus::Synced,
+            BitcoinDisplayUnit::Sats,
+        );
+        assert_eq!(recovery.send_max_to_recipient, Some(0));
+        assert!(recovery.recipients[0].is_recovery);
+        assert!(recovery.coins.iter().all(|(_, selected)| *selected));
+        assert_eq!(recovery.timelock(), 10);
+
+        let self_send = recovery.self_send();
+        assert!(self_send.recipients.is_empty());
+        assert!(self_send.is_user_coin_selection);
+    }
+
+    #[test]
+    fn recipient_validates_address_amount_label_and_truncates_btc_precision() {
+        let mut recipient = Recipient::default();
+        recipient.update(
+            Network::Bitcoin,
+            BitcoinDisplayUnit::Sats,
+            view::CreateSpendMessage::RecipientEdited(0, "address", "not an address".to_string()),
+        );
+        assert!(!recipient.address.valid);
+
+        recipient.update(
+            Network::Bitcoin,
+            BitcoinDisplayUnit::Sats,
+            view::CreateSpendMessage::RecipientEdited(0, "address", MAINNET_ADDR.to_string()),
+        );
+        assert!(recipient.address_valid());
+
+        recipient.update(
+            Network::Bitcoin,
+            BitcoinDisplayUnit::Sats,
+            view::CreateSpendMessage::RecipientEdited(0, "amount", "1 234".to_string()),
+        );
+        assert_eq!(recipient.amount().unwrap(), 1_234);
+        assert!(recipient.valid());
+
+        recipient.update(
+            Network::Bitcoin,
+            BitcoinDisplayUnit::BTC,
+            view::CreateSpendMessage::RecipientEdited(0, "amount", "0.123456789".to_string()),
+        );
+        assert_eq!(recipient.amount.value, "0.12345678");
+        assert_eq!(
+            recipient.amount.warning.as_deref(),
+            Some("Amount has been truncated to 8 decimal places")
+        );
+
+        recipient.update(
+            Network::Bitcoin,
+            BitcoinDisplayUnit::BTC,
+            view::CreateSpendMessage::RecipientEdited(0, "label", "x".repeat(101)),
+        );
+        assert!(!recipient.label.valid);
+        assert!(!recipient.valid());
+    }
+
+    #[test]
+    fn recipient_rejects_empty_zero_dust_and_wrong_network_amounts() {
+        let mut recipient = Recipient::default();
+        assert!(recipient.amount().is_err());
+
+        recipient.update(
+            Network::Bitcoin,
+            BitcoinDisplayUnit::Sats,
+            view::CreateSpendMessage::RecipientEdited(0, "address", MAINNET_ADDR.to_string()),
+        );
+        recipient.update(
+            Network::Bitcoin,
+            BitcoinDisplayUnit::Sats,
+            view::CreateSpendMessage::RecipientEdited(0, "amount", "0".to_string()),
+        );
+        assert!(recipient.amount().is_err());
+
+        recipient.update(
+            Network::Bitcoin,
+            BitcoinDisplayUnit::Sats,
+            view::CreateSpendMessage::RecipientEdited(0, "amount", "1".to_string()),
+        );
+        assert!(recipient.amount().is_err());
+
+        recipient.update(
+            Network::Signet,
+            BitcoinDisplayUnit::Sats,
+            view::CreateSpendMessage::RecipientEdited(0, "address", MAINNET_ADDR.to_string()),
+        );
+        assert!(!recipient.address.valid);
+    }
+
+    #[test]
+    fn duplicate_detection_and_check_valid_track_form_and_coin_selection() {
+        let wallet = wallet();
+        let coins = vec![coin(1, 10_000, Some(90))];
+        let mut state = DefineSpend::new(
+            Network::Bitcoin,
+            wallet,
+            &coins,
+            100,
+            None,
+            true,
+            Amount::from_sat(10_000),
+            Amount::ZERO,
+            SyncStatus::Synced,
+            BitcoinDisplayUnit::Sats,
+        )
+        .with_preselected_coins(&[coins[0].outpoint]);
+
+        state.feerate = form::Value {
+            value: "2".to_string(),
+            valid: true,
+            warning: None,
+        };
+        state.recipients[0].update(
+            Network::Bitcoin,
+            BitcoinDisplayUnit::Sats,
+            view::CreateSpendMessage::RecipientEdited(0, "address", MAINNET_ADDR.to_string()),
+        );
+        state.recipients[0].update(
+            Network::Bitcoin,
+            BitcoinDisplayUnit::Sats,
+            view::CreateSpendMessage::RecipientEdited(0, "amount", "1000".to_string()),
+        );
+        state.check_valid();
+        assert!(state.is_valid);
+        assert!(!state.is_duplicate);
+
+        state.recipients.push(state.recipients[0].clone());
+        state.batch_label.valid = true;
+        state.check_valid();
+        assert!(state.exists_duplicate());
+        assert!(state.is_duplicate);
+
+        state.batch_label.valid = false;
+        state.check_valid();
+        assert!(!state.is_valid);
+    }
+
+    #[test]
+    fn redraft_result_insufficient_funds_sets_missing_or_under_dust_state() {
+        let wallet = wallet();
+        let coins = vec![coin(1, 10_000, Some(90))];
+        let mut state = DefineSpend::new(
+            Network::Bitcoin,
+            wallet,
+            &coins,
+            100,
+            None,
+            true,
+            Amount::from_sat(10_000),
+            Amount::ZERO,
+            SyncStatus::Synced,
+            BitcoinDisplayUnit::Sats,
+        );
+        state.coins[0].1 = true;
+        state.apply_redraft_result(
+            Address::from_str(MAINNET_ADDR).unwrap(),
+            None,
+            false,
+            Ok(CreateSpendResult::InsufficientFunds { missing: 2_500 }),
+        );
+        assert_eq!(state.amount_left_to_select, Some(Amount::from_sat(2_500)));
+        assert!(state.coins[0].1);
+        assert!(state.fee_amount.is_none());
+
+        state.send_max_to_recipient = Some(0);
+        state.recipients[0].update(
+            Network::Bitcoin,
+            BitcoinDisplayUnit::Sats,
+            view::CreateSpendMessage::RecipientEdited(0, "address", MAINNET_ADDR.to_string()),
+        );
+        state.recipients[0].update(
+            Network::Bitcoin,
+            BitcoinDisplayUnit::Sats,
+            view::CreateSpendMessage::RecipientEdited(0, "amount", "1000".to_string()),
+        );
+        state.apply_redraft_result(
+            Address::from_str(MAINNET_ADDR).unwrap(),
+            Some(0),
+            false,
+            Ok(CreateSpendResult::InsufficientFunds { missing: 100 }),
+        );
+        assert!(state.amount_left_to_select.is_none());
+        assert!(state.recipients[0]
+            .dust_warning
+            .as_deref()
+            .is_some_and(|warning| warning.contains("Minimum amount")));
+        assert!(state.recipients[0].amount.value.is_empty());
+    }
+
+    #[test]
+    fn recovery_paths_count_only_confirmed_mature_unspent_coins() {
+        let wallet = wallet();
+        let mut spent = coin(2, 20_000, Some(80));
+        spent.spend_info = Some(coincubed::commands::LCSpendInfo {
+            txid: Txid::from_str(&format!("{:064x}", 88)).unwrap(),
+            height: Some(100),
+        });
+        let coins = vec![
+            coin(1, 10_000, Some(90)),
+            spent,
+            coin(3, 30_000, None),
+            coin(4, 40_000, Some(95)),
+        ];
+
+        let paths = recovery_paths(&wallet, &coins, 100);
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].sequence, 10);
+        assert_eq!(paths[0].number_of_coins, 1);
+        assert_eq!(paths[0].total_amount, Amount::from_sat(10_000));
+        assert_eq!(paths[0].threshold, 1);
+        assert_eq!(
+            paths[0].origins[0].0,
+            Fingerprint::from_str("8a64f2a9").unwrap()
+        );
+    }
+
+    #[test]
+    fn select_recovery_path_preserves_selection_across_reload_when_sequence_remains() {
+        let wallet = wallet();
+        let coins = vec![coin(1, 10_000, Some(90))];
+        let mut selector = SelectRecoveryPath::new(wallet, &coins, 100);
+        selector.selected_path = Some(0);
+
+        selector.load_from_coins_and_tip_height(&[coin(2, 20_000, Some(80))], 100);
+        assert_eq!(selector.selected_path, Some(0));
+        assert_eq!(
+            selector.recovery_paths[0].total_amount,
+            Amount::from_sat(20_000)
+        );
+
+        let mut draft = TransactionDraft::new(Network::Bitcoin, None);
+        selector.apply(&mut draft);
+        assert_eq!(draft.recovery_timelock, Some(10));
+
+        let daemon = crate::utils::mock::Daemon::new(vec![]);
+        let _ = selector.update(
+            Arc::new(crate::daemon::client::Coincubed::new(daemon.run())),
+            &Cache::default(),
+            Message::View(view::Message::CreateSpend(
+                view::CreateSpendMessage::SelectPath(0),
+            )),
+        );
+        assert_eq!(selector.selected_path, None);
+    }
+}

--- a/coincube-gui/src/app/state/vault/spend/step.rs
+++ b/coincube-gui/src/app/state/vault/spend/step.rs
@@ -1789,7 +1789,7 @@ mod tests {
         );
         assert_eq!(recipient.amount.value, "0.12345678");
         assert_eq!(
-            recipient.amount.warning.as_deref(),
+            recipient.amount.warning,
             Some("Amount has been truncated to 8 decimal places")
         );
 

--- a/coincube-gui/src/app/state/vault/test_support.rs
+++ b/coincube-gui/src/app/state/vault/test_support.rs
@@ -1,0 +1,30 @@
+//! Shared fixtures for vault test modules.
+
+use std::sync::Arc;
+
+use coincube_core::miniscript::bitcoin::Psbt;
+use tokio::sync::RwLock;
+
+use crate::services::connect::client::auth::AccessTokenResponse;
+
+/// An empty (no inputs/outputs) unsigned PSBT, suitable as a placeholder in tests.
+pub fn empty_psbt() -> Psbt {
+    use coincube_core::miniscript::bitcoin::{absolute, transaction, Transaction};
+
+    Psbt::from_unsigned_tx(Transaction {
+        version: transaction::Version::TWO,
+        lock_time: absolute::LockTime::Blocks(absolute::Height::ZERO),
+        input: vec![],
+        output: vec![],
+    })
+    .expect("empty unsigned tx is psbt-compatible")
+}
+
+/// A shared, never-expiring set of Connect access tokens for tests.
+pub fn tokens() -> Arc<RwLock<AccessTokenResponse>> {
+    Arc::new(RwLock::new(AccessTokenResponse {
+        access_token: "access".to_string(),
+        refresh_token: "refresh".to_string(),
+        expires_at: i64::MAX,
+    }))
+}

--- a/coincube-gui/src/app/view/buysell/mavapay/ui.rs
+++ b/coincube-gui/src/app/view/buysell/mavapay/ui.rs
@@ -1373,3 +1373,452 @@ fn success_icon_badge() -> widget::Container<'static, BuySellMessage, theme::The
             ..Default::default()
         })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::breez_liquid::BreezClient;
+    use coincube_core::miniscript::bitcoin;
+    use std::sync::Arc;
+
+    fn country(code: &str) -> &'static Country {
+        crate::services::coincube::get_countries()
+            .iter()
+            .find(|country| country.code == code)
+            .expect("fixture country should exist")
+    }
+
+    fn state(buy_or_sell: BuyOrSell, step: MavapayFlowStep, country_code: &str) -> MavapayState {
+        let mut state = MavapayState::new(
+            buy_or_sell,
+            step,
+            country(country_code),
+            Arc::new(BreezClient::disconnected(bitcoin::Network::Signet)),
+        );
+        state.sat_amount = 123_456;
+        state.btc_price = Some(5_000_000_000.0);
+        state
+    }
+
+    fn quote(
+        id: &str,
+        source_currency: MavapayUnitCurrency,
+        target_currency: MavapayUnitCurrency,
+        payment_method: MavapayPaymentMethod,
+    ) -> GetQuoteResponse {
+        GetQuoteResponse {
+            id: id.to_string(),
+            order_id: Some(format!("order-{id}")),
+            exchange_rate: 1.0,
+            usd_to_target_currency_rate: 1.0,
+            source_currency,
+            target_currency,
+            transaction_fees_in_source_currency: 100,
+            transaction_fees_in_target_currency: 10,
+            amount_in_source_currency: 12_000,
+            amount_in_target_currency: 6_000,
+            payment_method,
+            expiry: "2026-01-01T00:00:00Z".to_string(),
+            is_valid: true,
+            invoice: "lnbc1pfixtureinvoicewithmorethanfortyfivecharactersforui".to_string(),
+            hash: "hash".to_string(),
+            total_amount_in_source_currency: 12_500,
+            total_amount_in_target_currency: Some(6_000),
+            customer_internal_fee: 0,
+            created_at: Some("2026-01-01T00:00:00Z".to_string()),
+            updated_at: Some("2026-01-01T00:00:00Z".to_string()),
+            estimated_routing_fee: Some(4),
+            bank_name: Some("Fixture Bank".to_string()),
+            ngn_bank_account_number: Some("1234567890".to_string()),
+            ngn_account_name: Some("Mavapay Fixture".to_string()),
+            ngn_bank_code: Some("999".to_string()),
+        }
+    }
+
+    fn transaction(
+        status: TransactionStatus,
+        transaction_type: TransactionType,
+        payment_method: Option<MavapayPaymentMethod>,
+    ) -> OrderTransaction {
+        OrderTransaction {
+            order_id: "order-1".to_string(),
+            transaction_id: "tx-1".to_string(),
+            amount: 12_345,
+            fees: 250,
+            currency: MavapayCurrency::NigerianNaira,
+            transaction_type,
+            status,
+            payment_method,
+            created_at: "2026-01-01T12:00:00Z".to_string(),
+        }
+    }
+
+    fn order(status: TransactionStatus, quotes: Vec<OrderQuote>) -> GetOrderResponse {
+        GetOrderResponse {
+            id: 1,
+            order_id: "order-1".to_string(),
+            quote_id: Some("quote-1".to_string()),
+            amount: 12_345,
+            status,
+            currency: MavapayCurrency::NigerianNaira,
+            payment_method: MavapayPaymentMethod::BankTransfer,
+            is_valid: Some(true),
+            payment_btc_detail: Some("btc-address".to_string()),
+            created_at: "2026-01-01T12:00:00Z".to_string(),
+            updated_at: "2026-01-01T12:05:00Z".to_string(),
+            order_data: Some(OrderDataWrapper {
+                status: "ok".to_string(),
+                data: OrderDataInner { quotes },
+            }),
+        }
+    }
+
+    fn order_quote(
+        source_currency: MavapayUnitCurrency,
+        target_currency: MavapayUnitCurrency,
+    ) -> OrderQuote {
+        OrderQuote {
+            transaction_fees_in_source_currency: 111,
+            transaction_fees_in_target_currency: 22,
+            transaction_fees_in_usd_cent: 33,
+            payment_btc_detail: "bc1qfixtureaddress".to_string(),
+            total_amount: 12_345,
+            equivalent_amount: 6_789,
+            source_currency,
+            target_currency,
+        }
+    }
+
+    #[test]
+    fn formatting_and_status_helpers_cover_display_cases() {
+        assert_eq!(format_fiat_cents(0), "0.00");
+        assert_eq!(format_fiat_cents(5), "0.05");
+        assert_eq!(format_fiat_cents(1_234_567), "12,345.67");
+
+        assert_eq!(
+            format_currency_amount(12_345, &MavapayUnitCurrency::KenyanShillingCent),
+            "123.45 KES"
+        );
+        assert_eq!(
+            format_currency_amount(12_345, &MavapayUnitCurrency::SouthAfricanRandCent),
+            "123.45 ZAR"
+        );
+        assert_eq!(
+            format_currency_amount(12_345, &MavapayUnitCurrency::NigerianNairaKobo),
+            "123.45 NGN"
+        );
+        assert_eq!(
+            format_currency_amount(123_456_789, &MavapayUnitCurrency::BitcoinSatoshi),
+            "1.23456789 BTC"
+        );
+
+        assert_eq!(
+            format_amount(123_456_789, &MavapayCurrency::Bitcoin),
+            "1.23456789 BTC"
+        );
+        assert_eq!(
+            format_amount(12_345, &MavapayCurrency::KenyanShilling),
+            "123.45 KSh"
+        );
+        assert_eq!(
+            format_amount(12_345, &MavapayCurrency::SouthAfricanRand),
+            "123.45 ZAR"
+        );
+        assert_eq!(
+            format_amount(12_345, &MavapayCurrency::NigerianNaira),
+            "123.45 NGN"
+        );
+        assert_eq!(
+            format_fees(12_345, &MavapayCurrency::Bitcoin),
+            "12,345 sats"
+        );
+        assert_eq!(
+            format_fees(12_345, &MavapayCurrency::NigerianNaira),
+            "123.45 NGN"
+        );
+
+        assert_eq!(order_status_text(&TransactionStatus::Success), "Complete");
+        assert_eq!(order_status_text(&TransactionStatus::Paid), "Complete");
+        assert_eq!(order_status_text(&TransactionStatus::Pending), "Processing");
+        assert_eq!(order_status_text(&TransactionStatus::Expired), "Expired");
+        assert_eq!(order_status_text(&TransactionStatus::Failed), "Failed");
+
+        assert_eq!(
+            transaction_status_info(&transaction(
+                TransactionStatus::Pending,
+                TransactionType::Deposit,
+                None,
+            ))
+            .0,
+            "Processing"
+        );
+        assert_eq!(
+            transaction_status_info(&transaction(
+                TransactionStatus::Success,
+                TransactionType::Deposit,
+                Some(MavapayPaymentMethod::BankTransfer),
+            ))
+            .0,
+            "Processing"
+        );
+        assert_eq!(
+            transaction_status_info(&transaction(
+                TransactionStatus::Success,
+                TransactionType::Withdrawal,
+                Some(MavapayPaymentMethod::Lightning),
+            ))
+            .0,
+            "Complete"
+        );
+        assert_eq!(
+            transaction_status_info(&transaction(
+                TransactionStatus::Expired,
+                TransactionType::Withdrawal,
+                None,
+            ))
+            .0,
+            "Expired"
+        );
+        assert_eq!(
+            transaction_status_info(&transaction(
+                TransactionStatus::Failed,
+                TransactionType::Withdrawal,
+                None,
+            ))
+            .0,
+            "Failed"
+        );
+
+        assert_eq!(
+            order_type_from_payment(Some(&MavapayPaymentMethod::BankTransfer)).0,
+            "BUY"
+        );
+        assert_eq!(
+            order_type_from_payment(Some(&MavapayPaymentMethod::USDT)).0,
+            "BUY"
+        );
+        assert_eq!(
+            order_type_from_payment(Some(&MavapayPaymentMethod::Lightning)).0,
+            "SELL"
+        );
+        assert_eq!(
+            order_type_from_payment(Some(&MavapayPaymentMethod::Onchain)).0,
+            "SELL"
+        );
+        assert_eq!(order_type_from_payment(None).0, "N/A");
+
+        assert_ne!(pretty_timestamp("2026-01-01T12:00:00Z"), "unknown");
+        assert_eq!(pretty_timestamp("not a timestamp"), "unknown");
+    }
+
+    #[test]
+    fn input_forms_build_for_supported_buy_and_sell_countries() {
+        let buy = state(
+            BuyOrSell::Buy,
+            MavapayFlowStep::BuyInputFrom {
+                ln_invoice: None,
+                getting_invoice: false,
+                sending_quote: false,
+            },
+            "NG",
+        );
+        let _ = form(&buy);
+
+        let mut buy_without_price = state(
+            BuyOrSell::Buy,
+            MavapayFlowStep::BuyInputFrom {
+                ln_invoice: Some("invoice".to_string()),
+                getting_invoice: true,
+                sending_quote: false,
+            },
+            "NG",
+        );
+        buy_without_price.btc_price = None;
+        let _ = form(&buy_without_price);
+
+        let ngn = state(
+            BuyOrSell::Sell,
+            MavapayFlowStep::SellInputForm {
+                liquid_balance: Some(50_000),
+                banks: Some(MavapayBanks::Nigerian(vec![NigerianBank {
+                    bank_name: "Fixture Bank".to_string(),
+                    nip_bank_code: "999".to_string(),
+                }])),
+                beneficiary: Beneficiary::NGN {
+                    bank_account_name: Some("Recipient".to_string()),
+                    bank_account_number: "1234567890".to_string(),
+                    bank_code: "999".to_string(),
+                    bank_name: "Fixture Bank".to_string(),
+                },
+                sending_quote: false,
+            },
+            "NG",
+        );
+        let _ = form(&ngn);
+
+        let zar = state(
+            BuyOrSell::Sell,
+            MavapayFlowStep::SellInputForm {
+                liquid_balance: Some(50_000),
+                banks: Some(MavapayBanks::SouthAfrican(vec![
+                    "Capitec".to_string(),
+                    "Standard Bank".to_string(),
+                ])),
+                beneficiary: Beneficiary::ZAR {
+                    name: "Recipient".to_string(),
+                    bank_name: "Capitec".to_string(),
+                    bank_account_number: "1234567890".to_string(),
+                },
+                sending_quote: true,
+            },
+            "ZA",
+        );
+        let _ = form(&zar);
+
+        let kes = state(
+            BuyOrSell::Sell,
+            MavapayFlowStep::SellInputForm {
+                liquid_balance: Some(50_000),
+                banks: None,
+                beneficiary: Beneficiary::KES(KenyanBeneficiary::PayToPhone {
+                    account_name: "Recipient".to_string(),
+                    phone_number: "+254700000000".to_string(),
+                }),
+                sending_quote: false,
+            },
+            "KE",
+        );
+        let _ = form(&kes);
+
+        let invalid_ngn = state(
+            BuyOrSell::Sell,
+            MavapayFlowStep::SellInputForm {
+                liquid_balance: None,
+                banks: None,
+                beneficiary: Beneficiary::NGN {
+                    bank_account_name: None,
+                    bank_account_number: "not-a-number".to_string(),
+                    bank_code: String::new(),
+                    bank_name: String::new(),
+                },
+                sending_quote: false,
+            },
+            "NG",
+        );
+        let _ = form(&invalid_ngn);
+    }
+
+    #[test]
+    fn checkout_and_history_forms_build_for_result_shapes() {
+        let checkout = state(
+            BuyOrSell::Buy,
+            MavapayFlowStep::Checkout {
+                quote: quote(
+                    "quote-1",
+                    MavapayUnitCurrency::NigerianNairaKobo,
+                    MavapayUnitCurrency::BitcoinSatoshi,
+                    MavapayPaymentMethod::BankTransfer,
+                ),
+                fulfilled_order: None,
+                invoice_qr_code_data: None,
+                liquid_balance: None,
+                fulfilling_ln_invoice: false,
+                stream_order_id: Some("order-quote-1".to_string()),
+            },
+            "NG",
+        );
+        let _ = form(&checkout);
+
+        let fulfilled = state(
+            BuyOrSell::Buy,
+            MavapayFlowStep::Checkout {
+                quote: quote(
+                    "quote-2",
+                    MavapayUnitCurrency::NigerianNairaKobo,
+                    MavapayUnitCurrency::BitcoinSatoshi,
+                    MavapayPaymentMethod::BankTransfer,
+                ),
+                fulfilled_order: Some(order(TransactionStatus::Success, Vec::new())),
+                invoice_qr_code_data: None,
+                liquid_balance: None,
+                fulfilling_ln_invoice: false,
+                stream_order_id: None,
+            },
+            "NG",
+        );
+        let _ = form(&fulfilled);
+
+        for step in [
+            MavapayFlowStep::History {
+                transactions: None,
+                loading: true,
+            },
+            MavapayFlowStep::History {
+                transactions: Some(Vec::new()),
+                loading: false,
+            },
+            MavapayFlowStep::History {
+                transactions: Some(vec![transaction(
+                    TransactionStatus::Success,
+                    TransactionType::Withdrawal,
+                    Some(MavapayPaymentMethod::Lightning),
+                )]),
+                loading: false,
+            },
+            MavapayFlowStep::History {
+                transactions: None,
+                loading: false,
+            },
+        ] {
+            let history = state(BuyOrSell::Buy, step, "NG");
+            let _ = form(&history);
+        }
+    }
+
+    #[test]
+    fn order_detail_forms_build_for_loading_success_empty_and_failed_states() {
+        let base_transaction = transaction(
+            TransactionStatus::Paid,
+            TransactionType::Withdrawal,
+            Some(MavapayPaymentMethod::BankTransfer),
+        );
+
+        for step in [
+            MavapayFlowStep::OrderDetail {
+                transaction: base_transaction.clone(),
+                order: None,
+                loading: true,
+            },
+            MavapayFlowStep::OrderDetail {
+                transaction: base_transaction.clone(),
+                order: None,
+                loading: false,
+            },
+            MavapayFlowStep::OrderDetail {
+                transaction: base_transaction.clone(),
+                order: Some(order(TransactionStatus::Pending, Vec::new())),
+                loading: false,
+            },
+            MavapayFlowStep::OrderDetail {
+                transaction: base_transaction.clone(),
+                order: Some(order(
+                    TransactionStatus::Success,
+                    vec![
+                        order_quote(
+                            MavapayUnitCurrency::NigerianNairaKobo,
+                            MavapayUnitCurrency::BitcoinSatoshi,
+                        ),
+                        order_quote(
+                            MavapayUnitCurrency::BitcoinSatoshi,
+                            MavapayUnitCurrency::NigerianNairaKobo,
+                        ),
+                    ],
+                )),
+                loading: false,
+            },
+        ] {
+            let detail = state(BuyOrSell::Buy, step, "NG");
+            let _ = form(&detail);
+        }
+    }
+}

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -1463,7 +1463,7 @@ fn security_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccount
                 let status_color = if ok { color::ORANGE } else { color::RED };
 
                 let ip = a.ip_address.as_deref();
-                let ua = a.user_agent.as_deref();
+                let ua = a.device_name.as_deref();
                 let ip_and_ua = match (ip, ua) {
                     (Some(i), Some(u)) => {
                         let short_u = if u.chars().count() > 60 {
@@ -2981,7 +2981,7 @@ mod renewal_banner_tests {
             LoginActivity {
                 id: 1,
                 ip_address: Some("127.0.0.1".to_string()),
-                user_agent: Some(
+                device_name: Some(
                     "Browser with a very long user agent string that should truncate in the view"
                         .to_string(),
                 ),
@@ -2991,7 +2991,7 @@ mod renewal_banner_tests {
             LoginActivity {
                 id: 2,
                 ip_address: None,
-                user_agent: None,
+                device_name: None,
                 created_at: "2026-07-04T00:00:00Z".to_string(),
                 success: Some(false),
             },

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -2620,7 +2620,16 @@ mod renewal_banner_tests {
     //! `Option<Element>` and its `style`/`on_press` closures are deferred,
     //! so we can construct it headless and assert only Some/None.
     use super::*;
-    use crate::services::coincube::{ConnectPlan, PlanEntitlements, PlanProvenance, PlanStatus};
+    use crate::{
+        app::state::connect::{
+            account::SUPPORTED_PRICING_SCHEMA_VERSION, CheckoutState, DuressDisableState,
+        },
+        services::coincube::{
+            AvatarVariant, BillingHistoryEntry, ChargeStatus, CheckoutResponse, ConnectPlan,
+            FeaturesResponse, GetAvatarData, LightningAddress, LoginActivity, PlanEntitlements,
+            PlanFeatureInfo, PlanPrice, PlanProvenance, PlanStatus, User, VerifiedDevice,
+        },
+    };
 
     fn plan(tier: PlanTier, status: PlanStatus, renewal_at: Option<&str>) -> ConnectPlan {
         ConnectPlan {
@@ -2686,6 +2695,101 @@ mod renewal_banner_tests {
             buy_sell_enabled: None,
             p2p_enabled: None,
         }
+    }
+
+    fn user() -> User {
+        User {
+            id: 7,
+            email: "founder@example.com".to_string(),
+            email_verified: Some(true),
+        }
+    }
+
+    fn priced_features(
+        schema_version: Option<u32>,
+        purchasing_enabled: Option<bool>,
+    ) -> FeaturesResponse {
+        FeaturesResponse {
+            plans: vec![
+                PlanFeatureInfo {
+                    name: "free".to_string(),
+                    price: None,
+                    features: vec!["One Cube".to_string()],
+                    included_linked_participants: None,
+                },
+                PlanFeatureInfo {
+                    name: "pro".to_string(),
+                    price: Some(PlanPrice {
+                        monthly: 12,
+                        annual: 120,
+                    }),
+                    features: vec!["More Cubes".to_string(), "Duress mode".to_string()],
+                    included_linked_participants: None,
+                },
+                PlanFeatureInfo {
+                    name: "estate".to_string(),
+                    price: Some(PlanPrice {
+                        monthly: 24,
+                        annual: 240,
+                    }),
+                    features: vec!["Recovery alerts".to_string()],
+                    included_linked_participants: None,
+                },
+            ],
+            pricing_schema_version: schema_version,
+            purchasing_enabled,
+            marketplace_enabled: Some(true),
+            liquid_enabled: Some(true),
+            buy_sell_enabled: Some(true),
+            p2p_enabled: Some(false),
+        }
+    }
+
+    fn checkout_response() -> CheckoutResponse {
+        CheckoutResponse {
+            charge_id: "charge-1".to_string(),
+            lightning_invoice: "lnbc1abcdefghijklmnopqrstuvwxyz0123456789extra".to_string(),
+            on_chain_address: "bc1qtestaddress000000000000000000000000000000".to_string(),
+            amount_sats: 50_000,
+            amount_fiat: 25.0,
+            fiat_currency: "USD".to_string(),
+            plan: PlanTier::Pro,
+            billing_cycle: BillingCycle::Annual,
+            checkout_url: "https://checkout.example/charge-1".to_string(),
+            expires_at: "2026-08-01T00:00:00Z".to_string(),
+        }
+    }
+
+    fn billing_entry(status: ChargeStatus) -> BillingHistoryEntry {
+        BillingHistoryEntry {
+            charge_id: format!("charge-{status:?}"),
+            plan: PlanTier::Pro,
+            billing_cycle: BillingCycle::Monthly,
+            amount_sats: 42_000,
+            amount_fiat: 21.0,
+            fiat_currency: "USD".to_string(),
+            status,
+            created_at: "2026-07-01T12:00:00Z".to_string(),
+            paid_at: Some("2026-07-02T12:00:00Z".to_string()),
+        }
+    }
+
+    fn dashboard_panel() -> ConnectAccountPanel {
+        let mut panel = ConnectAccountPanel::new();
+        panel.step = ConnectFlowStep::Dashboard;
+        panel.user = Some(user());
+        panel.plan = Some(plan(
+            PlanTier::Pro,
+            PlanStatus::Active,
+            Some("2027-01-01T00:00:00Z"),
+        ));
+        panel.features = Some(priced_features(
+            Some(SUPPORTED_PRICING_SCHEMA_VERSION),
+            Some(true),
+        ));
+        panel.overview_contact_count = Some(3);
+        panel.overview_cube_count = Some(2);
+        panel
     }
 
     /// The provenance card renders only when the API sends `plan_provenance`
@@ -2765,5 +2869,328 @@ mod renewal_banner_tests {
         let _ = plan_billing_ux(&paid);
 
         let _ = register_ux("founder@example.com", "FOUNDER", false);
+    }
+
+    #[test]
+    fn formatting_and_color_helpers_are_stable() {
+        assert_eq!(format_date("2026-04-20T14:31:00Z"), "Apr 20, 2026");
+        assert_eq!(format_date("not-a-date"), "not-a-date");
+        assert_eq!(format_datetime("not-a-date"), "not-a-date");
+
+        assert_ne!(
+            plan_tier_color(&PlanTier::Free),
+            plan_tier_color(&PlanTier::Pro)
+        );
+        assert_ne!(
+            plan_tier_color(&PlanTier::Pro),
+            plan_tier_color(&PlanTier::Estate)
+        );
+    }
+
+    #[test]
+    fn auth_gate_and_error_views_build_for_each_step() {
+        let mut account = ConnectAccountPanel::new();
+        account.error = Some("temporary outage".to_string());
+
+        let unlock_at = chrono::DateTime::parse_from_rfc3339("2026-07-20T12:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        for step in [
+            ConnectFlowStep::CheckingSession,
+            ConnectFlowStep::Login {
+                email: "bad".to_string(),
+                loading: false,
+            },
+            ConnectFlowStep::Login {
+                email: "founder@example.com".to_string(),
+                loading: true,
+            },
+            ConnectFlowStep::Register {
+                email: "new@example.com".to_string(),
+                loading: false,
+            },
+            ConnectFlowStep::OtpVerification {
+                email: "founder@example.com".to_string(),
+                otp: "123456".to_string(),
+                sending: false,
+                is_signup: false,
+                cooldown: 5,
+            },
+            ConnectFlowStep::CheckingDuress {
+                status: DuressGateStatus::Checking,
+            },
+            ConnectFlowStep::CheckingDuress {
+                status: DuressGateStatus::Unreachable,
+            },
+            ConnectFlowStep::CheckingDuress {
+                status: DuressGateStatus::Incompatible,
+            },
+            ConnectFlowStep::DuressRecovery {
+                unlock_at: Some(unlock_at),
+                passphrase: "all-clear".to_string(),
+                submitting: false,
+                cleared: false,
+            },
+            ConnectFlowStep::DuressRecovery {
+                unlock_at: None,
+                passphrase: String::new(),
+                submitting: true,
+                cleared: true,
+            },
+        ] {
+            account.step = step;
+            let _ = connect_account_panel(&account);
+        }
+    }
+
+    #[test]
+    fn dashboard_account_tabs_build_loaded_empty_and_processing_states() {
+        let mut account = dashboard_panel();
+
+        for sub in [
+            ConnectSubMenu::Overview,
+            ConnectSubMenu::PlanBilling,
+            ConnectSubMenu::Security,
+            ConnectSubMenu::Contacts,
+            ConnectSubMenu::Duress,
+        ] {
+            account.active_sub = sub;
+            let _ = connect_account_panel(&account);
+        }
+
+        account.active_sub = ConnectSubMenu::Security;
+        account.verified_devices = Some(vec![
+            VerifiedDevice {
+                id: 1,
+                device_name: Some("Laptop".to_string()),
+                created_at: "2026-07-01T00:00:00Z".to_string(),
+                last_used_at: Some("2026-07-02T00:00:00Z".to_string()),
+                is_current: true,
+            },
+            VerifiedDevice {
+                id: 2,
+                device_name: None,
+                created_at: "2026-06-01T00:00:00Z".to_string(),
+                last_used_at: None,
+                is_current: false,
+            },
+        ]);
+        account.verified_devices_state.deleting_ids.insert(2);
+        account.login_activity = Some(vec![
+            LoginActivity {
+                id: 1,
+                ip_address: Some("127.0.0.1".to_string()),
+                user_agent: Some(
+                    "Browser with a very long user agent string that should truncate in the view"
+                        .to_string(),
+                ),
+                created_at: "2026-07-03T00:00:00Z".to_string(),
+                success: Some(true),
+            },
+            LoginActivity {
+                id: 2,
+                ip_address: None,
+                user_agent: None,
+                created_at: "2026-07-04T00:00:00Z".to_string(),
+                success: Some(false),
+            },
+        ]);
+        let _ = connect_account_panel(&account);
+
+        account.verified_devices = Some(Vec::new());
+        account.login_activity = Some(Vec::new());
+        let _ = connect_account_panel(&account);
+    }
+
+    #[test]
+    fn plan_billing_checkout_and_history_views_build_for_branch_states() {
+        let mut account = dashboard_panel();
+        account.active_sub = ConnectSubMenu::PlanBilling;
+
+        account.features = None;
+        account.plan = Some(granted_estate(Some("2027-07-04T00:00:00Z"), Some("Grant")));
+        account.campaign_redeem.code = "FOUNDERS".to_string();
+        account.campaign_redeem.result = Some(Ok("Code applied.".to_string()));
+        let _ = plan_billing_ux(&account);
+
+        account.features = Some(priced_features(
+            Some(SUPPORTED_PRICING_SCHEMA_VERSION + 1),
+            Some(false),
+        ));
+        account.selected_billing_cycle = BillingCycle::Annual;
+        account.campaign_redeem.submitting = true;
+        let _ = plan_billing_ux(&account);
+
+        account.show_billing_history = true;
+        account.billing_history = None;
+        let _ = plan_billing_ux(&account);
+        account.billing_history = Some(Vec::new());
+        let _ = plan_billing_ux(&account);
+        account.billing_history = Some(vec![
+            billing_entry(ChargeStatus::Unpaid),
+            billing_entry(ChargeStatus::Processing),
+            billing_entry(ChargeStatus::Paid),
+            billing_entry(ChargeStatus::Expired),
+        ]);
+        let _ = plan_billing_ux(&account);
+
+        account.show_billing_history = false;
+        for phase in [
+            CheckoutPhase::Creating,
+            CheckoutPhase::AwaitingPayment,
+            CheckoutPhase::Processing,
+            CheckoutPhase::Paid,
+            CheckoutPhase::Expired,
+            CheckoutPhase::Failed("invoice failed".to_string()),
+        ] {
+            account.checkout = Some(CheckoutState {
+                phase,
+                checkout: Some(checkout_response()),
+                lightning_qr: None,
+                poll_errors: 0,
+            });
+            let _ = plan_billing_ux(&account);
+        }
+    }
+
+    #[test]
+    fn duress_views_build_locked_setup_enabled_and_disable_states() {
+        let mut account = dashboard_panel();
+        account.active_sub = ConnectSubMenu::Duress;
+
+        account.plan = Some(plan(PlanTier::Free, PlanStatus::Active, None));
+        let _ = duress_ux(&account);
+
+        let mut entitled = plan(PlanTier::Pro, PlanStatus::Active, None);
+        entitled.entitlements.duress = true;
+        account.plan = Some(entitled);
+        account.duress_cubes = Some(vec![DuressCube {
+            server_id: 1,
+            uuid: Some("cube-uuid".to_string()),
+            name: "Family Vault".to_string(),
+            has_recovery_kit: true,
+            halves: Some((true, false)),
+            has_vault: Some(true),
+            is_passkey: Some(false),
+            local: true,
+        }]);
+        let _ = duress_ux(&account);
+
+        account.duress_locally_armed = true;
+        account.duress_state = Some(crate::services::coincube::DuressState {
+            active: false,
+            unlock_at: None,
+            enrolled: true,
+            this_device_registered: true,
+        });
+        let _ = duress_ux(&account);
+
+        account.duress_locally_armed = false;
+        account.duress_state = Some(crate::services::coincube::DuressState {
+            active: true,
+            unlock_at: None,
+            enrolled: true,
+            this_device_registered: false,
+        });
+        let _ = duress_ux(&account);
+
+        account.duress_disable = Some(DuressDisableState {
+            pin: "1234".to_string(),
+            submitting: false,
+            error: Some("bad pin".to_string()),
+        });
+        let _ = duress_ux(&account);
+    }
+
+    #[test]
+    fn connect_panel_and_avatar_views_build_active_paths() {
+        let mut panel = ConnectPanel::new(
+            None,
+            "cube-uuid".to_string(),
+            "Family Vault".to_string(),
+            "bitcoin".to_string(),
+            true,
+        );
+        panel.account.error = Some("connectivity".to_string());
+        for step in [
+            ConnectFlowStep::CheckingSession,
+            ConnectFlowStep::Login {
+                email: String::new(),
+                loading: false,
+            },
+            ConnectFlowStep::Register {
+                email: "new@example.com".to_string(),
+                loading: true,
+            },
+            ConnectFlowStep::Dashboard,
+        ] {
+            panel.account.step = step;
+            let _ = connect_panel(&panel);
+        }
+
+        let mut cube = ConnectCubePanel::new(
+            None,
+            "cube-uuid".to_string(),
+            "Family Vault".to_string(),
+            "bitcoin".to_string(),
+            true,
+        );
+        let _ = avatar_ux(&cube);
+
+        cube.lightning_address = Some(LightningAddress {
+            lightning_address: Some("founder@getcoincube.com".to_string()),
+        });
+        cube.avatar_step = AvatarFlowStep::Questionnaire;
+        cube.avatar_draft.gender = AvatarGender::Woman;
+        cube.avatar_draft.archetype = AvatarArchetype::Shogun;
+        cube.avatar_draft.age_feel = AvatarAgeFeel::Elder;
+        cube.avatar_draft.demeanor = AvatarDemeanor::Fierce;
+        cube.avatar_draft.armor_style = AvatarArmorStyle::Heavy;
+        cube.avatar_draft.accent_motif = AvatarAccentMotif::OrangeSun;
+        cube.avatar_draft.laser_eyes = true;
+        let _ = avatar_ux(&cube);
+
+        cube.avatar_step = AvatarFlowStep::Generating;
+        let _ = avatar_ux(&cube);
+
+        cube.avatar_error = Some("avatar unavailable".to_string());
+        let _ = avatar_ux(&cube);
+        cube.registration_error = Some("not registered".to_string());
+        let _ = avatar_ux(&cube);
+        cube.avatar_error = None;
+        cube.registration_error = None;
+
+        cube.avatar_step = AvatarFlowStep::Settings;
+        let _ = avatar_ux(&cube);
+        cube.avatar_data = Some(GetAvatarData {
+            has_avatar: true,
+            active_avatar_url: Some("https://cdn.example/avatar/7".to_string()),
+            identity: None,
+            variants: vec![
+                AvatarVariant {
+                    id: 7,
+                    index: 0,
+                    image_url: "https://cdn.example/avatar/7".to_string(),
+                },
+                AvatarVariant {
+                    id: 8,
+                    index: 1,
+                    image_url: "https://cdn.example/avatar/8".to_string(),
+                },
+            ],
+            regenerations_remaining: -1,
+            created_at: None,
+            updated_at: None,
+        });
+        let _ = avatar_ux(&cube);
+
+        cube.avatar_step = AvatarFlowStep::Reveal;
+        if let Some(data) = cube.avatar_data.as_mut() {
+            data.active_avatar_url = Some("https://cdn.example/avatar/none".to_string());
+            data.regenerations_remaining = 0;
+            data.variants.truncate(1);
+        }
+        let _ = avatar_ux(&cube);
     }
 }

--- a/coincube-gui/src/app/view/global_home.rs
+++ b/coincube-gui/src/app/view/global_home.rs
@@ -2141,6 +2141,145 @@ fn transfer_available(has_liquid: bool, has_vault: bool, has_spark: bool) -> boo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        app::{
+            cache::FiatPriceRequest,
+            settings::{display::DisplayMode, unit::BitcoinDisplayUnit},
+            view::shared::feerate_picker::FeeratePreset,
+        },
+        services::fiat::{Currency, PriceSource},
+    };
+    use coincube_core::miniscript::bitcoin::{bip32::ChildNumber, Address};
+    use std::{collections::HashMap, str::FromStr};
+
+    const MAINNET_ADDR: &str = "bc1qvrl2849aggm6qry9ea7xqp2kk39j8vaa8r3cwg";
+
+    struct ViewFixture {
+        entered_amount: form::Value<String>,
+        invalid_amount: form::Value<String>,
+        transfer_feerate: form::Value<String>,
+        invalid_feerate: form::Value<String>,
+        receive_address: Address,
+        receive_index: ChildNumber,
+        labels: HashMap<String, String>,
+        labels_editing: HashMap<String, form::Value<String>>,
+        fiat_converter: FiatAmountConverter,
+    }
+
+    impl ViewFixture {
+        fn new() -> Self {
+            let receive_address = Address::from_str(MAINNET_ADDR).unwrap().assume_checked();
+            let mut labels = HashMap::new();
+            labels.insert(receive_address.to_string(), "Vault receive".to_string());
+
+            Self {
+                entered_amount: form::Value {
+                    value: "50000".to_string(),
+                    valid: true,
+                    warning: None,
+                },
+                invalid_amount: form::Value {
+                    value: "not sats".to_string(),
+                    valid: false,
+                    warning: Some("Invalid amount format"),
+                },
+                transfer_feerate: form::Value {
+                    value: "3".to_string(),
+                    valid: true,
+                    warning: None,
+                },
+                invalid_feerate: form::Value {
+                    value: "0".to_string(),
+                    valid: false,
+                    warning: Some("Feerate must be positive"),
+                },
+                receive_address,
+                receive_index: ChildNumber::from(0),
+                labels,
+                labels_editing: HashMap::new(),
+                fiat_converter: FiatAmountConverter::new(
+                    50_000.0,
+                    Some(1_722_000_000),
+                    FiatPriceRequest::new(PriceSource::Coincube, Currency::USD),
+                )
+                .unwrap(),
+            }
+        }
+
+        fn config(
+            &self,
+            step: usize,
+            direction: Option<TransferDirection>,
+            wallet_picker: Option<PickerSide>,
+        ) -> GlobalViewConfig<'_> {
+            GlobalViewConfig {
+                liquid_balance: Amount::from_sat(125_000),
+                spark_balance: Amount::from_sat(250_000),
+                usdt_balance: 100_000_000,
+                usdt_balance_error: false,
+                pending_liquid_send_sats: 1_000,
+                pending_usdt_send_sats: 2_000,
+                pending_liquid_receive_sats: 3_000,
+                pending_usdt_receive_sats: 4_000,
+                vault_pending_send_sats: 5_000,
+                vault_pending_receive_sats: 6_000,
+                vault_balance: Amount::from_sat(375_000),
+                fiat_converter: Some(self.fiat_converter),
+                balance_masked: false,
+                total_balance_loading: false,
+                spark_balance_loaded: true,
+                liquid_balance_loaded: true,
+                usdt_balance_loaded: true,
+                vault_loaded: true,
+                display_mode: DisplayMode::FiatNative,
+                has_vault: true,
+                has_spark: true,
+                has_liquid: true,
+                current_view: HomeView { step },
+                transfer_direction: direction,
+                transfer_from: direction.map(|d| d.from_kind()),
+                transfer_to: direction.map(|d| d.to_kind()),
+                wallet_picker,
+                entered_amount: &self.entered_amount,
+                receive_address: Some(&self.receive_address),
+                receive_index: Some(&self.receive_index),
+                labels: &self.labels,
+                labels_editing: &self.labels_editing,
+                address_expanded: false,
+                bitcoin_unit: BitcoinDisplayUnit::Sats,
+                onchain_send_limit: Some((25_000, 5_000_000)),
+                onchain_receive_limit: Some((25_000, 5_000_000)),
+                is_sending: false,
+                is_tx_signed: false,
+                prepare_onchain_send_response: None,
+                spend_tx_fees: None,
+                transfer_feerate: &self.transfer_feerate,
+                transfer_feerate_loading: None,
+                spark_send_fee_sat: None,
+                pending_spark_incoming: Some(PendingTransfer {
+                    amount: Amount::from_sat(31_000),
+                    stage: TransferStage::PendingDeposit,
+                }),
+                pending_vault_incoming: Some(PendingTransfer {
+                    amount: Amount::from_sat(41_000),
+                    stage: TransferStage::PendingDeposit,
+                }),
+                btc_usd_price: Some(50_000.0),
+            }
+        }
+    }
+
+    fn directions() -> [TransferDirection; 6] {
+        use TransferDirection::*;
+        [
+            LiquidToVault,
+            VaultToLiquid,
+            LiquidToSpark,
+            SparkToLiquid,
+            VaultToSpark,
+            SparkToVault,
+        ]
+    }
 
     /// Every directed pair of distinct wallets must map to exactly one
     /// `TransferDirection`, and same-wallet pairs must map to `None`.
@@ -2211,6 +2350,145 @@ mod tests {
         assert_eq!(WalletKind::Liquid.badge(), "LIQUID");
         assert_eq!(WalletKind::Spark.badge(), "SPARK");
         assert_eq!(WalletKind::Vault.badge(), "VAULT");
+    }
+
+    #[test]
+    fn wallet_kind_labels_and_direction_display_are_stable() {
+        assert_eq!(WalletKind::Liquid.label(), "Liquid");
+        assert_eq!(WalletKind::Spark.label(), "Spark");
+        assert_eq!(WalletKind::Vault.label(), "Vault");
+
+        for direction in directions() {
+            assert_eq!(direction.from_wallet(), direction.from_kind().label());
+            assert_eq!(direction.to_wallet(), direction.to_kind().label());
+            assert_eq!(
+                direction.display(),
+                format!("{} → {}", direction.from_wallet(), direction.to_wallet())
+            );
+        }
+    }
+
+    #[test]
+    fn home_view_step_state_moves_forward_back_and_resets() {
+        let mut view = HomeView::default();
+
+        view.previous();
+        assert_eq!(view.step, 0);
+
+        view.next();
+        view.next();
+        assert_eq!(view.step, 2);
+
+        view.previous();
+        assert_eq!(view.step, 1);
+
+        view.reset();
+        assert_eq!(view.step, 0);
+    }
+
+    #[test]
+    fn global_home_overview_builds_loaded_masked_loading_and_absent_wallet_states() {
+        let fixture = ViewFixture::new();
+
+        let _ = global_home_view(fixture.config(0, None, None));
+
+        let mut masked = fixture.config(0, None, None);
+        masked.balance_masked = true;
+        masked.display_mode = DisplayMode::BitcoinNative;
+        let _ = global_home_view(masked);
+
+        let mut loading = fixture.config(0, None, None);
+        loading.total_balance_loading = true;
+        loading.spark_balance_loaded = false;
+        loading.liquid_balance_loaded = false;
+        loading.usdt_balance_loaded = false;
+        loading.vault_loaded = false;
+        loading.usdt_balance_error = true;
+        let _ = global_home_view(loading);
+
+        let mut spark_only = fixture.config(0, None, None);
+        spark_only.has_liquid = false;
+        spark_only.has_vault = false;
+        spark_only.has_spark = true;
+        spark_only.pending_spark_incoming = Some(PendingTransfer {
+            amount: Amount::from_sat(11_000),
+            stage: TransferStage::Completed,
+        });
+        let _ = global_home_view(spark_only);
+    }
+
+    #[test]
+    fn global_home_amount_step_builds_every_direction_and_wallet_picker() {
+        let fixture = ViewFixture::new();
+
+        for direction in directions() {
+            let _ = global_home_view(fixture.config(1, Some(direction), None));
+        }
+
+        let _ = global_home_view(fixture.config(
+            1,
+            Some(TransferDirection::LiquidToVault),
+            Some(PickerSide::From),
+        ));
+
+        let mut picker_without_liquid = fixture.config(
+            1,
+            Some(TransferDirection::VaultToSpark),
+            Some(PickerSide::To),
+        );
+        picker_without_liquid.has_liquid = false;
+        picker_without_liquid.transfer_from = Some(WalletKind::Vault);
+        picker_without_liquid.transfer_to = Some(WalletKind::Spark);
+        let _ = global_home_view(picker_without_liquid);
+    }
+
+    #[test]
+    fn global_home_confirm_step_builds_address_fee_and_sending_variants() {
+        let fixture = ViewFixture::new();
+
+        let mut liquid_to_vault = fixture.config(2, Some(TransferDirection::LiquidToVault), None);
+        let liquid_prepare = PreparePayOnchainResponse {
+            receiver_amount_sat: 49_000,
+            claim_fees_sat: 100,
+            total_fees_sat: 1_000,
+        };
+        liquid_to_vault.prepare_onchain_send_response = Some(&liquid_prepare);
+        let _ = global_home_view(liquid_to_vault);
+
+        let mut vault_to_spark = fixture.config(2, Some(TransferDirection::VaultToSpark), None);
+        vault_to_spark.address_expanded = true;
+        vault_to_spark.spend_tx_fees = Some(Amount::from_sat(750));
+        vault_to_spark.transfer_feerate_loading = Some(FeeratePreset::Fast);
+        let _ = global_home_view(vault_to_spark);
+
+        let mut vault_to_liquid_signed =
+            fixture.config(2, Some(TransferDirection::VaultToLiquid), None);
+        vault_to_liquid_signed.is_tx_signed = true;
+        vault_to_liquid_signed.is_sending = true;
+        vault_to_liquid_signed.spend_tx_fees = Some(Amount::from_sat(900));
+        let _ = global_home_view(vault_to_liquid_signed);
+
+        let mut spark_to_liquid = fixture.config(2, Some(TransferDirection::SparkToLiquid), None);
+        spark_to_liquid.spark_send_fee_sat = Some(222);
+        spark_to_liquid.receive_address = None;
+        let _ = global_home_view(spark_to_liquid);
+
+        let mut invalid_vault_send =
+            fixture.config(2, Some(TransferDirection::VaultToLiquid), None);
+        invalid_vault_send.entered_amount = &fixture.invalid_amount;
+        invalid_vault_send.transfer_feerate = &fixture.invalid_feerate;
+        let _ = global_home_view(invalid_vault_send);
+    }
+
+    #[test]
+    fn global_home_success_and_fallback_steps_build() {
+        let fixture = ViewFixture::new();
+
+        for direction in directions() {
+            let _ = global_home_view(fixture.config(3, Some(direction), None));
+        }
+
+        let _ = global_home_view(fixture.config(99, Some(TransferDirection::LiquidToVault), None));
     }
 
     /// Transfer needs two wallets to move funds between: any one wallet alone

--- a/coincube-gui/src/app/view/vault/psbt.rs
+++ b/coincube-gui/src/app/view/vault/psbt.rs
@@ -1805,3 +1805,408 @@ pub fn update_spend_success_view<'a>() -> Element<'a, Message> {
         .align_x(Alignment::Center)
         .into()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coincube_core::{
+        border_wallet::OrderedPattern,
+        descriptors::CoincubeDescriptor,
+        miniscript::bitcoin::{absolute, bip32::ChildNumber, transaction, Amount, Sequence, TxIn},
+    };
+    use coincubed::commands::LCSpendInfo;
+    use std::str::FromStr;
+
+    const DESC: &str = "wsh(or_d(multi(2,[f714c228/48'/1'/0'/2']tpubDEwJnTwfKoMvu8AXXBPydBVWDpzNP5tatjjZ56q4TQioGL7iL9xzTbMoCCQ3tfGihtff7vtR4xsjcRuhZ7HWARVAkGZ1HZcpBhVdou76k7j/<0;1>/*,[2522f23c/48'/1'/0'/2']tpubDEoTU4bDW1EXN1rnLXnRfue1a7DeqjJcs39PkEeLcVXhVKzCnFo9yQX2EeeXJ6kh4hgbz5o9v7YAc1EE97AEJpJbKNmDxE3ZQo4msGPSp2J/<0;1>/*),and_v(v:thresh(1,pkh([f714c228/48'/1'/0'/2']tpubDEwJnTwfKoMvu8AXXBPydBVWDpzNP5tatjjZ56q4TQioGL7iL9xzTbMoCCQ3tfGihtff7vtR4xsjcRuhZ7HWARVAkGZ1HZcpBhVdou76k7j/<2;3>/*),a:pkh([2522f23c/48'/1'/0'/2']tpubDEoTU4bDW1EXN1rnLXnRfue1a7DeqjJcs39PkEeLcVXhVKzCnFo9yQX2EeeXJ6kh4hgbz5o9v7YAc1EE97AEJpJbKNmDxE3ZQo4msGPSp2J/<2;3>/*)),older(65535))))#9s8ekrce";
+    const MAINNET_ADDR: &str = "bc1qvrl2849aggm6qry9ea7xqp2kk39j8vaa8r3cwg";
+    const GRID_PHRASE: &str =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    fn fingerprint(hex: &str) -> Fingerprint {
+        Fingerprint::from_str(hex).unwrap()
+    }
+
+    fn address() -> Address {
+        Address::from_str(MAINNET_ADDR).unwrap().assume_checked()
+    }
+
+    fn outpoint(n: u32) -> OutPoint {
+        OutPoint::new(Txid::from_str(&format!("{n:064x}")).unwrap(), n)
+    }
+
+    fn coin(n: u32, sats: u64, spent: bool) -> Coin {
+        Coin {
+            amount: Amount::from_sat(sats),
+            outpoint: outpoint(n),
+            address: address(),
+            block_height: Some(840_000),
+            derivation_index: ChildNumber::from(n),
+            spend_info: spent.then(|| LCSpendInfo {
+                txid: Txid::from_str(&format!("{:064x}", n + 100)).unwrap(),
+                height: None,
+            }),
+            is_immature: false,
+            is_change: false,
+            is_from_self: false,
+        }
+    }
+
+    fn tx_with_outputs() -> Transaction {
+        Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::Blocks(absolute::Height::ZERO),
+            input: vec![
+                TxIn {
+                    previous_output: outpoint(1),
+                    sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                    ..TxIn::default()
+                },
+                TxIn {
+                    previous_output: outpoint(2),
+                    sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                    ..TxIn::default()
+                },
+            ],
+            output: vec![
+                TxOut {
+                    value: Amount::from_sat(40_000),
+                    script_pubkey: address().script_pubkey(),
+                },
+                TxOut {
+                    value: Amount::from_sat(10_000),
+                    script_pubkey: address().script_pubkey(),
+                },
+            ],
+        }
+    }
+
+    fn form_value(value: &str, valid: bool) -> form::Value<String> {
+        form::Value {
+            value: value.to_string(),
+            valid,
+            warning: None,
+        }
+    }
+
+    fn quote() -> coincube_ui::component::quote_display::Quote {
+        coincube_ui::component::quote_display::Quote {
+            id: "test".to_string(),
+            text: "Steady hands.".to_string(),
+            author: "Coincube".to_string(),
+            source: "tests".to_string(),
+            category: "bitcoin-send".to_string(),
+            length: "short".to_string(),
+            contexts: vec!["bitcoin-send".to_string()],
+        }
+    }
+
+    fn image_handle() -> iced::widget::image::Handle {
+        iced::widget::image::Handle::from_rgba(1, 1, vec![255, 255, 255, 255])
+    }
+
+    fn signing_row(
+        fingerprint: Fingerprint,
+        label: &str,
+        kind: SigningKeyKind,
+        state: SigningKeyState,
+    ) -> SigningKeyRow {
+        SigningKeyRow {
+            fingerprint,
+            label: label.to_string(),
+            kind,
+            state,
+        }
+    }
+
+    #[test]
+    fn action_modals_build_for_success_pending_and_error_states() {
+        let mut conflicts = HashSet::new();
+        conflicts.insert(Txid::from_str(&format!("{:064x}", 1)).unwrap());
+        conflicts.insert(Txid::from_str(&format!("{:064x}", 2)).unwrap());
+        let quote = quote();
+        let image = image_handle();
+
+        let _ = save_action(false);
+        let _ = save_action(true);
+        let _ = delete_action(false);
+        let _ = delete_action(true);
+        let _ = keychain_unavailable_action(false);
+        let _ = keychain_unavailable_action(true);
+        let _ = broadcast_action(
+            &HashSet::new(),
+            false,
+            false,
+            None,
+            "40,000 sats",
+            &quote,
+            &image,
+            false,
+        );
+        let _ = broadcast_action(
+            &conflicts,
+            false,
+            true,
+            Some("mempool rejected".to_string()),
+            "40,000 sats",
+            &quote,
+            &image,
+            false,
+        );
+        let _ = broadcast_action(
+            &HashSet::new(),
+            true,
+            false,
+            None,
+            "40,000 sats",
+            &quote,
+            &image,
+            true,
+        );
+    }
+
+    #[test]
+    fn inputs_and_outputs_views_build_with_labels_missing_coins_change_and_external_rows() {
+        let tx = tx_with_outputs();
+        let mut coins = HashMap::new();
+        coins.insert(outpoint(1), coin(1, 60_000, false));
+        let mut labels = HashMap::new();
+        labels.insert(outpoint(1).to_string(), "input coin".to_string());
+        labels.insert(address().to_string(), "destination".to_string());
+        labels.insert(
+            OutPoint::new(tx.compute_txid(), 0).to_string(),
+            "payment output".to_string(),
+        );
+        let mut labels_editing = HashMap::new();
+        labels_editing.insert(outpoint(1).to_string(), form_value("editing", true));
+
+        let _ = inputs_view(
+            &coins,
+            &tx,
+            &labels,
+            &labels_editing,
+            BitcoinDisplayUnit::Sats,
+        );
+        let _ = outputs_view(
+            &tx,
+            Network::Bitcoin,
+            &[1],
+            &labels,
+            &labels_editing,
+            BitcoinDisplayUnit::Sats,
+            true,
+            false,
+        );
+        let _ = outputs_view(
+            &tx,
+            Network::Bitcoin,
+            &[0, 1],
+            &labels,
+            &labels_editing,
+            BitcoinDisplayUnit::BTC,
+            false,
+            false,
+        );
+        let _ = outputs_view(
+            &tx,
+            Network::Bitcoin,
+            &[1],
+            &labels,
+            &labels_editing,
+            BitcoinDisplayUnit::Sats,
+            false,
+            true,
+        );
+    }
+
+    #[test]
+    fn signing_picker_builds_all_key_states_and_path_shapes() {
+        let fg1 = fingerprint("f714c228");
+        let fg2 = fingerprint("2522f23c");
+        let fg3 = fingerprint("8a64f2a9");
+
+        assert_eq!(humanize_timelock(0), "");
+        assert_eq!(humanize_timelock(6), "1h");
+        assert_eq!(humanize_timelock(144), "1d");
+        assert_eq!(
+            signing_key_kind_caption(&SigningKeyKind::Master),
+            Some("This computer")
+        );
+        assert_eq!(signing_key_kind_caption(&SigningKeyKind::Unknown), None);
+
+        let active = SigningPath {
+            title: "Primary path".to_string(),
+            is_primary: true,
+            sequence: None,
+            active: true,
+            threshold: 2,
+            total: 9,
+            collected: 3,
+            can_request_all: true,
+            expanded: true,
+            keys: vec![
+                signing_row(
+                    fg1,
+                    "Already signed",
+                    SigningKeyKind::Master,
+                    SigningKeyState::Signed,
+                ),
+                signing_row(
+                    fg2,
+                    "Hardware signing",
+                    SigningKeyKind::Hardware,
+                    SigningKeyState::InProgress("Waiting for device".to_string()),
+                ),
+                signing_row(
+                    fg3,
+                    "Cannot sign",
+                    SigningKeyKind::Unknown,
+                    SigningKeyState::Disabled("Unavailable".to_string()),
+                ),
+                signing_row(
+                    fg1,
+                    "Connect prompt",
+                    SigningKeyKind::Keychain,
+                    SigningKeyState::NeedsSignIn("Sign in to resolve".to_string()),
+                ),
+                signing_row(
+                    fg2,
+                    "Retry keychain",
+                    SigningKeyKind::Keychain,
+                    SigningKeyState::Retry(0),
+                ),
+                signing_row(
+                    fg3,
+                    "Master signer",
+                    SigningKeyKind::Master,
+                    SigningKeyState::Available(SigningKeyAction::Master),
+                ),
+                signing_row(
+                    fg1,
+                    "Hardware signer",
+                    SigningKeyKind::Hardware,
+                    SigningKeyState::Available(SigningKeyAction::Hardware(0)),
+                ),
+                signing_row(
+                    fg2,
+                    "Border signer",
+                    SigningKeyKind::BorderWallet,
+                    SigningKeyState::Available(SigningKeyAction::BorderWallet),
+                ),
+                signing_row(
+                    fg3,
+                    "Keychain signer",
+                    SigningKeyKind::Keychain,
+                    SigningKeyState::Available(SigningKeyAction::Keychain),
+                ),
+            ],
+        };
+
+        let inactive_collapsed = SigningPath {
+            title: "Recovery path".to_string(),
+            is_primary: false,
+            sequence: Some(144),
+            active: false,
+            threshold: 1,
+            total: 1,
+            collected: 0,
+            can_request_all: false,
+            expanded: false,
+            keys: Vec::new(),
+        };
+
+        let inactive_expanded = SigningPath {
+            title: "Expanded recovery path".to_string(),
+            is_primary: false,
+            sequence: Some(65535),
+            active: false,
+            threshold: 1,
+            total: 1,
+            collected: 0,
+            can_request_all: false,
+            expanded: true,
+            keys: vec![signing_row(
+                fg1,
+                "Unavailable key",
+                SigningKeyKind::Unknown,
+                SigningKeyState::Disabled("Inactive path".to_string()),
+            )],
+        };
+
+        let _ = sign_action(
+            vec![active, inactive_collapsed, inactive_expanded],
+            vec!["Connect is not ready yet.".to_string()],
+        );
+    }
+
+    #[test]
+    fn path_and_border_wallet_reconstruction_views_build_each_step() {
+        let policy = CoincubeDescriptor::from_str(DESC).unwrap().policy();
+        let mut signed_pubkeys = HashMap::new();
+        signed_pubkeys.insert(fingerprint("f714c228"), 1);
+        let sigs = PathSpendInfo {
+            threshold: 2,
+            sigs_count: 1,
+            signed_pubkeys,
+        };
+        let aliases = HashMap::from([(fingerprint("f714c228"), "Laptop key".to_string())]);
+        let _ = path_view(policy.primary_path(), &sigs, &aliases);
+
+        let mut phrase_words = vec![form_value("", false); 12];
+        phrase_words[0].value = "abandon".to_string();
+        let phrase_recon = BorderWalletReconstructionState {
+            target_fingerprint: fingerprint("f714c228"),
+            network: Network::Bitcoin,
+            step: ReconStep::RecoveryPhrase,
+            phrase_words,
+            phrase_valid: false,
+            grid: None,
+            pattern: OrderedPattern::new(),
+            checksum_word: None,
+            error: Some("Check the phrase".to_string()),
+        };
+        let _ = border_wallet_recon_view(&phrase_recon);
+
+        let mut pattern = OrderedPattern::new();
+        pattern.add(CellRef::new(0, 0)).unwrap();
+        let grid_recon = BorderWalletReconstructionState {
+            target_fingerprint: fingerprint("2522f23c"),
+            network: Network::Bitcoin,
+            step: ReconStep::Grid,
+            phrase_words: vec![form_value("abandon", true); 12],
+            phrase_valid: true,
+            grid: Some(WordGrid::from_recovery_phrase(GRID_PHRASE).unwrap()),
+            pattern,
+            checksum_word: Some("about".to_string()),
+            error: Some("Pick eleven cells".to_string()),
+        };
+        let _ = border_wallet_recon_view(&grid_recon);
+
+        let mut complete_pattern = OrderedPattern::new();
+        for col in 0..PATTERN_LENGTH as u8 {
+            complete_pattern.add(CellRef::new(0, col)).unwrap();
+        }
+        let complete_grid_recon = BorderWalletReconstructionState {
+            target_fingerprint: fingerprint("8a64f2a9"),
+            network: Network::Bitcoin,
+            step: ReconStep::Grid,
+            phrase_words: vec![form_value("abandon", true); 12],
+            phrase_valid: true,
+            grid: Some(WordGrid::from_recovery_phrase(GRID_PHRASE).unwrap()),
+            pattern: complete_pattern,
+            checksum_word: None,
+            error: None,
+        };
+        let _ = border_wallet_recon_view(&complete_grid_recon);
+    }
+
+    #[test]
+    fn update_spend_views_build_valid_invalid_processing_and_success_states() {
+        let valid = form_value("cHNidP8=", true);
+        let invalid = form_value("not psbt", false);
+
+        let _ = update_spend_view("original-psbt".to_string(), &valid, false);
+        let _ = update_spend_view("original-psbt".to_string(), &valid, true);
+        let _ = update_spend_view("original-psbt".to_string(), &invalid, false);
+        let _ = update_spend_success_view();
+    }
+}

--- a/coincube-gui/src/app/view/vault/settings/mod.rs
+++ b/coincube-gui/src/app/view/vault/settings/mod.rs
@@ -2140,3 +2140,284 @@ pub fn register_wallet_modal<'a>(
     .width(Length::Fixed(500.0))
     .into()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        app::{
+            cache::NodeNetStats,
+            menu::{SettingsOption, VaultSubMenu},
+        },
+        node::bitcoind::NodeResources,
+    };
+    use std::{net::SocketAddr, path::PathBuf};
+
+    fn value(text: &str, valid: bool) -> form::Value<String> {
+        form::Value {
+            value: text.to_string(),
+            valid,
+            warning: None,
+        }
+    }
+
+    fn menu() -> Menu {
+        Menu::Vault(VaultSubMenu::Settings(Some(SettingsOption::Node)))
+    }
+
+    fn bitcoind_config(rpc_auth: BitcoindRpcAuth) -> coincubed::config::BitcoindConfig {
+        coincubed::config::BitcoindConfig {
+            rpc_auth,
+            addr: "127.0.0.1:8332".parse::<SocketAddr>().unwrap(),
+        }
+    }
+
+    fn electrum_config() -> coincubed::config::ElectrumConfig {
+        coincubed::config::ElectrumConfig {
+            addr: "ssl://electrum.example:50002".to_string(),
+            validate_domain: true,
+        }
+    }
+
+    fn cookie_auth_values(valid: bool) -> RpcAuthValues {
+        RpcAuthValues {
+            cookie_path: value("/tmp/bitcoin/.cookie", valid),
+            user: value("", true),
+            password: value("", true),
+        }
+    }
+
+    fn userpass_auth_values(valid: bool) -> RpcAuthValues {
+        RpcAuthValues {
+            cookie_path: value("", true),
+            user: value("rpcuser", valid),
+            password: value("rpcpassword", valid),
+        }
+    }
+
+    #[test]
+    fn pure_formatting_helpers_cover_thresholds_and_predicates() {
+        assert_eq!(human_bytes(42), "42 B");
+        assert_eq!(human_bytes(2 * 1024), "2 KB");
+        assert_eq!(human_bytes(45 * 1024 * 1024), "45 MB");
+        assert_eq!(human_bytes(1024 * 1024 * 1024), "1.0 GB");
+
+        assert_eq!(expire_message_units(0), Vec::<String>::new());
+        assert_eq!(expire_message_units(6), vec!["1h"]);
+        assert_eq!(expire_message_units(144), vec!["1d"]);
+        assert_eq!(expire_message_units(52_596), vec!["1y"]);
+
+        assert!(is_ok_and(&Ok::<_, ()>(7), |v| *v > 3));
+        assert!(!is_ok_and(&Ok::<_, ()>(2), |v| *v > 3));
+        assert!(!is_ok_and(&Err::<u32, _>("nope"), |v| *v > 3));
+    }
+
+    #[test]
+    fn dashboard_wrapped_settings_sections_build() {
+        let menu = menu();
+        let cache = Cache::default();
+        let valid_email = value("friend@example.com", true);
+        let invalid_email = value("not an email", false);
+
+        let _ = link("https://example.com/docs", "Docs");
+        let _ = list(&menu, &cache, false);
+        let _ = bitcoind_settings(&menu, &cache, vec![text("child").into()]);
+        let _ = import_export(&menu, &cache);
+        let _ = remote_backend_section(&menu, &cache, &valid_email, false, true);
+        let _ = remote_backend_section(&menu, &cache, &invalid_email, true, false);
+    }
+
+    #[test]
+    fn bitcoind_and_electrum_cards_build_for_configured_and_editing_states() {
+        let cookie = BitcoindRpcAuth::CookieFile(PathBuf::from("/tmp/bitcoin/.cookie"));
+        let userpass = BitcoindRpcAuth::UserPass("rpcuser".to_string(), "secret".to_string());
+        let socket = value("127.0.0.1:8332", true);
+        let invalid_socket = value("bad socket", false);
+        let cookie_values = cookie_auth_values(true);
+        let invalid_userpass_values = userpass_auth_values(false);
+
+        let _ = bitcoind(
+            true,
+            Network::Bitcoin,
+            &bitcoind_config(cookie),
+            840_000,
+            Some(true),
+            true,
+            Some(NodeFlavor::Knots),
+        );
+        let _ = bitcoind(
+            true,
+            Network::Testnet,
+            &bitcoind_config(userpass),
+            0,
+            Some(false),
+            false,
+            None,
+        );
+        let _ = bitcoind_edit(
+            true,
+            Network::Bitcoin,
+            840_000,
+            &socket,
+            &cookie_values,
+            &RpcAuthType::CookieFile,
+            false,
+        );
+        let _ = bitcoind_edit(
+            false,
+            Network::Signet,
+            0,
+            &invalid_socket,
+            &invalid_userpass_values,
+            &RpcAuthType::UserPass,
+            true,
+        );
+
+        let electrum_cfg = electrum_config();
+        let electrum_addr = value("ssl://electrum.example:50002", true);
+        let invalid_electrum_addr = value("", false);
+        let _ = electrum_edit(true, Network::Bitcoin, 840_000, &electrum_addr, false, true);
+        let _ = electrum_edit(
+            false,
+            Network::Regtest,
+            0,
+            &invalid_electrum_addr,
+            true,
+            false,
+        );
+        let _ = electrum(
+            true,
+            Network::Bitcoin,
+            &electrum_cfg,
+            840_000,
+            Some(true),
+            true,
+        );
+        let _ = electrum(false, Network::Bitcoin, &electrum_cfg, 0, None, false);
+        let _ = is_running_label::<SettingsEditMessage>(Some(true));
+        let _ = is_running_label::<SettingsEditMessage>(Some(false));
+        let _ = is_running_label::<SettingsEditMessage>(None);
+    }
+
+    #[test]
+    fn rescan_view_builds_progress_validation_and_processing_states() {
+        let good_year = value("2024", true);
+        let good_month = value("7", true);
+        let good_day = value("20", true);
+        let bad_year = value("abcd", false);
+
+        let _ = rescan(
+            &good_year,
+            &good_month,
+            &good_day,
+            Some(0.42),
+            false,
+            false,
+            true,
+            false,
+            false,
+            false,
+        );
+        let _ = rescan(
+            &good_year,
+            &good_month,
+            &good_day,
+            None,
+            true,
+            false,
+            true,
+            false,
+            false,
+            false,
+        );
+        let _ = rescan(
+            &bad_year,
+            &good_month,
+            &good_day,
+            None,
+            false,
+            true,
+            false,
+            true,
+            true,
+            true,
+        );
+    }
+
+    #[test]
+    fn node_backend_status_builds_switch_sync_warning_and_setup_states() {
+        let stats = NodeNetStats {
+            connections_in: 2,
+            connections_out: 8,
+            upload_used: 45 * 1024 * 1024,
+            upload_target: 1024 * 1024 * 1024,
+            onion_address: Some("abc123.onion".to_string()),
+        };
+
+        let _ = node_backend_status(
+            "COINCUBE | Connect",
+            icon::network_icon(),
+            Some(0.91),
+            Some(true),
+            Some("UpdateTip: headers progress"),
+            true,
+            true,
+            true,
+            false,
+            false,
+            Some("Heads up".to_string()),
+        );
+        let _ = node_backend_status(
+            "Local node",
+            icon::bitcoin_icon(),
+            Some(0.995),
+            Some(false),
+            None,
+            false,
+            true,
+            false,
+            false,
+            true,
+            None,
+        );
+        let _ = inbound_tor_section(false, true, true, false, false, false, None);
+        let _ = inbound_tor_section(true, true, true, true, true, true, Some(&stats));
+        let _ = inbound_tor_section(true, false, false, true, false, true, Some(&stats));
+    }
+
+    #[test]
+    fn node_setup_and_resource_panels_build_for_all_stages() {
+        let addr = value("127.0.0.1:8332", true);
+        let invalid_addr = value("bad", false);
+        let cookie_values = cookie_auth_values(false);
+        let userpass_values = userpass_auth_values(false);
+        let prune = value("15000", true);
+        let max_mempool = value("", true);
+
+        let _ = pending_node_setup_panel(&addr, &cookie_values, &RpcAuthType::CookieFile, false);
+        let _ = pending_node_setup_panel(
+            &invalid_addr,
+            &userpass_values,
+            &RpcAuthType::UserPass,
+            true,
+        );
+        let _ = node_setup_mode_picker_panel();
+        let _ = internal_node_setup_panel(NodeFlavor::Knots, true, false, false, None, 72.0);
+        let _ = internal_node_setup_panel(NodeFlavor::Core, false, true, false, None, 0.0);
+        let _ = internal_node_setup_panel(NodeFlavor::Knots, false, false, true, None, 100.0);
+        let _ = internal_node_setup_panel(
+            NodeFlavor::Core,
+            false,
+            false,
+            false,
+            Some("download failed"),
+            0.0,
+        );
+        let _ = flavor_switch_confirm(NodeFlavor::Knots);
+        let _ = node_resources_section(&prune, &max_mempool, false);
+        let _ = node_resources_section(&prune, &max_mempool, true);
+
+        assert_eq!(NodeResources::small_computer().max_mempool_mb, Some(100));
+        assert_eq!(NodeResources::regular_computer().max_mempool_mb, None);
+    }
+}

--- a/coincube-gui/src/app/wallets/types.rs
+++ b/coincube-gui/src/app/wallets/types.rs
@@ -267,3 +267,272 @@ impl From<LiquidRefundableSwap> for DomainRefundableSwap {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use breez_sdk_liquid::model::{
+        AssetInfo as LiquidAssetInfo, PaymentDetails as LiquidPaymentDetails,
+        PaymentState as LiquidPaymentState, PaymentType as LiquidPaymentType,
+    };
+    use breez_sdk_liquid::prelude::{
+        Payment as LiquidPayment, RefundableSwap as LiquidRefundableSwap,
+    };
+
+    fn liquid_payment_with(details: LiquidPaymentDetails) -> LiquidPayment {
+        LiquidPayment {
+            destination: Some("destination".to_string()),
+            tx_id: Some("txid".to_string()),
+            unblinding_data: Some("unblind".to_string()),
+            timestamp: 1_722_000_000,
+            amount_sat: 25_000,
+            fees_sat: 125,
+            swapper_fees_sat: Some(50),
+            payment_type: LiquidPaymentType::Receive,
+            status: LiquidPaymentState::Pending,
+            details,
+        }
+    }
+
+    #[test]
+    fn wallet_kind_defaults_to_spark_and_serializes_as_snake_case() {
+        assert_eq!(WalletKind::default(), WalletKind::Spark);
+        assert_eq!(
+            serde_json::to_string(&WalletKind::Spark).unwrap(),
+            "\"spark\""
+        );
+        assert_eq!(
+            serde_json::to_string(&WalletKind::Liquid).unwrap(),
+            "\"liquid\""
+        );
+
+        let decoded: WalletKind = serde_json::from_str("\"liquid\"").unwrap();
+        assert_eq!(decoded, WalletKind::Liquid);
+    }
+
+    #[test]
+    fn payment_status_predicates_match_ui_state_groups() {
+        for status in [
+            DomainPaymentStatus::Failed,
+            DomainPaymentStatus::TimedOut,
+            DomainPaymentStatus::Refundable,
+        ] {
+            assert!(status.is_destructive());
+        }
+
+        for status in [
+            DomainPaymentStatus::Created,
+            DomainPaymentStatus::Pending,
+            DomainPaymentStatus::RefundPending,
+            DomainPaymentStatus::WaitingFeeAcceptance,
+        ] {
+            assert!(status.is_in_flight());
+        }
+
+        assert!(!DomainPaymentStatus::Complete.is_destructive());
+        assert!(!DomainPaymentStatus::Complete.is_in_flight());
+    }
+
+    #[test]
+    fn liquid_payment_states_map_to_domain_statuses() {
+        let cases = [
+            (LiquidPaymentState::Created, DomainPaymentStatus::Created),
+            (LiquidPaymentState::Pending, DomainPaymentStatus::Pending),
+            (LiquidPaymentState::Complete, DomainPaymentStatus::Complete),
+            (LiquidPaymentState::Failed, DomainPaymentStatus::Failed),
+            (LiquidPaymentState::TimedOut, DomainPaymentStatus::TimedOut),
+            (
+                LiquidPaymentState::Refundable,
+                DomainPaymentStatus::Refundable,
+            ),
+            (
+                LiquidPaymentState::RefundPending,
+                DomainPaymentStatus::RefundPending,
+            ),
+            (
+                LiquidPaymentState::WaitingFeeAcceptance,
+                DomainPaymentStatus::WaitingFeeAcceptance,
+            ),
+        ];
+
+        for (sdk_status, expected) in cases {
+            assert_eq!(DomainPaymentStatus::from(sdk_status), expected);
+        }
+    }
+
+    #[test]
+    fn payment_details_description_prefers_non_empty_payer_note() {
+        let lightning = DomainPaymentDetails::Lightning {
+            description: "invoice description".to_string(),
+            payer_note: Some("payer note".to_string()),
+        };
+        assert_eq!(lightning.description(), "payer note");
+
+        let liquid = DomainPaymentDetails::LiquidAsset {
+            asset_id: "asset".to_string(),
+            asset_info: None,
+            description: "asset description".to_string(),
+            payer_note: Some(String::new()),
+        };
+        assert_eq!(liquid.description(), "asset description");
+
+        let bitcoin = DomainPaymentDetails::OnChainBitcoin {
+            swap_id: None,
+            bitcoin_address: None,
+            description: "bitcoin description".to_string(),
+            auto_accepted_fees: false,
+            liquid_expiration_blockheight: 0,
+            bitcoin_expiration_blockheight: 0,
+            lockup_tx_id: None,
+            claim_tx_id: None,
+            refund_tx_id: None,
+            refund_tx_amount_sat: None,
+        };
+        assert_eq!(bitcoin.description(), "bitcoin description");
+    }
+
+    #[test]
+    fn domain_payment_is_incoming_only_for_receives() {
+        let mut payment = DomainPayment {
+            tx_id: None,
+            destination: None,
+            timestamp: 0,
+            amount_sat: 0,
+            fees_sat: 0,
+            direction: DomainPaymentDirection::Receive,
+            status: DomainPaymentStatus::Complete,
+            details: DomainPaymentDetails::Lightning {
+                description: String::new(),
+                payer_note: None,
+            },
+        };
+
+        assert!(payment.is_incoming());
+        payment.direction = DomainPaymentDirection::Send;
+        assert!(!payment.is_incoming());
+    }
+
+    #[test]
+    fn liquid_lightning_payment_maps_to_domain_payment() {
+        let sdk_payment = liquid_payment_with(LiquidPaymentDetails::Lightning {
+            swap_id: "swap".to_string(),
+            description: "invoice".to_string(),
+            liquid_expiration_blockheight: 100,
+            preimage: Some("preimage".to_string()),
+            invoice: Some("lnbc".to_string()),
+            bolt12_offer: None,
+            payment_hash: Some("hash".to_string()),
+            destination_pubkey: None,
+            lnurl_info: None,
+            bip353_address: None,
+            payer_note: Some("thanks".to_string()),
+            claim_tx_id: None,
+            refund_tx_id: Some("refund".to_string()),
+            refund_tx_amount_sat: Some(10),
+            settled_at: None,
+        });
+
+        let domain = DomainPayment::from(sdk_payment);
+
+        assert_eq!(domain.tx_id.as_deref(), Some("txid"));
+        assert_eq!(domain.destination.as_deref(), Some("destination"));
+        assert_eq!(domain.timestamp, 1_722_000_000);
+        assert_eq!(domain.amount_sat, 25_000);
+        assert_eq!(domain.fees_sat, 125);
+        assert_eq!(domain.direction, DomainPaymentDirection::Receive);
+        assert_eq!(domain.status, DomainPaymentStatus::Pending);
+        assert_eq!(
+            domain.details,
+            DomainPaymentDetails::Lightning {
+                description: "invoice".to_string(),
+                payer_note: Some("thanks".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn liquid_asset_payment_maps_asset_amount_to_minor_units() {
+        let sdk_payment = liquid_payment_with(LiquidPaymentDetails::Liquid {
+            destination: "liquid-address".to_string(),
+            description: "asset transfer".to_string(),
+            asset_id: "usdt-asset".to_string(),
+            asset_info: Some(LiquidAssetInfo {
+                name: "Tether USD".to_string(),
+                ticker: "USDt".to_string(),
+                amount: 1.23456789,
+                fees: Some(0.00000001),
+            }),
+            lnurl_info: None,
+            bip353_address: None,
+            payer_note: Some("asset note".to_string()),
+        });
+
+        let domain = DomainPayment::from(sdk_payment);
+
+        assert_eq!(
+            domain.details,
+            DomainPaymentDetails::LiquidAsset {
+                asset_id: "usdt-asset".to_string(),
+                asset_info: Some(DomainLiquidAssetInfo {
+                    amount_minor: 123_456_789,
+                    precision: USDT_PRECISION,
+                }),
+                description: "asset transfer".to_string(),
+                payer_note: Some("asset note".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn liquid_bitcoin_payment_maps_swap_fields_to_domain_details() {
+        let sdk_payment = liquid_payment_with(LiquidPaymentDetails::Bitcoin {
+            swap_id: "swap-id".to_string(),
+            bitcoin_address: "bc1qaddress".to_string(),
+            description: "chain swap".to_string(),
+            auto_accepted_fees: true,
+            liquid_expiration_blockheight: 123,
+            bitcoin_expiration_blockheight: 456,
+            lockup_tx_id: Some("lockup".to_string()),
+            claim_tx_id: Some("claim".to_string()),
+            refund_tx_id: Some("refund".to_string()),
+            refund_tx_amount_sat: Some(900),
+        });
+
+        let domain = DomainPayment::from(sdk_payment);
+
+        assert_eq!(
+            domain.details,
+            DomainPaymentDetails::OnChainBitcoin {
+                swap_id: Some("swap-id".to_string()),
+                bitcoin_address: Some("bc1qaddress".to_string()),
+                description: "chain swap".to_string(),
+                auto_accepted_fees: true,
+                liquid_expiration_blockheight: 123,
+                bitcoin_expiration_blockheight: 456,
+                lockup_tx_id: Some("lockup".to_string()),
+                claim_tx_id: Some("claim".to_string()),
+                refund_tx_id: Some("refund".to_string()),
+                refund_tx_amount_sat: Some(900),
+            }
+        );
+    }
+
+    #[test]
+    fn refundable_swap_maps_only_ui_fields() {
+        let domain = DomainRefundableSwap::from(LiquidRefundableSwap {
+            swap_address: "swap-address".to_string(),
+            timestamp: 1_722_000_001,
+            amount_sat: 42_000,
+            last_refund_tx_id: Some("ignored".to_string()),
+        });
+
+        assert_eq!(
+            domain,
+            DomainRefundableSwap {
+                swap_address: "swap-address".to_string(),
+                timestamp: 1_722_000_001,
+                amount_sat: 42_000,
+            }
+        );
+    }
+}

--- a/coincube-gui/src/export.rs
+++ b/coincube-gui/src/export.rs
@@ -1647,11 +1647,179 @@ pub async fn app_backup_export(
 
 #[cfg(test)]
 mod tests {
-    use std::env;
+    use std::{
+        collections::hash_map::DefaultHasher,
+        env,
+        hash::{Hash, Hasher},
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     use encrypted_backup::Version;
 
     use super::*;
+
+    fn unique_temp_path(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after unix epoch")
+            .as_nanos();
+        env::temp_dir()
+            .join(format!(
+                "coincube-export-test-{}-{unique}",
+                std::process::id()
+            ))
+            .join(label)
+    }
+
+    #[test]
+    fn import_export_type_messages_status_and_hashing_are_stable() {
+        assert_eq!(
+            ImportExportType::Transactions.end_message(),
+            "Export successful!"
+        );
+        assert_eq!(
+            ImportExportType::LiquidPayments.end_message(),
+            "Export successful!"
+        );
+        assert_eq!(
+            ImportExportType::ExportPsbt("psbt".to_string()).end_message(),
+            "Export successful!"
+        );
+        assert_eq!(
+            ImportExportType::ExportXpub("xpub".to_string()).end_message(),
+            "Export successful!"
+        );
+        assert_eq!(
+            ImportExportType::ExportLabels.end_message(),
+            "Export successful!"
+        );
+        assert_eq!(
+            ImportExportType::ImportPsbt(None).end_message(),
+            "Import successful"
+        );
+        assert_eq!(
+            ImportExportType::ImportXpub(Network::Bitcoin).end_message(),
+            "Import successful"
+        );
+        assert_eq!(
+            ImportExportType::FromBackup.end_message(),
+            "Import successful"
+        );
+        assert_eq!(
+            ImportExportType::ImportDescriptor.end_message(),
+            "Import successful"
+        );
+
+        let mut export = Export::new(
+            None,
+            None,
+            Box::new(PathBuf::from("out.txt")),
+            ImportExportType::ExportPsbt("psbt".to_string()),
+        );
+        assert!(matches!(export.state(), Status::Init));
+        export.sender = None;
+        assert!(matches!(export.state(), Status::Stopped));
+
+        let data = ExportSubscriptionData {
+            daemon: None,
+            breez_client: None,
+            path: PathBuf::from("out.txt"),
+            export_type: ImportExportType::ExportPsbt("psbt-a".to_string()),
+        };
+        let mut hasher = DefaultHasher::new();
+        data.hash(&mut hasher);
+        assert_ne!(hasher.finish(), 0);
+
+        let _: view::Message = ImportExportMessage::Close.into();
+    }
+
+    #[test]
+    fn import_export_error_display_covers_user_facing_variants() {
+        for error in [
+            Error::Io("disk".to_string()),
+            Error::HandleLost,
+            Error::UnexpectedEnd,
+            Error::JoinError("join".to_string()),
+            Error::ChannelLost,
+            Error::NoParentDir,
+            Error::Daemon("offline".to_string()),
+            Error::TxTimeMissing,
+            Error::DaemonMissing,
+            Error::ParsePsbt,
+            Error::ParseDescriptor,
+            Error::Bip329Export("labels".to_string()),
+            Error::BackupImport("backup".to_string()),
+            Error::ParseXpub,
+            Error::XpubNetwork,
+            Error::TxidNotMatch,
+            Error::InsanePsbt,
+            Error::OutpointNotOwned,
+            Error::UnknownFormat,
+            Error::EncryptionFailed,
+        ] {
+            assert!(!error.to_string().is_empty());
+        }
+
+        for error in [
+            RestoreBackupError::Network,
+            RestoreBackupError::InvalidDescriptor,
+            RestoreBackupError::WrongDescriptor,
+            RestoreBackupError::NoAccount,
+            RestoreBackupError::SeveralAccounts,
+            RestoreBackupError::LianaConnectNotSupported,
+            RestoreBackupError::GetLabels,
+            RestoreBackupError::LabelsNotEmpty,
+            RestoreBackupError::InvalidPsbt,
+            RestoreBackupError::Daemon(DaemonError::NoAnswer),
+        ] {
+            assert!(!error.to_string().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn export_string_creates_parent_directory_and_reports_progress() {
+        let path = unique_temp_path("nested/out.txt");
+        let root = path
+            .parent()
+            .and_then(Path::parent)
+            .expect("test path has parent")
+            .to_path_buf();
+        let (sender, mut receiver) = unbounded_channel();
+
+        export_string(&sender, path.clone(), "hello export".to_string())
+            .await
+            .expect("export string");
+
+        assert_eq!(
+            fs::read_to_string(&path).expect("read exported file"),
+            "hello export"
+        );
+        assert!(matches!(receiver.try_recv(), Ok(Progress::Progress(100.0))));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn import_xpub_and_parser_failures_are_reported_without_side_effects() {
+        let path = unique_temp_path("bad-xpub.txt");
+        fs::create_dir_all(path.parent().expect("test path has parent")).unwrap();
+        fs::write(&path, "not an xpub").unwrap();
+        let (sender, _receiver) = unbounded_channel();
+
+        let err = import_xpub(&sender, path.clone(), Network::Bitcoin)
+            .await
+            .expect_err("invalid xpub should fail");
+        assert!(matches!(err, Error::ParseXpub));
+        assert!(parse_raw_xpub("not an xpub").is_none());
+        assert!(parse_coldcard_xpub_json("{bad json").is_none());
+        assert!(parse_coldcard_xpub_ccxp("{bad json").is_none());
+
+        let root = path
+            .parent()
+            .and_then(Path::parent)
+            .expect("test path has parent")
+            .to_path_buf();
+        let _ = fs::remove_dir_all(root);
+    }
 
     #[tokio::test]
     async fn test_import_descriptor_from_file() {

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -2474,6 +2474,194 @@ mod find_or_create_cube_tests {
         assert_eq!(cube.vault_wallet_id.as_ref(), Some(&wid));
     }
 
+    #[tokio::test]
+    async fn existing_wallet_match_returns_its_cube_without_rewriting_settings() {
+        let nd = temp_network_dir("existing-wallet");
+        let wid = wallet_id();
+        let mut settings = app::settings::Settings::default();
+        let existing =
+            app::settings::CubeSettings::new("Existing".to_string(), bitcoin::Network::Bitcoin)
+                .with_vault(wid.clone());
+        let existing_id = existing.id.clone();
+        settings.cubes.push(existing);
+        update_settings_file(&nd, |_| Some(settings)).await.unwrap();
+
+        let cube = find_or_create_cube(
+            &nd,
+            Some(&wid),
+            &Some("Ignored Alias".to_string()),
+            bitcoin::Network::Bitcoin,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("existing wallet should be found");
+
+        assert_eq!(cube.id, existing_id);
+        assert_eq!(cube.name, "Existing");
+        let reloaded = app::settings::Settings::from_file(&nd).unwrap();
+        assert_eq!(reloaded.cubes.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn restore_fails_when_original_cube_already_has_a_vault() {
+        let nd = temp_network_dir("restore-conflict");
+        let wid = wallet_id();
+        let mut settings = app::settings::Settings::default();
+        let mut restored = app::settings::CubeSettings::new(
+            "Already Restored".to_string(),
+            bitcoin::Network::Bitcoin,
+        )
+        .with_vault(WalletId::new("otherwallet".to_string(), Some(9)));
+        restored.id = ORIG_UUID.to_string();
+        settings.cubes.push(restored);
+        update_settings_file(&nd, |_| Some(settings)).await.unwrap();
+
+        let err = find_or_create_cube(
+            &nd,
+            Some(&wid),
+            &None,
+            bitcoin::Network::Bitcoin,
+            None,
+            Some(RestoreCubeIdentity {
+                uuid: ORIG_UUID.to_string(),
+                name: "My Vault".to_string(),
+            }),
+            None,
+        )
+        .await
+        .expect_err("restore should reject an already recovered cube");
+
+        assert!(err.contains("already been recovered"));
+    }
+
+    #[tokio::test]
+    async fn originating_cube_attaches_wallet_and_restore_credentials() {
+        let nd = temp_network_dir("originating");
+        let wid = wallet_id();
+        let fp = bitcoin::bip32::Fingerprint::from([0xaa, 0xbb, 0xcc, 0xdd]);
+        let seed = RestoreCubeSeed {
+            pin: zeroize::Zeroizing::new("135790".to_string()),
+            master_signer_fingerprint: fp,
+        };
+        let mut settings = app::settings::Settings::default();
+        let shell =
+            app::settings::CubeSettings::new("Shell".to_string(), bitcoin::Network::Bitcoin);
+        let shell_id = shell.id.clone();
+        settings.cubes.push(shell);
+        update_settings_file(&nd, |_| Some(settings)).await.unwrap();
+
+        let cube = find_or_create_cube(
+            &nd,
+            Some(&wid),
+            &None,
+            bitcoin::Network::Bitcoin,
+            Some(shell_id.clone()),
+            None,
+            Some(&seed),
+        )
+        .await
+        .expect("originating cube should be updated");
+
+        assert_eq!(cube.id, shell_id);
+        assert_eq!(cube.vault_wallet_id.as_ref(), Some(&wid));
+        assert_eq!(cube.master_signer_fingerprint, Some(fp));
+        assert!(cube.verify_pin("135790"));
+    }
+
+    #[tokio::test]
+    async fn originating_cube_errors_when_missing_or_already_vaulted() {
+        let nd = temp_network_dir("originating-errors");
+        let wid = wallet_id();
+        let mut settings = app::settings::Settings::default();
+        let occupied =
+            app::settings::CubeSettings::new("Occupied".to_string(), bitcoin::Network::Bitcoin)
+                .with_vault(WalletId::new("otherwallet".to_string(), Some(2)));
+        let occupied_id = occupied.id.clone();
+        settings.cubes.push(occupied);
+        update_settings_file(&nd, |_| Some(settings)).await.unwrap();
+
+        let occupied_err = find_or_create_cube(
+            &nd,
+            Some(&wid),
+            &None,
+            bitcoin::Network::Bitcoin,
+            Some(occupied_id),
+            None,
+            None,
+        )
+        .await
+        .expect_err("originating cube with an existing vault should fail");
+        assert!(occupied_err.contains("already has a vault"));
+
+        let missing_err = find_or_create_cube(
+            &nd,
+            Some(&wid),
+            &None,
+            bitcoin::Network::Bitcoin,
+            Some("missing-cube".to_string()),
+            None,
+            None,
+        )
+        .await
+        .expect_err("missing originating cube should fail");
+        assert!(missing_err.contains("Cannot find originating cube"));
+    }
+
+    #[tokio::test]
+    async fn empty_cube_fallback_attaches_wallet_before_minting_new_cube() {
+        let nd = temp_network_dir("empty-cube");
+        let wid = wallet_id();
+        let mut settings = app::settings::Settings::default();
+        let empty =
+            app::settings::CubeSettings::new("Empty".to_string(), bitcoin::Network::Bitcoin);
+        let empty_id = empty.id.clone();
+        settings.cubes.push(empty);
+        update_settings_file(&nd, |_| Some(settings)).await.unwrap();
+
+        let cube = find_or_create_cube(
+            &nd,
+            Some(&wid),
+            &Some("Should Not Mint".to_string()),
+            bitcoin::Network::Bitcoin,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("empty cube should be reused");
+
+        assert_eq!(cube.id, empty_id);
+        assert_eq!(cube.vault_wallet_id.as_ref(), Some(&wid));
+        let reloaded = app::settings::Settings::from_file(&nd).unwrap();
+        assert_eq!(reloaded.cubes.len(), 1, "must reuse instead of minting");
+    }
+
+    #[tokio::test]
+    async fn first_non_restore_cube_uses_default_alias_when_none_is_given() {
+        let nd = temp_network_dir("first-default");
+        let wid = wallet_id();
+
+        let cube = find_or_create_cube(
+            &nd,
+            Some(&wid),
+            &None,
+            bitcoin::Network::Signet,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("first cube should be created");
+
+        assert_eq!(cube.name, "My signet Cube");
+        assert_eq!(cube.network, bitcoin::Network::Signet);
+        assert_eq!(cube.vault_wallet_id.as_ref(), Some(&wid));
+        let reloaded = app::settings::Settings::from_file(&nd).unwrap();
+        assert_eq!(reloaded.cubes.len(), 1);
+    }
+
     /// Upgrade path: a previous (buggy) recovery left the wallet attached to a
     /// *duplicate* Cube with a different UUID, while the original Cube is still
     /// recoverable. Re-running recovery must reconcile — move the wallet onto

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -2345,6 +2345,21 @@ mod find_or_create_cube_tests {
         WalletId::new("abcd1234".to_string(), Some(1_700_000_000))
     }
 
+    /// Reload settings written earlier in the test, tolerating the transient
+    /// misses Windows raises when a virus scanner or search indexer briefly
+    /// holds a just-written settings.json (surfacing as NotFound or a
+    /// permission error). The file has always been written by this point, so a
+    /// miss is transient — retry briefly before giving up.
+    fn reload(nd: &NetworkDirectory) -> app::settings::Settings {
+        for _ in 0..20 {
+            if let Ok(settings) = app::settings::Settings::from_file(nd) {
+                return settings;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        app::settings::Settings::from_file(nd).expect("reload settings after retries")
+    }
+
     /// The reported scenario: recovery on a wiped install (no settings
     /// file). The restored Cube must carry the original UUID + name, not a
     /// freshly generated one.
@@ -2410,7 +2425,7 @@ mod find_or_create_cube_tests {
 
         assert_eq!(cube.id, ORIG_UUID);
         assert_ne!(cube.id, other_id, "must not reuse the unrelated Cube");
-        let reloaded = app::settings::Settings::from_file(&nd).unwrap();
+        let reloaded = reload(&nd);
         assert_eq!(reloaded.cubes.len(), 2, "unrelated Cube is preserved");
     }
 
@@ -2444,7 +2459,7 @@ mod find_or_create_cube_tests {
 
         assert_eq!(cube.id, ORIG_UUID);
         assert_eq!(cube.vault_wallet_id.as_ref(), Some(&wid));
-        let reloaded = app::settings::Settings::from_file(&nd).unwrap();
+        let reloaded = reload(&nd);
         assert_eq!(
             reloaded.cubes.len(),
             1,
@@ -2500,7 +2515,7 @@ mod find_or_create_cube_tests {
 
         assert_eq!(cube.id, existing_id);
         assert_eq!(cube.name, "Existing");
-        let reloaded = app::settings::Settings::from_file(&nd).unwrap();
+        let reloaded = reload(&nd);
         assert_eq!(reloaded.cubes.len(), 1);
     }
 
@@ -2634,7 +2649,7 @@ mod find_or_create_cube_tests {
 
         assert_eq!(cube.id, empty_id);
         assert_eq!(cube.vault_wallet_id.as_ref(), Some(&wid));
-        let reloaded = app::settings::Settings::from_file(&nd).unwrap();
+        let reloaded = reload(&nd);
         assert_eq!(reloaded.cubes.len(), 1, "must reuse instead of minting");
     }
 
@@ -2658,7 +2673,7 @@ mod find_or_create_cube_tests {
         assert_eq!(cube.name, "My signet Cube");
         assert_eq!(cube.network, bitcoin::Network::Signet);
         assert_eq!(cube.vault_wallet_id.as_ref(), Some(&wid));
-        let reloaded = app::settings::Settings::from_file(&nd).unwrap();
+        let reloaded = reload(&nd);
         assert_eq!(reloaded.cubes.len(), 1);
     }
 
@@ -2705,7 +2720,7 @@ mod find_or_create_cube_tests {
         assert_eq!(cube.id, ORIG_UUID, "wallet must move to the restored UUID");
         assert_eq!(cube.vault_wallet_id.as_ref(), Some(&wid));
 
-        let reloaded = app::settings::Settings::from_file(&nd).unwrap();
+        let reloaded = reload(&nd);
         assert!(
             reloaded.cubes.iter().all(|c| c.id != dup_id),
             "the spurious duplicate Cube must be removed outright"

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -3799,6 +3799,9 @@ async fn check_network_datadir(path: NetworkDirectory) -> Result<State, String> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+
+    use crate::{app::state::connect::ConnectFlowStep, services::coincube::User};
 
     fn owner_self(has_recipient: bool, tier: &str, kinds: &[&str]) -> OwnerSelfRecoverySummary {
         OwnerSelfRecoverySummary {
@@ -3806,6 +3809,316 @@ mod tests {
             tier: tier.to_string(),
             envelope_kinds: kinds.iter().map(|k| k.to_string()).collect(),
         }
+    }
+
+    fn test_datadir() -> CoincubeDirectory {
+        CoincubeDirectory::new(PathBuf::new())
+    }
+
+    fn home() -> Home {
+        Home::new(test_datadir(), Some(Network::Bitcoin)).0
+    }
+
+    fn signed_in_home() -> Home {
+        let mut home = home();
+        home.connect_account.step = ConnectFlowStep::Dashboard;
+        home.connect_account.user = Some(User {
+            id: 7,
+            email: "founder@example.com".to_string(),
+            email_verified: Some(true),
+        });
+        home
+    }
+
+    fn cube(id: &str, name: &str, network: Network) -> CubeSettings {
+        CubeSettings::new_with_raw_id(id.to_string(), name.to_string(), network)
+    }
+
+    fn remote_cube(uuid: &str, name: &str, network: Network) -> RemoteCube {
+        RemoteCube {
+            id: 42,
+            uuid: uuid.to_string(),
+            name: name.to_string(),
+            network: settings::network_to_api_string(network),
+            has_recovery_kit: true,
+            has_encrypted_seed: true,
+            phone_recoverable: false,
+            phone_full_cube: false,
+        }
+    }
+
+    #[test]
+    fn bip39_suggestions_are_lowercase_limited_and_prefix_checked() {
+        assert!(bip39_suggestions("", 5).is_empty());
+        assert!(bip39_suggestions("ab", 0).is_empty());
+
+        let suggestions = bip39_suggestions("AB", 3);
+        assert_eq!(suggestions.len(), 3);
+        assert!(suggestions.iter().all(|word| word.starts_with("ab")));
+    }
+
+    #[test]
+    fn cube_limit_prefers_server_limit_and_counts_remote_cubes_on_current_network() {
+        let mut home = home();
+        home.account_tier = AccountTier::Free;
+        assert_eq!(home.cube_limit(), 2);
+
+        home.server_cube_limit = Some(5);
+        assert_eq!(home.cube_limit(), 5);
+
+        home.state = State::Cubes {
+            cubes: vec![
+                cube("local-a", "Local A", Network::Bitcoin),
+                cube("local-b", "Local B", Network::Bitcoin),
+            ],
+            create_cube: false,
+        };
+        home.remote_cubes = vec![
+            remote_cube("remote-mainnet", "Remote Mainnet", Network::Bitcoin),
+            remote_cube("remote-signet", "Remote Signet", Network::Signet),
+        ];
+
+        assert_eq!(home.total_cube_count(), 3);
+    }
+
+    #[test]
+    fn create_cube_form_toggles_and_resets_transient_inputs() {
+        let mut home = home();
+        home.state = State::Cubes {
+            cubes: Vec::new(),
+            create_cube: false,
+        };
+
+        let _ = home.update(Message::View(ViewMessage::ShowCreateCube(true)));
+        assert!(matches!(
+            home.state,
+            State::Cubes {
+                create_cube: true,
+                ..
+            }
+        ));
+
+        let _ = home.update(Message::View(ViewMessage::CubeNameEdited("  ".to_string())));
+        assert!(!home.create_cube_name.valid);
+        assert!(home.error.is_none());
+
+        home.create_cube_name.value = "Temporary".to_string();
+        home.create_cube_pin.digits = [
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+        ];
+        home.create_cube_pin_confirm.digits = [
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+        ];
+        home.recovery_words[0] = "abandon".to_string();
+        home.recovery_active_index = Some(0);
+        home.passkey_mode = true;
+
+        let _ = home.update(Message::View(ViewMessage::ShowCreateCube(false)));
+
+        assert!(matches!(
+            home.state,
+            State::Cubes {
+                create_cube: false,
+                ..
+            }
+        ));
+        assert!(home.create_cube_name.value.is_empty());
+        assert_eq!(home.create_cube_pin.value(), "");
+        assert_eq!(home.create_cube_pin_confirm.value(), "");
+        assert!(home.recovery_words.iter().all(String::is_empty));
+        assert!(home.recovery_active_index.is_none());
+        assert_eq!(home.passkey_mode, feature_flags::PASSKEY_ENABLED);
+    }
+
+    #[test]
+    fn create_cube_validation_reports_pin_and_limit_errors_before_side_effects() {
+        let mut home = home();
+        home.state = State::Cubes {
+            cubes: Vec::new(),
+            create_cube: true,
+        };
+        home.create_cube_name.value = "My Cube".to_string();
+
+        let _ = home.update(Message::View(ViewMessage::CreateCube));
+        assert_eq!(home.error.as_deref(), Some("Please enter all 4 PIN digits"));
+
+        home.create_cube_pin.digits = [
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+        ];
+        let _ = home.update(Message::View(ViewMessage::CreateCube));
+        assert_eq!(
+            home.error.as_deref(),
+            Some("Please confirm all 4 PIN digits")
+        );
+
+        home.create_cube_pin_confirm.digits = [
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "5".to_string(),
+        ];
+        let _ = home.update(Message::View(ViewMessage::CreateCube));
+        assert_eq!(home.error.as_deref(), Some("PIN codes do not match"));
+
+        home.state = State::Cubes {
+            cubes: vec![
+                cube("local-a", "Local A", Network::Bitcoin),
+                cube("local-b", "Local B", Network::Bitcoin),
+            ],
+            create_cube: true,
+        };
+        home.create_cube_pin_confirm.digits = [
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+        ];
+        home.account_tier = AccountTier::Free;
+        home.server_cube_limit = None;
+
+        let _ = home.update(Message::View(ViewMessage::CreateCube));
+        assert!(home
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("Cube limit reached (2/2)")));
+        assert!(!home.creating_cube);
+    }
+
+    #[test]
+    fn recovery_word_input_normalizes_to_valid_bip39_prefixes() {
+        let mut home = home();
+        home.error = Some("old".to_string());
+
+        let _ = home.update(Message::View(ViewMessage::RecoveryWordInput {
+            index: 0,
+            word: "ABANDON123!".to_string(),
+        }));
+
+        assert_eq!(home.recovery_words[0], "abandon");
+        assert_eq!(home.recovery_active_index, Some(0));
+        assert!(home.error.is_none());
+
+        let _ = home.update(Message::View(ViewMessage::SelectRecoverySuggestion {
+            index: 0,
+            word: "ability".to_string(),
+        }));
+        assert_eq!(home.recovery_words[0], "ability");
+        assert!(home.recovery_active_index.is_none());
+
+        let _ = home.update(Message::View(ViewMessage::RecoveryWordInput {
+            index: 20,
+            word: "zoo".to_string(),
+        }));
+        assert_eq!(home.recovery_words[0], "ability");
+    }
+
+    #[test]
+    fn invalid_recovery_submit_clears_words_and_sets_parse_error() {
+        let mut home = home();
+        home.recovery_words[0] = "abandon".to_string();
+        home.recovery_active_index = Some(0);
+
+        let _ = home.update(Message::View(ViewMessage::SubmitRecovery));
+
+        assert!(home.recovery_words.iter().all(String::is_empty));
+        assert!(home.recovery_active_index.is_none());
+        assert!(home.error.is_some());
+    }
+
+    #[test]
+    fn remote_cube_and_recovery_method_modals_follow_selected_cube() {
+        let mut home = home();
+        home.remote_cubes = vec![remote_cube("remote-a", "Remote A", Network::Bitcoin)];
+
+        let _ = home.update(Message::View(ViewMessage::ShowRecoveryMethodPicker(
+            "remote-a".to_string(),
+        )));
+        assert!(matches!(
+            &home.recovery_method_modal,
+            Some(modal) if modal.cube.uuid == "remote-a"
+        ));
+
+        let _ = home.update(Message::View(ViewMessage::CloseRecoveryMethodPicker));
+        assert!(home.recovery_method_modal.is_none());
+
+        let _ = home.update(Message::View(ViewMessage::DeleteCube(
+            DeleteCubeMessage::ShowRemoteModal("remote-a".to_string()),
+        )));
+        assert!(matches!(
+            &home.delete_remote_cube_modal,
+            Some(modal) if modal.cube.uuid == "remote-a" && !modal.deleting
+        ));
+
+        let _ = home.update(Message::View(ViewMessage::DeleteCube(
+            DeleteCubeMessage::ConfirmRemoteDelete("remote-a".to_string()),
+        )));
+        assert!(matches!(
+            &home.delete_remote_cube_modal,
+            Some(modal)
+                if !modal.deleting
+                    && modal.error.as_deref() == Some("Not authenticated with Connect")
+        ));
+
+        let _ = home.update(Message::View(ViewMessage::DeleteCube(
+            DeleteCubeMessage::CloseRemoteModal,
+        )));
+        assert!(home.delete_remote_cube_modal.is_none());
+    }
+
+    #[test]
+    fn loaded_remote_cubes_limits_and_checked_state_update_home_cache() {
+        let mut home = home();
+
+        let _ = home.update(Message::CubeLimitsLoaded(Ok(CubeLimitsResponse {
+            network: "mainnet".to_string(),
+            current_count: 1,
+            max_allowed: 4,
+        })));
+        assert_eq!(home.server_cube_limit, Some(4));
+
+        let remote = remote_cube("local-a", "Remote A", Network::Bitcoin);
+        let _ = home.update(Message::RemoteCubesLoaded(Ok(vec![remote.clone()])));
+        assert_eq!(home.remote_cubes.len(), 1);
+
+        let _ = home.update(Message::RemoteCubesLoaded(Err("offline".to_string())));
+        assert_eq!(home.remote_cubes.len(), 1);
+
+        let _ = home.update(Message::Checked(Ok(State::Cubes {
+            cubes: vec![cube("local-a", "Local A", Network::Bitcoin)],
+            create_cube: false,
+        })));
+
+        assert!(home.remote_cubes.is_empty());
+        assert!(matches!(home.state, State::Cubes { .. }));
+    }
+
+    #[test]
+    fn rename_modal_edits_and_cancels_without_touching_disk() {
+        let mut home = home();
+        home.state = State::Cubes {
+            cubes: vec![cube("local-a", "Local A", Network::Bitcoin)],
+            create_cube: false,
+        };
+
+        let _ = home.update(Message::View(ViewMessage::RenameCube(0)));
+        assert_eq!(home.rename_cube_modal, Some((0, "Local A".to_string())));
+
+        let _ = home.update(Message::View(ViewMessage::RenameCubeNameEdited(
+            "Renamed".to_string(),
+        )));
+        assert_eq!(home.rename_cube_modal, Some((0, "Renamed".to_string())));
+
+        let _ = home.update(Message::View(ViewMessage::RenameCubeCancel));
+        assert!(home.rename_cube_modal.is_none());
     }
 
     #[test]
@@ -3841,5 +4154,160 @@ mod tests {
         // Descriptor sealed but no seed → recoverable, but Vault-only scope.
         let s = owner_self(true, "vault_only", &["descriptor"]);
         assert_eq!(derive_phone_recovery(Some(&s)), (true, false));
+    }
+
+    #[test]
+    fn view_builds_home_sections_and_create_recovery_states() {
+        let mut home = home();
+        home.view();
+
+        home.state = State::NoCube;
+        home.error = Some("create error".to_string());
+        home.view();
+
+        home.state = State::RecoveryInput;
+        home.recovery_words[0] = "ab".to_string();
+        home.recovery_active_index = Some(0);
+        home.view();
+
+        home.state = State::Cubes {
+            cubes: vec![cube("local-a", "Local A", Network::Bitcoin)],
+            create_cube: true,
+        };
+        home.create_cube_name.value = "New Cube".to_string();
+        home.create_cube_name.valid = true;
+        home.create_cube_pin.digits = [
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+        ];
+        home.create_cube_pin_confirm.digits = [
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+        ];
+        home.view();
+
+        let mut signed_in = signed_in_home();
+        signed_in.connect_expanded = true;
+        signed_in.state = State::Cubes {
+            cubes: vec![cube("local-a", "Local A", Network::Bitcoin)],
+            create_cube: false,
+        };
+        signed_in.remote_cubes = vec![remote_cube("remote-a", "Remote A", Network::Bitcoin)];
+        signed_in.view();
+
+        signed_in.active_section = HomeSection::Connect(app::menu::ConnectSubMenu::Security);
+        signed_in.view();
+
+        signed_in.active_section = HomeSection::RecoverVault;
+        signed_in.view();
+    }
+
+    #[test]
+    fn pure_home_view_helpers_build_for_local_remote_and_form_variants() {
+        let mut local = cube("local-a", "Local A", Network::Bitcoin);
+        let _ = cubes_list_item(&local, 0, false);
+
+        local.remote_synced = true;
+        let _ = cubes_list_item(&local, 1, true);
+
+        local.recovery_kit_last_backed_up_descriptor_fingerprint = Some("hash".to_string());
+        let _ = cubes_list_item(&local, 2, true);
+
+        let mut remote = remote_cube("remote-a", "Remote A", Network::Bitcoin);
+        let _ = remote_cube_list_item(&remote);
+        remote.has_encrypted_seed = false;
+        let _ = remote_cube_list_item(&remote);
+
+        let valid_name = coincube_ui::component::form::Value {
+            value: "New Cube".to_string(),
+            valid: true,
+            warning: None,
+        };
+        let invalid_name = coincube_ui::component::form::Value {
+            value: String::new(),
+            valid: false,
+            warning: None,
+        };
+        let mut pin = pin_input::PinInput::new();
+        pin.digits = [
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+        ];
+        let _ = create_cube_form(&valid_name, &pin, &pin, &None, false, false, true);
+        let _ = create_cube_form(
+            &invalid_name,
+            &pin_input::PinInput::new(),
+            &pin_input::PinInput::new(),
+            &Some("form error".to_string()),
+            true,
+            true,
+            false,
+        );
+
+        let mut words: [String; 12] = Default::default();
+        words[0] = "ab".to_string();
+        let _ = recovery_input_view(&words, Some(0));
+        words.fill("abandon".to_string());
+        let _ = recovery_input_view(&words, None);
+    }
+
+    #[test]
+    fn modal_views_and_non_destructive_modal_updates_build() {
+        let cube = cube("local-a", "Local A", Network::Bitcoin);
+        let network_dir = test_datadir().network_directory(Network::Bitcoin);
+        let mut delete_modal =
+            DeleteCubeModal::new(cube.clone(), network_dir, None, Some(true), true);
+
+        let _ = delete_modal.view();
+        let _ = delete_modal.update(Message::View(ViewMessage::DeleteCube(
+            DeleteCubeMessage::DeleteConnectBackup(true),
+        )));
+        assert!(delete_modal.delete_connect_backup);
+
+        let _ = delete_modal.update(Message::View(ViewMessage::DeleteCube(
+            DeleteCubeMessage::DeleteLianaConnect(true),
+        )));
+        assert!(delete_modal.delete_liana_connect);
+
+        let remote = remote_cube("remote-a", "Remote A", Network::Bitcoin);
+        let _ = DeleteRemoteCubeModal {
+            cube: remote.clone(),
+            deleting: false,
+            error: Some("server refused".to_string()),
+        }
+        .view();
+        let _ = DeleteRemoteCubeModal {
+            cube: remote.clone(),
+            deleting: true,
+            error: None,
+        }
+        .view();
+        let _ = RecoveryMethodModal { cube: remote }.view();
+
+        let mut home = signed_in_home();
+        home.state = State::Cubes {
+            cubes: vec![cube],
+            create_cube: false,
+        };
+        home.rename_cube_modal = Some((0, "Renamed Cube".to_string()));
+        home.view();
+        home.rename_cube_modal = None;
+        home.delete_remote_cube_modal = Some(DeleteRemoteCubeModal {
+            cube: remote_cube("remote-b", "Remote B", Network::Bitcoin),
+            deleting: false,
+            error: None,
+        });
+        home.view();
+        home.delete_remote_cube_modal = None;
+        home.recovery_method_modal = Some(RecoveryMethodModal {
+            cube: remote_cube("remote-c", "Remote C", Network::Bitcoin),
+        });
+        home.view();
     }
 }

--- a/coincube-gui/src/installer/step/backend.rs
+++ b/coincube-gui/src/installer/step/backend.rs
@@ -765,3 +765,368 @@ impl From<ImportRemoteWallet> for Box<dyn Step> {
         Box::new(s)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dir::CoincubeDirectory;
+    use crate::installer::step::Step;
+    use std::path::PathBuf;
+
+    fn directory() -> CoincubeDirectory {
+        CoincubeDirectory::new(PathBuf::new())
+    }
+
+    fn network_dir(network: Network) -> NetworkDirectory {
+        directory().network_directory(network)
+    }
+
+    fn context_with(remote_backend: RemoteBackend, network: Network) -> Context {
+        Context::new(network, directory(), remote_backend, None, None)
+    }
+
+    fn hardware_wallets(network: Network) -> HardwareWallets {
+        HardwareWallets::new(directory(), network)
+    }
+
+    fn auth_client(email: &str) -> AuthClient {
+        AuthClient::new(
+            "https://auth.example.test".to_string(),
+            "public-key".to_string(),
+            email.to_string(),
+        )
+    }
+
+    #[test]
+    fn choose_backend_skips_only_on_unsupported_networks() {
+        let bitcoin = ChooseBackend::new(Network::Bitcoin);
+        let signet = ChooseBackend::new(Network::Signet);
+        let regtest = ChooseBackend::new(Network::Regtest);
+        let ctx = context_with(RemoteBackend::Undefined, Network::Bitcoin);
+
+        assert!(!bitcoin.skip(&ctx));
+        assert!(!signet.skip(&ctx));
+        assert!(regtest.skip(&ctx));
+    }
+
+    #[test]
+    fn choose_backend_local_selection_applies_none_and_revert_restores_undefined() {
+        let mut step = ChooseBackend::new(Network::Bitcoin);
+        let mut ctx = context_with(RemoteBackend::Undefined, Network::Bitcoin);
+
+        let _task = step.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::SelectBackend(message::SelectBackend::ContinueWithLocalWallet(true)),
+        );
+        assert!(step.apply(&mut ctx));
+        assert!(matches!(ctx.remote_backend, RemoteBackend::None));
+
+        step.revert(&mut ctx);
+        assert!(matches!(ctx.remote_backend, RemoteBackend::Undefined));
+    }
+
+    #[test]
+    fn choose_backend_remote_selection_leaves_backend_for_login_step() {
+        let mut step = ChooseBackend::new(Network::Bitcoin);
+        let mut ctx = context_with(RemoteBackend::Undefined, Network::Bitcoin);
+
+        let _task = step.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::SelectBackend(message::SelectBackend::ContinueWithLocalWallet(false)),
+        );
+
+        assert!(step.apply(&mut ctx));
+        assert!(matches!(ctx.remote_backend, RemoteBackend::Undefined));
+    }
+
+    #[test]
+    fn remote_backend_login_initial_state_and_skip_rules_are_stable() {
+        let login = RemoteBackendLogin::new(Network::Bitcoin, network_dir(Network::Bitcoin));
+        let regtest_login =
+            RemoteBackendLogin::new(Network::Regtest, network_dir(Network::Regtest));
+        let undefined = context_with(RemoteBackend::Undefined, Network::Bitcoin);
+        let none = context_with(RemoteBackend::None, Network::Bitcoin);
+        let regtest = context_with(RemoteBackend::Undefined, Network::Regtest);
+
+        assert!(!login.processing);
+        assert!(login.connect_accounts.is_empty());
+        assert!(matches!(
+            login.step,
+            ConnectionStep::EnterEmail { ref email }
+                if email.value.is_empty() && email.valid
+        ));
+        assert!(!login.skip(&undefined));
+        assert!(login.skip(&none));
+        assert!(regtest_login.skip(&regtest));
+    }
+
+    #[test]
+    fn remote_backend_login_validates_email_and_rejects_empty_otp_requests() {
+        let mut login = RemoteBackendLogin::new(Network::Bitcoin, network_dir(Network::Bitcoin));
+
+        let _task = login.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::SelectBackend(message::SelectBackend::EmailEdited(
+                "not-an-email".to_string(),
+            )),
+        );
+        assert!(matches!(
+            login.step,
+            ConnectionStep::EnterEmail { ref email }
+                if email.value == "not-an-email" && !email.valid
+        ));
+
+        let _task = login.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::SelectBackend(message::SelectBackend::EmailEdited(
+                "user@example.com".to_string(),
+            )),
+        );
+        assert!(matches!(
+            login.step,
+            ConnectionStep::EnterEmail { ref email }
+                if email.value == "user@example.com" && email.valid
+        ));
+
+        let mut empty = RemoteBackendLogin::new(Network::Bitcoin, network_dir(Network::Bitcoin));
+        let _task = empty.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::SelectBackend(message::SelectBackend::RequestOTP),
+        );
+        assert!(matches!(
+            empty.step,
+            ConnectionStep::EnterEmail { ref email }
+                if email.value.is_empty() && !email.valid
+        ));
+        assert!(!empty.processing);
+    }
+
+    #[test]
+    fn remote_backend_login_tracks_cached_accounts_and_otp_result() {
+        let mut login = RemoteBackendLogin::new(Network::Bitcoin, network_dir(Network::Bitcoin));
+
+        let _task = login.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::SelectBackend(message::SelectBackend::ExistingConnectAccounts(vec![
+                "a@example.com".to_string(),
+                "b@example.com".to_string(),
+            ])),
+        );
+        assert_eq!(
+            login.connect_accounts,
+            vec!["a@example.com".to_string(), "b@example.com".to_string()]
+        );
+
+        let _task = login.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::SelectBackend(message::SelectBackend::EmailEdited(
+                "user@example.com".to_string(),
+            )),
+        );
+        let _task = login.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::SelectBackend(message::SelectBackend::OTPRequested(Ok((
+                auth_client("user@example.com"),
+                "https://backend.example.test".to_string(),
+            )))),
+        );
+
+        assert!(!login.processing);
+        assert!(matches!(
+            login.step,
+            ConnectionStep::EnterOtp {
+                ref email,
+                ref backend_api_url,
+                ref otp,
+                ..
+            } if email == "user@example.com"
+                && backend_api_url == "https://backend.example.test"
+                && otp.value.is_empty()
+        ));
+    }
+
+    #[test]
+    fn remote_backend_login_enter_otp_handles_edits_resend_errors_and_auth_failures() {
+        let mut login = RemoteBackendLogin::new(Network::Bitcoin, network_dir(Network::Bitcoin));
+        login.step = ConnectionStep::EnterOtp {
+            client: auth_client("user@example.com"),
+            backend_api_url: "https://backend.example.test".to_string(),
+            email: "user@example.com".to_string(),
+            otp: form::Value::default(),
+        };
+
+        let _task = login.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::SelectBackend(message::SelectBackend::OTPEdited(" 123 ".to_string())),
+        );
+        assert!(matches!(
+            login.step,
+            ConnectionStep::EnterOtp { ref otp, .. } if otp.value == "123"
+        ));
+        assert!(!login.processing);
+
+        let _task = login.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::SelectBackend(message::SelectBackend::OTPResent(Err(Error::Unexpected(
+                "mail failed".to_string(),
+            )))),
+        );
+        assert!(!login.processing);
+        assert!(matches!(
+            login.connection_error,
+            Some(Error::Unexpected(ref msg)) if msg == "mail failed"
+        ));
+
+        let _task = login.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::SelectBackend(message::SelectBackend::Connected(Err(Error::Auth(
+                AuthError {
+                    http_status: Some(403),
+                    error: "forbidden".to_string(),
+                },
+            )))),
+        );
+        assert_eq!(login.auth_error, Some("Token has expired or is invalid"));
+
+        let _task = login.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::SelectBackend(message::SelectBackend::EditEmail),
+        );
+        assert!(matches!(
+            login.step,
+            ConnectionStep::EnterEmail { ref email }
+                if email.value == "user@example.com" && email.valid
+        ));
+    }
+
+    #[test]
+    fn remote_backend_login_apply_without_connection_clears_remote_backend() {
+        let mut login = RemoteBackendLogin::new(Network::Bitcoin, network_dir(Network::Bitcoin));
+        let mut ctx = context_with(RemoteBackend::Undefined, Network::Bitcoin);
+
+        assert!(login.apply(&mut ctx));
+
+        assert!(matches!(ctx.remote_backend, RemoteBackend::None));
+    }
+
+    #[test]
+    fn import_remote_wallet_initial_state_and_skip_rules_are_stable() {
+        let mut step = ImportRemoteWallet::new(Network::Bitcoin);
+        let undefined = context_with(RemoteBackend::Undefined, Network::Bitcoin);
+        let none = context_with(RemoteBackend::None, Network::Bitcoin);
+
+        assert!(step.skip(&undefined));
+        assert!(step.skip(&none));
+
+        step.load_context(&undefined);
+        assert!(matches!(step.backend, RemoteBackend::Undefined));
+        assert!(step.invitation_token.value.is_empty());
+        assert!(step.imported_descriptor.value.is_empty());
+        assert!(step.invitation.is_none());
+        assert!(step.wallets.is_empty());
+        assert!(step.descriptor.is_none());
+        assert!(step.error.is_none());
+    }
+
+    #[test]
+    fn import_remote_wallet_tracks_invitation_token_and_fetch_result() {
+        let mut step = ImportRemoteWallet::new(Network::Bitcoin);
+
+        let _task = step.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::ImportRemoteWallet(message::ImportRemoteWallet::ImportInvitationToken(
+                "invite-123".to_string(),
+            )),
+        );
+        assert_eq!(step.invitation_token.value, "invite-123");
+
+        let _task = step.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::ImportRemoteWallet(message::ImportRemoteWallet::InvitationFetched(Err(
+                Error::Unexpected("missing".to_string()),
+            ))),
+        );
+        assert!(!step.invitation_token.valid);
+
+        let invitation = api::WalletInvitation {
+            id: "invitation-id".to_string(),
+            wallet_name: "Family Vault".to_string(),
+            wallet_id: "wallet-id".to_string(),
+            status: api::WalletInvitationStatus::Pending,
+        };
+        let _task = step.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::ImportRemoteWallet(message::ImportRemoteWallet::InvitationFetched(Ok(
+                invitation.clone(),
+            ))),
+        );
+
+        assert_eq!(
+            step.invitation.as_ref().map(|i| i.wallet_name.as_str()),
+            Some("Family Vault")
+        );
+    }
+
+    #[test]
+    fn import_remote_wallet_records_remote_wallet_and_accept_errors() {
+        let mut step = ImportRemoteWallet::new(Network::Bitcoin);
+
+        let _task = step.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::ImportRemoteWallet(message::ImportRemoteWallet::RemoteWallets(Ok(Vec::new()))),
+        );
+        assert!(step.wallets.is_empty());
+
+        let _task = step.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::ImportRemoteWallet(message::ImportRemoteWallet::RemoteWallets(Err(
+                Error::Unexpected("list failed".to_string()),
+            ))),
+        );
+        assert_eq!(step.error.as_deref(), Some("Unexpected: list failed"));
+
+        let _task = step.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::ImportRemoteWallet(message::ImportRemoteWallet::InvitationAccepted(Err(
+                Error::Unexpected("accept failed".to_string()),
+            ))),
+        );
+        assert_eq!(step.error.as_deref(), Some("Unexpected: accept failed"));
+    }
+
+    #[test]
+    fn import_remote_wallet_rejects_invalid_descriptor_text() {
+        let mut step = ImportRemoteWallet::new(Network::Bitcoin);
+
+        let _task = step.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::ImportRemoteWallet(message::ImportRemoteWallet::ImportDescriptor(
+                "not a descriptor".to_string(),
+            )),
+        );
+
+        assert_eq!(step.imported_descriptor.value, "not a descriptor");
+        assert!(!step.imported_descriptor.valid);
+
+        let _task = step.update(
+            &mut hardware_wallets(Network::Bitcoin),
+            Message::ImportRemoteWallet(message::ImportRemoteWallet::ConfirmDescriptor),
+        );
+        assert!(step.descriptor.is_none());
+        assert!(!step.imported_descriptor.valid);
+    }
+
+    #[test]
+    fn import_remote_wallet_apply_copies_state_to_context() {
+        let mut step = ImportRemoteWallet::new(Network::Bitcoin);
+        let mut ctx = context_with(RemoteBackend::Undefined, Network::Bitcoin);
+        step.wallet_alias = Some("Family Vault".to_string());
+        step.backend = RemoteBackend::None;
+
+        assert!(step.apply(&mut ctx));
+
+        assert!(ctx.hw_is_used);
+        assert!(matches!(ctx.remote_backend, RemoteBackend::None));
+        assert_eq!(ctx.wallet_alias, "Family Vault");
+    }
+}

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -2422,6 +2422,10 @@ mod tests {
 
     use super::*;
 
+    const TESTNET_XPUB: &str = "tpubD6NzVbkrYhZ4XHQ1pLJ7pdpEGWCVbSUEaUakxnrtENzaZaDp4vL6gBgGH7n983ZPgsVe5G2JEAM2oYZkEPCNrfo9XLq8nHFhp9GzFjGc1uQ";
+    const TESTNET_DESCRIPTOR_KEY: &str = "[8a550171/48'/1'/0'/2']tpubD6NzVbkrYhZ4XHQ1pLJ7pdpEGWCVbSUEaUakxnrtENzaZaDp4vL6gBgGH7n983ZPgsVe5G2JEAM2oYZkEPCNrfo9XLq8nHFhp9GzFjGc1uQ";
+    const MAINNET_DESCRIPTOR_KEY: &str = "[abcdef01/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW";
+
     #[test]
     fn test_default_derivation_path() {
         assert_eq!(
@@ -2667,5 +2671,251 @@ mod tests {
         // A placement carrying no coordinates is treated as used elsewhere.
         let picker = picker_with_placed_key(vec![(0, 0)], vec![], fg);
         assert!(picker.key_placed_elsewhere(fg));
+    }
+
+    fn raw_key(id: u64, fingerprint: &str, owner_id: u64) -> CubeKeyRaw {
+        CubeKeyRaw {
+            id,
+            name: format!("Key {id}"),
+            xpub: TESTNET_XPUB.to_string(),
+            fingerprint: fingerprint.to_string(),
+            derivation_path: "m/48'/1'/0'/2'".to_string(),
+            network: "signet".to_string(),
+            status: "active".to_string(),
+            primary_owner_id: owner_id,
+            keychain_id: Some(1),
+            curve: "secp256k1".to_string(),
+            taproot: true,
+            cube_id: 1,
+            created_at: "2026-07-20T00:00:00Z".to_string(),
+            updated_at: "2026-07-20T00:00:00Z".to_string(),
+            owner_user_id: owner_id,
+            owner_email: format!("owner{owner_id}@example.com"),
+            is_own_key: true,
+            used_by_vault: false,
+        }
+    }
+
+    fn resolved_key(id: u64, fingerprint: &str, owner_id: u64) -> ResolvedCubeKey {
+        ResolvedCubeKey {
+            raw: raw_key(id, fingerprint, owner_id),
+            owner: KeychainKeyOwner::SelfUser {
+                primary_owner_id: owner_id,
+            },
+        }
+    }
+
+    fn keychain_key(fingerprint: Fingerprint, owner_id: u64, key_id: u64) -> Key {
+        let mut key = manual_key(fingerprint);
+        key.source = KeySource::KeychainKey {
+            owner: KeychainKeyOwner::SelfUser {
+                primary_owner_id: owner_id,
+            },
+            key_id,
+            name: format!("Key {key_id}"),
+        };
+        key
+    }
+
+    #[test]
+    fn selected_key_fingerprint_and_network_checks_cover_key_shapes() {
+        assert!(SelectedKey::None.fingerprint().is_none());
+        let fg = Fingerprint::from_str("8a550171").unwrap();
+        assert_eq!(SelectedKey::Existing(fg).fingerprint(), Some(fg));
+        assert_eq!(
+            SelectedKey::New(Box::new(manual_key(fg))).fingerprint(),
+            Some(fg)
+        );
+
+        let testnet_key = DescriptorPublicKey::from_str(TESTNET_DESCRIPTOR_KEY).unwrap();
+        assert!(check_key_network(&testnet_key, Network::Signet));
+        assert!(!check_key_network(&testnet_key, Network::Bitcoin));
+
+        let mainnet_key = DescriptorPublicKey::from_str(MAINNET_DESCRIPTOR_KEY).unwrap();
+        assert!(check_key_network(&mainnet_key, Network::Bitcoin));
+        assert!(!check_key_network(&mainnet_key, Network::Regtest));
+
+        let DescriptorPublicKey::XPub(xpub) = testnet_key else {
+            panic!("fixture should be a descriptor xpub");
+        };
+        let multixkey = new_multixkey_from_xpub(xpub, 3);
+        assert_eq!(
+            multixkey
+                .derivation_paths
+                .paths()
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            vec!["6".to_string(), "7".to_string()]
+        );
+        assert_eq!(multixkey.wildcard, Wildcard::Unhardened);
+    }
+
+    #[test]
+    fn xpub_entry_validates_empty_invalid_origin_network_duplicate_and_imported_keys() {
+        let mut picker = empty_picker();
+
+        let _ = picker.on_select_enter_xpub();
+        assert_eq!(picker.step, Step::PasteXpubEntry);
+        assert!(picker.form_xpub.valid);
+
+        let _ = picker.on_update_xpub(String::new());
+        assert!(picker.form_xpub.valid);
+
+        let _ = picker.on_update_xpub("not an xpub".to_string());
+        assert!(!picker.form_xpub.valid);
+        assert_eq!(picker.form_xpub.warning, Some("Invalid Xpub"));
+
+        let _ = picker.on_update_xpub(TESTNET_XPUB.to_string());
+        assert!(!picker.form_xpub.valid);
+        assert_eq!(picker.form_xpub.warning, Some("Origin missing"));
+
+        let _ = picker.on_update_xpub(format!("{TESTNET_DESCRIPTOR_KEY}/0/*"));
+        assert!(!picker.form_xpub.valid);
+        assert_eq!(picker.form_xpub.warning, Some("Wrong derivation path"));
+
+        picker.network = Network::Bitcoin;
+        let _ = picker.on_update_xpub(TESTNET_DESCRIPTOR_KEY.to_string());
+        assert!(!picker.form_xpub.valid);
+        assert_eq!(picker.form_xpub.warning, Some("Wrong network"));
+
+        picker.network = Network::Signet;
+        let fg = Fingerprint::from_str("8a550171").unwrap();
+        picker.keys.insert(fg, (vec![(0, 0)], manual_key(fg)));
+        let _ = picker.on_update_xpub(TESTNET_DESCRIPTOR_KEY.to_string());
+        assert!(!picker.form_xpub.valid);
+        assert_eq!(picker.form_xpub.warning, Some("Key already used"));
+
+        picker.keys.clear();
+        let _ = picker.on_update_xpub(TESTNET_DESCRIPTOR_KEY.to_string());
+        assert!(picker.form_xpub.valid);
+        assert!(matches!(picker.selected_key, SelectedKey::New(_)));
+        assert_eq!(picker.step, Step::Details);
+
+        picker.step = Step::Grid;
+        picker.selected_key = SelectedKey::None;
+        picker.keys.insert(fg, (vec![(0, 0)], manual_key(fg)));
+        let _ = picker.on_import_xpub(TESTNET_DESCRIPTOR_KEY.to_string());
+        assert_eq!(
+            picker.import_xpub_error.as_deref(),
+            Some("Imported key already used")
+        );
+        assert_eq!(picker.focus, Focus::None);
+    }
+
+    #[test]
+    fn alias_previous_next_retry_and_collapse_state_are_synchronous() {
+        let fg = Fingerprint::from_str("8a550171").unwrap();
+        let mut picker = picker_with_placed_key(vec![(0, 0)], vec![(1, 0)], fg);
+        let new_fg = Fingerprint::from_str("c658b283").unwrap();
+        picker.selected_key = SelectedKey::New(Box::new(manual_key(new_fg)));
+        picker.form_alias.value = "Existing".to_string();
+        picker.keys.get_mut(&fg).unwrap().1.name = "Existing".to_string();
+
+        let _ = picker.on_update_alias("Existing".to_string());
+        assert!(!picker.form_alias.valid);
+        assert_eq!(
+            picker.form_alias.warning,
+            Some("This alias is already used for another key")
+        );
+
+        let long_alias = "abcdefghijklmnopqrstuvwxyz".to_string();
+        let before = picker.form_alias.value.clone();
+        let _ = picker.on_update_alias(long_alias);
+        assert_eq!(picker.form_alias.value, before);
+
+        let _ = picker.on_update_alias("Fresh".to_string());
+        assert!(picker.form_alias.valid);
+        assert_eq!(picker.form_alias.value, "Fresh");
+
+        picker.step = Step::Details;
+        picker.focus = Focus::Device(fg);
+        picker.form_xpub.value = "stale".to_string();
+        picker.form_xpub.valid = false;
+        picker.form_safety_net_token.value = "stale".to_string();
+        picker.form_safety_net_token.valid = false;
+        let _ = picker.on_previous();
+        assert_eq!(picker.step, Step::HardwareListen);
+        assert_eq!(picker.focus, Focus::None);
+        assert!(picker.form_xpub.value.is_empty());
+        assert!(picker.form_xpub.valid);
+        assert!(picker.form_safety_net_token.value.is_empty());
+        assert!(picker.form_safety_net_token.valid);
+
+        let _ = picker.on_collapse(true);
+        assert!(picker.options_collapsed);
+        picker.focus = Focus::GenerateMasterKey;
+        picker.form_account = Some(ChildNumber::from_hardened_idx(7).unwrap());
+        let _ = picker.on_retry();
+        assert!(picker.details_error.is_none());
+    }
+
+    #[test]
+    fn keychain_key_selection_accepts_valid_keys_and_rejects_conflicts() {
+        let mut picker = empty_picker();
+        let fg = Fingerprint::from_str("8a550171").unwrap();
+
+        let _ = picker.on_select_keychain_key(resolved_key(1, "8a550171", 7));
+        assert!(matches!(picker.selected_key, SelectedKey::New(_)));
+        assert_eq!(picker.form_alias.value, "Key 1");
+        assert_eq!(picker.step, Step::Details);
+
+        let mut invalid = resolved_key(2, "not-hex", 7);
+        let _ = picker.on_select_keychain_key(invalid.clone());
+        assert_eq!(
+            picker.error.as_deref(),
+            Some("Invalid fingerprint: not-hex")
+        );
+
+        invalid.raw.fingerprint = "8a550171".to_string();
+        invalid.raw.xpub = "not-xpub".to_string();
+        let _ = picker.on_select_keychain_key(invalid.clone());
+        assert_eq!(picker.error.as_deref(), Some("Invalid xpub: not-xpub"));
+
+        invalid.raw.xpub = TESTNET_XPUB.to_string();
+        invalid.raw.derivation_path = "not-path".to_string();
+        let _ = picker.on_select_keychain_key(invalid);
+        assert_eq!(
+            picker.error.as_deref(),
+            Some("Invalid derivation path: not-path")
+        );
+
+        let mut bitcoin_picker = empty_picker();
+        bitcoin_picker.network = Network::Bitcoin;
+        let _ = bitcoin_picker.on_select_keychain_key(resolved_key(3, "8a550171", 7));
+        assert_eq!(
+            bitcoin_picker.error.as_deref(),
+            Some("Key network does not match")
+        );
+
+        let mut elsewhere_picker = picker_with_placed_key(vec![(0, 0)], vec![(1, 0)], fg);
+        let _ = elsewhere_picker.on_select_keychain_key(resolved_key(4, "8a550171", 7));
+        assert_eq!(
+            elsewhere_picker.error.as_deref(),
+            Some("This Keychain key is already used elsewhere in this Vault.")
+        );
+
+        let owner_fg = Fingerprint::from_str("c658b283").unwrap();
+        let mut owner_picker = empty_picker();
+        owner_picker.actual_path.coordinates = vec![(0, 0)];
+        owner_picker
+            .keys
+            .insert(owner_fg, (vec![(1, 0)], keychain_key(owner_fg, 42, 99)));
+        let _ = owner_picker.on_select_keychain_key(resolved_key(5, "8a550171", 42));
+        assert_eq!(
+            owner_picker.error.as_deref(),
+            Some("This owner already has a Keychain key placed in this Vault.")
+        );
+
+        let mut collision_picker = empty_picker();
+        collision_picker.actual_path.coordinates = vec![(0, 0)];
+        collision_picker
+            .keys
+            .insert(fg, (vec![(0, 0)], keychain_key(fg, 7, 99)));
+        let _ = collision_picker.on_select_keychain_key(resolved_key(6, "8a550171", 7));
+        assert_eq!(
+            collision_picker.error.as_deref(),
+            Some("A different key with the same master fingerprint is already in this Vault.")
+        );
     }
 }

--- a/coincube-gui/src/installer/view/mod.rs
+++ b/coincube-gui/src/installer/view/mod.rs
@@ -2976,3 +2976,260 @@ pub fn recovery_kit_restore<'a>(
         Some(Message::Previous),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::{
+        installer::step::{
+            recovery_kit_restore::{RestoreCubeCandidate, RestorePhase},
+            RestoreScope,
+        },
+        node::bitcoind::NodeFlavor,
+        services::coincube::{RecoveryKitStatus, RECOVERY_KIT_SCHEME_AES_256_GCM},
+    };
+
+    fn value(text: &str, valid: bool) -> form::Value<String> {
+        form::Value {
+            value: text.to_string(),
+            warning: None,
+            valid,
+        }
+    }
+
+    fn recovery_status(
+        has_recovery_kit: bool,
+        has_encrypted_seed: bool,
+        has_encrypted_wallet_descriptor: bool,
+    ) -> RecoveryKitStatus {
+        RecoveryKitStatus {
+            has_recovery_kit,
+            has_encrypted_seed,
+            has_encrypted_wallet_descriptor,
+            encryption_scheme: RECOVERY_KIT_SCHEME_AES_256_GCM.to_string(),
+            created_at: None,
+            updated_at: None,
+            owner_self: None,
+        }
+    }
+
+    fn candidate(
+        id: u64,
+        name: &str,
+        has_recovery_kit: bool,
+        has_encrypted_seed: bool,
+        has_encrypted_wallet_descriptor: bool,
+    ) -> RestoreCubeCandidate {
+        RestoreCubeCandidate {
+            id,
+            uuid: format!("cube-{id}"),
+            name: name.to_string(),
+            network: "bitcoin".to_string(),
+            status: recovery_status(
+                has_recovery_kit,
+                has_encrypted_seed,
+                has_encrypted_wallet_descriptor,
+            ),
+        }
+    }
+
+    #[test]
+    fn expire_message_units_formats_minutes_hours_days_months_and_years() {
+        assert!(expire_message_units(0).is_empty());
+        assert_eq!(expire_message_units(1), vec!["10m".to_string()]);
+        assert_eq!(expire_message_units(6), vec!["1h".to_string()]);
+        assert_eq!(
+            expire_message_units(144),
+            vec!["1d".to_string()],
+            "144 ten-minute blocks is roughly one day"
+        );
+        assert_eq!(expire_message_units(4383), vec!["1m".to_string()]);
+        assert_eq!(expire_message_units(52596), vec!["1y".to_string()]);
+        assert_eq!(
+            expire_message_units(52596 + 4383 + 144),
+            vec!["1y".to_string(), "1m".to_string(), "1d".to_string()]
+        );
+    }
+
+    #[test]
+    fn node_and_login_views_construct_for_main_branches() {
+        let valid = value("127.0.0.1:8332", true);
+        let remote = value("192.168.1.10:8332", true);
+        let invalid = value("not an address", false);
+        let auth = RpcAuthValues {
+            cookie_path: value("/tmp/.cookie", true),
+            user: value("rpcuser", true),
+            password: value("rpcpass", true),
+        };
+
+        let _ = define_bitcoind(&valid, &auth, &RpcAuthType::CookieFile);
+        let _ = define_bitcoind(&remote, &auth, &RpcAuthType::UserPass);
+        let _ = define_electrum(&valid, true);
+        let _ = define_esplora(&invalid, "https://example.test/api");
+
+        let _ = choose_backend((1, 3));
+        let _ = connection_step_enter_email(
+            &value("user@example.com", true),
+            false,
+            None,
+            &["user@example.com".to_string()],
+            None,
+        );
+        let otp = value("123456", true);
+        let _ = connection_step_enter_otp("user@example.com", &otp, false, None, None);
+        let _ = connection_step_connected("user@example.com", false, None, None);
+        let _ = login(
+            (2, 3),
+            connection_step_connected("user@example.com", true, None, None),
+        );
+    }
+
+    #[test]
+    fn connect_and_bitcoind_choice_views_construct_for_authenticated_and_local_paths() {
+        let email = value("user@example.com", true);
+        let otp = value("123456", true);
+        let prune = value("15000", true);
+        let max_mempool = value("", true);
+
+        let _ = define_coincube_connect((1, 4), &email, &otp, false, true, false, None);
+        let _ = define_coincube_connect((1, 4), &email, &otp, true, false, true, Some("try again"));
+
+        let _ = select_bitcoind_type(
+            (2, 4),
+            bitcoin::Network::Regtest,
+            false,
+            false,
+            15_000,
+            true,
+            NodeFlavor::Core,
+        );
+        let _ = select_bitcoind_type(
+            (2, 4),
+            bitcoin::Network::Bitcoin,
+            true,
+            true,
+            15_000,
+            true,
+            NodeFlavor::Knots,
+        );
+        let _ = select_bitcoind_type(
+            (2, 4),
+            bitcoin::Network::Bitcoin,
+            false,
+            false,
+            15_000,
+            false,
+            NodeFlavor::Core,
+        );
+
+        let _ = start_internal_bitcoind(
+            (3, 4),
+            NodeFlavor::Knots,
+            Some(NodeFlavor::Core),
+            false,
+            true,
+            &prune,
+            &max_mempool,
+            None,
+            None,
+            None,
+            Some(&DownloadState::Idle),
+            None,
+        );
+        let _ = start_internal_bitcoind(
+            (3, 4),
+            NodeFlavor::Core,
+            None,
+            true,
+            false,
+            &prune,
+            &max_mempool,
+            Some(&PathBuf::from("/tmp/bitcoind")),
+            Some(&Ok(())),
+            None,
+            Some(&DownloadState::Finished(vec![])),
+            Some(&InstallState::Finished),
+        );
+    }
+
+    #[test]
+    fn simple_installer_views_construct_for_ready_and_blocked_states() {
+        let alias = value("My vault", true);
+        let invalid_alias = value("This alias is too long", false);
+        let warn = "Seed backup still recommended".to_string();
+
+        let _ = install((4, 4), Some("user@example.com"), true, false, None, None);
+        let _ = install(
+            (4, 4),
+            None,
+            false,
+            true,
+            Some(&warn),
+            Some("Connect backup enabled".to_string()),
+        );
+        let _ = wallet_alias((1, 2), None, &alias);
+        let _ = wallet_alias((1, 2), Some("user@example.com"), &invalid_alias);
+    }
+
+    #[test]
+    fn recovery_kit_restore_views_construct_for_each_phase() {
+        let email = value("user@example.com", true);
+        let otp = value("123456", true);
+        let available = candidate(1, "Available", true, true, true);
+        let no_kit = candidate(2, "No Kit", false, false, false);
+        let descriptor_only = candidate(3, "Descriptor Only", true, false, true);
+
+        let phases = vec![
+            RestorePhase::Email,
+            RestorePhase::OtpEntry,
+            RestorePhase::LoadingCubes,
+            RestorePhase::CubePicker {
+                cubes: vec![available.clone(), no_kit, descriptor_only.clone()],
+                selected: None,
+            },
+            RestorePhase::PasswordEntry {
+                selected: available.clone(),
+                attempts: 1,
+            },
+            RestorePhase::Decrypting {
+                selected: available.clone(),
+            },
+            RestorePhase::Ready {
+                selected: descriptor_only,
+                seed: None,
+                descriptor: None,
+            },
+            RestorePhase::Error {
+                message: "could not decrypt".to_string(),
+            },
+        ];
+
+        for phase in &phases {
+            let _ = recovery_kit_restore(
+                (1, 5),
+                RestoreScope::DescriptorOnly,
+                phase,
+                &email,
+                &otp,
+                "correct horse battery staple",
+                false,
+                Some("inline error"),
+            );
+        }
+
+        let _ = recovery_kit_restore(
+            (1, 5),
+            RestoreScope::Full,
+            &RestorePhase::CubePicker {
+                cubes: vec![candidate(4, "Seed Only", true, true, false)],
+                selected: None,
+            },
+            &email,
+            &otp,
+            "",
+            true,
+            None,
+        );
+    }
+}

--- a/coincube-gui/src/loader.rs
+++ b/coincube-gui/src/loader.rs
@@ -1158,4 +1158,114 @@ mod tests {
         fs::write(&garbage, "not valid toml : : :").unwrap();
         assert!(!backend_is_internal_bitcoind(&garbage, &internal_datadir));
     }
+
+    fn cube_settings() -> CubeSettings {
+        CubeSettings::new_with_raw_id(
+            "cube-uuid".to_string(),
+            "Family Vault".to_string(),
+            bitcoin::Network::Bitcoin,
+        )
+    }
+
+    fn loader_without_wallet(start_internal_bitcoind: bool) -> Loader {
+        Loader::new(
+            CoincubeDirectory::new(PathBuf::new()),
+            GUIConfig::new(start_internal_bitcoind),
+            bitcoin::Network::Bitcoin,
+            None,
+            None,
+            None,
+            cube_settings(),
+            None,
+            None,
+        )
+        .0
+    }
+
+    #[test]
+    fn loader_without_wallet_uses_config_for_bitcoind_and_none_subscriptions() {
+        let mut loader = loader_without_wallet(true);
+        assert!(loader.start_bitcoind());
+        assert!(!loader.vault_uses_internal_bitcoind());
+        let _ = loader.subscription();
+        let _ = loader.view();
+
+        loader.step = Step::StartingDaemon { progress: 0.895 };
+        let _ = loader.update(Message::LoadingTick);
+        assert!(matches!(
+            loader.step,
+            Step::StartingDaemon { progress } if (progress - 0.9).abs() < f32::EPSILON
+        ));
+        let _ = loader.subscription();
+
+        loader.step = Step::FullScan { progress: 0.899 };
+        let _ = loader.update(Message::LoadingTick);
+        assert!(matches!(
+            loader.step,
+            Step::FullScan { progress } if (progress - 0.9).abs() < f32::EPSILON
+        ));
+
+        let _ = loader.update(Message::Synced(Err(Error::Unexpected("boom".to_string()))));
+        assert!(matches!(loader.step, Step::Error(_)));
+        let _ = loader.update(Message::Failure(DaemonError::NoAnswer));
+        assert!(!loader.daemon_started);
+        let _ = loader.update(Message::None);
+    }
+
+    #[test]
+    fn loader_standalone_views_cover_steps_and_error_copy() {
+        let mut quote_provider = QuoteProvider::new();
+        let quote = quote_provider.select("loading");
+        let image_handle = quote_display::image_handle_for_context("loading");
+
+        let _ = view(&Step::Connecting, &quote, &image_handle);
+        let _ = view(
+            &Step::StartingDaemon { progress: 0.5 },
+            &quote,
+            &image_handle,
+        );
+        let _ = view(&Step::FullScan { progress: 0.5 }, &quote, &image_handle);
+        let _ = view(
+            &Step::Error(Box::new(Error::Config(ConfigError::FileNotFound))),
+            &quote,
+            &image_handle,
+        );
+        let _ = view(
+            &Step::Error(Box::new(Error::Daemon(DaemonError::NoAnswer))),
+            &quote,
+            &image_handle,
+        );
+        let _ = cover::<ViewMessage, _>(
+            Some(("warn", &Error::Unexpected("details".to_string()))),
+            text("body"),
+        );
+        let _ = cover::<ViewMessage, _>(None, text("body"));
+    }
+
+    #[test]
+    fn loader_error_display_and_from_impls_are_stable() {
+        assert_eq!(
+            Error::Config(ConfigError::FileNotFound).to_string(),
+            "Config error: Could not locate the configuration file."
+        );
+        assert!(Error::Daemon(DaemonError::NoAnswer)
+            .to_string()
+            .contains("Tenshu daemon error"));
+        assert!(Error::BitcoindLogs(std::io::Error::other("log"))
+            .to_string()
+            .contains("Bitcoind logs error"));
+        assert_eq!(
+            Error::Unexpected("odd".to_string()).to_string(),
+            "Unexpected error: odd"
+        );
+
+        assert!(matches!(
+            Error::from(ConfigError::FileNotFound),
+            Error::Config(ConfigError::FileNotFound)
+        ));
+        assert!(matches!(
+            Error::from(DaemonError::NoAnswer),
+            Error::Daemon(DaemonError::NoAnswer)
+        ));
+    }
 }

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -794,7 +794,7 @@ pub struct VerifiedDevice {
 pub struct LoginActivity {
     pub id: u32,
     pub ip_address: Option<String>,
-    pub user_agent: Option<String>,
+    pub device_name: Option<String>,
     pub created_at: String,
     pub success: Option<bool>,
 }

--- a/coincube-gui/src/services/connect/client/backend/api.rs
+++ b/coincube-gui/src/services/connect/client/backend/api.rs
@@ -518,3 +518,263 @@ pub mod payload {
         pub alias: String,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coincube_core::miniscript::bitcoin::{
+        absolute, consensus::encode::serialize_hex, transaction::Version as TxVersion, Address,
+        ScriptBuf, Sequence, Transaction as BitcoinTransaction, TxIn, TxOut, Witness,
+    };
+    use serde_json::json;
+
+    const MAINNET_ADDRESS: &str = "bc1qnsexk3gnuyayu92fc3tczvc7k62u22a22ua2kv";
+    const ZERO_TXID: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+    const ONE_TXID: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+
+    #[derive(Deserialize)]
+    struct AddressProbe {
+        #[serde(deserialize_with = "deser_addr_assume_checked")]
+        address: bitcoin::Address,
+    }
+
+    #[derive(Deserialize)]
+    struct AmountProbe {
+        #[serde(deserialize_with = "deser_amount_from_sats")]
+        amount: Amount,
+    }
+
+    #[derive(Deserialize)]
+    struct TransactionProbe {
+        #[serde(deserialize_with = "deser_hex")]
+        tx: BitcoinTransaction,
+    }
+
+    fn dummy_transaction() -> BitcoinTransaction {
+        BitcoinTransaction {
+            version: TxVersion::TWO,
+            lock_time: absolute::LockTime::Blocks(absolute::Height::ZERO),
+            input: vec![TxIn {
+                previous_output: OutPoint::from_str(&format!("{ZERO_TXID}:0")).unwrap(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(1_000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        }
+    }
+
+    #[test]
+    fn custom_deserializers_parse_checked_address_amount_and_raw_tx_hex() {
+        let address: AddressProbe = serde_json::from_value(json!({
+            "address": MAINNET_ADDRESS
+        }))
+        .unwrap();
+        assert_eq!(address.address.to_string(), MAINNET_ADDRESS);
+
+        let amount: AmountProbe = serde_json::from_value(json!({ "amount": 12_345 })).unwrap();
+        assert_eq!(amount.amount, Amount::from_sat(12_345));
+
+        let tx = dummy_transaction();
+        let parsed: TransactionProbe = serde_json::from_value(json!({
+            "tx": serialize_hex(&tx)
+        }))
+        .unwrap();
+        assert_eq!(parsed.tx, tx);
+    }
+
+    #[test]
+    fn custom_deserializers_reject_invalid_wire_values() {
+        assert!(serde_json::from_value::<AddressProbe>(json!({
+            "address": "not an address"
+        }))
+        .is_err());
+        assert!(serde_json::from_value::<AmountProbe>(json!({
+            "amount": -1
+        }))
+        .is_err());
+        assert!(serde_json::from_value::<TransactionProbe>(json!({
+            "tx": "not hex"
+        }))
+        .is_err());
+    }
+
+    #[test]
+    fn enum_wire_values_are_lowercase() {
+        let status: WalletStatus = serde_json::from_str("\"recovering\"").unwrap();
+        assert!(matches!(status, WalletStatus::Recovering));
+
+        let role: UserRole = serde_json::from_str("\"owner\"").unwrap();
+        assert!(matches!(role, UserRole::Owner));
+
+        let invitation_status: WalletInvitationStatus =
+            serde_json::from_str("\"accepted\"").unwrap();
+        assert!(matches!(
+            invitation_status,
+            WalletInvitationStatus::Accepted
+        ));
+
+        let payment_kind: PaymentKind = serde_json::from_str("\"incoming\"").unwrap();
+        assert!(matches!(payment_kind, PaymentKind::Incoming));
+
+        let utxo_kind: UTXOKind = serde_json::from_str("\"change\"").unwrap();
+        assert!(matches!(utxo_kind, UTXOKind::Change));
+    }
+
+    #[test]
+    fn coin_deserialization_maps_backend_fields_to_typed_values() {
+        let coin: Coin = serde_json::from_value(json!({
+            "address": MAINNET_ADDRESS,
+            "amount": 50_000,
+            "derivation_index": 7,
+            "outpoint": format!("{ZERO_TXID}:1"),
+            "block_height": 800_000,
+            "spend_info": {
+                "txid": ONE_TXID,
+                "height": 800_100
+            },
+            "is_immature": false,
+            "is_change_address": true,
+            "is_from_self": true
+        }))
+        .unwrap();
+
+        assert_eq!(coin.address.to_string(), MAINNET_ADDRESS);
+        assert_eq!(coin.amount, Amount::from_sat(50_000));
+        assert_eq!(coin.derivation_index, bip32::ChildNumber::from(7));
+        assert_eq!(coin.outpoint.to_string(), format!("{ZERO_TXID}:1"));
+        assert_eq!(coin.block_height, Some(800_000));
+        assert_eq!(coin.spend_info.as_ref().unwrap().txid.to_string(), ONE_TXID);
+        assert_eq!(coin.spend_info.as_ref().unwrap().height, Some(800_100));
+        assert!(coin.is_change_address);
+        assert!(coin.is_from_self);
+        assert!(!coin.is_immature);
+    }
+
+    #[test]
+    fn revealed_addresses_deserialize_checked_addresses_and_continue_cursor() {
+        let list: ListRevealedAddresses = serde_json::from_value(json!({
+            "addresses": [{
+                "address": MAINNET_ADDRESS,
+                "derivation_index": 5,
+                "label": "savings",
+                "used_count": 2
+            }],
+            "continue_from": 4
+        }))
+        .unwrap();
+
+        assert_eq!(list.addresses.len(), 1);
+        assert_eq!(list.addresses[0].address.to_string(), MAINNET_ADDRESS);
+        assert_eq!(
+            list.addresses[0].derivation_index,
+            bip32::ChildNumber::from(5)
+        );
+        assert_eq!(list.addresses[0].label.as_deref(), Some("savings"));
+        assert_eq!(list.addresses[0].used_count, 2);
+        assert_eq!(list.continue_from, Some(bip32::ChildNumber::from(4)));
+    }
+
+    #[test]
+    fn transaction_deserialization_decodes_raw_hex_and_nested_io() {
+        let tx = dummy_transaction();
+        let transaction: Transaction = serde_json::from_value(json!({
+            "uuid": "tx-uuid",
+            "txid": ZERO_TXID,
+            "fee": 123,
+            "fee_rate": 4,
+            "block_height": null,
+            "confirmed_at": null,
+            "label": "payroll",
+            "raw": serialize_hex(&tx),
+            "inputs": [{
+                "txid": ONE_TXID,
+                "vout": 0,
+                "amount": 1000,
+                "label": null,
+                "kind": "external",
+                "coin": null
+            }],
+            "outputs": [{
+                "address": MAINNET_ADDRESS,
+                "label": null,
+                "address_label": "deposit",
+                "amount": 877,
+                "kind": "deposit",
+                "coin": null
+            }],
+            "is_batch": false
+        }))
+        .unwrap();
+
+        assert_eq!(transaction.uuid, "tx-uuid");
+        assert_eq!(transaction.txid, ZERO_TXID);
+        assert_eq!(transaction.raw, tx);
+        assert!(matches!(transaction.inputs[0].kind, UTXOKind::External));
+        assert!(matches!(transaction.outputs[0].kind, UTXOKind::Deposit));
+        assert!(!transaction.is_batch);
+    }
+
+    #[test]
+    fn payload_serializers_preserve_backend_wire_shape() {
+        let address = Address::from_str(MAINNET_ADDRESS).unwrap();
+        let recipient = payload::Recipient {
+            amount: Some(10_000),
+            address,
+            is_max: false,
+        };
+        assert_eq!(
+            serde_json::to_value(&recipient).unwrap(),
+            json!({
+                "amount": 10_000,
+                "address": MAINNET_ADDRESS,
+                "is_max": false
+            })
+        );
+
+        let rbf = payload::GenerateRbfPsbt {
+            txid: Txid::from_str(ZERO_TXID).unwrap(),
+            feerate: None,
+            is_cancel: true,
+            save: true,
+        };
+        assert_eq!(
+            serde_json::to_value(&rbf).unwrap(),
+            json!({
+                "txid": ZERO_TXID,
+                "feerate": null,
+                "is_cancel": true,
+                "save": true
+            })
+        );
+
+        let update = payload::UpdateWallet {
+            alias: Some("Family Vault".to_string()),
+            ledger_hmac: Some(payload::UpdateLedgerHmac {
+                fingerprint: "aabbccdd".to_string(),
+                hmac: "hmac-token".to_string(),
+            }),
+            fingerprint_aliases: Some(vec![payload::UpdateFingerprintAlias {
+                fingerprint: "11223344".to_string(),
+                alias: "Alice".to_string(),
+            }]),
+        };
+        assert_eq!(
+            serde_json::to_value(&update).unwrap(),
+            json!({
+                "alias": "Family Vault",
+                "ledger_hmac": {
+                    "fingerprint": "aabbccdd",
+                    "hmac": "hmac-token"
+                },
+                "fingerprint_aliases": [{
+                    "fingerprint": "11223344",
+                    "alias": "Alice"
+                }]
+            })
+        );
+    }
+}

--- a/coincube-gui/src/services/connect/login.rs
+++ b/coincube-gui/src/services/connect/login.rs
@@ -593,3 +593,239 @@ pub async fn connect_with_credentials(
         Ok(BackendState::NoWallet(client))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::settings::AuthConfig;
+    use std::path::PathBuf;
+
+    fn auth_client(email: &str) -> AuthClient {
+        AuthClient::new(
+            "https://auth.example.test".to_string(),
+            "public-key".to_string(),
+            email.to_string(),
+        )
+    }
+
+    fn wallet_settings(email: &str, wallet_id: &str) -> WalletSettings {
+        WalletSettings {
+            name: "Test Wallet".to_string(),
+            alias: None,
+            descriptor_checksum: "checksum".to_string(),
+            pinned_at: None,
+            keys: Vec::new(),
+            hardware_wallets: Vec::new(),
+            remote_backend_auth: Some(AuthConfig::new(email.to_string(), wallet_id.to_string())),
+            start_internal_bitcoind: None,
+        }
+    }
+
+    fn login_with_step(step: ConnectionStep) -> CoincubeLiteLogin {
+        CoincubeLiteLogin {
+            datadir: CoincubeDirectory::new(PathBuf::new()),
+            network: Network::Bitcoin,
+            settings: wallet_settings("user@example.com", "wallet-id"),
+            breez_client: None,
+            spark_backend: None,
+            wallet_id: "wallet-id".to_string(),
+            email: "user@example.com".to_string(),
+            processing: false,
+            step,
+            connection_error: None,
+            auth_error: None,
+        }
+    }
+
+    #[test]
+    fn error_display_strings_include_context() {
+        assert_eq!(Error::CredentialsMissing.to_string(), "credentials missing");
+        assert_eq!(
+            Error::Unexpected("boom".to_string()).to_string(),
+            "Unexpected error: boom"
+        );
+        assert_eq!(
+            Error::Auth(AuthError {
+                http_status: Some(403),
+                error: "forbidden".to_string(),
+            })
+            .to_string(),
+            "Authentication error: 403: forbidden"
+        );
+    }
+
+    #[test]
+    fn checking_auth_file_moves_to_email_step_without_showing_missing_credentials() {
+        let mut login = login_with_step(ConnectionStep::CheckingAuthFile);
+
+        let _task = login.update(Message::Connected(Err(Error::CredentialsMissing)));
+
+        assert!(!login.processing);
+        assert!(matches!(login.step, ConnectionStep::CheckEmail));
+        assert!(login.connection_error.is_none());
+    }
+
+    #[test]
+    fn checking_auth_file_surfaces_unexpected_errors() {
+        let mut login = login_with_step(ConnectionStep::CheckingAuthFile);
+
+        let _task = login.update(Message::Connected(Err(Error::Unexpected(
+            "cache corrupt".to_string(),
+        ))));
+
+        assert!(!login.processing);
+        assert!(matches!(login.step, ConnectionStep::CheckEmail));
+        assert!(matches!(
+            login.connection_error,
+            Some(Error::Unexpected(ref msg)) if msg == "cache corrupt"
+        ));
+    }
+
+    #[test]
+    fn check_email_request_and_otp_result_transition_to_enter_otp() {
+        let mut login = login_with_step(ConnectionStep::CheckEmail);
+
+        let _task = login.update(Message::View(ViewMessage::RequestOTP));
+        assert!(login.processing);
+        assert!(login.connection_error.is_none());
+        assert!(login.auth_error.is_none());
+
+        let _task = login.update(Message::OTPRequested(Ok((
+            auth_client("user@example.com"),
+            "https://backend.example.test".to_string(),
+            Some("https://grpc.example.test".to_string()),
+        ))));
+
+        assert!(!login.processing);
+        assert!(matches!(
+            login.step,
+            ConnectionStep::EnterOtp {
+                ref backend_api_url,
+                ref grpc_url,
+                ref otp,
+                ..
+            } if backend_api_url == "https://backend.example.test"
+                && grpc_url.as_deref() == Some("https://grpc.example.test")
+                && otp.value.is_empty()
+        ));
+    }
+
+    #[test]
+    fn check_email_otp_request_failure_is_stored() {
+        let mut login = login_with_step(ConnectionStep::CheckEmail);
+
+        let _task = login.update(Message::OTPRequested(Err(Error::Unexpected(
+            "mail failed".to_string(),
+        ))));
+
+        assert!(!login.processing);
+        assert!(matches!(
+            login.connection_error,
+            Some(Error::Unexpected(ref msg)) if msg == "mail failed"
+        ));
+    }
+
+    #[test]
+    fn enter_otp_resend_resets_input_and_records_resend_errors() {
+        let mut login = login_with_step(ConnectionStep::EnterOtp {
+            client: auth_client("user@example.com"),
+            backend_api_url: "https://backend.example.test".to_string(),
+            grpc_url: None,
+            otp: form::Value {
+                value: "123456".to_string(),
+                warning: Some("old"),
+                valid: false,
+            },
+        });
+
+        let _task = login.update(Message::View(ViewMessage::RequestOTP));
+        assert!(login.processing);
+        assert!(matches!(
+            login.step,
+            ConnectionStep::EnterOtp { ref otp, .. }
+                if otp.value.is_empty() && otp.warning.is_none() && otp.valid
+        ));
+
+        let _task = login.update(Message::OTPResent(Err(Error::Unexpected(
+            "resend failed".to_string(),
+        ))));
+        assert!(!login.processing);
+        assert!(matches!(
+            login.connection_error,
+            Some(Error::Unexpected(ref msg)) if msg == "resend failed"
+        ));
+    }
+
+    #[test]
+    fn enter_otp_trims_input_and_submits_at_six_digits() {
+        let mut login = login_with_step(ConnectionStep::EnterOtp {
+            client: auth_client("user@example.com"),
+            backend_api_url: "https://backend.example.test".to_string(),
+            grpc_url: None,
+            otp: form::Value::default(),
+        });
+
+        let _task = login.update(Message::View(ViewMessage::OTPEdited(" 123 ".to_string())));
+        assert!(!login.processing);
+        assert!(matches!(
+            login.step,
+            ConnectionStep::EnterOtp { ref otp, .. } if otp.value == "123" && otp.valid
+        ));
+
+        let _task = login.update(Message::View(ViewMessage::OTPEdited(
+            " 123456 ".to_string(),
+        )));
+        assert!(login.processing);
+        assert!(login.connection_error.is_none());
+        assert!(login.auth_error.is_none());
+        assert!(matches!(
+            login.step,
+            ConnectionStep::EnterOtp { ref otp, .. } if otp.value == "123456" && otp.valid
+        ));
+    }
+
+    #[test]
+    fn enter_otp_connected_errors_split_auth_from_generic_failures() {
+        let mut login = login_with_step(ConnectionStep::EnterOtp {
+            client: auth_client("user@example.com"),
+            backend_api_url: "https://backend.example.test".to_string(),
+            grpc_url: None,
+            otp: form::Value::default(),
+        });
+
+        let _task = login.update(Message::Connected(Err(Error::Auth(AuthError {
+            http_status: Some(403),
+            error: "forbidden".to_string(),
+        }))));
+
+        assert!(!login.processing);
+        assert_eq!(login.auth_error, Some("Token is expired or is invalid"));
+        assert!(login.connection_error.is_none());
+
+        let _task = login.update(Message::Connected(Err(Error::Auth(AuthError {
+            http_status: Some(500),
+            error: "server".to_string(),
+        }))));
+
+        assert!(matches!(login.connection_error, Some(Error::Auth(_))));
+    }
+
+    #[test]
+    fn enter_otp_run_error_is_stored() {
+        let mut login = login_with_step(ConnectionStep::EnterOtp {
+            client: auth_client("user@example.com"),
+            backend_api_url: "https://backend.example.test".to_string(),
+            grpc_url: None,
+            otp: form::Value::default(),
+        });
+
+        let _task = login.update(Message::Run(Err(Error::Unexpected(
+            "coin cache failed".to_string(),
+        ))));
+
+        assert!(matches!(
+            login.connection_error,
+            Some(Error::Unexpected(ref msg)) if msg == "coin cache failed"
+        ));
+    }
+}

--- a/coincube-gui/src/services/duress/enroll.rs
+++ b/coincube-gui/src/services/duress/enroll.rs
@@ -28,9 +28,21 @@ pub const RECOMMENDED_ALL_CLEAR_LEN: usize = 24;
 
 /// Argon2id parameters, matching the regular-PIN and recovery-kit KDFs
 /// (19 MiB, 2 iterations, 1 lane) so duress secrets are no weaker than the
-/// rest of the app.
+/// rest of the app. Test builds drop to the argon2 minimum: the suite hashes
+/// secrets many times over and the 19 MiB cost starves CI under parallel load.
+/// Verification reads the parameters from the stored PHC string, so a hash
+/// made at either cost still round-trips.
+#[cfg(not(test))]
 const ARGON_M_COST: u32 = 19456;
+#[cfg(not(test))]
 const ARGON_T_COST: u32 = 2;
+#[cfg(not(test))]
+const ARGON_P_COST: u32 = 1;
+#[cfg(test)]
+const ARGON_M_COST: u32 = 8;
+#[cfg(test)]
+const ARGON_T_COST: u32 = 1;
+#[cfg(test)]
 const ARGON_P_COST: u32 = 1;
 
 /// Bits of entropy in this desktop's generated duress code.

--- a/coincube-gui/src/services/fiat/api.rs
+++ b/coincube-gui/src/services/fiat/api.rs
@@ -47,3 +47,36 @@ pub trait PriceApi {
 
     async fn list_currencies(&self) -> Result<ListCurrenciesResult, PriceApiError>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::PriceApiError;
+    use crate::services::http::NotSuccessResponseInfo;
+
+    #[test]
+    fn display_renders_actionable_error_messages() {
+        assert_eq!(
+            PriceApiError::RequestFailed("timeout".to_string()).to_string(),
+            "Request failed: timeout"
+        );
+        assert_eq!(
+            PriceApiError::CannotParseResponse("bad json".to_string()).to_string(),
+            "Cannot parse response: bad json"
+        );
+        assert_eq!(
+            PriceApiError::CannotParseData("price".to_string()).to_string(),
+            "Cannot parse data: price"
+        );
+    }
+
+    #[test]
+    fn display_unwraps_coincube_error_envelope() {
+        let err = PriceApiError::NotSuccessResponse(NotSuccessResponseInfo {
+            status_code: 429,
+            text: r#"{"success":false,"error":{"code":"rate_limited","message":"slow down"}}"#
+                .to_string(),
+        });
+
+        assert_eq!(err.to_string(), "Not success response (429): slow down");
+    }
+}

--- a/coincube-gui/src/services/fiat/source.rs
+++ b/coincube-gui/src/services/fiat/source.rs
@@ -165,3 +165,160 @@ impl PriceSource {
         Ok(ListCurrenciesResult { currencies })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{PriceSource, ALL_PRICE_SOURCES};
+    use crate::services::fiat::{api::PriceApiError, currency::Currency};
+    use serde_json::json;
+    use std::str::FromStr;
+
+    #[test]
+    fn all_price_sources_round_trip_through_display_and_parse() {
+        assert_eq!(
+            ALL_PRICE_SOURCES,
+            [
+                PriceSource::Coincube,
+                PriceSource::MempoolSpace,
+                PriceSource::CoinGecko,
+            ]
+        );
+
+        for source in ALL_PRICE_SOURCES {
+            let rendered = source.to_string();
+            assert_eq!(PriceSource::from_str(&rendered), Ok(source));
+            assert_eq!(PriceSource::from_str(&rendered.to_uppercase()), Ok(source));
+        }
+
+        assert_eq!(
+            PriceSource::from_str("unknown-source"),
+            Err("Invalid price source".to_string())
+        );
+    }
+
+    #[test]
+    fn attribution_and_user_agent_match_upstream_requirements() {
+        assert_eq!(
+            PriceSource::Coincube.attribution(),
+            Some("Powered by Coincube".to_string())
+        );
+        assert_eq!(
+            PriceSource::CoinGecko.attribution(),
+            Some("Powered by CoinGecko".to_string())
+        );
+        assert_eq!(PriceSource::MempoolSpace.attribution(), None);
+
+        assert_eq!(PriceSource::Coincube.user_agent(), None);
+        assert_eq!(PriceSource::MempoolSpace.user_agent(), None);
+        assert_eq!(
+            PriceSource::CoinGecko.user_agent(),
+            Some(format!("coincube-gui/{}", env!("CARGO_PKG_VERSION")))
+        );
+    }
+
+    #[test]
+    fn urls_use_the_expected_provider_endpoints() {
+        assert!(PriceSource::Coincube
+            .get_price_url(Currency::MXN)
+            .ends_with("/api/v1/exchange-rates/price/MXN"));
+        assert!(PriceSource::Coincube
+            .list_currencies_url()
+            .ends_with("/api/v1/exchange-rates/currencies"));
+        assert_eq!(
+            PriceSource::CoinGecko.get_price_url(Currency::USD),
+            "https://api.coingecko.com/api/v3/exchange_rates"
+        );
+        assert_eq!(
+            PriceSource::CoinGecko.list_currencies_url(),
+            "https://api.coingecko.com/api/v3/exchange_rates"
+        );
+        assert_eq!(
+            PriceSource::MempoolSpace.get_price_url(Currency::USD),
+            "https://mempool.space/api/v1/prices"
+        );
+        assert_eq!(
+            PriceSource::MempoolSpace.list_currencies_url(),
+            "https://mempool.space/api/v1/prices"
+        );
+    }
+
+    #[test]
+    fn parses_prices_for_each_provider_shape() {
+        let coincube = PriceSource::Coincube
+            .parse_price_data(Currency::USD, &json!({"value": 102_000.25}))
+            .unwrap();
+        assert_eq!(coincube.value, 102_000.25);
+        assert_eq!(coincube.updated_at, None);
+
+        let coingecko = PriceSource::CoinGecko
+            .parse_price_data(
+                Currency::EUR,
+                &json!({"rates": {"eur": {"value": 91_000.5}}}),
+            )
+            .unwrap();
+        assert_eq!(coingecko.value, 91_000.5);
+        assert_eq!(coingecko.updated_at, None);
+
+        let mempool = PriceSource::MempoolSpace
+            .parse_price_data(Currency::MXN, &json!({"MXN": 1_800_000, "time": 12345}))
+            .unwrap();
+        assert_eq!(mempool.value, 1_800_000.0);
+        assert_eq!(mempool.updated_at, Some(12345));
+    }
+
+    #[test]
+    fn price_parse_errors_name_the_missing_field() {
+        for source in ALL_PRICE_SOURCES {
+            let err = source
+                .parse_price_data(Currency::USD, &json!({}))
+                .expect_err("empty payload should not contain a price");
+            assert!(matches!(err, PriceApiError::CannotParseData(field) if field == "price"));
+        }
+    }
+
+    #[test]
+    fn parses_currency_lists_and_filters_unknown_codes() {
+        let coincube = PriceSource::Coincube
+            .parse_currencies_data(&json!({"currencies": ["USD", "MXN", "NOPE"]}))
+            .unwrap();
+        assert_eq!(coincube.currencies, vec![Currency::USD, Currency::MXN]);
+
+        let coingecko = PriceSource::CoinGecko
+            .parse_currencies_data(&json!({"rates": {"usd": {}, "mxn": {}, "btc": {}}}))
+            .unwrap();
+        assert!(coingecko.currencies.contains(&Currency::USD));
+        assert!(coingecko.currencies.contains(&Currency::MXN));
+        assert_eq!(coingecko.currencies.len(), 2);
+
+        let mempool = PriceSource::MempoolSpace
+            .parse_currencies_data(&json!({"USD": 100000, "MXN": 1800000, "time": 12345}))
+            .unwrap();
+        assert!(mempool.currencies.contains(&Currency::USD));
+        assert!(mempool.currencies.contains(&Currency::MXN));
+        assert_eq!(mempool.currencies.len(), 2);
+    }
+
+    #[test]
+    fn currency_parse_errors_describe_the_bad_container() {
+        let coincube = PriceSource::Coincube
+            .parse_currencies_data(&json!({"currencies": "USD"}))
+            .expect_err("Coincube currencies must be an array");
+        assert!(
+            matches!(coincube, PriceApiError::CannotParseData(msg) if msg == "data is not array")
+        );
+
+        let coingecko = PriceSource::CoinGecko
+            .parse_currencies_data(&json!({"rates": []}))
+            .expect_err("CoinGecko rates must be an object");
+        assert!(
+            matches!(coingecko, PriceApiError::CannotParseData(msg) if msg == "data is not object")
+        );
+
+        let mempool = PriceSource::MempoolSpace
+            .parse_currencies_data(&json!(["USD"]))
+            .expect_err("mempool.space payload must be an object");
+        assert!(
+            matches!(mempool, PriceApiError::CannotParseData(msg) if msg == "data is not object")
+        );
+    }
+}

--- a/coincube-gui/src/services/http.rs
+++ b/coincube-gui/src/services/http.rs
@@ -61,3 +61,29 @@ impl ResponseExt for Response {
         Ok(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::NotSuccessResponseInfo;
+
+    #[test]
+    fn message_unwraps_standard_api_error_envelope() {
+        let info = NotSuccessResponseInfo {
+            status_code: 400,
+            text: r#"{"success":false,"error":{"code":"bad_request","message":"Invalid cube"}}"#
+                .to_string(),
+        };
+
+        assert_eq!(info.message(), "Invalid cube");
+    }
+
+    #[test]
+    fn message_falls_back_to_raw_body_for_non_envelope_errors() {
+        let info = NotSuccessResponseInfo {
+            status_code: 500,
+            text: "plain upstream failure".to_string(),
+        };
+
+        assert_eq!(info.message(), "plain upstream failure");
+    }
+}

--- a/coincube-gui/src/services/mavapay/api.rs
+++ b/coincube-gui/src/services/mavapay/api.rs
@@ -571,3 +571,441 @@ pub struct SimulatePayInRequest {
     pub amount: Option<u64>,
     pub currency: MavapayCurrency,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::{coincube::CoincubeError, http::NotSuccessResponseInfo};
+    use serde_json::{json, Value};
+    use std::str::FromStr;
+
+    #[test]
+    fn api_result_deserializes_success_alias_and_errors() {
+        let ok: MavapayApiResult<u64> =
+            serde_json::from_value(json!({ "status": "ok", "data": 42 })).unwrap();
+        match ok {
+            MavapayApiResult::Success { data } => assert_eq!(data, 42),
+            MavapayApiResult::Error { .. } => panic!("expected success variant"),
+        }
+
+        let err: MavapayApiResult<u64> =
+            serde_json::from_value(json!({ "status": "error", "message": "no quote" })).unwrap();
+        match err {
+            MavapayApiResult::Error { message } => assert_eq!(message, "no quote"),
+            MavapayApiResult::Success { .. } => panic!("expected error variant"),
+        }
+    }
+
+    #[test]
+    fn mavapay_response_deserializes_success_alias() {
+        let response: MavapayResponse<String> =
+            serde_json::from_value(json!({ "status": "ok", "data": "paid" })).unwrap();
+
+        match response {
+            MavapayResponse::Success { data } => assert_eq!(data, "paid"),
+            MavapayResponse::Error { .. } => panic!("expected success variant"),
+        }
+    }
+
+    #[test]
+    fn coincube_errors_convert_to_mavapay_error_envelopes() {
+        let api: MavapayApiResult<()> = CoincubeError::Api("bad currency".to_string()).into();
+        match api {
+            MavapayApiResult::Error { message } => assert_eq!(message, "bad currency"),
+            MavapayApiResult::Success { .. } => panic!("expected error variant"),
+        }
+
+        let unsuccessful: MavapayApiResult<()> =
+            CoincubeError::Unsuccessful(NotSuccessResponseInfo {
+                status_code: 400,
+                text: r#"{"success":false,"error":{"code":"bad","message":"Invalid account"}}"#
+                    .to_string(),
+            })
+            .into();
+        match unsuccessful {
+            MavapayApiResult::Error { message } => assert_eq!(message, "Invalid account"),
+            MavapayApiResult::Success { .. } => panic!("expected error variant"),
+        }
+    }
+
+    #[test]
+    fn mavapay_error_display_strings_are_actionable() {
+        let cases = [
+            (
+                MavapayError::Http(Some(502), "upstream".to_string()),
+                "[502]: upstream",
+            ),
+            (MavapayError::Http(None, "offline".to_string()), "offline"),
+            (
+                MavapayError::InvalidResponse("missing data".to_string()),
+                "Invalid response: missing data",
+            ),
+            (
+                MavapayError::ApiError("declined".to_string()),
+                "Mavapay Error: declined",
+            ),
+            (MavapayError::QuoteExpired, "Quote has expired"),
+            (MavapayError::InsufficientFunds, "Insufficient funds"),
+            (
+                MavapayError::InvalidCurrency,
+                "Invalid or unsupported currency",
+            ),
+            (MavapayError::InvalidAmount, "Invalid amount"),
+            (
+                MavapayError::BankAccountValidationFailed,
+                "Bank account validation failed",
+            ),
+            (MavapayError::PaymentFailed, "Payment failed"),
+            (MavapayError::PaymentTimeout, "Payment timeout"),
+        ];
+
+        for (err, expected) in cases {
+            assert_eq!(err.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn unsuccessful_response_converts_to_http_error() {
+        let err = MavapayError::from(NotSuccessResponseInfo {
+            status_code: 409,
+            text: "duplicate order".to_string(),
+        });
+
+        assert_eq!(err.to_string(), "[409]: duplicate order");
+    }
+
+    #[test]
+    fn currencies_parse_display_and_serialize_as_iso_codes() {
+        let cases = [
+            (
+                "NGN",
+                MavapayCurrency::NigerianNaira,
+                "Nigerian Naira (NGN)",
+            ),
+            (
+                "KES",
+                MavapayCurrency::KenyanShilling,
+                "Kenyan Shilling (KES)",
+            ),
+            (
+                "ZAR",
+                MavapayCurrency::SouthAfricanRand,
+                "South African Rand (ZAR)",
+            ),
+            ("BTC", MavapayCurrency::Bitcoin, "Bitcoin (BTC)"),
+        ];
+
+        assert_eq!(
+            MavapayCurrency::all(),
+            &[
+                MavapayCurrency::NigerianNaira,
+                MavapayCurrency::KenyanShilling,
+                MavapayCurrency::SouthAfricanRand,
+                MavapayCurrency::Bitcoin,
+            ]
+        );
+
+        for (code, currency, display) in cases {
+            assert_eq!(MavapayCurrency::from_str(code).unwrap(), currency);
+            assert_eq!(currency.to_string(), display);
+            assert_eq!(
+                serde_json::to_string(&currency).unwrap(),
+                format!("\"{code}\"")
+            );
+        }
+
+        assert!(MavapayCurrency::from_str("USD").is_err());
+    }
+
+    #[test]
+    fn unit_currencies_report_fiat_status_and_parent_currency() {
+        let cases = [
+            (
+                MavapayUnitCurrency::KenyanShillingCent,
+                true,
+                "Kenyan Cent",
+                "Kenyan Cents",
+                MavapayCurrency::KenyanShilling,
+                "KESCENT",
+            ),
+            (
+                MavapayUnitCurrency::SouthAfricanRandCent,
+                true,
+                "South African Cent",
+                "South African Cents",
+                MavapayCurrency::SouthAfricanRand,
+                "ZARCENT",
+            ),
+            (
+                MavapayUnitCurrency::NigerianNairaKobo,
+                true,
+                "Nigerian Kobo",
+                "Nigerian Kobos",
+                MavapayCurrency::NigerianNaira,
+                "NGNKOBO",
+            ),
+            (
+                MavapayUnitCurrency::BitcoinSatoshi,
+                false,
+                "Satoshi",
+                "Bitcoin (Sats)",
+                MavapayCurrency::Bitcoin,
+                "BTCSAT",
+            ),
+        ];
+
+        for (unit, is_fiat, as_str, display, parent, code) in cases {
+            assert_eq!(unit.is_fiat(), is_fiat);
+            assert_eq!(unit.as_str(), as_str);
+            assert_eq!(unit.to_string(), display);
+            assert_eq!(MavapayCurrency::from(&unit), parent);
+            assert_eq!(serde_json::to_string(&unit).unwrap(), format!("\"{code}\""));
+        }
+    }
+
+    #[test]
+    fn payment_methods_keep_wire_values_and_user_labels() {
+        let cases = [
+            (
+                MavapayPaymentMethod::Lightning,
+                "Bitcoin Lightning",
+                "LIGHTNING",
+            ),
+            (
+                MavapayPaymentMethod::BankTransfer,
+                "Bank Transfer",
+                "BANKTRANSFER",
+            ),
+            (
+                MavapayPaymentMethod::Onchain,
+                "Bitcoin Mainnet Transaction",
+                "ONCHAIN",
+            ),
+            (MavapayPaymentMethod::USDT, "USDT Transaction", "USDT"),
+        ];
+
+        assert_eq!(
+            MavapayPaymentMethod::all(),
+            &[
+                MavapayPaymentMethod::Lightning,
+                MavapayPaymentMethod::BankTransfer,
+                MavapayPaymentMethod::Onchain,
+                MavapayPaymentMethod::USDT,
+            ]
+        );
+
+        for (method, label, wire) in cases {
+            assert_eq!(method.as_str(), label);
+            assert_eq!(
+                serde_json::to_string(&method).unwrap(),
+                format!("\"{wire}\"")
+            );
+        }
+    }
+
+    #[test]
+    fn beneficiary_format_matches_serialized_payload_shape() {
+        let lightning = Beneficiary::Lightning {
+            ln_invoice: "lnbc1".to_string(),
+        };
+        assert_eq!(lightning.format(), "lnInvoice");
+        assert_eq!(
+            serde_json::to_value(&lightning).unwrap(),
+            json!({ "lnInvoice": "lnbc1" })
+        );
+
+        let lightning_address = Beneficiary::LightningAddress {
+            ln_address: "pay@example.com".to_string(),
+        };
+        assert_eq!(lightning_address.format(), "lnAddress");
+        assert_eq!(
+            serde_json::to_value(&lightning_address).unwrap(),
+            json!({ "lnAddress": "pay@example.com" })
+        );
+
+        let onchain = Beneficiary::Onchain {
+            on_chain_address: "bc1qaddress".to_string(),
+        };
+        assert_eq!(onchain.format(), "onChainAddress");
+        assert_eq!(
+            serde_json::to_value(&onchain).unwrap(),
+            json!({ "onChainAddress": "bc1qaddress" })
+        );
+
+        assert_eq!(
+            Beneficiary::KES(KenyanBeneficiary::PayToPhone {
+                account_name: "Amina".to_string(),
+                phone_number: "254700000000".to_string(),
+            })
+            .format(),
+            "kesPayToPhone"
+        );
+        assert_eq!(
+            Beneficiary::KES(KenyanBeneficiary::PayToBill {
+                account_name: "Amina".to_string(),
+                account_number: "123".to_string(),
+                paybill_number: "456".to_string(),
+            })
+            .format(),
+            "kesPayToBill"
+        );
+    }
+
+    #[test]
+    fn get_quote_request_serializes_optional_fields_and_beneficiary() {
+        let beneficiary = Beneficiary::Lightning {
+            ln_invoice: "lnbc1".to_string(),
+        };
+        let request = GetQuoteRequest {
+            amount: 10_000,
+            source_currency: MavapayUnitCurrency::BitcoinSatoshi,
+            target_currency: MavapayUnitCurrency::NigerianNairaKobo,
+            payment_method: MavapayPaymentMethod::Lightning,
+            payment_currency: MavapayUnitCurrency::BitcoinSatoshi,
+            speed: OnchainTransferSpeed::Fast,
+            autopayout: true,
+            customer_internal_fee: None,
+            beneficiary_format: beneficiary.format(),
+            beneficiary,
+        };
+
+        let value = serde_json::to_value(&request).unwrap();
+
+        assert_eq!(value["amount"], 10_000);
+        assert_eq!(value["sourceCurrency"], "BTCSAT");
+        assert_eq!(value["targetCurrency"], "NGNKOBO");
+        assert_eq!(value["paymentMethod"], "LIGHTNING");
+        assert_eq!(value["paymentCurrency"], "BTCSAT");
+        assert_eq!(value["speed"], "fast");
+        assert_eq!(value["autopayout"], true);
+        assert_eq!(value["beneficiaryFormat"], "lnInvoice");
+        assert_eq!(value["beneficiary"], json!({ "lnInvoice": "lnbc1" }));
+        assert!(value.get("customerInternalFee").is_none());
+    }
+
+    #[test]
+    fn banks_deserialize_nigerian_or_south_african_lists() {
+        let nigerian: MavapayBanks = serde_json::from_value(json!([
+            { "bankName": "Access Bank", "nipBankCode": "044" }
+        ]))
+        .unwrap();
+        match nigerian {
+            MavapayBanks::Nigerian(banks) => {
+                assert_eq!(banks[0].to_string(), "Access Bank: 044");
+            }
+            MavapayBanks::SouthAfrican(_) => panic!("expected Nigerian banks"),
+        }
+
+        let south_african: MavapayBanks =
+            serde_json::from_value(json!(["ABSA", "Capitec"])).unwrap();
+        match south_african {
+            MavapayBanks::SouthAfrican(banks) => assert_eq!(banks, vec!["ABSA", "Capitec"]),
+            MavapayBanks::Nigerian(_) => panic!("expected South African banks"),
+        }
+    }
+
+    fn order_response(order_data: Option<OrderDataWrapper>) -> GetOrderResponse {
+        GetOrderResponse {
+            id: 1,
+            order_id: "order".to_string(),
+            quote_id: Some("quote".to_string()),
+            amount: 100,
+            status: TransactionStatus::Pending,
+            currency: MavapayCurrency::Bitcoin,
+            payment_method: MavapayPaymentMethod::Lightning,
+            is_valid: Some(true),
+            payment_btc_detail: Some("lnbc".to_string()),
+            created_at: "2026-07-20T00:00:00Z".to_string(),
+            updated_at: "2026-07-20T00:00:00Z".to_string(),
+            order_data,
+        }
+    }
+
+    fn quote(total_amount: u64) -> OrderQuote {
+        OrderQuote {
+            transaction_fees_in_source_currency: 1,
+            transaction_fees_in_target_currency: 2,
+            transaction_fees_in_usd_cent: 3,
+            payment_btc_detail: "lnbc".to_string(),
+            total_amount,
+            equivalent_amount: 5,
+            source_currency: MavapayUnitCurrency::BitcoinSatoshi,
+            target_currency: MavapayUnitCurrency::NigerianNairaKobo,
+        }
+    }
+
+    #[test]
+    fn order_response_quotes_returns_nested_quotes_or_empty_slice() {
+        assert!(order_response(None).quotes().is_empty());
+
+        let response = order_response(Some(OrderDataWrapper {
+            status: "ok".to_string(),
+            data: OrderDataInner {
+                quotes: vec![quote(99)],
+            },
+        }));
+
+        assert_eq!(response.quotes().len(), 1);
+        assert_eq!(response.quotes()[0].total_amount, 99);
+    }
+
+    fn order_transaction_json(payment_method: Value) -> Value {
+        json!({
+            "orderId": "order",
+            "transactionId": "tx",
+            "amount": 2500,
+            "fees": 25,
+            "currency": "BTC",
+            "transactionType": "WITHDRAWAL",
+            "status": "PAID",
+            "paymentMethod": payment_method,
+            "createdAt": "2026-07-20T00:00:00Z"
+        })
+    }
+
+    #[test]
+    fn order_transaction_treats_empty_payment_method_as_none() {
+        let transaction: OrderTransaction =
+            serde_json::from_value(order_transaction_json(json!(""))).unwrap();
+
+        assert_eq!(transaction.payment_method, None);
+    }
+
+    #[test]
+    fn order_transaction_deserializes_present_payment_method() {
+        let transaction: OrderTransaction =
+            serde_json::from_value(order_transaction_json(json!("LIGHTNING"))).unwrap();
+
+        assert_eq!(
+            transaction.payment_method,
+            Some(MavapayPaymentMethod::Lightning)
+        );
+    }
+
+    #[test]
+    fn transaction_status_and_onchain_speed_expose_display_and_wire_values() {
+        assert_eq!(TransactionStatus::Pending.to_string(), "PENDING");
+        assert_eq!(TransactionStatus::Success.to_string(), "SUCCESS");
+        assert_eq!(TransactionStatus::Expired.to_string(), "EXPIRED");
+        assert_eq!(TransactionStatus::Failed.to_string(), "FAILED");
+        assert_eq!(TransactionStatus::Paid.to_string(), "PAID");
+
+        assert_eq!(
+            OnchainTransferSpeed::all(),
+            &[
+                OnchainTransferSpeed::Slow,
+                OnchainTransferSpeed::Medium,
+                OnchainTransferSpeed::Fast,
+            ]
+        );
+        assert_eq!(OnchainTransferSpeed::Slow.to_string(), "Slow");
+        assert_eq!(
+            serde_json::to_string(&OnchainTransferSpeed::Medium).unwrap(),
+            "\"medium\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TransactionType::Withdrawal).unwrap(),
+            "\"WITHDRAWAL\""
+        );
+    }
+}

--- a/coincube-spark-bridge/src/main.rs
+++ b/coincube-spark-bridge/src/main.rs
@@ -115,3 +115,23 @@ mod smoke_test {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+    use clap::Parser;
+
+    #[test]
+    fn cli_defaults_to_json_rpc_server_mode() {
+        let cli = Cli::try_parse_from(["coincube-spark-bridge"]).unwrap();
+
+        assert!(!cli.smoke_test);
+    }
+
+    #[test]
+    fn cli_accepts_smoke_test_flag() {
+        let cli = Cli::try_parse_from(["coincube-spark-bridge", "--smoke-test"]).unwrap();
+
+        assert!(cli.smoke_test);
+    }
+}

--- a/coincube-spark-bridge/src/sdk_adapter.rs
+++ b/coincube-spark-bridge/src/sdk_adapter.rs
@@ -34,6 +34,12 @@ pub const STABLE_BALANCE_LABEL: &str = "USDB";
 /// staging builds at an alternate allowlisted domain.
 const DEFAULT_LNURL_DOMAIN: &str = "coincube.io";
 
+fn configured_lnurl_domain(raw: Option<String>) -> String {
+    raw.map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_LNURL_DOMAIN.to_string())
+}
+
 /// Cloneable SDK handle. The inner [`BreezSdk`] is `Send + Sync`, so the
 /// bridge can freely share it across async tasks serving different
 /// JSON-RPC requests concurrently.
@@ -67,12 +73,7 @@ pub fn mainnet_config(api_key: String) -> breez_sdk_spark::Config {
     // configured" and fall back to the default. An empty string
     // would otherwise be handed to the SDK as a valid domain and
     // produce nonsense Lightning Addresses like `user@`.
-    let lnurl_domain = std::env::var("COINCUBE_LNURL_DOMAIN")
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| DEFAULT_LNURL_DOMAIN.to_string());
-    config.lnurl_domain = Some(lnurl_domain);
+    config.lnurl_domain = Some(configured_lnurl_domain(std::env::var("COINCUBE_LNURL_DOMAIN").ok()));
     // Cross-chain stablecoin send (USDT/USDC to EVM/Solana/Tron). Opt-in: the
     // providers (Orchestra, Boltz) run background work such as websockets, so
     // the SDK leaves them off unless this is set. Mainnet-only, which is all
@@ -128,4 +129,65 @@ pub async fn connect_mainnet(
         .build()
         .await?;
     Ok(SdkHandle { sdk: Arc::new(sdk) })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn configured_lnurl_domain_falls_back_for_missing_or_blank_values() {
+        assert_eq!(configured_lnurl_domain(None), DEFAULT_LNURL_DOMAIN);
+        assert_eq!(
+            configured_lnurl_domain(Some(String::new())),
+            DEFAULT_LNURL_DOMAIN
+        );
+        assert_eq!(
+            configured_lnurl_domain(Some(" \t\n ".to_string())),
+            DEFAULT_LNURL_DOMAIN
+        );
+    }
+
+    #[test]
+    fn configured_lnurl_domain_trims_custom_domain() {
+        assert_eq!(
+            configured_lnurl_domain(Some(" staging.coincube.io ".to_string())),
+            "staging.coincube.io"
+        );
+    }
+
+    #[test]
+    fn mainnet_config_wires_stable_balance_and_claim_fee_defaults() {
+        let config = mainnet_config("api-key".to_string());
+
+        assert_eq!(config.api_key.as_deref(), Some("api-key"));
+
+        let stable_balance = config
+            .stable_balance_config
+            .as_ref()
+            .expect("stable balance config should be enabled");
+        assert_eq!(stable_balance.tokens.len(), 1);
+        assert_eq!(stable_balance.tokens[0].label, STABLE_BALANCE_LABEL);
+        assert_eq!(
+            stable_balance.tokens[0].token_identifier,
+            USDB_MAINNET_TOKEN_IDENTIFIER
+        );
+        assert!(stable_balance.default_active_label.is_none());
+        assert!(stable_balance.threshold_sats.is_none());
+        assert!(stable_balance.max_slippage_bps.is_none());
+
+        let cross_chain = config
+            .cross_chain_config
+            .as_ref()
+            .expect("cross-chain config should be enabled");
+        assert!(cross_chain.default_slippage_bps.is_none());
+        assert!(cross_chain.default_target_overpay_bps.is_none());
+
+        assert!(matches!(
+            config.max_deposit_claim_fee,
+            Some(MaxFee::NetworkRecommended {
+                leeway_sat_per_vbyte: 5
+            })
+        ));
+    }
 }

--- a/coincube-ui/src/theme/palette.rs
+++ b/coincube-ui/src/theme/palette.rs
@@ -1165,3 +1165,61 @@ impl Palette {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn theme_mode_defaults_and_round_trips_lowercase_wire_values() {
+        assert_eq!(ThemeMode::default(), ThemeMode::Dark);
+        assert_eq!(serde_json::to_string(&ThemeMode::Dark).unwrap(), "\"dark\"");
+        assert_eq!(
+            serde_json::to_string(&ThemeMode::Light).unwrap(),
+            "\"light\""
+        );
+
+        let decoded: ThemeMode = serde_json::from_str("\"light\"").unwrap();
+        assert_eq!(decoded, ThemeMode::Light);
+    }
+
+    #[test]
+    fn dark_palette_is_default_and_matches_mode_dispatch() {
+        let dark = Palette::dark();
+
+        assert_eq!(dark, Palette::default());
+        assert_eq!(Palette::from_mode(ThemeMode::Dark), dark);
+        assert_eq!(dark.general.background, color::LIGHT_BLACK);
+        assert_eq!(dark.general.foreground, color::BLACK);
+        assert_eq!(dark.text.primary, color::WHITE);
+        assert_eq!(dark.buttons.primary.active.background, color::ORANGE);
+        assert_eq!(dark.buttons.primary.active.text, color::LIGHT_BLACK);
+        assert_eq!(dark.buttons.primary.hovered.background, color::DARK_ORANGE);
+        assert_eq!(
+            dark.buttons.orange_outline.active.background,
+            color::TRANSPARENT
+        );
+        assert_eq!(dark.text_inputs.invalid.active.border, Some(color::RED));
+        assert_eq!(dark.togglers.off.background, color::GREY_2);
+    }
+
+    #[test]
+    fn light_palette_matches_mode_dispatch_and_light_surface_contracts() {
+        let light = Palette::light();
+
+        assert_eq!(Palette::from_mode(ThemeMode::Light), light);
+        assert_ne!(light, Palette::dark());
+        assert_eq!(light.general.background, color::LIGHT_BG);
+        assert_eq!(light.general.foreground, color::WARM_PAPER);
+        assert_eq!(light.text.primary, color::DARK_GRAY);
+        assert_eq!(light.text.success, color::DARK_GREEN);
+        assert_eq!(light.buttons.menu.hovered.background, color::LIGHT_HOVER);
+        assert_eq!(light.cards.simple.background, color::LIGHT_CARD_BG);
+        assert_eq!(light.notifications.debug.text, Some(color::DARK_GRAY));
+        assert_eq!(
+            light.sliders.rail_backgrounds,
+            (color::ORANGE, color::LIGHT_BORDER)
+        );
+        assert_eq!(light.togglers.off.background, color::LIGHT_BORDER);
+    }
+}

--- a/coincube-ui/src/widget/text_input.rs
+++ b/coincube-ui/src/widget/text_input.rs
@@ -1507,3 +1507,326 @@ fn alignment_offset(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone)]
+    struct TestParagraph {
+        content: String,
+        font: iced::Font,
+        size: Pixels,
+        line_height: text::LineHeight,
+        align_x: text::Alignment,
+        align_y: alignment::Vertical,
+        wrapping: text::Wrapping,
+        shaping: text::Shaping,
+        bounds: Size,
+    }
+
+    impl Default for TestParagraph {
+        fn default() -> Self {
+            Self {
+                content: String::new(),
+                font: iced::Font::default(),
+                size: Pixels(16.0),
+                line_height: text::LineHeight::default(),
+                align_x: text::Alignment::Left,
+                align_y: alignment::Vertical::Top,
+                wrapping: text::Wrapping::default(),
+                shaping: text::Shaping::default(),
+                bounds: Size::new(200.0, 20.0),
+            }
+        }
+    }
+
+    impl text::Paragraph for TestParagraph {
+        type Font = iced::Font;
+
+        fn with_text(text: Text<&str, Self::Font>) -> Self {
+            Self {
+                content: text.content.to_string(),
+                font: text.font,
+                size: text.size,
+                line_height: text.line_height,
+                align_x: text.align_x,
+                align_y: text.align_y,
+                wrapping: text.wrapping,
+                shaping: text.shaping,
+                bounds: text.bounds,
+            }
+        }
+
+        fn with_spans<Link>(_text: Text<&[text::Span<'_, Link, Self::Font>], Self::Font>) -> Self {
+            Self::default()
+        }
+
+        fn resize(&mut self, new_bounds: Size) {
+            self.bounds = new_bounds;
+        }
+
+        fn compare(&self, text: Text<(), Self::Font>) -> text::Difference {
+            if self.bounds != text.bounds {
+                text::Difference::Bounds
+            } else {
+                text::Difference::None
+            }
+        }
+
+        fn size(&self) -> Pixels {
+            self.size
+        }
+
+        fn font(&self) -> Self::Font {
+            self.font
+        }
+
+        fn line_height(&self) -> text::LineHeight {
+            self.line_height
+        }
+
+        fn align_x(&self) -> text::Alignment {
+            self.align_x
+        }
+
+        fn align_y(&self) -> alignment::Vertical {
+            self.align_y
+        }
+
+        fn wrapping(&self) -> text::Wrapping {
+            self.wrapping
+        }
+
+        fn shaping(&self) -> text::Shaping {
+            self.shaping
+        }
+
+        fn bounds(&self) -> Size {
+            self.bounds
+        }
+
+        fn min_bounds(&self) -> Size {
+            Size::new(self.content.chars().count() as f32 * 10.0, self.size.0)
+        }
+
+        fn hit_test(&self, point: Point) -> Option<text::Hit> {
+            (point.x >= 0.0).then(|| {
+                let index = ((point.x / 10.0).floor() as usize).min(self.content.len());
+                text::Hit::CharOffset(index)
+            })
+        }
+
+        fn hit_span(&self, _point: Point) -> Option<usize> {
+            None
+        }
+
+        fn span_bounds(&self, _index: usize) -> Vec<Rectangle> {
+            Vec::new()
+        }
+
+        fn grapheme_position(&self, _line: usize, index: usize) -> Option<Point> {
+            Some(Point::new(index as f32 * 10.0, 0.0))
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    enum Msg {
+        Input(String),
+        Paste(String),
+        Submit,
+    }
+
+    fn input_msg(value: String) -> Msg {
+        Msg::Input(value)
+    }
+
+    fn paste_msg(value: String) -> Msg {
+        Msg::Paste(value)
+    }
+
+    fn plain(content: &str) -> paragraph::Plain<TestParagraph> {
+        paragraph::Plain::new(Text {
+            content: content.to_string(),
+            font: iced::Font::default(),
+            line_height: text::LineHeight::default(),
+            bounds: Size::new(200.0, 20.0),
+            size: Pixels(16.0),
+            align_x: text::Alignment::Left,
+            align_y: alignment::Vertical::Top,
+            shaping: text::Shaping::default(),
+            wrapping: text::Wrapping::default(),
+        })
+    }
+
+    #[test]
+    fn builder_methods_store_handlers_and_visual_options() {
+        let input = TextInput::<Msg>::new("hint", "value")
+            .id("field")
+            .secure(true)
+            .on_input(Msg::Input)
+            .on_paste(Msg::Paste)
+            .on_submit(Msg::Submit)
+            .font(iced::Font::MONOSPACE)
+            .icon(Icon {
+                font: iced::Font::MONOSPACE,
+                code_point: '*',
+                size: Some(Pixels(12.0)),
+                spacing: 6.0,
+                side: Side::Right,
+            })
+            .width(Length::Fixed(120.0))
+            .padding(8)
+            .size(18)
+            .line_height(1.1)
+            .align_x(alignment::Horizontal::Right);
+
+        assert!(input.id.is_some());
+        assert_eq!(input.placeholder, "hint");
+        assert_eq!(input.value.to_string(), "value");
+        assert!(input.is_secure);
+        assert_eq!(input.font, Some(iced::Font::MONOSPACE));
+        assert!(matches!(input.width, Length::Fixed(120.0)));
+        assert_eq!(input.padding, Padding::from(8));
+        assert_eq!(input.size, Some(Pixels(18.0)));
+        assert_eq!(input.line_height, text::LineHeight::Relative(1.1));
+        assert_eq!(input.alignment, alignment::Horizontal::Right);
+
+        let icon = input.icon.as_ref().expect("icon should be stored");
+        assert_eq!(icon.code_point, '*');
+        assert!(matches!(icon.side, Side::Right));
+        assert_eq!(icon.spacing, 6.0);
+
+        assert_eq!(
+            (input.on_input.as_ref().unwrap())("typed".to_string()),
+            Msg::Input("typed".to_string())
+        );
+        assert_eq!(
+            (input.on_paste.as_ref().unwrap())("pasted".to_string()),
+            Msg::Paste("pasted".to_string())
+        );
+        assert_eq!(input.on_submit, Some(Msg::Submit));
+    }
+
+    #[test]
+    fn maybe_builders_accept_some_and_none() {
+        let enabled = TextInput::<Msg>::new("", "")
+            .on_input_maybe(Some(input_msg as fn(String) -> Msg))
+            .on_paste_maybe(Some(paste_msg as fn(String) -> Msg))
+            .on_submit_maybe(Some(Msg::Submit));
+
+        assert_eq!(
+            (enabled.on_input.as_ref().unwrap())("a".to_string()),
+            Msg::Input("a".to_string())
+        );
+        assert_eq!(
+            (enabled.on_paste.as_ref().unwrap())("b".to_string()),
+            Msg::Paste("b".to_string())
+        );
+        assert_eq!(enabled.on_submit, Some(Msg::Submit));
+
+        let disabled = TextInput::<Msg>::new("", "")
+            .on_input_maybe(None::<fn(String) -> Msg>)
+            .on_paste_maybe(None::<fn(String) -> Msg>)
+            .on_submit_maybe(None);
+
+        assert!(disabled.on_input.is_none());
+        assert!(disabled.on_paste.is_none());
+        assert!(disabled.on_submit.is_none());
+    }
+
+    #[test]
+    fn id_and_task_constructors_are_available_for_widget_operations() {
+        assert_eq!(Id::new("field"), Id::from("field"));
+        assert_eq!(Id::new("field"), Id::from("field".to_string()));
+        assert_ne!(Id::unique(), Id::unique());
+
+        let _: Task<Msg> = focus("field");
+        let _: Task<Msg> = move_cursor_to_end("field");
+        let _: Task<Msg> = move_cursor_to_front("field");
+        let _: Task<Msg> = move_cursor_to("field", 3);
+        let _: Task<Msg> = select_all("field");
+    }
+
+    #[test]
+    fn state_focus_cursor_and_operation_text_are_consistent() {
+        let value = Value::new("hello");
+        let mut state = State::<TestParagraph>::new();
+
+        assert!(!state.is_focused());
+        assert_eq!(state.cursor().state(&value), cursor::State::Index(0));
+
+        state.focus();
+        assert!(state.is_focused());
+        assert_eq!(state.cursor().state(&value), cursor::State::Index(5));
+
+        state.move_cursor_to_front();
+        assert_eq!(state.cursor().state(&value), cursor::State::Index(0));
+
+        state.move_cursor_to(2);
+        assert_eq!(state.cursor().state(&value), cursor::State::Index(2));
+
+        state.select_all();
+        assert_eq!(state.cursor().selection(&value), Some((0, 5)));
+
+        state.value = plain("typed");
+        state.placeholder = plain("placeholder");
+        assert_eq!(operation::TextInput::text(&state), "typed");
+
+        state.value = plain("");
+        assert_eq!(operation::TextInput::text(&state), "placeholder");
+
+        operation::TextInput::select_range(&mut state, 1, 4);
+        assert_eq!(state.cursor().selection(&value), Some((1, 4)));
+
+        operation::Focusable::unfocus(&mut state);
+        assert!(!state.is_focused());
+        operation::Focusable::focus(&mut state);
+        assert!(state.is_focused());
+    }
+
+    #[test]
+    fn offset_and_alignment_helpers_cover_scroll_and_alignment_edges() {
+        let value = Value::new("abcdefghij");
+        let mut state = State::<TestParagraph>::new();
+        state.value = plain("abcdefghij");
+
+        let bounds = Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 30.0,
+            height: 20.0,
+        };
+
+        assert_eq!(offset(bounds, &value, &state), 0.0);
+
+        state.focus();
+        state.move_cursor_to_end();
+        assert_eq!(offset(bounds, &value, &state), 75.0);
+
+        state.move_cursor_to(3);
+        assert_eq!(offset(bounds, &value, &state), 5.0);
+
+        state.select_all();
+        assert_eq!(offset(bounds, &value, &state), 75.0);
+
+        assert_eq!(find_cursor_position(bounds, &value, &state, 15.0), Some(9));
+
+        assert_eq!(
+            alignment_offset(100.0, 40.0, alignment::Horizontal::Left),
+            0.0
+        );
+        assert_eq!(
+            alignment_offset(100.0, 40.0, alignment::Horizontal::Center),
+            30.0
+        );
+        assert_eq!(
+            alignment_offset(100.0, 40.0, alignment::Horizontal::Right),
+            60.0
+        );
+        assert_eq!(
+            alignment_offset(40.0, 100.0, alignment::Horizontal::Right),
+            0.0
+        );
+    }
+}

--- a/contrib/coverage-bridge.sh
+++ b/contrib/coverage-bridge.sh
@@ -1,29 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Rust coverage for the main workspace. This intentionally excludes fuzz
-# targets: libFuzzer binaries do not behave like normal test binaries under
-# `-- --list` or coverage collection.
+# Rust coverage for the standalone Spark bridge workspace. The bridge is
+# intentionally excluded from the root workspace so its Breez Spark dependency
+# graph can stay isolated from the GUI's Breez Liquid dependency graph.
 #
 # Common local usage:
-#   ./contrib/coverage.sh
-#   HTML=1 ./contrib/coverage.sh
-#   FAIL_UNDER_LINES=45 ./contrib/coverage.sh
-#   COVERAGE_TARGET_LINES=50 FAIL_UNDER_LINES=45 ./contrib/coverage.sh
-#   CARGO_TOOLCHAIN=nightly COVERAGE_DOCTESTS=1 ./contrib/coverage.sh
+#   ./contrib/coverage-bridge.sh
+#   HTML=1 ./contrib/coverage-bridge.sh
+#   FAIL_UNDER_LINES=10 ./contrib/coverage-bridge.sh
 
+BRIDGE_MANIFEST="${BRIDGE_MANIFEST:-coincube-spark-bridge/Cargo.toml}"
 OUTPUT_DIR="${OUTPUT_DIR:-target/coverage}"
-LCOV_PATH="${LCOV_PATH:-${OUTPUT_DIR}/lcov.info}"
-SUMMARY_PATH="${SUMMARY_PATH:-${OUTPUT_DIR}/summary.json}"
+LCOV_PATH="${LCOV_PATH:-${OUTPUT_DIR}/bridge-lcov.info}"
+SUMMARY_PATH="${SUMMARY_PATH:-${OUTPUT_DIR}/bridge-summary.json}"
 HTML="${HTML:-0}"
 COVERAGE_CLEAN="${COVERAGE_CLEAN:-1}"
 CARGO_TOOLCHAIN="${CARGO_TOOLCHAIN:-}"
-COVERAGE_DOCTESTS="${COVERAGE_DOCTESTS:-0}"
 COVERAGE_TARGET_LINES="${COVERAGE_TARGET_LINES:-}"
-
-# The GUI embeds this value at compile time. Unit and integration tests do not
-# contact Breez unless explicitly configured, so mirror CI's harmless default.
-export BREEZ_API_KEY="${BREEZ_API_KEY:-DUMMY_BREEZ_API_KEY}"
 
 if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
   cat >&2 <<'EOF'
@@ -44,25 +38,14 @@ fi
 cargo_llvm_cov+=(llvm-cov)
 
 test_args=(
+  --manifest-path "${BRIDGE_MANIFEST}"
   --workspace
-  --exclude coincube-fuzz
-  --lib
-  --bins
-  --tests
   --no-report
 )
 
 report_args=(
-  --ignore-filename-regex '/(target|fuzz)/'
-)
-
-if [[ "${COVERAGE_DOCTESTS}" == "1" ]]; then
-  report_args+=(--doctests)
-fi
-
-test_command=(
-  "${cargo_llvm_cov[@]}"
-  "${test_args[@]}"
+  --manifest-path "${BRIDGE_MANIFEST}"
+  --ignore-filename-regex '/target/'
 )
 
 if [[ -n "${FAIL_UNDER_LINES:-}" ]]; then
@@ -76,22 +59,12 @@ if [[ -n "${FAIL_UNDER_REGIONS:-}" ]]; then
 fi
 
 if [[ "${COVERAGE_CLEAN}" == "1" ]]; then
-  "${cargo_llvm_cov[@]}" clean --workspace
+  "${cargo_llvm_cov[@]}" clean --manifest-path "${BRIDGE_MANIFEST}" --workspace
 fi
 
 set +e
-"${test_command[@]}" "$@"
+"${cargo_llvm_cov[@]}" "${test_args[@]}" "$@"
 run_status=$?
-
-doctest_status=0
-if [[ "${COVERAGE_DOCTESTS}" == "1" ]]; then
-  "${cargo_llvm_cov[@]}" \
-    --workspace \
-    --exclude coincube-fuzz \
-    --doc \
-    --no-report
-  doctest_status=$?
-fi
 
 "${cargo_llvm_cov[@]}" report \
   "${report_args[@]}" \
@@ -111,13 +84,13 @@ if [[ "${HTML}" == "1" ]]; then
   "${cargo_llvm_cov[@]}" report \
     "${report_args[@]}" \
     --html \
-    --output-dir "${OUTPUT_DIR}/html"
+    --output-dir "${OUTPUT_DIR}/bridge-html"
   html_status=$?
 fi
 set -e
 
 cat <<EOF
-Coverage artifacts written:
+Bridge coverage artifacts written:
   LCOV:    ${LCOV_PATH}
   Summary: ${SUMMARY_PATH}
 EOF
@@ -127,26 +100,22 @@ if [[ -n "${COVERAGE_TARGET_LINES}" ]]; then
 fi
 
 if [[ "${HTML}" == "1" ]]; then
-  echo "  HTML:    ${OUTPUT_DIR}/html/index.html"
+  echo "  HTML:    ${OUTPUT_DIR}/bridge-html/index.html"
 fi
 
 if [[ "${run_status}" -ne 0 ]]; then
-  echo "Coverage test run failed with exit status ${run_status}." >&2
+  echo "Bridge coverage test run failed with exit status ${run_status}." >&2
   exit "${run_status}"
 fi
-if [[ "${doctest_status}" -ne 0 ]]; then
-  echo "Coverage doctest run failed with exit status ${doctest_status}." >&2
-  exit "${doctest_status}"
-fi
 if [[ "${lcov_status}" -ne 0 ]]; then
-  echo "LCOV generation failed with exit status ${lcov_status}." >&2
+  echo "Bridge LCOV generation failed with exit status ${lcov_status}." >&2
   exit "${lcov_status}"
 fi
 if [[ "${summary_status}" -ne 0 ]]; then
-  echo "Coverage summary generation failed with exit status ${summary_status}." >&2
+  echo "Bridge coverage summary generation failed with exit status ${summary_status}." >&2
   exit "${summary_status}"
 fi
 if [[ "${html_status}" -ne 0 ]]; then
-  echo "Coverage HTML generation failed with exit status ${html_status}." >&2
+  echo "Bridge coverage HTML generation failed with exit status ${html_status}." >&2
   exit "${html_status}"
 fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Settings persistence behavior changes on Windows (retries, sync, empty-file handling) can affect cube configuration durability; otherwise the PR is mostly tests and CI with a small Connect UI field change.
> 
> **Overview**
> Adds **large unit/UI test suites** across Connect, Buy/Sell, Spark receive, vault spend/PSBT/keychain sign, global home, Mavapay views, duress helpers, and related state machines, plus shared vault test fixtures (`empty_psbt`, Connect tokens).
> 
> **CI reliability and coverage:** workspace coverage gets explicit line targets and a non-breaking floor (~26%); a separate **Spark bridge** coverage job runs `coverage-bridge.sh`. Integration electrs legs now **deselect and re-run** all `simple_reorg`-driven chain tests serially with a higher timeout (including `test_reorg_detection` and `test_reorg_status_recovery`). Unit test matrix uses **`fail-fast: false`** and a Windows step to reduce Defender interference with temp-file tests.
> 
> **Production-adjacent fixes:** `settings.json` read/write **retries** transient `PermissionDenied` / path races, **flush+sync** after writes, safer handling when an existing file is empty (parse error vs defaults), and explicit drop before delete on Windows. **PIN hashing** uses minimal Argon2 cost only under `cfg(test)` to speed CI. Connect **login activity** display uses `device_name` instead of `user_agent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a555a9365323b79320b2f7464610623934691ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Lightning Address LNURL domain handling by trimming whitespace and reverting to defaults when blank.
  * Updated Security dashboard “device” display to use server-provided device name.
  * Hardened `settings.json` loading/writing to retry transient permission/lock issues and ensure data is flushed/synced before other reads.

* **Tests**
  * Significantly expanded unit/UI test coverage across GUI flows, vault/PSBT, settings, export/import, parsing, and Spark bridge CLI/state logic.

* **Chores**
  * Expanded coverage CI with line-gating and a dedicated Spark bridge coverage job; reduced integration flakiness for reorg-heavy tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->