### PR TITLE
Keychain CRK Status Fixes

### DIFF
--- a/coincube-gui/src/app/cache.rs
+++ b/coincube-gui/src/app/cache.rs
@@ -161,6 +161,12 @@ pub struct Cache {
     /// drift banner (W12). `None` when no descriptor has ever been
     /// backed up, or when the kit has been removed.
     pub recovery_kit_last_backed_up_descriptor_fingerprint: Option<String>,
+    /// Keychain (phone) analogue of the field above: mirrors
+    /// `CubeSettings::recovery_kit_last_backed_up_keychain_descriptor_fingerprint`.
+    /// The Settings card compares it to `current_descriptor_fingerprint` to
+    /// surface the phone copy's independent drift verdict (per-method drift,
+    /// PR 3). `None` when never phone-sealed or after the kit is removed.
+    pub recovery_kit_last_backed_up_keychain_descriptor_fingerprint: Option<String>,
     /// Connect gRPC base URL, populated once `Message::ConnectStreamReady`
     /// fires after login. `None` until then or for local-daemon installs
     /// — the Keychain "Sign via Keychain" button stays disabled while
@@ -229,6 +235,7 @@ impl std::default::Default for Cache {
             current_cube_server_id: None,
             current_descriptor_fingerprint: None,
             recovery_kit_last_backed_up_descriptor_fingerprint: None,
+            recovery_kit_last_backed_up_keychain_descriptor_fingerprint: None,
             connect_grpc_url: None,
             connect_tokens: None,
             connect_stream_status: crate::app::ConnectionStatus::default(),

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1674,6 +1674,9 @@ impl App {
             recovery_kit_last_backed_up_descriptor_fingerprint: cube_settings
                 .recovery_kit_last_backed_up_descriptor_fingerprint
                 .clone(),
+            recovery_kit_last_backed_up_keychain_descriptor_fingerprint: cube_settings
+                .recovery_kit_last_backed_up_keychain_descriptor_fingerprint
+                .clone(),
             ..Default::default()
         };
 
@@ -3263,6 +3266,16 @@ impl App {
                         self.cube_settings
                             .recovery_kit_last_backed_up_descriptor_fingerprint = cube
                             .recovery_kit_last_backed_up_descriptor_fingerprint
+                            .clone();
+                        // Same for the keychain (phone) drift slot (per-method
+                        // drift, PR 3).
+                        self.cache
+                            .recovery_kit_last_backed_up_keychain_descriptor_fingerprint = cube
+                            .recovery_kit_last_backed_up_keychain_descriptor_fingerprint
+                            .clone();
+                        self.cube_settings
+                            .recovery_kit_last_backed_up_keychain_descriptor_fingerprint = cube
+                            .recovery_kit_last_backed_up_keychain_descriptor_fingerprint
                             .clone();
 
                         // Clear cached fiat display price if disabled.

--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -1586,6 +1586,24 @@ mod test {
             Some("kc-fp".to_string());
         assert!(cube.has_recovery_kit());
         assert_eq!(cube.connect_state(), CubeConnectState::BackedUp);
+
+        // The keychain slot must survive persistence — the field is
+        // `skip_serializing_if = "Option::is_none"` but populated here, so it
+        // has to appear in the serialized form and come back verbatim. A future
+        // `skip_serializing` (or a rename without a serde alias) would silently
+        // drop the fingerprint and regress the Cube to "no recovery kit" on the
+        // next launch, so round-trip through the JSON persistence API.
+        let json = serde_json::to_string(&cube).expect("CubeSettings must serialize");
+        let restored: CubeSettings = serde_json::from_str(&json).expect("CubeSettings must deserialize");
+        assert_eq!(
+            restored
+                .recovery_kit_last_backed_up_keychain_descriptor_fingerprint
+                .as_deref(),
+            Some("kc-fp"),
+            "keychain fingerprint must persist across a serialize/deserialize round-trip"
+        );
+        assert!(restored.has_recovery_kit());
+        assert_eq!(restored.connect_state(), CubeConnectState::BackedUp);
     }
 
     #[test]

--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -504,15 +504,25 @@ impl CubeSettings {
         self.passkey_metadata.is_some()
     }
 
-    /// True when this Cube has a Cube Recovery Kit pushed to Connect. We treat
-    /// a recorded backed-up descriptor fingerprint as the CRK-presence signal
-    /// (`recovery_kit_last_backed_up_descriptor_fingerprint` is set on a
-    /// successful kit upload and cleared on delete). Distinct from
+    /// True when this Cube has a Cube Recovery Kit pushed to Connect **from this
+    /// device**, by either method. We treat a recorded backed-up descriptor
+    /// fingerprint as the CRK-presence signal — set on a successful kit upload
+    /// (password slot) or phone seal (keychain slot) and cleared on delete. Both
+    /// slots count: a keychain-only backup is a recovery kit too, so keying off
+    /// the password slot alone would make the Home card read "no recovery kit"
+    /// while Settings (which reads the server per-method status) reads "backed
+    /// up" (keychain-crk-status-fixes). This stays a **local** heuristic: it
+    /// reflects backups made from this device, not the server-authoritative
+    /// state, so an other-device backup can still read `false` here — the same
+    /// limitation the password slot has always had. Distinct from
     /// [`backed_up`](Self::backed_up), which tracks the *local* seed-phrase
     /// backup, not the server-side recovery kit.
     pub fn has_recovery_kit(&self) -> bool {
         self.recovery_kit_last_backed_up_descriptor_fingerprint
             .is_some()
+            || self
+                .recovery_kit_last_backed_up_keychain_descriptor_fingerprint
+                .is_some()
     }
 
     /// Classifies this Cube's relationship to Connect for the card indicator
@@ -1556,6 +1566,26 @@ mod test {
         // as Sovereign — registration is the gating signal.
         cube.remote_synced = false;
         assert_eq!(cube.connect_state(), CubeConnectState::Sovereign);
+    }
+
+    #[test]
+    fn keychain_only_backup_reads_as_backed_up() {
+        use super::{CubeConnectState, CubeSettings};
+        use coincube_core::miniscript::bitcoin::Network;
+
+        // A keychain-only backup persists the keychain descriptor slot but not
+        // the password slot. `has_recovery_kit` must still report a kit, so the
+        // Home card reads "Backed up" in agreement with Settings — not "no
+        // recovery kit" (keychain-crk-status-fixes).
+        let mut cube = CubeSettings::new("Keychain-only".to_string(), Network::Bitcoin);
+        cube.remote_synced = true;
+        assert!(cube
+            .recovery_kit_last_backed_up_descriptor_fingerprint
+            .is_none());
+        cube.recovery_kit_last_backed_up_keychain_descriptor_fingerprint =
+            Some("kc-fp".to_string());
+        assert!(cube.has_recovery_kit());
+        assert_eq!(cube.connect_state(), CubeConnectState::BackedUp);
     }
 
     #[test]

--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -419,6 +419,15 @@ pub struct CubeSettings {
     /// on `delete_recovery_kit`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recovery_kit_last_backed_up_descriptor_fingerprint: Option<String>,
+    /// Keychain (owner-self "phone") analogue of
+    /// `recovery_kit_last_backed_up_descriptor_fingerprint`: SHA-256 (hex) of
+    /// the `DescriptorBlob` plaintext last **sealed to the phone** recovery
+    /// envelope. Drives the phone copy's independent drift verdict (per-method
+    /// drift, PR 3). `None` when no descriptor was ever phone-sealed; written on
+    /// a successful `PhoneSealResult`, cleared alongside the password slot on
+    /// Remove-all. Back-compat is free — only the phone-seal path ever writes it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovery_kit_last_backed_up_keychain_descriptor_fingerprint: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -459,6 +468,7 @@ impl CubeSettings {
             allow_random_grid_phrase: false,
             balance_masked: false,
             recovery_kit_last_backed_up_descriptor_fingerprint: None,
+            recovery_kit_last_backed_up_keychain_descriptor_fingerprint: None,
         }
     }
 

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -4768,6 +4768,54 @@ mod duress_enroll_tests {
     }
 
     #[test]
+    fn duress_cube_has_recovery_kit_mirrors_list_cubes_verbatim() {
+        // Symptom 2 (a keychain-only Cube tagged "No recovery kit") is fixed
+        // server-side: `list_cubes` now reports `hasRecoveryKit=true` for a
+        // Cube whose only backup is the phone (Keychain) envelope. The desktop
+        // must carry that flag through **verbatim** — `load_duress_cubes`
+        // assigns `DuressCube.has_recovery_kit = c.has_recovery_kit` (this file,
+        // ~line 4161) and must never re-derive it from the password `halves`,
+        // or a keychain-only backup would read as unbacked again.
+        use crate::services::coincube::CubeResponse;
+
+        // A keychain-only Cube: `hasRecoveryKit` true, but NO password halves in
+        // the per-cube status (both false).
+        let c: CubeResponse = serde_json::from_value(serde_json::json!({
+            "id": 42,
+            "uuid": "keychain-only-uuid",
+            "name": "Keychain-only",
+            "network": "mainnet",
+            "status": "active",
+            "hasRecoveryKit": true,
+        }))
+        .expect("list_cubes cube deserializes");
+        assert!(
+            c.has_recovery_kit,
+            "hasRecoveryKit must deserialize to has_recovery_kit"
+        );
+
+        // Model the loader's assignment: a plain copy of the server flag, with
+        // the password halves empty (keychain-only).
+        let dc = DuressCube {
+            server_id: c.id,
+            uuid: Some(c.uuid),
+            name: c.name,
+            has_recovery_kit: c.has_recovery_kit,
+            halves: Some((false, false)),
+            has_vault: Some(true),
+            is_passkey: Some(false),
+            local: true,
+        };
+        // The flag is mirrored verbatim and stays independent of the password
+        // halves — true even though both halves are absent.
+        assert_eq!(dc.has_recovery_kit, c.has_recovery_kit);
+        assert!(
+            dc.has_recovery_kit && dc.halves == Some((false, false)),
+            "has_recovery_kit must come from list_cubes, not the password halves"
+        );
+    }
+
+    #[test]
     fn require_backup_ack_gating() {
         let mut panel = ConnectAccountPanel::new();
 

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -27,7 +27,7 @@ use crate::app::view;
 use crate::app::view::settings::general::backup_overview;
 use crate::app::view::{
     PhoneKeyOutcome, RecoveryKitMessage, RecoveryKitMode, RecoveryKitUploadOutcome,
-    RecoveryProtectionMode,
+    RecoveryProtectionMode, RemoveFailure,
 };
 use crate::app::wallet::Wallet;
 use crate::feature_flags;
@@ -759,8 +759,13 @@ pub fn update(
                     let reload = load_status(rk, client, server_cube_id);
                     Task::batch([persist, reload])
                 }
-                Err(e) => {
-                    rk.flow = RecoveryKitState::Error { message: e.clone() };
+                Err(RemoveFailure {
+                    message,
+                    password_kit_deleted,
+                }) => {
+                    rk.flow = RecoveryKitState::Error {
+                        message: message.clone(),
+                    };
                     // Removal runs sequentially and can partially succeed — e.g.
                     // the password kit was deleted, then the phone (Keychain)
                     // step failed. The server state has already changed even
@@ -770,8 +775,27 @@ pub fn update(
                     // no longer has once the user dismisses the error. Mirrors
                     // the `PhoneSealResult` partial-failure handling.
                     let reload = load_status(rk, client, server_cube_id);
+                    // `load_status` only fixes the in-memory `rk.status`; the
+                    // persisted per-method fingerprint slots drive
+                    // `has_recovery_kit()` / `connect_state()`. When the password
+                    // kit was already torn down before the failure, its local
+                    // fingerprint now points at a kit Connect no longer holds, so
+                    // clear just that slot. The keychain slot stays: its copy may
+                    // well survive the failure (the very reason we failed loudly),
+                    // and a retry — or the phone-seal path — reconciles it.
+                    let clear_stale_password = if password_kit_deleted {
+                        persist_descriptor_fingerprint(
+                            cache,
+                            local_cube_id,
+                            DescriptorFingerprintSlot::Password,
+                            None,
+                        )
+                    } else {
+                        Task::none()
+                    };
                     Task::batch([
-                        Task::done(Message::View(view::Message::ShowError(e))),
+                        Task::done(Message::View(view::Message::ShowError(message))),
+                        clear_stale_password,
                         reload,
                     ])
                 }
@@ -1492,16 +1516,42 @@ async fn remove_backups(
     client: CoincubeClient,
     cube_id: u64,
     delete_keychain: bool,
-) -> Result<(), String> {
+) -> Result<(), RemoveFailure> {
     normalize_delete_result(client.delete_recovery_kit(cube_id).await).map_err(|e| {
-        format!(
-            "Couldn't remove your password-encrypted Recovery Kit ({}). It's still \
-             restorable — try Remove again.",
-            e
-        )
+        RemoveFailure {
+            message: format!(
+                "Couldn't remove your password-encrypted Recovery Kit ({}). It's still \
+                 restorable — try Remove again.",
+                e
+            ),
+            // The delete itself failed, so the password kit is still on Connect
+            // and the local fingerprint slot is still accurate — don't drop it.
+            password_kit_deleted: false,
+        }
     })?;
+    // The password kit is now gone (deleted, or a 404 meaning it was already
+    // absent). The phone-half work below can still fail, but the password half
+    // is torn down — tag any failure so the caller clears the now-stale local
+    // password fingerprint slot instead of leaving it pointing at a dead kit.
+    remove_phone_copy(&client, cube_id, delete_keychain)
+        .await
+        .map_err(|message| RemoveFailure {
+            message,
+            password_kit_deleted: true,
+        })
+}
+
+/// Tear down (or verify absent) the owner-keychain (phone) copy — the second
+/// half of [`remove_backups`], split out so the password-half and phone-half
+/// failures can carry different `password_kit_deleted` flags. Returns the
+/// user-facing error string on failure; the caller wraps it in [`RemoveFailure`].
+async fn remove_phone_copy(
+    client: &CoincubeClient,
+    cube_id: u64,
+    delete_keychain: bool,
+) -> Result<(), String> {
     if delete_keychain {
-        match find_owner_self_recipient(&client, cube_id).await {
+        match find_owner_self_recipient(client, cube_id).await {
             Ok(recipient) => match client
                 .delete_recovery_kit_recipient(cube_id, recipient.key_id)
                 .await
@@ -1528,7 +1578,7 @@ async fn remove_backups(
             // device — the user must contact support.
             Err(OwnerSelfError::NoRecipient) => {
                 verify_phone_copy_gone(
-                    &client,
+                    client,
                     cube_id,
                     "The copy sealed to your phone (Keychain) is still restorable but its \
                      recovery key is no longer registered, so it couldn't be removed from this \
@@ -1555,7 +1605,7 @@ async fn remove_backups(
         // recipient may well still exist — a fresh Remove (with up-to-date
         // status) would target it — so the message says to retry.
         verify_phone_copy_gone(
-            &client,
+            client,
             cube_id,
             "The copy sealed to your phone (Keychain) is still restorable. Reopen Settings and \
              try Remove again to clear it.",
@@ -2613,7 +2663,10 @@ mod tests {
         let client = CoincubeClient::for_test("http://localhost");
         let _ = update(
             &mut rk,
-            RecoveryKitMessage::RemoveResult(Err("phone step failed".to_string())),
+            RecoveryKitMessage::RemoveResult(Err(RemoveFailure {
+                message: "phone step failed".to_string(),
+                password_kit_deleted: true,
+            })),
             &Cache::default(),
             "cube-1",
             SeedSource::Mnemonic,
@@ -2793,14 +2846,18 @@ mod tests {
         status.assert();
         assert_eq!(list.hits(), 0, "recipient path must not be resolved");
         assert!(
-            err.contains("phone") || err.contains("Keychain"),
-            "error must name the surviving phone path: {}",
-            err
+            err.password_kit_deleted,
+            "password kit was deleted before the verify failed — the caller must drop its slot"
         );
         assert!(
-            err.contains("try Remove again"),
+            err.message.contains("phone") || err.message.contains("Keychain"),
+            "error must name the surviving phone path: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("try Remove again"),
             "stale-overview survivor must advise a retry, not contact support: {}",
-            err
+            err.message
         );
     }
 
@@ -2832,9 +2889,13 @@ mod tests {
             .expect_err("hard kit-delete error must fail loudly");
         kit.assert();
         assert!(
-            err.contains("password"),
+            !err.password_kit_deleted,
+            "the delete itself failed, so the kit is still on Connect — the local slot stays"
+        );
+        assert!(
+            err.message.contains("password"),
             "error must name the password path: {}",
-            err
+            err.message
         );
         assert_eq!(
             list.hits(),
@@ -2876,9 +2937,13 @@ mod tests {
         list.assert();
         recip.assert();
         assert!(
-            err.contains("phone") || err.contains("Keychain"),
+            err.password_kit_deleted,
+            "password kit was deleted before the recipient step failed — its slot must drop"
+        );
+        assert!(
+            err.message.contains("phone") || err.message.contains("Keychain"),
             "error must name the phone path: {}",
-            err
+            err.message
         );
     }
 
@@ -2971,9 +3036,13 @@ mod tests {
         list.assert();
         status.assert();
         assert!(
-            err.contains("phone") || err.contains("Keychain"),
+            err.password_kit_deleted,
+            "the kit 404 counts as torn down (idempotent), so its slot must drop"
+        );
+        assert!(
+            err.message.contains("phone") || err.message.contains("Keychain"),
             "error must name the surviving phone path: {}",
-            err
+            err.message
         );
     }
 
@@ -3007,9 +3076,13 @@ mod tests {
         list.assert();
         status.assert();
         assert!(
-            err.contains("confirm"),
+            err.password_kit_deleted,
+            "the kit 404 counts as torn down (idempotent), so its slot must drop"
+        );
+        assert!(
+            err.message.contains("confirm"),
             "error must flag the unconfirmed removal: {}",
-            err
+            err.message
         );
     }
 }

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -761,7 +761,19 @@ pub fn update(
                 }
                 Err(e) => {
                     rk.flow = RecoveryKitState::Error { message: e.clone() };
-                    Task::done(Message::View(view::Message::ShowError(e)))
+                    // Removal runs sequentially and can partially succeed — e.g.
+                    // the password kit was deleted, then the phone (Keychain)
+                    // step failed. The server state has already changed even
+                    // though the overall op reports failure, so refresh status
+                    // now (it only updates `rk.status`, not the `Error` flow) —
+                    // otherwise the card keeps showing a password backup Connect
+                    // no longer has once the user dismisses the error. Mirrors
+                    // the `PhoneSealResult` partial-failure handling.
+                    let reload = load_status(rk, client, server_cube_id);
+                    Task::batch([
+                        Task::done(Message::View(view::Message::ShowError(e))),
+                        reload,
+                    ])
                 }
             }
         }
@@ -2506,6 +2518,35 @@ mod tests {
         assert!(matches!(rk.flow, RecoveryKitState::None));
         let s = rk.status.as_ref().expect("status must survive Cancel");
         assert!(s.has_encrypted_seed && s.has_encrypted_wallet_descriptor);
+    }
+
+    #[test]
+    fn remove_failure_refreshes_status_for_partial_removal() {
+        // A partial removal (password kit deleted, then the phone step failed)
+        // leaves the cached status stale — Connect no longer has the password
+        // kit. The error handler must kick off a status refresh so the card
+        // reflects reality once the user dismisses the error, rather than keep
+        // showing a password backup that's already gone.
+        let mut rk = RecoveryKit::new();
+        rk.status = Some(status_both_modes());
+        rk.flow = RecoveryKitState::Removing;
+        assert!(!rk.status_loading);
+        let client = CoincubeClient::for_test("http://localhost");
+        let _ = update(
+            &mut rk,
+            RecoveryKitMessage::RemoveResult(Err("phone step failed".to_string())),
+            &Cache::default(),
+            "cube-1",
+            SeedSource::Mnemonic,
+            Some(client),
+            Some(42),
+            None,
+        );
+        assert!(matches!(rk.flow, RecoveryKitState::Error { .. }));
+        assert!(
+            rk.status_loading,
+            "RemoveResult(Err) must refresh status so the card drops the deleted kit"
+        );
     }
 
     // ---- remove_backups delete set (the ConfirmRemove teardown) ----

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -1481,7 +1481,9 @@ fn normalize_delete_result(res: Result<(), CoincubeError>) -> Result<(), String>
 ///   * always → `DELETE /recovery-kit` (the password kit), `404`-tolerant;
 ///   * `delete_keychain` → resolve the `owner-self` recipient and
 ///     `DELETE .../recipients/{keyId}`, which cascade-deletes its envelopes
-///     server-side. A missing recipient / `404` is idempotent success.
+///     server-side. A `404` on the recipient DELETE is idempotent success; a
+///     *missing* recipient is **verified** gone via [`verify_phone_copy_gone`]
+///     rather than assumed (F5).
 ///
 /// A password-kit failure returns **before** touching the keychain half, so the
 /// envelopes stay untouched and the user can retry cleanly. Both deletes are
@@ -1515,9 +1517,16 @@ async fn remove_backups(
                     ))
                 }
             },
-            // No recipient registered any more — nothing to delete on the phone
-            // side. Treat as success (the phone copy isn't restorable).
-            Err(OwnerSelfError::NoRecipient) => {}
+            // No owner-self recipient to delete. The cached status said the
+            // phone copy existed, so this normally means it was already torn
+            // down elsewhere (the recipient DELETE cascades its envelopes) — but
+            // F5 forbids *assuming* a restorable path is gone. Re-fetch status
+            // and only succeed if the phone envelopes are confirmed absent; a
+            // survivor (or a state we can't confirm) fails loudly so we never
+            // clear the drift slots over a live phone copy.
+            Err(OwnerSelfError::NoRecipient) => {
+                verify_phone_copy_gone(&client, cube_id).await?;
+            }
             Err(e) => {
                 return Err(format!(
                     "Couldn't reach the copy sealed to your phone (Keychain) ({}). The phone \
@@ -1528,6 +1537,45 @@ async fn remove_backups(
         }
     }
     Ok(())
+}
+
+/// Confirm the owner-keychain (phone) copy is actually gone before treating a
+/// missing recipient as a successful removal (F5). Reached only from the
+/// `NoRecipient` branch of [`remove_backups`], where the cached status said
+/// envelopes existed but no owner-self recipient remains to delete. Re-fetches
+/// `/recovery-kit/status`:
+///   * envelopes still present → hard error (the phone copy survives and can't
+///     be removed from here — its recovery key is unregistered);
+///   * no envelopes / no kit at all → the copy is confirmed gone → `Ok`;
+///   * the check itself fails → uncertain → hard error, so we never claim a
+///     removal we couldn't confirm.
+async fn verify_phone_copy_gone(client: &CoincubeClient, cube_id: u64) -> Result<(), String> {
+    match client.get_recovery_kit_status(cube_id).await {
+        Ok(status) => {
+            let phone_present = status
+                .owner_self
+                .as_ref()
+                .map(|o| o.has_envelope())
+                .unwrap_or(false);
+            if phone_present {
+                Err(
+                    "The copy sealed to your phone (Keychain) is still restorable but its \
+                     recovery key is no longer registered, so it couldn't be removed from this \
+                     device. Contact support to clear it."
+                        .to_string(),
+                )
+            } else {
+                Ok(())
+            }
+        }
+        // No kit at all on the server → nothing restorable survives.
+        Err(CoincubeError::NotFound) => Ok(()),
+        Err(e) => Err(format!(
+            "Removed your password kit, but couldn't confirm the copy sealed to your phone \
+             (Keychain) was cleared ({}). Reopen Settings to check before relying on removal.",
+            e
+        )),
+    }
 }
 
 /// On upload failure, restore the `PasswordEntry` screen from the
@@ -2723,9 +2771,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remove_backups_missing_recipient_is_idempotent_success() {
+    async fn remove_backups_missing_recipient_verified_gone_is_success() {
         // Keychain flagged enabled but the recipient is already gone (404 on the
-        // list) → nothing to delete on the phone side; still success.
+        // list). The status re-fetch confirms no phone envelopes survive (the
+        // recipient DELETE cascaded them elsewhere) → success.
         let server = MockServer::start();
         let kit = server.mock(|when, then| {
             when.method(MockMethod::DELETE)
@@ -2737,12 +2786,118 @@ mod tests {
                 .path("/api/v1/connect/cubes/42/recovery-kit/recipients");
             then.status(404);
         });
+        // Verification: no owner-self envelopes remain → the phone copy is gone.
+        let status = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/status");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "hasRecoveryKit": false,
+                        "hasEncryptedSeed": false,
+                        "hasEncryptedWalletDescriptor": false,
+                        "encryptionScheme": "",
+                        "ownerSelf": null
+                    }
+                }));
+        });
 
         let client = CoincubeClient::for_test(server.base_url());
         remove_backups(client, 42, true)
             .await
-            .expect("missing recipient must be idempotent success");
+            .expect("verified-gone phone copy must be idempotent success");
         kit.assert();
         list.assert();
+        status.assert();
+    }
+
+    #[tokio::test]
+    async fn remove_backups_orphaned_envelopes_fail_loudly() {
+        // The recipient is gone (404 on the list) but the status re-fetch shows
+        // owner-self envelopes still present — an orphaned, still-restorable
+        // phone copy the desktop can't delete (no recipient key to target). F5:
+        // this must fail loudly, not report success while a path survives.
+        let server = MockServer::start();
+        let kit = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(404);
+        });
+        let list = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/recipients");
+            then.status(404);
+        });
+        let status = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/status");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "hasRecoveryKit": false,
+                        "hasEncryptedSeed": false,
+                        "hasEncryptedWalletDescriptor": false,
+                        "encryptionScheme": "",
+                        "ownerSelf": {
+                            "hasRecipient": false,
+                            "tier": "",
+                            "envelopeKinds": ["descriptor"]
+                        }
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = remove_backups(client, 42, true)
+            .await
+            .expect_err("a surviving phone copy must fail loudly (F5)");
+        kit.assert();
+        list.assert();
+        status.assert();
+        assert!(
+            err.contains("phone") || err.contains("Keychain"),
+            "error must name the surviving phone path: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_backups_missing_recipient_unverifiable_fails() {
+        // Recipient gone, and the verification status fetch itself fails (500) —
+        // we can't confirm the phone copy was cleared, so we must not claim
+        // success (F5); the error tells the user to re-check.
+        let server = MockServer::start();
+        let kit = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(404);
+        });
+        let list = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/recipients");
+            then.status(404);
+        });
+        let status = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/status");
+            then.status(500);
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = remove_backups(client, 42, true)
+            .await
+            .expect_err("an unconfirmable phone copy must not report success");
+        kit.assert();
+        list.assert();
+        status.assert();
+        assert!(
+            err.contains("confirm"),
+            "error must flag the unconfirmed removal: {}",
+            err
+        );
     }
 }

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -24,6 +24,7 @@ use crate::app::cache::Cache;
 use crate::app::message::Message;
 use crate::app::settings::{self, update_settings_file};
 use crate::app::view;
+use crate::app::view::settings::general::backup_overview;
 use crate::app::view::{
     PhoneKeyOutcome, RecoveryKitMessage, RecoveryKitMode, RecoveryKitUploadOutcome,
     RecoveryProtectionMode,
@@ -163,6 +164,11 @@ pub enum RecoveryKitState {
         now_has_seed: bool,
         now_has_descriptor: bool,
     },
+    /// Full-page confirmation before any delete happens (master F5). Lists which
+    /// backup paths will be torn down (derived from the current `rk.status` in
+    /// the view) and waits for an explicit `ConfirmRemove`. No payload — the
+    /// delete set is rebuilt from `rk.status` at confirm time.
+    ConfirmRemove,
     Removing,
     Error {
         message: String,
@@ -229,6 +235,7 @@ impl std::fmt::Debug for RecoveryKitState {
                 .field("now_has_seed", now_has_seed)
                 .field("now_has_descriptor", now_has_descriptor)
                 .finish(),
+            Self::ConfirmRemove => write!(f, "ConfirmRemove"),
             Self::Removing => write!(f, "Removing"),
             Self::Error { message } => f.debug_struct("Error").field("message", message).finish(),
         }
@@ -575,8 +582,24 @@ pub fn update(
                 return Task::none();
             }
             match res {
-                Ok(()) => {
+                Ok(descriptor_fingerprint) => {
                     rk.reset_flow();
+                    // Persist the keychain drift slot from the descriptor that was
+                    // actually sealed (per-method drift, PR 3). Mirror
+                    // `next_fingerprint_to_persist`'s rule: only a seal that
+                    // included a descriptor writes the slot — never wipe a stored
+                    // fingerprint on a descriptor-less seal (the seal path always
+                    // seals a descriptor today, so this is normally `Some`).
+                    let persist = if let Some(fp) = descriptor_fingerprint {
+                        persist_descriptor_fingerprint(
+                            cache,
+                            local_cube_id,
+                            DescriptorFingerprintSlot::Keychain,
+                            Some(fp),
+                        )
+                    } else {
+                        Task::none()
+                    };
                     let reload = load_status(rk, client, server_cube_id);
                     let toast = Task::done(Message::View(view::Message::ShowToast(
                         log::Level::Info,
@@ -584,7 +607,7 @@ pub fn update(
                          your Keychain."
                             .to_string(),
                     )));
-                    Task::batch([toast, reload])
+                    Task::batch([toast, persist, reload])
                 }
                 Err(e) => {
                     rk.flow = RecoveryKitState::Error { message: e.clone() };
@@ -623,7 +646,12 @@ pub fn update(
                     // fingerprint through its own dedicated call.
                     let fp_to_persist = next_fingerprint_to_persist(&outcome);
                     let persist = if let Some(fp) = fp_to_persist {
-                        persist_descriptor_fingerprint(cache, local_cube_id, Some(fp))
+                        persist_descriptor_fingerprint(
+                            cache,
+                            local_cube_id,
+                            DescriptorFingerprintSlot::Password,
+                            Some(fp),
+                        )
                     } else {
                         Task::none()
                     };
@@ -678,6 +706,15 @@ pub fn update(
         }
 
         RecoveryKitMessage::Remove => {
+            // Removal is destructive and irreversible (master F5): don't delete
+            // on the first press. Take over the page with a confirmation screen
+            // that names exactly which backup paths will be torn down; the
+            // actual delete runs only on `ConfirmRemove`. Cancel → `reset_flow`.
+            rk.flow = RecoveryKitState::ConfirmRemove;
+            Task::none()
+        }
+
+        RecoveryKitMessage::ConfirmRemove => {
             let Some(client) = client else {
                 return Task::done(Message::View(view::Message::ShowError(
                     "Sign in to Connect to remove your Recovery Kit.".to_string(),
@@ -688,9 +725,21 @@ pub fn update(
                     "This Cube isn't registered with Connect yet.".to_string(),
                 )));
             };
+            // Build the delete set from the current status — the same
+            // per-method view the confirm screen showed the user. The password
+            // kit is always torn down (idempotent, 404-tolerant); the keychain
+            // half only when a phone envelope set is present.
+            let overview = backup_overview(rk.status.as_ref());
+            let delete_keychain = overview.keychain.is_some();
+            if !overview.any_enabled() {
+                // No-op guard: nothing enabled (e.g. status changed underneath
+                // us). Return to the card rather than firing empty deletes.
+                rk.reset_flow();
+                return load_status(rk, Some(client), server_cube_id);
+            }
             rk.flow = RecoveryKitState::Removing;
             Task::perform(
-                async move { normalize_delete_result(client.delete_recovery_kit(cube_id).await) },
+                async move { remove_backups(client, cube_id, delete_keychain).await },
                 |res| {
                     Message::View(view::Message::Settings(view::SettingsMessage::RecoveryKit(
                         RecoveryKitMessage::RemoveResult(res),
@@ -703,9 +752,10 @@ pub fn update(
             match res {
                 Ok(()) => {
                     rk.reset_flow();
-                    // Clear local drift fingerprint cache — there's
-                    // nothing backed up to compare against any more.
-                    let persist = persist_descriptor_fingerprint(cache, local_cube_id, None);
+                    // Clear both local drift fingerprint slots — Remove-all left
+                    // nothing backed up to compare against, by either method
+                    // (per-method drift, PR 3).
+                    let persist = clear_descriptor_fingerprints(cache, local_cube_id);
                     let reload = load_status(rk, client, server_cube_id);
                     Task::batch([persist, reload])
                 }
@@ -1169,19 +1219,27 @@ fn start_phone_seal(
 /// upload the envelope set (PR 2). Owner-side desktop crypto only. The seed half
 /// is included iff the recipient's registered tier is Full-Cube. The seed
 /// plaintext stays `Zeroizing` exactly as the password path keeps it.
+///
+/// On success returns the SHA-256 fingerprint of the descriptor blob that was
+/// sealed — the same helper the password path uses — so the handler can persist
+/// the keychain drift slot (per-method drift, PR 3). `None` only if the
+/// fingerprint couldn't be computed; the seal always includes a descriptor.
 async fn seal_phone(
     client: CoincubeClient,
     cube_id: u64,
     descriptor_blob: Option<DescriptorBlob>,
     mnemonic: Option<Zeroizing<Vec<String>>>,
     cube_meta: SeedBlobCube,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     let recipient = find_owner_self_recipient(&client, cube_id)
         .await
         .map_err(|e| e.to_string())?;
     let descriptor_blob = descriptor_blob.ok_or_else(|| {
         "Create a Vault first — phone recovery needs a Wallet Descriptor to back up.".to_string()
     })?;
+    // Fingerprint the exact descriptor being sealed, before it's serialized into
+    // the envelope, so the keychain drift slot reflects what the phone now holds.
+    let descriptor_fingerprint = descriptor_blob_fingerprint(&descriptor_blob);
     let descriptor_json: Zeroizing<Vec<u8>> = Zeroizing::new(
         serde_json::to_vec(&descriptor_blob).map_err(|e| format!("serialize descriptor: {}", e))?,
     );
@@ -1205,7 +1263,8 @@ async fn seal_phone(
     };
     seal_and_upload_owner_self(&client, cube_id, &recipient, &descriptor_json, seed_json)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    Ok(descriptor_fingerprint)
 }
 
 /// Detect the owner's phone-registered `owner-self` recovery recipient (PR 1).
@@ -1398,6 +1457,67 @@ fn normalize_delete_result(res: Result<(), CoincubeError>) -> Result<(), String>
     }
 }
 
+/// Tear down every backup path for this Cube (master F5). "Remove clears
+/// everything", so the password-kit delete runs **unconditionally** — it's
+/// idempotent and a `404` (envelope-only Cube, or a kit already removed from
+/// another device) counts as success — while the keychain teardown runs only
+/// when a phone envelope set is present. The deletes run **sequentially** and
+/// **fail loudly** on the first hard error, naming the path that's still
+/// restorable so the caller never reports success while recovery material
+/// survives:
+///
+///   * always → `DELETE /recovery-kit` (the password kit), `404`-tolerant;
+///   * `delete_keychain` → resolve the `owner-self` recipient and
+///     `DELETE .../recipients/{keyId}`, which cascade-deletes its envelopes
+///     server-side. A missing recipient / `404` is idempotent success.
+///
+/// A password-kit failure returns **before** touching the keychain half, so the
+/// envelopes stay untouched and the user can retry cleanly. Both deletes are
+/// idempotent, so a retry after a partial success finishes the teardown.
+async fn remove_backups(
+    client: CoincubeClient,
+    cube_id: u64,
+    delete_keychain: bool,
+) -> Result<(), String> {
+    normalize_delete_result(client.delete_recovery_kit(cube_id).await).map_err(|e| {
+        format!(
+            "Couldn't remove your password-encrypted Recovery Kit ({}). It's still \
+             restorable — try Remove again.",
+            e
+        )
+    })?;
+    if delete_keychain {
+        match find_owner_self_recipient(&client, cube_id).await {
+            Ok(recipient) => match client
+                .delete_recovery_kit_recipient(cube_id, recipient.key_id)
+                .await
+            {
+                // 404 → the recipient was already gone; the cascade left nothing
+                // to remove. Idempotent success.
+                Ok(()) | Err(CoincubeError::NotFound) => {}
+                Err(e) => {
+                    return Err(format!(
+                        "Couldn't remove the copy sealed to your phone (Keychain) ({}). The \
+                         phone copy is still restorable — try Remove again.",
+                        e
+                    ))
+                }
+            },
+            // No recipient registered any more — nothing to delete on the phone
+            // side. Treat as success (the phone copy isn't restorable).
+            Err(OwnerSelfError::NoRecipient) => {}
+            Err(e) => {
+                return Err(format!(
+                    "Couldn't reach the copy sealed to your phone (Keychain) ({}). The phone \
+                     copy may still be restorable — try Remove again.",
+                    e
+                ))
+            }
+        }
+    }
+    Ok(())
+}
+
 /// On upload failure, restore the `PasswordEntry` screen from the
 /// snapshot we stashed inside `Uploading { pending }` at submit
 /// time. The user keeps their password, confirm, acknowledge flag,
@@ -1525,9 +1645,37 @@ async fn encrypt_and_upload(
     })
 }
 
+/// Which per-method descriptor drift slot a persist targets (per-method drift,
+/// PR 3). The password kit and the phone (Keychain) envelope each cache their
+/// own last-sealed descriptor fingerprint so drift is judged independently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DescriptorFingerprintSlot {
+    Password,
+    Keychain,
+}
+
+/// Write one method's cached descriptor fingerprint onto a `CubeSettings`. Pure
+/// (no IO) so the slot routing is unit-testable; `persist_descriptor_fingerprint`
+/// and `clear_descriptor_fingerprints` apply it inside the settings-file update.
+fn apply_descriptor_fingerprint(
+    cube: &mut settings::CubeSettings,
+    slot: DescriptorFingerprintSlot,
+    fingerprint: Option<String>,
+) {
+    match slot {
+        DescriptorFingerprintSlot::Password => {
+            cube.recovery_kit_last_backed_up_descriptor_fingerprint = fingerprint;
+        }
+        DescriptorFingerprintSlot::Keychain => {
+            cube.recovery_kit_last_backed_up_keychain_descriptor_fingerprint = fingerprint;
+        }
+    }
+}
+
 fn persist_descriptor_fingerprint(
     cache: &Cache,
     local_cube_id: &str,
+    slot: DescriptorFingerprintSlot,
     fingerprint: Option<String>,
 ) -> Task<Message> {
     let network_dir = cache.datadir_path.network_directory(cache.network);
@@ -1536,7 +1684,32 @@ fn persist_descriptor_fingerprint(
         async move {
             update_settings_file(&network_dir, |mut s| {
                 if let Some(cube) = s.cubes.iter_mut().find(|c| c.id == cube_id) {
-                    cube.recovery_kit_last_backed_up_descriptor_fingerprint = fingerprint.clone();
+                    apply_descriptor_fingerprint(cube, slot, fingerprint.clone());
+                }
+                Some(s)
+            })
+            .await
+            .map_err(|e| format!("Failed to update settings: {}", e))
+        },
+        |res: Result<(), String>| match res {
+            Ok(()) => Message::SettingsSaved,
+            Err(e) => Message::View(view::Message::ShowError(e)),
+        },
+    )
+}
+
+/// Clear **both** per-method descriptor drift slots in a single settings write —
+/// the Remove-all path leaves nothing backed up to compare against, by either
+/// method (per-method drift, PR 3).
+fn clear_descriptor_fingerprints(cache: &Cache, local_cube_id: &str) -> Task<Message> {
+    let network_dir = cache.datadir_path.network_directory(cache.network);
+    let cube_id = local_cube_id.to_string();
+    Task::perform(
+        async move {
+            update_settings_file(&network_dir, |mut s| {
+                if let Some(cube) = s.cubes.iter_mut().find(|c| c.id == cube_id) {
+                    apply_descriptor_fingerprint(cube, DescriptorFingerprintSlot::Password, None);
+                    apply_descriptor_fingerprint(cube, DescriptorFingerprintSlot::Keychain, None);
                 }
                 Some(s)
             })
@@ -1922,6 +2095,102 @@ mod tests {
         assert_eq!(next_fingerprint_to_persist(&outcome), Some("a".repeat(64)));
     }
 
+    // ── Per-method descriptor drift slots (plan §PR3) ───────────────────────
+    //
+    // The password kit and the phone (Keychain) envelope each cache their own
+    // last-sealed descriptor fingerprint so drift is judged independently. These
+    // pin the slot routing `persist_descriptor_fingerprint` /
+    // `clear_descriptor_fingerprints` apply inside the settings-file update.
+
+    fn cube_with_both_slots() -> settings::CubeSettings {
+        let mut cube = settings::CubeSettings::new("Slots".to_string(), Network::Bitcoin);
+        cube.recovery_kit_last_backed_up_descriptor_fingerprint = Some("pw-fp".to_string());
+        cube.recovery_kit_last_backed_up_keychain_descriptor_fingerprint =
+            Some("kc-fp".to_string());
+        cube
+    }
+
+    #[test]
+    fn keychain_persist_writes_only_the_keychain_slot() {
+        // A phone seal persists the keychain slot and must not touch the
+        // password slot (they're independent restore paths).
+        let mut cube = settings::CubeSettings::new("C".to_string(), Network::Bitcoin);
+        cube.recovery_kit_last_backed_up_descriptor_fingerprint = Some("pw-fp".to_string());
+        apply_descriptor_fingerprint(
+            &mut cube,
+            DescriptorFingerprintSlot::Keychain,
+            Some("kc-fp".to_string()),
+        );
+        assert_eq!(
+            cube.recovery_kit_last_backed_up_keychain_descriptor_fingerprint
+                .as_deref(),
+            Some("kc-fp")
+        );
+        assert_eq!(
+            cube.recovery_kit_last_backed_up_descriptor_fingerprint
+                .as_deref(),
+            Some("pw-fp"),
+            "keychain persist must leave the password slot intact"
+        );
+    }
+
+    #[test]
+    fn password_persist_writes_only_the_password_slot() {
+        let mut cube = settings::CubeSettings::new("C".to_string(), Network::Bitcoin);
+        cube.recovery_kit_last_backed_up_keychain_descriptor_fingerprint =
+            Some("kc-fp".to_string());
+        apply_descriptor_fingerprint(
+            &mut cube,
+            DescriptorFingerprintSlot::Password,
+            Some("pw-fp".to_string()),
+        );
+        assert_eq!(
+            cube.recovery_kit_last_backed_up_descriptor_fingerprint
+                .as_deref(),
+            Some("pw-fp")
+        );
+        assert_eq!(
+            cube.recovery_kit_last_backed_up_keychain_descriptor_fingerprint
+                .as_deref(),
+            Some("kc-fp"),
+            "password persist must leave the keychain slot intact"
+        );
+    }
+
+    #[test]
+    fn remove_clears_both_slots() {
+        // `clear_descriptor_fingerprints` applies both clears in one write —
+        // Remove-all leaves nothing to drift against by either method.
+        let mut cube = cube_with_both_slots();
+        apply_descriptor_fingerprint(&mut cube, DescriptorFingerprintSlot::Password, None);
+        apply_descriptor_fingerprint(&mut cube, DescriptorFingerprintSlot::Keychain, None);
+        assert!(cube
+            .recovery_kit_last_backed_up_descriptor_fingerprint
+            .is_none());
+        assert!(cube
+            .recovery_kit_last_backed_up_keychain_descriptor_fingerprint
+            .is_none());
+    }
+
+    #[test]
+    fn seal_persists_the_sealed_descriptor_fingerprint() {
+        // The keychain slot the seal writes is exactly `descriptor_blob_fingerprint`
+        // of the sealed blob (the same SHA-256 helper the password path uses), so
+        // a later re-render compares like-for-like and reports no spurious drift.
+        let blob = descriptor_some().unwrap();
+        let sealed_fp = descriptor_blob_fingerprint(&blob).unwrap();
+        let mut cube = settings::CubeSettings::new("C".to_string(), Network::Bitcoin);
+        apply_descriptor_fingerprint(
+            &mut cube,
+            DescriptorFingerprintSlot::Keychain,
+            Some(sealed_fp.clone()),
+        );
+        assert_eq!(
+            cube.recovery_kit_last_backed_up_keychain_descriptor_fingerprint,
+            Some(sealed_fp)
+        );
+    }
+
     // Regression tests for the W10 post-vault-creation nudge: the
     // decision must be based on a *freshly-loaded* status, not the
     // in-memory cache at the moment the vault transition fires. A
@@ -2166,5 +2435,273 @@ mod tests {
             descriptor_blob_fingerprint(&a).unwrap(),
             descriptor_blob_fingerprint(&b).unwrap(),
         );
+    }
+
+    // ── Remove-clears-everything behind confirmation (plan §PR2, master F5) ──
+
+    use crate::services::coincube::OwnerSelfRecoverySummary;
+    use httpmock::{Method as MockMethod, MockServer};
+    use serde_json::json;
+
+    fn status_both_modes() -> RecoveryKitStatus {
+        RecoveryKitStatus {
+            owner_self: Some(OwnerSelfRecoverySummary {
+                has_recipient: true,
+                tier: "full_cube".into(),
+                envelope_kinds: vec!["seed".into(), "descriptor".into()],
+                updated_at: Some("2026-06-01T00:00:00Z".into()),
+            }),
+            ..status_complete()
+        }
+    }
+
+    /// One `owner-self` recipient row (keyId 7) as the recipients endpoint
+    /// returns it; `remove_backups` reads `keyId` to target the DELETE.
+    fn owner_self_recipients_body() -> serde_json::Value {
+        json!({
+            "success": true,
+            "data": [{ "id": 1, "keyId": 7, "role": "owner-self", "tier": "full_cube" }]
+        })
+    }
+
+    // ---- Remove is confirm-gated: it deletes nothing, Cancel is intact ----
+
+    #[test]
+    fn remove_enters_confirm_and_deletes_nothing() {
+        // Pressing Remove must NOT fire a delete — it only takes over the page
+        // with the confirmation screen. The handler never touches the client,
+        // so no network call is possible from this transition.
+        let mut rk = RecoveryKit::new();
+        rk.status = Some(status_both_modes());
+        let _ = update(
+            &mut rk,
+            RecoveryKitMessage::Remove,
+            &Cache::default(),
+            "cube-1",
+            SeedSource::Mnemonic,
+            None,
+            Some(42),
+            None,
+        );
+        assert!(matches!(rk.flow, RecoveryKitState::ConfirmRemove));
+        // Status is untouched — the confirm view reads it to name the paths.
+        assert!(rk.status.is_some());
+    }
+
+    #[test]
+    fn cancel_from_confirm_restores_card_with_status_intact() {
+        let mut rk = RecoveryKit::new();
+        rk.status = Some(status_both_modes());
+        rk.flow = RecoveryKitState::ConfirmRemove;
+        let _ = update(
+            &mut rk,
+            RecoveryKitMessage::Cancel,
+            &Cache::default(),
+            "cube-1",
+            SeedSource::Mnemonic,
+            None,
+            Some(42),
+            None,
+        );
+        assert!(matches!(rk.flow, RecoveryKitState::None));
+        let s = rk.status.as_ref().expect("status must survive Cancel");
+        assert!(s.has_encrypted_seed && s.has_encrypted_wallet_descriptor);
+    }
+
+    // ---- remove_backups delete set (the ConfirmRemove teardown) ----
+
+    #[tokio::test]
+    async fn remove_backups_keychain_only_tolerates_kit_404_and_deletes_recipient() {
+        // Envelope-only Cube: the password-kit DELETE 404s (tolerated), then the
+        // owner-self recipient is resolved and DELETEd (cascading its envelopes).
+        let server = MockServer::start();
+        let kit = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(404);
+        });
+        let list = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/recipients");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(owner_self_recipients_body());
+        });
+        let recip = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit/recipients/7");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "success": true, "data": { "deleted": true } }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        remove_backups(client, 42, true)
+            .await
+            .expect("keychain-only remove should succeed");
+        kit.assert();
+        list.assert();
+        recip.assert();
+    }
+
+    #[tokio::test]
+    async fn remove_backups_both_modes_deletes_kit_and_recipient() {
+        let server = MockServer::start();
+        let kit = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "success": true, "data": { "status": "deleted" } }));
+        });
+        let list = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/recipients");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(owner_self_recipients_body());
+        });
+        let recip = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit/recipients/7");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "success": true, "data": { "deleted": true } }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        remove_backups(client, 42, true)
+            .await
+            .expect("both-modes remove should succeed");
+        kit.assert();
+        list.assert();
+        recip.assert();
+    }
+
+    #[tokio::test]
+    async fn remove_backups_password_only_deletes_kit_and_skips_recipient() {
+        let server = MockServer::start();
+        let kit = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "success": true, "data": { "status": "deleted" } }));
+        });
+        // No keychain half → the recipients endpoint must never be touched.
+        let list = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/recipients");
+            then.status(200).json_body(owner_self_recipients_body());
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        remove_backups(client, 42, false)
+            .await
+            .expect("password-only remove should succeed");
+        kit.assert();
+        assert_eq!(list.hits(), 0, "recipient path must not be resolved");
+    }
+
+    #[tokio::test]
+    async fn remove_backups_kit_delete_failure_names_password_and_leaves_envelopes() {
+        // A hard (non-404) kit-delete error must fail loudly, name the password
+        // path, and return BEFORE touching the recipient — envelopes untouched.
+        let server = MockServer::start();
+        let kit = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(500);
+        });
+        let list = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/recipients");
+            then.status(200).json_body(owner_self_recipients_body());
+        });
+        let recip = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit/recipients/7");
+            then.status(200)
+                .json_body(json!({ "success": true, "data": {} }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = remove_backups(client, 42, true)
+            .await
+            .expect_err("hard kit-delete error must fail loudly");
+        kit.assert();
+        assert!(
+            err.contains("password"),
+            "error must name the password path: {}",
+            err
+        );
+        assert_eq!(
+            list.hits(),
+            0,
+            "must not resolve recipient after kit failure"
+        );
+        assert_eq!(recip.hits(), 0, "envelopes must be left untouched");
+    }
+
+    #[tokio::test]
+    async fn remove_backups_recipient_delete_failure_after_kit_names_phone() {
+        // Kit deleted OK, then the recipient DELETE fails — the error must name
+        // the phone (Keychain) path that's still restorable (F5).
+        let server = MockServer::start();
+        let kit = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(200)
+                .json_body(json!({ "success": true, "data": { "status": "deleted" } }));
+        });
+        let list = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/recipients");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(owner_self_recipients_body());
+        });
+        let recip = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit/recipients/7");
+            then.status(500);
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = remove_backups(client, 42, true)
+            .await
+            .expect_err("recipient-delete failure must fail loudly");
+        kit.assert();
+        list.assert();
+        recip.assert();
+        assert!(
+            err.contains("phone") || err.contains("Keychain"),
+            "error must name the phone path: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_backups_missing_recipient_is_idempotent_success() {
+        // Keychain flagged enabled but the recipient is already gone (404 on the
+        // list) → nothing to delete on the phone side; still success.
+        let server = MockServer::start();
+        let kit = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(404);
+        });
+        let list = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/recipients");
+            then.status(404);
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        remove_backups(client, 42, true)
+            .await
+            .expect("missing recipient must be idempotent success");
+        kit.assert();
+        list.assert();
     }
 }

--- a/coincube-gui/src/app/state/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/state/settings/recovery_kit.rs
@@ -1523,9 +1523,18 @@ async fn remove_backups(
             // F5 forbids *assuming* a restorable path is gone. Re-fetch status
             // and only succeed if the phone envelopes are confirmed absent; a
             // survivor (or a state we can't confirm) fails loudly so we never
-            // clear the drift slots over a live phone copy.
+            // clear the drift slots over a live phone copy. A survivor here has
+            // no recipient key left to target, so it can't be removed from this
+            // device — the user must contact support.
             Err(OwnerSelfError::NoRecipient) => {
-                verify_phone_copy_gone(&client, cube_id).await?;
+                verify_phone_copy_gone(
+                    &client,
+                    cube_id,
+                    "The copy sealed to your phone (Keychain) is still restorable but its \
+                     recovery key is no longer registered, so it couldn't be removed from this \
+                     device. Contact support to clear it.",
+                )
+                .await?;
             }
             Err(e) => {
                 return Err(format!(
@@ -1535,21 +1544,48 @@ async fn remove_backups(
                 ))
             }
         }
+    } else {
+        // The cached overview showed no phone copy, so we skipped the keychain
+        // teardown — but that view can be stale (a phone copy sealed elsewhere,
+        // or a status race). F5 forbids *assuming* a restorable path is gone,
+        // and the caller is about to clear the keychain drift slot on the
+        // strength of this removal. Confirm no phone envelopes survive before
+        // returning success; a survivor fails loudly so we never wipe the local
+        // fingerprint over a live copy. Unlike the orphaned case above, a
+        // recipient may well still exist — a fresh Remove (with up-to-date
+        // status) would target it — so the message says to retry.
+        verify_phone_copy_gone(
+            &client,
+            cube_id,
+            "The copy sealed to your phone (Keychain) is still restorable. Reopen Settings and \
+             try Remove again to clear it.",
+        )
+        .await?;
     }
     Ok(())
 }
 
-/// Confirm the owner-keychain (phone) copy is actually gone before treating a
-/// missing recipient as a successful removal (F5). Reached only from the
-/// `NoRecipient` branch of [`remove_backups`], where the cached status said
-/// envelopes existed but no owner-self recipient remains to delete. Re-fetches
-/// `/recovery-kit/status`:
-///   * envelopes still present → hard error (the phone copy survives and can't
-///     be removed from here — its recovery key is unregistered);
+/// Confirm the owner-keychain (phone) copy is actually gone before a removal
+/// reports success and the caller clears the keychain drift slot (F5). Reached
+/// from two branches of [`remove_backups`]:
+///   * the `NoRecipient` branch, where the cached status said envelopes existed
+///     but no owner-self recipient remains to delete; and
+///   * the `delete_keychain == false` branch, where the cached overview showed
+///     no phone copy at all and the teardown was skipped — that view can be
+///     stale, so we verify rather than assume.
+///
+/// Re-fetches `/recovery-kit/status`:
+///   * envelopes still present → hard error with the caller-supplied
+///     `present_msg` (the advice differs: orphaned recipient → contact support;
+///     stale overview → retry Remove);
 ///   * no envelopes / no kit at all → the copy is confirmed gone → `Ok`;
 ///   * the check itself fails → uncertain → hard error, so we never claim a
 ///     removal we couldn't confirm.
-async fn verify_phone_copy_gone(client: &CoincubeClient, cube_id: u64) -> Result<(), String> {
+async fn verify_phone_copy_gone(
+    client: &CoincubeClient,
+    cube_id: u64,
+    present_msg: &str,
+) -> Result<(), String> {
     match client.get_recovery_kit_status(cube_id).await {
         Ok(status) => {
             let phone_present = status
@@ -1558,12 +1594,7 @@ async fn verify_phone_copy_gone(client: &CoincubeClient, cube_id: u64) -> Result
                 .map(|o| o.has_envelope())
                 .unwrap_or(false);
             if phone_present {
-                Err(
-                    "The copy sealed to your phone (Keychain) is still restorable but its \
-                     recovery key is no longer registered, so it couldn't be removed from this \
-                     device. Contact support to clear it."
-                        .to_string(),
-                )
+                Err(present_msg.to_string())
             } else {
                 Ok(())
             }
@@ -2677,11 +2708,29 @@ mod tests {
                 .header("content-type", "application/json")
                 .json_body(json!({ "success": true, "data": { "status": "deleted" } }));
         });
-        // No keychain half → the recipients endpoint must never be touched.
+        // No keychain half → the recipients endpoint must never be touched. We
+        // still verify no phone copy survives before reporting success (F5), so
+        // `/status` is fetched and confirms nothing is sealed to the phone.
         let list = server.mock(|when, then| {
             when.method(MockMethod::GET)
                 .path("/api/v1/connect/cubes/42/recovery-kit/recipients");
             then.status(200).json_body(owner_self_recipients_body());
+        });
+        let status = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/status");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "hasRecoveryKit": false,
+                        "hasEncryptedSeed": false,
+                        "hasEncryptedWalletDescriptor": false,
+                        "encryptionScheme": "",
+                        "ownerSelf": null
+                    }
+                }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());
@@ -2689,7 +2738,70 @@ mod tests {
             .await
             .expect("password-only remove should succeed");
         kit.assert();
+        status.assert();
         assert_eq!(list.hits(), 0, "recipient path must not be resolved");
+    }
+
+    #[tokio::test]
+    async fn remove_backups_password_only_surviving_phone_copy_fails_loudly() {
+        // `delete_keychain == false` because the cached overview showed no phone
+        // copy — but the status re-fetch reveals owner-self envelopes still
+        // present (a stale/racy overview hid a live copy). F5: this must fail
+        // loudly rather than report success and let the caller clear the
+        // keychain drift slot over a restorable copy. The recipients endpoint is
+        // never touched (we skipped the teardown), and the message tells the
+        // user to retry — a fresh Remove would target the now-visible copy.
+        let server = MockServer::start();
+        let kit = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "success": true, "data": { "status": "deleted" } }));
+        });
+        let list = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/recipients");
+            then.status(200).json_body(owner_self_recipients_body());
+        });
+        let status = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit/status");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "hasRecoveryKit": false,
+                        "hasEncryptedSeed": false,
+                        "hasEncryptedWalletDescriptor": false,
+                        "encryptionScheme": "",
+                        "ownerSelf": {
+                            "hasRecipient": true,
+                            "tier": "",
+                            "envelopeKinds": ["descriptor"]
+                        }
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = remove_backups(client, 42, false)
+            .await
+            .expect_err("a stale-overview-hidden phone copy must fail loudly (F5)");
+        kit.assert();
+        status.assert();
+        assert_eq!(list.hits(), 0, "recipient path must not be resolved");
+        assert!(
+            err.contains("phone") || err.contains("Keychain"),
+            "error must name the surviving phone path: {}",
+            err
+        );
+        assert!(
+            err.contains("try Remove again"),
+            "stale-overview survivor must advise a retry, not contact support: {}",
+            err
+        );
     }
 
     #[tokio::test]

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1222,9 +1222,12 @@ pub enum RecoveryKitMessage {
     /// three-way [`PhoneKeyOutcome`] so the choice screen can enable the phone
     /// options (`Present`), show guidance (`Absent`), or surface an error.
     ProvisionResult(PhoneKeyOutcome),
-    /// Async result of the phone seal+upload (PR 2). `Ok(())` on success; the
-    /// error string is display-safe.
-    PhoneSealResult(Result<(), String>),
+    /// Async result of the phone seal+upload (PR 2). On success carries the
+    /// SHA-256 fingerprint of the descriptor that was sealed, so the handler can
+    /// persist the keychain drift slot (per-method drift, PR 3); the hex is
+    /// redacted from `Debug` (a stable cross-session identifier). The error
+    /// string is display-safe.
+    PhoneSealResult(Result<Option<String>, String>),
     /// User toggled the "I've written this down" gate on the password
     /// screen. Submit is inert until this is true.
     AcknowledgeToggled(bool),
@@ -1238,9 +1241,16 @@ pub enum RecoveryKitMessage {
     /// User dismissed the Completed screen — return to card view and
     /// trigger a fresh `LoadStatus`.
     DismissCompleted,
-    /// User clicked Remove. Fires `delete_recovery_kit`.
+    /// User clicked Remove on the card. Enters the `ConfirmRemove` confirmation
+    /// screen — it does **not** delete anything (master F5: removal is
+    /// destructive and irreversible, so it's gated behind an explicit confirm).
     Remove,
-    /// Async result of Remove.
+    /// User confirmed removal on the `ConfirmRemove` screen. Fires the actual
+    /// delete set — `delete_recovery_kit` for the password half and/or
+    /// `delete_recovery_kit_recipient` (cascades envelopes) for the phone half,
+    /// run sequentially; partial failure fails loudly.
+    ConfirmRemove,
+    /// Async result of the removal.
     RemoveResult(Result<(), String>),
 }
 
@@ -1318,7 +1328,16 @@ impl std::fmt::Debug for RecoveryKitMessage {
             }
             Self::ProvisionPhone => write!(f, "ProvisionPhone"),
             Self::ProvisionResult(r) => f.debug_tuple("ProvisionResult").field(r).finish(),
-            Self::PhoneSealResult(r) => f.debug_tuple("PhoneSealResult").field(r).finish(),
+            // Redact the descriptor fingerprint hex (a stable cross-session
+            // identifier), preserving Ok/Err and presence for diagnostics.
+            Self::PhoneSealResult(Ok(fp)) => f
+                .debug_tuple("PhoneSealResult")
+                .field(&Ok::<_, ()>(fp.as_ref().map(|_| "<redacted>")))
+                .finish(),
+            Self::PhoneSealResult(Err(e)) => f
+                .debug_tuple("PhoneSealResult")
+                .field(&Err::<(), _>(e))
+                .finish(),
             Self::AcknowledgeToggled(b) => f.debug_tuple("AcknowledgeToggled").field(b).finish(),
             Self::SubmitPassword => write!(f, "SubmitPassword"),
             Self::UploadResult(Ok(o)) => f.debug_tuple("UploadResult(Ok)").field(o).finish(),
@@ -1328,6 +1347,7 @@ impl std::fmt::Debug for RecoveryKitMessage {
                 .finish(),
             Self::DismissCompleted => write!(f, "DismissCompleted"),
             Self::Remove => write!(f, "Remove"),
+            Self::ConfirmRemove => write!(f, "ConfirmRemove"),
             Self::RemoveResult(r) => f.debug_tuple("RemoveResult").field(r).finish(),
         }
     }
@@ -2284,6 +2304,20 @@ mod recovery_kit_upload_outcome_debug_tests {
         assert!(
             !rendered.contains(CANARY_FP),
             "Debug(RecoveryKitMessage::UploadResult(Ok(..))) leaked fingerprint: {}",
+            rendered
+        );
+        assert!(rendered.contains("<redacted>"));
+    }
+
+    #[test]
+    fn phone_seal_result_ok_debug_does_not_leak_fingerprint() {
+        // The keychain drift fingerprint (PR 3) is the same class of stable
+        // cross-session identifier as the upload outcome's — redact its hex.
+        let msg = RecoveryKitMessage::PhoneSealResult(Ok(Some(CANARY_FP.to_string())));
+        let rendered = format!("{:?}", msg);
+        assert!(
+            !rendered.contains(CANARY_FP),
+            "Debug(RecoveryKitMessage::PhoneSealResult(Ok(..))) leaked fingerprint: {}",
             rendered
         );
         assert!(rendered.contains("<redacted>"));

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -1250,8 +1250,29 @@ pub enum RecoveryKitMessage {
     /// `delete_recovery_kit_recipient` (cascades envelopes) for the phone half,
     /// run sequentially; partial failure fails loudly.
     ConfirmRemove,
-    /// Async result of the removal.
-    RemoveResult(Result<(), String>),
+    /// Async result of the removal. The error carries [`RemoveFailure`] so the
+    /// handler can tell whether the password kit was already torn down before
+    /// the failure and drop the now-stale local fingerprint slot accordingly.
+    RemoveResult(Result<(), RemoveFailure>),
+}
+
+/// Failure payload from the removal flow ([`remove_backups`]). The password
+/// Recovery Kit delete runs **first and unconditionally**, so any failure
+/// *after* it (the Keychain teardown or the phone-copy verification) leaves the
+/// local `recovery_kit_last_backed_up_descriptor_fingerprint` pointing at a kit
+/// Connect no longer holds. `password_kit_deleted` lets the error handler clear
+/// just that slot so `has_recovery_kit()` / `connect_state()` don't keep
+/// reporting a password backup that's gone. No sensitive fields — `message` is
+/// the user-facing error copy — so `Debug` is derived.
+#[derive(Clone, Debug)]
+pub struct RemoveFailure {
+    /// User-facing error copy, shown via `ShowError` and stored on the
+    /// `Error` flow state.
+    pub message: String,
+    /// Whether the password kit was already deleted server-side before the
+    /// failure. `false` only when the password delete itself was the failing
+    /// step (the kit is still present, so the local slot is still accurate).
+    pub password_kit_deleted: bool,
 }
 
 /// What the upload handler hands back to the state machine on success.

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -123,21 +123,22 @@ fn recovery_section<'a>(
                 "back up your Cube Recovery Kit",
             ));
         } else {
-            // W12 drift: compute on the fly by comparing the cached live
-            // fingerprint (refreshed every App tick) with the last-backed-up
-            // fingerprint (persisted on `CubeSettings`). Only meaningful when a
-            // descriptor has actually been backed up — otherwise the card's
-            // "incomplete" copy already prompts the user.
-            let server_has_descriptor = rk
-                .status
-                .as_ref()
-                .map(|s| s.has_encrypted_wallet_descriptor)
-                .unwrap_or(false);
+            // W12 drift, per method (PR 3): compare the live descriptor
+            // fingerprint (refreshed every App tick) against each method's
+            // last-backed-up fingerprint (persisted per-method on `CubeSettings`).
+            // A method's descriptor presence comes from the server status via
+            // `backup_overview`; the positive-evidence-only rule keeps a missing
+            // slot from firing that method's banner.
+            let overview = backup_overview(rk.status.as_ref());
             let drift = descriptor_drift(
-                server_has_descriptor,
                 cache.current_descriptor_fingerprint.as_deref(),
+                overview.password.map(|m| m.descriptor).unwrap_or(false),
                 cache
                     .recovery_kit_last_backed_up_descriptor_fingerprint
+                    .as_deref(),
+                overview.keychain.map(|m| m.descriptor).unwrap_or(false),
+                cache
+                    .recovery_kit_last_backed_up_keychain_descriptor_fingerprint
                     .as_deref(),
             );
             col = col.push(recovery_kit_card(
@@ -502,20 +503,117 @@ pub(crate) fn backup_pill<'a>(label: &'static str) -> Element<'a, Message> {
         .into()
 }
 
+/// Which halves a single backup method holds. A method is "enabled" (in use)
+/// when it holds at least one half; whether it's *complete* depends on the
+/// Cube's shape (see [`method_complete`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MethodBackup {
+    pub(crate) seed: bool,
+    pub(crate) descriptor: bool,
+}
+
+/// One source of truth for "what's backed up, by which method" — the master
+/// §definitions distilled into a per-method view the card (and, later, the
+/// duress-vault-gate `CubeBackupCompleteness`) both read. `password` /
+/// `keychain` are `Some` iff that method holds any restorable material (a
+/// recipient without envelopes never counts — master F1). `last_updated` is
+/// the later of the password kit's and the phone envelope's timestamps.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BackupOverview {
+    /// Password-encrypted kit. `Some` ⇔ any password blob present.
+    pub(crate) password: Option<MethodBackup>,
+    /// Owner-keychain ("phone") envelopes. `Some` ⇔ any envelope kind present
+    /// (`has_envelope`; never `has_recipient` alone — master F1).
+    pub(crate) keychain: Option<MethodBackup>,
+    /// `max(kit.updated_at, owner_self.updated_at)`, compared by parsed instant.
+    pub(crate) last_updated: Option<String>,
+}
+
+impl BackupOverview {
+    /// At least one method holds restorable material.
+    pub(crate) fn any_enabled(&self) -> bool {
+        self.password.is_some() || self.keychain.is_some()
+    }
+}
+
+/// Distill a `RecoveryKitStatus` into the per-method [`BackupOverview`]. Absent
+/// status (not loaded yet) → every method `None`. Keychain presence keys off
+/// `has_envelope()` (kinds non-empty), never a bare recipient (master F1).
+pub(crate) fn backup_overview(status: Option<&RecoveryKitStatus>) -> BackupOverview {
+    let Some(s) = status else {
+        return BackupOverview {
+            password: None,
+            keychain: None,
+            last_updated: None,
+        };
+    };
+    let password =
+        (s.has_encrypted_seed || s.has_encrypted_wallet_descriptor).then_some(MethodBackup {
+            seed: s.has_encrypted_seed,
+            descriptor: s.has_encrypted_wallet_descriptor,
+        });
+    let keychain = s
+        .owner_self
+        .as_ref()
+        .filter(|o| o.has_envelope())
+        .map(|o| MethodBackup {
+            seed: o.envelope_kinds.iter().any(|k| k == "seed"),
+            descriptor: o.envelope_kinds.iter().any(|k| k == "descriptor"),
+        });
+    let owner_updated = s.owner_self.as_ref().and_then(|o| o.updated_at.as_deref());
+    let last_updated = later_timestamp(s.updated_at.as_deref(), owner_updated);
+    BackupOverview {
+        password,
+        keychain,
+        last_updated,
+    }
+}
+
+/// Whether a method independently holds everything the Cube's shape requires
+/// (master §definitions: completeness is per-method):
+///   * passkey — descriptor only (the seed is unextractable on-device);
+///   * mnemonic + vault — seed **and** descriptor;
+///   * mnemonic, no vault — seed alone.
+pub(crate) fn method_complete(m: &MethodBackup, has_vault: bool, is_passkey: bool) -> bool {
+    if is_passkey {
+        m.descriptor
+    } else if has_vault {
+        m.seed && m.descriptor
+    } else {
+        m.seed
+    }
+}
+
+/// The later of two RFC 3339 timestamps, compared by parsed instant so
+/// mixed-precision strings sort correctly. Falls back to whichever side parses
+/// when only one does, and to the first present value when neither parses.
+fn later_timestamp(a: Option<&str>, b: Option<&str>) -> Option<String> {
+    match (a, b) {
+        (Some(a), Some(b)) => {
+            let pa = chrono::DateTime::parse_from_rfc3339(a).ok();
+            let pb = chrono::DateTime::parse_from_rfc3339(b).ok();
+            match (pa, pb) {
+                (Some(pa), Some(pb)) => Some(if pa >= pb { a } else { b }.to_string()),
+                (Some(_), None) => Some(a.to_string()),
+                (None, Some(_)) => Some(b.to_string()),
+                // Neither parses — deterministic fall back to the first (password).
+                (None, None) => Some(a.to_string()),
+            }
+        }
+        (Some(a), None) => Some(a.to_string()),
+        (None, Some(b)) => Some(b.to_string()),
+        (None, None) => None,
+    }
+}
+
 /// Which Recovery-Kit backup methods are actually in place, from the status.
-/// Returns `(password_present, keychain_present)`. Password = ciphertext on the
-/// password kit; Keychain = recovery material actually sealed to the owner's
-/// phone key (envelope uploaded, not merely a recipient registered). Shared by
-/// the Settings card and the protection-choice wizard screen.
+/// Returns `(password_present, keychain_present)` — presence, not completeness,
+/// so a partial method still shows its pill. Thin wrapper over
+/// [`backup_overview`]; shared by the Settings card and the protection-choice
+/// wizard screen.
 pub(crate) fn backup_methods_present(status: Option<&RecoveryKitStatus>) -> (bool, bool) {
-    let password = status
-        .map(|s| s.has_encrypted_seed || s.has_encrypted_wallet_descriptor)
-        .unwrap_or(false);
-    let keychain = status
-        .and_then(|s| s.owner_self.as_ref())
-        .map(|o| o.has_envelope())
-        .unwrap_or(false);
-    (password, keychain)
+    let o = backup_overview(status);
+    (o.password.is_some(), o.keychain.is_some())
 }
 
 /// Format an RFC 3339 timestamp as the API returns it (e.g.
@@ -529,6 +627,191 @@ fn format_backup_time(raw: &str) -> String {
                 .to_string()
         })
         .unwrap_or_else(|_| raw.to_string())
+}
+
+/// The computed textual state of the Recovery-Kit card — title, subtitle, and
+/// primary CTA — factored out of [`recovery_kit_card`] so the per-method state
+/// matrix (plan §PR1) is unit-testable without standing up iced Elements.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CardState {
+    title: &'static str,
+    subtitle: String,
+    primary_label: &'static str,
+    primary_mode: RecoveryKitMode,
+}
+
+/// The "Create" (nothing backed up yet) card state, per Cube shape.
+fn create_state(is_passkey: bool) -> CardState {
+    if is_passkey {
+        CardState {
+            title: "Back up your Wallet Descriptor",
+            subtitle: "Your Master Seed Phrase is protected by your passkey and isn't included \
+                       in the Recovery Kit — we back up the Wallet Descriptor only."
+                .to_string(),
+            primary_label: "Create Recovery Kit",
+            primary_mode: RecoveryKitMode::Create,
+        }
+    } else {
+        CardState {
+            title: "Back up your Cube Recovery Kit",
+            subtitle: "Back up your Master Seed Phrase and Wallet Descriptor to your Connect \
+                       account so you can restore your Cube if you lose this device."
+                .to_string(),
+            primary_label: "Create Recovery Kit",
+            primary_mode: RecoveryKitMode::Create,
+        }
+    }
+}
+
+/// A sentence naming the missing half of an incomplete enabled method (`label`
+/// is "password" / "phone"), or `None` when the method is complete for the
+/// shape. An enabled method holds at least one half, so for the mnemonic+vault
+/// shape the gap is whichever half is absent; for the descriptor-only (passkey)
+/// and seed-only (vaultless) shapes it names that required half.
+fn method_gap_sentence(
+    m: &MethodBackup,
+    has_vault: bool,
+    is_passkey: bool,
+    label: &str,
+) -> Option<String> {
+    if method_complete(m, has_vault, is_passkey) {
+        return None;
+    }
+    let missing_half = if is_passkey || m.seed {
+        // Passkey needs the descriptor; a mnemonic+vault method that already
+        // holds the seed is missing the descriptor.
+        "Wallet Descriptor"
+    } else {
+        // No seed present — the seed is what's missing (mnemonic, either shape).
+        "Master Seed Phrase"
+    };
+    Some(format!(
+        "Your {} backup is missing the {}.",
+        label, missing_half
+    ))
+}
+
+/// The CTA that closes the *password* method's gap, when the password method is
+/// enabled and incomplete. `None` when password is absent or already complete —
+/// the gap is then on the keychain method, closed by re-sealing via `Rotate`.
+fn password_gap_cta(
+    password: &Option<MethodBackup>,
+    has_vault: bool,
+    is_passkey: bool,
+) -> Option<(&'static str, RecoveryKitMode)> {
+    let pw = password.as_ref()?;
+    if method_complete(pw, has_vault, is_passkey) {
+        return None;
+    }
+    if pw.seed && !pw.descriptor {
+        // Seed backed up, descriptor missing → the existing AddDescriptor branch.
+        Some(("Add Wallet Descriptor", RecoveryKitMode::AddDescriptor))
+    } else {
+        // Descriptor present but seed missing (or vaultless seed-shape with no
+        // seed) → the existing AddSeed branch.
+        Some(("Add Master Seed Phrase", RecoveryKitMode::AddSeed))
+    }
+}
+
+/// Derive the card's copy + primary CTA from the per-method [`BackupOverview`]
+/// and the Cube's shape. The Cube reads "backed up" iff ≥1 method is enabled
+/// and every enabled method is complete for the shape (master F6); any
+/// enabled-but-incomplete method drops to the "Finish backing up" state,
+/// naming each gap (password first) with the CTA pointed at the first gap.
+/// `status_present` distinguishes "loaded, no methods" (Create) from "not
+/// loaded yet" (loading / sign-in copy — mnemonic only, matching prior copy).
+fn recovery_kit_card_state(
+    overview: &BackupOverview,
+    is_passkey: bool,
+    has_vault: bool,
+    loading: bool,
+    status_present: bool,
+) -> CardState {
+    // Not loaded yet. The passkey card historically shows its Create copy here;
+    // the mnemonic card shows a loading / sign-in line. Preserve both.
+    if !status_present {
+        if is_passkey {
+            return create_state(true);
+        }
+        return CardState {
+            title: "Cube Recovery Kit",
+            subtitle: if loading {
+                "Checking your Connect account…".to_string()
+            } else {
+                "Sign in to Connect to back up your Cube Recovery Kit.".to_string()
+            },
+            primary_label: "Create Recovery Kit",
+            primary_mode: RecoveryKitMode::Create,
+        };
+    }
+
+    // No method enabled → Create.
+    if !overview.any_enabled() {
+        return create_state(is_passkey);
+    }
+
+    // Per-method completeness. A disabled method vacuously satisfies the
+    // conjunction, so `unwrap_or(true)`.
+    let pw_complete = overview
+        .password
+        .as_ref()
+        .map(|m| method_complete(m, has_vault, is_passkey))
+        .unwrap_or(true);
+    let kc_complete = overview
+        .keychain
+        .as_ref()
+        .map(|m| method_complete(m, has_vault, is_passkey))
+        .unwrap_or(true);
+
+    if pw_complete && kc_complete {
+        // Every enabled method complete → backed up.
+        let title = if is_passkey {
+            "Wallet Descriptor backed up"
+        } else {
+            "Recovery Kit backed up"
+        };
+        let subtitle = format!(
+            "Last updated {}.",
+            overview
+                .last_updated
+                .as_deref()
+                .map(format_backup_time)
+                .unwrap_or_else(|| "—".to_string())
+        );
+        return CardState {
+            title,
+            subtitle,
+            primary_label: "Update",
+            primary_mode: RecoveryKitMode::Rotate,
+        };
+    }
+
+    // At least one enabled method is incomplete → "Finish backing up", listing
+    // each gap in deterministic order (password first).
+    let mut gaps: Vec<String> = Vec::new();
+    if let Some(pw) = &overview.password {
+        if let Some(s) = method_gap_sentence(pw, has_vault, is_passkey, "password") {
+            gaps.push(s);
+        }
+    }
+    if let Some(kc) = &overview.keychain {
+        if let Some(s) = method_gap_sentence(kc, has_vault, is_passkey, "phone") {
+            gaps.push(s);
+        }
+    }
+
+    // The CTA closes the first gap (password first); a keychain-only gap
+    // re-seals via Rotate (the protection-choice → phone re-seal fills whatever
+    // the tier requires in one pass).
+    let (primary_label, primary_mode) = password_gap_cta(&overview.password, has_vault, is_passkey)
+        .unwrap_or(("Finish backing up", RecoveryKitMode::Rotate));
+
+    CardState {
+        title: "Finish backing up your Recovery Kit",
+        subtitle: gaps.join(" "),
+        primary_label,
+        primary_mode,
+    }
 }
 
 /// Cube Recovery Kit card — rendered below the local paper-phrase
@@ -548,7 +831,7 @@ fn recovery_kit_card<'a>(
     has_vault: bool,
     status: Option<&RecoveryKitStatus>,
     loading: bool,
-    drift: bool,
+    drift: DescriptorDrift,
 ) -> Element<'a, Message> {
     // Passkey + no vault => nothing to back up yet. Render a thin
     // informational card rather than the regular flow.
@@ -569,85 +852,24 @@ fn recovery_kit_card<'a>(
         .into();
     }
 
-    let (title, subtitle, primary_label, primary_mode) = if is_passkey {
-        // Passkey variant — descriptor-only. Two states.
-        match status {
-            Some(s) if s.has_encrypted_wallet_descriptor => (
-                "Wallet Descriptor backed up",
-                format!(
-                    "Last updated {}.",
-                    s.updated_at
-                        .as_deref()
-                        .map(format_backup_time)
-                        .unwrap_or_else(|| "—".to_string())
-                ),
-                "Update",
-                RecoveryKitMode::Rotate,
-            ),
-            _ => (
-                "Back up your Wallet Descriptor",
-                "Your Master Seed Phrase is protected by your passkey and isn't included \
-                 in the Recovery Kit — we back up the Wallet Descriptor only."
-                    .to_string(),
-                "Create Recovery Kit",
-                RecoveryKitMode::Create,
-            ),
-        }
-    } else {
-        // Mnemonic variant — full four-state matrix per plan §6.3.
-        match status {
-            Some(s) if !s.has_recovery_kit => (
-                "Back up your Cube Recovery Kit",
-                "Back up your Master Seed Phrase and Wallet Descriptor to your Connect \
-                 account so you can restore your Cube if you lose this device."
-                    .to_string(),
-                "Create Recovery Kit",
-                RecoveryKitMode::Create,
-            ),
-            Some(s) if s.has_encrypted_seed && !s.has_encrypted_wallet_descriptor && has_vault => (
-                "Finish backing up your Recovery Kit",
-                "Your Master Seed Phrase is backed up, but your Wallet Descriptor isn't."
-                    .to_string(),
-                "Add Wallet Descriptor",
-                RecoveryKitMode::AddDescriptor,
-            ),
-            Some(s) if !s.has_encrypted_seed && s.has_encrypted_wallet_descriptor => (
-                "Finish backing up your Recovery Kit",
-                "Your Wallet Descriptor is backed up, but your Master Seed Phrase isn't."
-                    .to_string(),
-                "Add Master Seed Phrase",
-                RecoveryKitMode::AddSeed,
-            ),
-            Some(s) => (
-                "Recovery Kit backed up",
-                format!(
-                    "Last updated {}.",
-                    s.updated_at
-                        .as_deref()
-                        .map(format_backup_time)
-                        .unwrap_or_else(|| "—".to_string())
-                ),
-                "Update",
-                RecoveryKitMode::Rotate,
-            ),
-            None => (
-                "Cube Recovery Kit",
-                if loading {
-                    "Checking your Connect account…".to_string()
-                } else {
-                    "Sign in to Connect to back up your Cube Recovery Kit.".to_string()
-                },
-                "Create Recovery Kit",
-                RecoveryKitMode::Create,
-            ),
-        }
-    };
+    // One source of truth for what's backed up, by which method (master
+    // §definitions). Drives the card state, the pills, and Remove visibility.
+    let overview = backup_overview(status);
+    let CardState {
+        title,
+        subtitle,
+        primary_label,
+        primary_mode,
+    } = recovery_kit_card_state(&overview, is_passkey, has_vault, loading, status.is_some());
 
-    // Drift overrides the "complete" state: primary CTA becomes
-    // "Update now" and the subtitle swaps to the drift warning.
-    let (subtitle, primary_label, primary_mode) = if drift {
+    // Drift overrides the "complete" state: primary CTA becomes "Update now"
+    // and the subtitle swaps to a drift warning naming the stale method(s)
+    // (per-method drift, PR 3). Each method is judged independently, so a
+    // keychain-only kit can now drift (unlike PR 1, which kept drift
+    // password-scoped); re-sealing one method clears only its warning.
+    let (subtitle, primary_label, primary_mode) = if drift.any() {
         (
-            "Your Wallet Descriptor changed since your last backup — update now.".to_string(),
+            drift_subtitle(&drift).to_string(),
             "Update now",
             RecoveryKitMode::Rotate,
         )
@@ -655,8 +877,8 @@ fn recovery_kit_card<'a>(
         (subtitle, primary_label, primary_mode)
     };
 
-    // Render with Remove button when a kit exists.
-    let has_kit = status.map(|s| s.has_recovery_kit).unwrap_or(false);
+    // Render with Remove button when any method is enabled.
+    let has_kit = overview.any_enabled();
     let mut actions = Row::new().spacing(10).align_y(Alignment::Center).push(
         button::primary(None, primary_label)
             .padding([8, 16])
@@ -672,8 +894,10 @@ fn recovery_kit_card<'a>(
         );
     }
 
-    // Which backup methods are actually in place — drives the method pills.
-    let (password_present, keychain_present) = backup_methods_present(status);
+    // Which backup methods are actually in place (presence, not completeness) —
+    // drives the method pills. A partial method still shows its pill.
+    let (password_present, keychain_present) =
+        (overview.password.is_some(), overview.keychain.is_some());
 
     let mut body = Column::new()
         .spacing(4)
@@ -692,9 +916,9 @@ fn recovery_kit_card<'a>(
             .push(Space::new().height(Length::Fixed(2.0)))
             .push(pills);
     }
-    if drift {
+    if drift.any() {
         body = body.push(
-            text("⚠ Descriptor out of sync with your Connect backup.")
+            text(drift_warning_line(&drift))
                 .size(12)
                 .style(coincube_ui::theme::text::warning),
         );
@@ -879,20 +1103,54 @@ pub fn fiat_price<'a>(
     .into()
 }
 
-/// Decide whether the Recovery-Kit card should flag "descriptor
-/// drift". Split out of `general_section` so the branch table is
-/// testable without standing up a full `Cache`.
+/// Per-method descriptor drift verdict (per-method drift, PR 3). Each enabled
+/// method's cached descriptor fingerprint is compared to the live descriptor
+/// independently, so re-sealing one method clears only that method's warning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct DescriptorDrift {
+    pub(crate) password: bool,
+    pub(crate) keychain: bool,
+}
+
+impl DescriptorDrift {
+    /// Any enabled method's descriptor is out of sync with the live Vault.
+    pub(crate) fn any(&self) -> bool {
+        self.password || self.keychain
+    }
+}
+
+/// Per-method drift verdicts for the Recovery-Kit card. Each method is judged by
+/// the same positive-evidence-only rule as [`method_descriptor_drift`]:
+/// `{password,keychain}_present` is whether that method has a descriptor on the
+/// server; `*_slot` is that method's last locally-cached upload fingerprint;
+/// `live` is what the wallet would currently upload.
+fn descriptor_drift(
+    live: Option<&str>,
+    password_present: bool,
+    password_slot: Option<&str>,
+    keychain_present: bool,
+    keychain_slot: Option<&str>,
+) -> DescriptorDrift {
+    DescriptorDrift {
+        password: method_descriptor_drift(password_present, live, password_slot),
+        keychain: method_descriptor_drift(keychain_present, live, keychain_slot),
+    }
+}
+
+/// Whether a single backup method's descriptor is out of sync with the live
+/// Vault. Split out of `general_section` so the branch table is testable without
+/// standing up a full `Cache`, and shared by both methods (PR 3).
 ///
-/// - `server_has_descriptor`: the Connect-side `RecoveryKitStatus`
-///   reports a descriptor half is backed up.
+/// - `present`: this method reports a descriptor backed up on Connect
+///   (password: `has_encrypted_wallet_descriptor`; keychain:
+///   `envelope_kinds ∋ "descriptor"`).
 /// - `live`: SHA-256 of what the live wallet would currently upload
 ///   (`None` when no Vault is loaded).
-/// - `cached`: SHA-256 of what this device last uploaded
-///   (`None` when the local cache was cleared, the kit was made from
-///   a different install, or the backup happened before the cache
-///   field existed).
-fn descriptor_drift(server_has_descriptor: bool, live: Option<&str>, cached: Option<&str>) -> bool {
-    if !server_has_descriptor {
+/// - `cached`: SHA-256 of what this device last backed up for this method
+///   (`None` when the local slot was cleared, the kit was made from a different
+///   install, or the backup predates the slot field).
+fn method_descriptor_drift(present: bool, live: Option<&str>, cached: Option<&str>) -> bool {
+    if !present {
         return false;
     }
     match (live, cached) {
@@ -904,8 +1162,8 @@ fn descriptor_drift(server_has_descriptor: bool, live: Option<&str>, cached: Opt
         // kit restored onto this device (we never re-uploaded so
         // never populated the cache), kit uploaded from a different
         // device, and installs that pre-date the cache field. In
-        // all three, the server's `has_encrypted_wallet_descriptor`
-        // flag already tells us a backup exists — firing the banner
+        // all three, the server's descriptor-present flag already
+        // tells us a backup exists — firing the banner
         // here produces a *permanent* false positive that stays up
         // until the user manually re-uploads, training them to
         // ignore the signal entirely (banner blindness). The
@@ -918,6 +1176,31 @@ fn descriptor_drift(server_has_descriptor: bool, live: Option<&str>, cached: Opt
     }
 }
 
+/// The card subtitle when a descriptor has drifted — names the stale method(s)
+/// (per-method drift, PR 3). Empty string when nothing drifted (callers guard
+/// with [`DescriptorDrift::any`]).
+fn drift_subtitle(d: &DescriptorDrift) -> &'static str {
+    match (d.password, d.keychain) {
+        (true, true) => {
+            "Your Wallet Descriptor changed since your last backup — update both copies now."
+        }
+        (true, false) => "Your password backup's Wallet Descriptor is out of date — update now.",
+        (false, true) => "Your phone backup's Wallet Descriptor is out of date — update now.",
+        (false, false) => "",
+    }
+}
+
+/// The inline ⚠ warning line under the pills when a descriptor has drifted —
+/// names the stale method(s) (per-method drift, PR 3).
+fn drift_warning_line(d: &DescriptorDrift) -> &'static str {
+    match (d.password, d.keychain) {
+        (true, true) => "⚠ Your password and phone descriptors are out of sync with your Vault.",
+        (true, false) => "⚠ Your password descriptor is out of sync with your Vault.",
+        (false, true) => "⚠ Your phone descriptor is out of sync with your Vault.",
+        (false, false) => "",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -926,19 +1209,19 @@ mod tests {
     fn no_drift_when_server_has_no_descriptor() {
         // Card's "incomplete" copy already covers this case; drift
         // must not double up the signal.
-        assert!(!descriptor_drift(false, Some("a"), Some("b")));
-        assert!(!descriptor_drift(false, Some("a"), None));
-        assert!(!descriptor_drift(false, None, Some("b")));
+        assert!(!method_descriptor_drift(false, Some("a"), Some("b")));
+        assert!(!method_descriptor_drift(false, Some("a"), None));
+        assert!(!method_descriptor_drift(false, None, Some("b")));
     }
 
     #[test]
     fn drift_when_live_and_cached_differ() {
-        assert!(descriptor_drift(true, Some("a"), Some("b")));
+        assert!(method_descriptor_drift(true, Some("a"), Some("b")));
     }
 
     #[test]
     fn no_drift_when_live_and_cached_match() {
-        assert!(!descriptor_drift(true, Some("a"), Some("a")));
+        assert!(!method_descriptor_drift(true, Some("a"), Some("a")));
     }
 
     #[test]
@@ -948,19 +1231,490 @@ mod tests {
         // cached fingerprint is the normal state after a kit is
         // restored to this device, uploaded from another device, or
         // created by a client version predating the cache field.
-        // The server's `has_encrypted_wallet_descriptor=true` is the
+        // The server's descriptor-present flag is the
         // authoritative signal that a backup exists; firing a
         // permanent banner here would train users to tune it out.
-        assert!(!descriptor_drift(true, Some("a"), None));
+        assert!(!method_descriptor_drift(true, Some("a"), None));
     }
 
     #[test]
     fn no_drift_when_live_missing() {
         // No Vault loaded yet — can't compute a comparison.
-        // `server_has_descriptor` being true here means another
+        // `present` being true here means another
         // device backed up the descriptor; we can't usefully flag
         // drift until this device has a wallet to diff against.
-        assert!(!descriptor_drift(true, None, Some("b")));
-        assert!(!descriptor_drift(true, None, None));
+        assert!(!method_descriptor_drift(true, None, Some("b")));
+        assert!(!method_descriptor_drift(true, None, None));
+    }
+
+    // ── Per-method descriptor drift (plan §PR3) ─────────────────────────────
+    //
+    // Each enabled method is judged independently against the live descriptor,
+    // so re-sealing one method clears only that method's warning. The
+    // positive-evidence-only rule carries over per slot (a missing slot never
+    // fires that method's banner).
+
+    #[test]
+    fn drift_only_flags_the_stale_method() {
+        // Password fresh (slot matches live), keychain stale (slot differs).
+        let d = descriptor_drift(Some("live"), true, Some("live"), true, Some("old"));
+        assert_eq!(
+            d,
+            DescriptorDrift {
+                password: false,
+                keychain: true
+            }
+        );
+        assert!(d.any());
+        // The inverse: password stale, keychain fresh.
+        let d = descriptor_drift(Some("live"), true, Some("old"), true, Some("live"));
+        assert_eq!(
+            d,
+            DescriptorDrift {
+                password: true,
+                keychain: false
+            }
+        );
+    }
+
+    #[test]
+    fn drift_flags_both_methods_when_both_stale() {
+        let d = descriptor_drift(Some("live"), true, Some("old"), true, Some("older"));
+        assert_eq!(
+            d,
+            DescriptorDrift {
+                password: true,
+                keychain: true
+            }
+        );
+    }
+
+    #[test]
+    fn no_drift_when_both_methods_match_live() {
+        let d = descriptor_drift(Some("live"), true, Some("live"), true, Some("live"));
+        assert!(!d.any());
+    }
+
+    #[test]
+    fn drift_ignores_a_disabled_method() {
+        // Keychain not present on the server → its slot is irrelevant even if it
+        // differs from live; only the enabled password method is judged.
+        let d = descriptor_drift(Some("live"), true, Some("old"), false, Some("whatever"));
+        assert_eq!(
+            d,
+            DescriptorDrift {
+                password: true,
+                keychain: false
+            }
+        );
+    }
+
+    #[test]
+    fn restored_install_with_no_slots_never_drifts() {
+        // Both methods present on the server, but neither local slot exists
+        // (fresh restore / other-device upload / pre-field install) →
+        // positive-evidence-only means no banner for either method.
+        let d = descriptor_drift(Some("live"), true, None, true, None);
+        assert!(!d.any());
+    }
+
+    #[test]
+    fn no_drift_before_a_vault_loads() {
+        // No live fingerprint yet → nothing to compare, either method.
+        let d = descriptor_drift(None, true, Some("old"), true, Some("older"));
+        assert!(!d.any());
+    }
+
+    #[test]
+    fn drift_copy_names_the_stale_methods() {
+        let phone_only = DescriptorDrift {
+            password: false,
+            keychain: true,
+        };
+        assert!(drift_subtitle(&phone_only).contains("phone"));
+        assert!(drift_warning_line(&phone_only).contains("phone"));
+
+        let password_only = DescriptorDrift {
+            password: true,
+            keychain: false,
+        };
+        assert!(drift_subtitle(&password_only).contains("password"));
+        assert!(drift_warning_line(&password_only).contains("password"));
+
+        let both = DescriptorDrift {
+            password: true,
+            keychain: true,
+        };
+        assert!(drift_subtitle(&both).contains("both"));
+        assert!(
+            drift_warning_line(&both).contains("password")
+                && drift_warning_line(&both).contains("phone")
+        );
+
+        // No drift → empty (callers guard with `any()`).
+        let none = DescriptorDrift::default();
+        assert!(drift_subtitle(&none).is_empty());
+        assert!(drift_warning_line(&none).is_empty());
+    }
+
+    // ── Per-method backup overview + card state matrix (plan §PR1) ──────────
+    //
+    // These pin the single source of truth (`backup_overview`/`method_complete`)
+    // and the card copy derived from it. The bug they guard: the old card read
+    // only the password-kit halves, so a keychain-only backup showed "Create
+    // Recovery Kit" with a contradictory Keychain pill and no timestamp.
+
+    use crate::services::coincube::OwnerSelfRecoverySummary;
+
+    /// Password-kit status with the given halves; `owner` folds in the keychain
+    /// (phone) summary. `has_recovery_kit` mirrors the password halves (the
+    /// server's password-scoped flag) so these fixtures match real payloads.
+    fn status(
+        seed: bool,
+        descriptor: bool,
+        updated_at: Option<&str>,
+        owner: Option<OwnerSelfRecoverySummary>,
+    ) -> RecoveryKitStatus {
+        RecoveryKitStatus {
+            has_recovery_kit: seed || descriptor,
+            has_encrypted_seed: seed,
+            has_encrypted_wallet_descriptor: descriptor,
+            encryption_scheme: "aes-256-gcm".into(),
+            created_at: None,
+            updated_at: updated_at.map(|s| s.to_string()),
+            owner_self: owner,
+        }
+    }
+
+    fn owner(kinds: &[&str], updated_at: Option<&str>) -> OwnerSelfRecoverySummary {
+        OwnerSelfRecoverySummary {
+            has_recipient: true,
+            tier: "full_cube".into(),
+            envelope_kinds: kinds.iter().map(|k| k.to_string()).collect(),
+            updated_at: updated_at.map(|s| s.to_string()),
+        }
+    }
+
+    /// Convenience: card state for a mnemonic-with-vault cube.
+    fn mnemonic_vault_state(st: &RecoveryKitStatus) -> CardState {
+        recovery_kit_card_state(&backup_overview(Some(st)), false, true, false, true)
+    }
+
+    // ---- method_complete truth table (all shapes) ----
+
+    #[test]
+    fn method_complete_passkey_needs_descriptor_only() {
+        let seed_only = MethodBackup {
+            seed: true,
+            descriptor: false,
+        };
+        let desc_only = MethodBackup {
+            seed: false,
+            descriptor: true,
+        };
+        assert!(!method_complete(&seed_only, true, true));
+        assert!(method_complete(&desc_only, true, true));
+        // has_vault is irrelevant for passkey.
+        assert!(method_complete(&desc_only, false, true));
+    }
+
+    #[test]
+    fn method_complete_mnemonic_vaultless_needs_seed_only() {
+        let seed_only = MethodBackup {
+            seed: true,
+            descriptor: false,
+        };
+        let desc_only = MethodBackup {
+            seed: false,
+            descriptor: true,
+        };
+        assert!(method_complete(&seed_only, false, false));
+        assert!(!method_complete(&desc_only, false, false));
+    }
+
+    #[test]
+    fn method_complete_mnemonic_vault_needs_both() {
+        let both = MethodBackup {
+            seed: true,
+            descriptor: true,
+        };
+        let seed_only = MethodBackup {
+            seed: true,
+            descriptor: false,
+        };
+        let desc_only = MethodBackup {
+            seed: false,
+            descriptor: true,
+        };
+        assert!(method_complete(&both, true, false));
+        assert!(!method_complete(&seed_only, true, false));
+        assert!(!method_complete(&desc_only, true, false));
+    }
+
+    // ---- backup_overview presence rules (master F1) ----
+
+    #[test]
+    fn overview_absent_status_is_all_none() {
+        let o = backup_overview(None);
+        assert!(o.password.is_none());
+        assert!(o.keychain.is_none());
+        assert!(o.last_updated.is_none());
+        assert!(!o.any_enabled());
+    }
+
+    #[test]
+    fn overview_recipient_without_envelopes_never_counts_as_keychain() {
+        // A registered recipient with an empty envelope set is NOT a backup
+        // (master F1 — presence = restorable material, not a bare recipient).
+        let st = status(false, false, None, Some(owner(&[], None)));
+        let o = backup_overview(Some(&st));
+        assert!(
+            o.keychain.is_none(),
+            "empty envelope set must not enable keychain"
+        );
+        assert!(!o.any_enabled());
+    }
+
+    #[test]
+    fn overview_keychain_reads_envelope_kinds() {
+        let st = status(
+            false,
+            false,
+            None,
+            Some(owner(&["seed", "descriptor"], None)),
+        );
+        let o = backup_overview(Some(&st));
+        let kc = o.keychain.expect("keychain enabled by envelopes");
+        assert!(kc.seed && kc.descriptor);
+        assert!(
+            o.password.is_none(),
+            "no password blobs → no password method"
+        );
+    }
+
+    #[test]
+    fn overview_last_updated_is_the_later_of_the_two() {
+        // Keychain sealed after the password kit → keychain timestamp wins.
+        let st = status(
+            true,
+            true,
+            Some("2026-05-01T00:00:00Z"),
+            Some(owner(&["seed", "descriptor"], Some("2026-06-01T00:00:00Z"))),
+        );
+        let o = backup_overview(Some(&st));
+        assert_eq!(o.last_updated.as_deref(), Some("2026-06-01T00:00:00Z"));
+    }
+
+    // ---- password-only regression (master F4): the original four states ----
+
+    #[test]
+    fn password_only_no_kit_is_create() {
+        let st = status(false, false, None, None);
+        let s = mnemonic_vault_state(&st);
+        assert_eq!(s.title, "Back up your Cube Recovery Kit");
+        assert_eq!(s.primary_mode, RecoveryKitMode::Create);
+    }
+
+    #[test]
+    fn password_only_seed_only_with_vault_prompts_add_descriptor() {
+        let st = status(true, false, Some("2026-05-01T00:00:00Z"), None);
+        let s = mnemonic_vault_state(&st);
+        assert_eq!(s.title, "Finish backing up your Recovery Kit");
+        assert_eq!(s.primary_mode, RecoveryKitMode::AddDescriptor);
+        assert_eq!(s.primary_label, "Add Wallet Descriptor");
+        assert!(s.subtitle.contains("Wallet Descriptor"));
+    }
+
+    #[test]
+    fn password_only_descriptor_only_prompts_add_seed() {
+        let st = status(false, true, Some("2026-05-01T00:00:00Z"), None);
+        let s = mnemonic_vault_state(&st);
+        assert_eq!(s.title, "Finish backing up your Recovery Kit");
+        assert_eq!(s.primary_mode, RecoveryKitMode::AddSeed);
+        assert_eq!(s.primary_label, "Add Master Seed Phrase");
+        assert!(s.subtitle.contains("Master Seed Phrase"));
+    }
+
+    #[test]
+    fn password_only_both_halves_is_backed_up() {
+        let st = status(true, true, Some("2026-05-08T14:36:50Z"), None);
+        let s = mnemonic_vault_state(&st);
+        assert_eq!(s.title, "Recovery Kit backed up");
+        assert_eq!(s.primary_mode, RecoveryKitMode::Rotate);
+        assert_eq!(s.primary_label, "Update");
+        assert!(s.subtitle.contains("Last updated"));
+        assert!(s.subtitle.contains("8 May 2026"));
+    }
+
+    #[test]
+    fn password_only_seed_only_vaultless_is_backed_up() {
+        // A seed-only kit on a vaultless cube is already complete.
+        let st = status(true, false, Some("2026-05-01T00:00:00Z"), None);
+        let s = recovery_kit_card_state(&backup_overview(Some(&st)), false, false, false, true);
+        assert_eq!(s.title, "Recovery Kit backed up");
+        assert_eq!(s.primary_mode, RecoveryKitMode::Rotate);
+    }
+
+    // ---- keychain-only (the shipped bug) ----
+
+    #[test]
+    fn keychain_only_full_cube_is_backed_up_with_pill_and_remove() {
+        // Phone-sealed both halves, no password kit. This used to show "Create".
+        let st = status(
+            false,
+            false,
+            None,
+            Some(owner(&["seed", "descriptor"], Some("2026-06-01T09:00:00Z"))),
+        );
+        let o = backup_overview(Some(&st));
+        let s = mnemonic_vault_state(&st);
+        assert_eq!(s.title, "Recovery Kit backed up");
+        assert_eq!(s.primary_mode, RecoveryKitMode::Rotate);
+        assert!(
+            s.subtitle.contains("1 Jun 2026"),
+            "timestamp from owner_self: {}",
+            s.subtitle
+        );
+        // Keychain pill shows; password pill does not; Remove is offered.
+        assert_eq!(backup_methods_present(Some(&st)), (false, true));
+        assert!(o.any_enabled(), "has_kit → Remove button visible");
+    }
+
+    #[test]
+    fn keychain_descriptor_only_on_vault_cube_misses_the_seed() {
+        // Phone sealed only the descriptor; a mnemonic+vault cube needs the seed.
+        let st = status(
+            false,
+            false,
+            None,
+            Some(owner(&["descriptor"], Some("2026-06-01T00:00:00Z"))),
+        );
+        let s = mnemonic_vault_state(&st);
+        assert_eq!(s.title, "Finish backing up your Recovery Kit");
+        assert_eq!(
+            s.subtitle, "Your phone backup is missing the Master Seed Phrase.",
+            "keychain gap must name the phone method + missing seed"
+        );
+        // No password method → the CTA re-seals via Rotate.
+        assert_eq!(s.primary_mode, RecoveryKitMode::Rotate);
+    }
+
+    // ---- cross-method halves: never "backed up" (master F6) ----
+
+    #[test]
+    fn cross_method_halves_surface_both_gaps_and_are_never_backed_up() {
+        // Password holds the seed only; keychain holds the descriptor only.
+        // Neither method is independently complete for a mnemonic+vault cube,
+        // so the Cube is NOT backed up (per-method conjunction, not a union).
+        let st = status(
+            true,
+            false,
+            Some("2026-05-01T00:00:00Z"),
+            Some(owner(&["descriptor"], Some("2026-05-02T00:00:00Z"))),
+        );
+        let s = mnemonic_vault_state(&st);
+        assert_eq!(s.title, "Finish backing up your Recovery Kit");
+        // Both gaps listed, password first.
+        assert_eq!(
+            s.subtitle,
+            "Your password backup is missing the Wallet Descriptor. \
+             Your phone backup is missing the Master Seed Phrase."
+        );
+        // CTA closes the first (password) gap.
+        assert_eq!(s.primary_mode, RecoveryKitMode::AddDescriptor);
+        // Both pills present (presence, not completeness).
+        assert_eq!(backup_methods_present(Some(&st)), (true, true));
+    }
+
+    // ---- both methods complete ----
+
+    #[test]
+    fn both_methods_complete_shows_two_pills_and_later_timestamp() {
+        let st = status(
+            true,
+            true,
+            Some("2026-05-01T00:00:00Z"),
+            Some(owner(&["seed", "descriptor"], Some("2026-07-01T00:00:00Z"))),
+        );
+        let o = backup_overview(Some(&st));
+        let s = mnemonic_vault_state(&st);
+        assert_eq!(s.title, "Recovery Kit backed up");
+        assert_eq!(backup_methods_present(Some(&st)), (true, true));
+        // Later of the two timestamps (keychain).
+        assert_eq!(o.last_updated.as_deref(), Some("2026-07-01T00:00:00Z"));
+        assert!(s.subtitle.contains("1 Jul 2026"));
+    }
+
+    // ---- older API (owner_self None) → exact prior behavior ----
+
+    #[test]
+    fn older_api_without_owner_self_matches_password_only_states() {
+        // owner_self absent on older APIs → keychain never enabled; the card
+        // behaves exactly as the pre-keychain password-only card did.
+        let complete = status(true, true, Some("2026-05-01T00:00:00Z"), None);
+        assert_eq!(
+            mnemonic_vault_state(&complete).title,
+            "Recovery Kit backed up"
+        );
+        let absent = status(false, false, None, None);
+        assert_eq!(
+            mnemonic_vault_state(&absent).title,
+            "Back up your Cube Recovery Kit"
+        );
+        assert!(backup_overview(Some(&absent)).keychain.is_none());
+    }
+
+    // ---- passkey variant (descriptor-only shape) ----
+
+    #[test]
+    fn passkey_descriptor_backed_up() {
+        let st = status(false, true, Some("2026-05-01T00:00:00Z"), None);
+        let s = recovery_kit_card_state(&backup_overview(Some(&st)), true, true, false, true);
+        assert_eq!(s.title, "Wallet Descriptor backed up");
+        assert_eq!(s.primary_mode, RecoveryKitMode::Rotate);
+    }
+
+    #[test]
+    fn passkey_no_kit_is_create() {
+        let st = status(false, false, None, None);
+        let s = recovery_kit_card_state(&backup_overview(Some(&st)), true, true, false, true);
+        assert_eq!(s.title, "Back up your Wallet Descriptor");
+        assert_eq!(s.primary_mode, RecoveryKitMode::Create);
+    }
+
+    // ---- not-loaded-yet (status None) preserves prior copy ----
+
+    #[test]
+    fn not_loaded_mnemonic_shows_loading_or_signin() {
+        let loading = recovery_kit_card_state(&backup_overview(None), false, true, true, false);
+        assert_eq!(loading.title, "Cube Recovery Kit");
+        assert!(loading.subtitle.contains("Checking"));
+        let idle = recovery_kit_card_state(&backup_overview(None), false, true, false, false);
+        assert!(idle.subtitle.contains("Sign in"));
+    }
+
+    // ---- later_timestamp comparison ----
+
+    #[test]
+    fn later_timestamp_prefers_the_later_instant() {
+        assert_eq!(
+            later_timestamp(Some("2026-01-01T00:00:00Z"), Some("2026-02-01T00:00:00Z")).as_deref(),
+            Some("2026-02-01T00:00:00Z")
+        );
+        assert_eq!(
+            later_timestamp(Some("2026-03-01T00:00:00Z"), Some("2026-02-01T00:00:00Z")).as_deref(),
+            Some("2026-03-01T00:00:00Z")
+        );
+        // Only one side present.
+        assert_eq!(
+            later_timestamp(Some("2026-03-01T00:00:00Z"), None).as_deref(),
+            Some("2026-03-01T00:00:00Z")
+        );
+        assert_eq!(later_timestamp(None, None), None);
+        // One side unparseable → prefer the parseable side.
+        assert_eq!(
+            later_timestamp(Some("not-a-date"), Some("2026-02-01T00:00:00Z")).as_deref(),
+            Some("2026-02-01T00:00:00Z")
+        );
     }
 }

--- a/coincube-gui/src/app/view/settings/recovery_kit.rs
+++ b/coincube-gui/src/app/view/settings/recovery_kit.rs
@@ -522,7 +522,120 @@ pub fn uploading_view() -> Element<'static, Message> {
         .into()
 }
 
-/// "Removing" placeholder while `delete_recovery_kit` is in flight.
+/// The Connect-hosted backup paths a confirmed Remove will delete, given which
+/// methods are present. Deterministic order (password first) so the confirm
+/// screen and its regression test agree. Pure so the three method combinations
+/// are unit-testable without building the Element.
+pub(crate) fn confirm_remove_paths(password: bool, keychain: bool) -> Vec<&'static str> {
+    let mut paths = Vec::new();
+    if password {
+        paths.push("Your password-encrypted Recovery Kit");
+    }
+    if keychain {
+        paths.push("The copy sealed to your phone (Keychain)");
+    }
+    paths
+}
+
+/// Confirmation takeover shown before any delete happens (master F5). Names the
+/// exact backup paths that will be torn down (from the current
+/// `backup_overview`), states the teardown is irreversible, reassures that the
+/// Cube and its local backup phrase are untouched, and warns that without a
+/// hosted kit the Cube can't be restored from Connect if the device is lost.
+/// The destructive action uses the alert (non-primary) style; Cancel is the
+/// safe default.
+pub fn confirm_remove_view<'a>(password: bool, keychain: bool) -> Element<'a, Message> {
+    // Which paths will be deleted. At least one is always true when this screen
+    // is reachable (Remove only shows when a method is enabled).
+    let mut what = Column::new().spacing(6).width(Length::Fixed(600.0));
+    for path in confirm_remove_paths(password, keychain) {
+        what = what.push(text(format!("• {}", path)).size(15));
+    }
+
+    let mut col = Column::new()
+        .spacing(16)
+        .width(Length::Fill)
+        .push(header())
+        .push(Space::new().height(Length::Fixed(8.0)))
+        .push(
+            Row::new()
+                .width(Length::Fill)
+                .push(Space::new().width(Length::Fill))
+                .push(icon::trash_icon().size(80).color(color::RED))
+                .push(Space::new().width(Length::Fill)),
+        )
+        .push(
+            Row::new()
+                .width(Length::Fill)
+                .push(Space::new().width(Length::Fill))
+                .push(text("Remove your Recovery Kit?").size(22).bold())
+                .push(Space::new().width(Length::Fill)),
+        )
+        .push(Space::new().height(Length::Fixed(8.0)))
+        .push(
+            Row::new()
+                .width(Length::Fill)
+                .push(Space::new().width(Length::Fill))
+                .push(
+                    Container::new(text("This will delete from your Connect account:").size(16))
+                        .width(Length::Fixed(600.0)),
+                )
+                .push(Space::new().width(Length::Fill)),
+        )
+        .push(
+            Row::new()
+                .width(Length::Fill)
+                .push(Space::new().width(Length::Fill))
+                .push(what)
+                .push(Space::new().width(Length::Fill)),
+        )
+        .push(Space::new().height(Length::Fixed(8.0)))
+        .push(
+            Row::new()
+                .width(Length::Fill)
+                .push(Space::new().width(Length::Fill))
+                .push(
+                    Container::new(
+                        text(
+                            "COINCUBE can't undo this. Your Cube and the recovery phrase you \
+                             wrote down stay exactly as they are — this only removes the copies \
+                             hosted in Connect. Afterwards, if you lose this device you won't be \
+                             able to restore this Cube from Connect; you'll need your local \
+                             recovery phrase.",
+                        )
+                        .size(14),
+                    )
+                    .width(Length::Fixed(600.0)),
+                )
+                .push(Space::new().width(Length::Fill)),
+        )
+        .push(Space::new().height(Length::Fixed(16.0)));
+
+    col = col.push(
+        Row::new()
+            .spacing(20)
+            .width(Length::Fill)
+            .align_y(Alignment::Center)
+            .push(Space::new().width(Length::Fill))
+            .push(
+                ui_button::secondary(None, "Cancel")
+                    .on_press(wrap(RecoveryKitMessage::Cancel))
+                    .padding([8, 16])
+                    .width(Length::Fixed(150.0)),
+            )
+            .push(
+                ui_button::alert(None, "Remove backup")
+                    .on_press(wrap(RecoveryKitMessage::ConfirmRemove))
+                    .padding([8, 16])
+                    .width(Length::Fixed(220.0)),
+            )
+            .push(Space::new().width(Length::Fill)),
+    );
+
+    col.into()
+}
+
+/// "Removing" placeholder while the delete set is in flight.
 pub fn removing_view() -> Element<'static, Message> {
     Column::new()
         .spacing(20)
@@ -645,6 +758,12 @@ pub fn dispatch<'a>(
             error.as_deref(),
         )),
         RecoveryKitState::Uploading { .. } => Some(uploading_view()),
+        RecoveryKitState::ConfirmRemove => {
+            // Name exactly which backup paths the confirm will delete, from the
+            // current per-method presence (master F5).
+            let (password, keychain) = backup_methods_present(status);
+            Some(confirm_remove_view(password, keychain))
+        }
         RecoveryKitState::Removing => Some(removing_view()),
         RecoveryKitState::Completed {
             updated_at,
@@ -656,5 +775,42 @@ pub fn dispatch<'a>(
             *now_has_descriptor,
         )),
         RecoveryKitState::Error { message } => Some(error_view(message)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The confirm screen must name exactly the backup paths that will be
+    // deleted, in a deterministic order, for each method combination (plan
+    // §PR2). Testing the pure path list is the Element-free equivalent of the
+    // three-combination confirm-view snapshot.
+
+    #[test]
+    fn confirm_remove_paths_password_only() {
+        assert_eq!(
+            confirm_remove_paths(true, false),
+            vec!["Your password-encrypted Recovery Kit"]
+        );
+    }
+
+    #[test]
+    fn confirm_remove_paths_keychain_only() {
+        assert_eq!(
+            confirm_remove_paths(false, true),
+            vec!["The copy sealed to your phone (Keychain)"]
+        );
+    }
+
+    #[test]
+    fn confirm_remove_paths_both_lists_password_first() {
+        assert_eq!(
+            confirm_remove_paths(true, true),
+            vec![
+                "Your password-encrypted Recovery Kit",
+                "The copy sealed to your phone (Keychain)",
+            ]
+        );
     }
 }

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -2188,6 +2188,9 @@ pub fn create_app_with_remote_backend(
             recovery_kit_last_backed_up_descriptor_fingerprint: cube_settings
                 .recovery_kit_last_backed_up_descriptor_fingerprint
                 .clone(),
+            recovery_kit_last_backed_up_keychain_descriptor_fingerprint: cube_settings
+                .recovery_kit_last_backed_up_keychain_descriptor_fingerprint
+                .clone(),
             // grpc_url isn't known yet — `Message::ConnectStreamReady`
             // backfills both fields once `get_service_config` returns.
             // Tokens we have right now (shared Arc with the REST client)

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -3808,6 +3808,7 @@ mod tests {
             has_recipient,
             tier: tier.to_string(),
             envelope_kinds: kinds.iter().map(|k| k.to_string()).collect(),
+            updated_at: None,
         }
     }
 

--- a/coincube-gui/src/loader.rs
+++ b/coincube-gui/src/loader.rs
@@ -676,6 +676,10 @@ pub async fn load_application(
             .cube_settings
             .recovery_kit_last_backed_up_descriptor_fingerprint
             .clone(),
+        recovery_kit_last_backed_up_keychain_descriptor_fingerprint: config
+            .cube_settings
+            .recovery_kit_last_backed_up_keychain_descriptor_fingerprint
+            .clone(),
         // Local-daemon path has no Connect tokens or gRPC URL; the user
         // would have to sign in via the Connect tab to populate these.
         connect_grpc_url: None,

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -1637,6 +1637,42 @@ impl CoincubeClient {
         let res = self.client.get(&url).send().await?;
         Self::parse_recovery_response(res).await
     }
+
+    /// `DELETE /api/v1/connect/cubes/{cubeId}/recovery-kit/recipients/{keyId}`
+    /// (authenticated, owner-only). True-deletes the recovery recipient and
+    /// **cascade-deletes its envelopes** server-side — revoking the phone
+    /// (Keychain) recovery mode. Used by the Remove-clears-everything flow to
+    /// tear down the owner-self keychain half (the password half goes via
+    /// [`Self::delete_recovery_kit`]). `404` → `NotFound` (recipient already
+    /// gone — the caller treats it as idempotent success); `429` →
+    /// `RateLimited`; other non-2xx → `Unsuccessful` with the body preserved.
+    pub async fn delete_recovery_kit_recipient(
+        &self,
+        cube_id: u64,
+        key_id: u64,
+    ) -> Result<(), CoincubeError> {
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/recovery-kit/recipients/{}",
+            self.base_url, cube_id, key_id
+        );
+        let res = self.client.delete(&url).send().await?;
+        let status = res.status();
+        if status.is_success() {
+            return Ok(());
+        }
+        match status.as_u16() {
+            404 => Err(CoincubeError::NotFound),
+            429 => Err(CoincubeError::RateLimited {
+                retry_after: parse_retry_after(res.headers()),
+            }),
+            _ => Err(CoincubeError::Unsuccessful(
+                crate::services::http::NotSuccessResponseInfo {
+                    status_code: status.as_u16(),
+                    text: res.text().await.unwrap_or_default(),
+                },
+            )),
+        }
+    }
 }
 
 // =============================================================================
@@ -2268,6 +2304,47 @@ mod recovery_kit_tests {
         let client = CoincubeClient::for_test(server.base_url());
         let err = client
             .delete_recovery_kit(42)
+            .await
+            .expect_err("expected NotFound");
+        mock.assert();
+        assert!(err.is_not_found());
+    }
+
+    #[tokio::test]
+    async fn delete_recovery_kit_recipient_ok_on_200() {
+        // Owner-self recipient DELETE — cascades envelopes server-side. The
+        // route embeds the keyId; assert we hit the exact path.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit/recipients/7");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({ "success": true, "data": { "deleted": true } }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        client
+            .delete_recovery_kit_recipient(42, 7)
+            .await
+            .expect("recipient delete should succeed");
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn delete_recovery_kit_recipient_404_maps_to_not_found() {
+        // Recipient already gone (removed from another device, or a race).
+        // Surfaced typed so the Remove flow treats it as idempotent success.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::DELETE)
+                .path("/api/v1/connect/cubes/42/recovery-kit/recipients/7");
+            then.status(404);
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .delete_recovery_kit_recipient(42, 7)
             .await
             .expect_err("expected NotFound");
         mock.assert();

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -1527,6 +1527,13 @@ pub struct OwnerSelfRecoverySummary {
     /// `"seed"`). Empty when a recipient is registered but nothing sealed yet.
     #[serde(default)]
     pub envelope_kinds: Vec<String>,
+    /// When the phone (keychain) envelope set was last sealed/updated, RFC 3339.
+    /// Folded into the card's "Last updated" line alongside the password kit's
+    /// `updated_at` (the later of the two wins). Absent on older APIs that don't
+    /// yet emit it (API PR 1c) → `None`, which keeps the card's timestamp on the
+    /// password kit's value.
+    #[serde(default)]
+    pub updated_at: Option<String>,
 }
 
 impl OwnerSelfRecoverySummary {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how hosted recovery material is deleted and how local backup/drift state is persisted; mistakes could misreport backup status or leave restorable Connect copies after a failed remove, though confirm gating and verification reduce that risk.
> 
> **Overview**
> Recovery Kit **Settings** and **Home** now treat **password** and **phone (Keychain)** backups as separate methods: a shared `BackupOverview` drives card copy (including keychain-only “backed up”), method pills, and Remove visibility instead of only password-kit halves.
> 
> **Per-method descriptor drift** adds a persisted keychain fingerprint slot (alongside the password slot). The card compares each method’s last-sealed hash to the live vault independently, with method-specific warning copy. Successful phone seal persists that slot; upload/remove paths route fingerprints through `DescriptorFingerprintSlot`. `has_recovery_kit()` and local connect-state heuristics count either slot so keychain-only cubes no longer read as unbacked up on Home.
> 
> **Remove** is confirm-gated (`ConfirmRemove` lists exactly which paths will be deleted), then runs sequential teardown: always `delete_recovery_kit` (404-tolerant), optionally delete the owner-self recipient (new client API), with server status verification before claiming phone copy is gone. Partial failures refresh status and may clear only the password fingerprint via `RemoveFailure.password_kit_deleted`.
> 
> Also: duress cube list keeps server `hasRecoveryKit` verbatim; `OwnerSelfRecoverySummary.updated_at` feeds “Last updated”; seal-result fingerprints redacted in `Debug`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eff7e49a0381da5ab9c0056662a7ab1cd615cbf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Recovery Kit status now distinguishes password vs phone (keychain) backups with per-method drift indicators and updated “update now” guidance.
  - Removing Recovery Kit backups now includes an explicit confirm step and presents an exact, ordered delete list.
  - Backup removal properly supports password-only, phone-only, and combined configurations.

- **Bug Fixes**
  - Improved persistence and refresh of Recovery Kit backup state across restarts.
  - Corrected keychain-only backup detection and duress/verification behavior.
  - Prevented sensitive backup fingerprint details from appearing in diagnostic output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->