### PR TITLE
More testing

### DIFF
--- a/coincube-gui/src/app/breez_spark/assets.rs
+++ b/coincube-gui/src/app/breez_spark/assets.rs
@@ -108,3 +108,66 @@ pub fn stable_token_as_sats(amount: u64, decimals: u32, btc_usd_price: Option<f6
     let usd_value = amount as f64 / 10_f64.powi(decimals as i32);
     (usd_value / price * 100_000_000.0) as u64
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spark_assets_have_stable_order_and_labels() {
+        assert_eq!(
+            list_assets(),
+            vec![SparkAsset::Bitcoin, SparkAsset::Lightning]
+        );
+        assert_eq!(SparkAsset::Bitcoin.label(), "BTC");
+        assert_eq!(SparkAsset::Lightning.label(), "Lightning");
+    }
+
+    #[test]
+    fn format_token_display_handles_precision_edges() {
+        assert_eq!(format_token_display(42, 0), "42");
+        assert_eq!(format_token_display(12, 1), "1.20");
+        assert_eq!(format_token_display(105, 2), "1.05");
+        assert_eq!(format_token_display(1_234_567, 6), "1.23");
+        assert_eq!(format_token_display(1_999_999, 6), "2.00");
+        assert_eq!(format_token_display(1_234_567_890_000, 6), "1,234,567.89");
+    }
+
+    #[test]
+    fn format_token_display_clamps_extreme_decimals() {
+        assert_eq!(
+            format_token_display(u64::MAX, MAX_TOKEN_DECIMALS_U64 + 1),
+            "1.84"
+        );
+    }
+
+    #[test]
+    fn format_token_display_rounds_half_up_and_carries_to_whole_units() {
+        assert_eq!(format_token_display(1_234_999, 6), "1.23");
+        assert_eq!(format_token_display(1_235_000, 6), "1.24");
+        assert_eq!(format_token_display(999_995, 6), "1.00");
+        assert_eq!(format_token_display(9_999_950, 6), "10.00");
+    }
+
+    #[test]
+    fn stable_token_as_sats_converts_usd_pegged_balance() {
+        assert_eq!(stable_token_as_sats(50_000_000, 6, Some(50_000.0)), 100_000);
+        assert_eq!(stable_token_as_sats(123, 0, Some(41_000.0)), 300_000);
+    }
+
+    #[test]
+    fn stable_token_as_sats_requires_positive_price() {
+        assert_eq!(stable_token_as_sats(50_000_000, 6, None), 0);
+        assert_eq!(stable_token_as_sats(50_000_000, 6, Some(0.0)), 0);
+        assert_eq!(stable_token_as_sats(50_000_000, 6, Some(-1.0)), 0);
+    }
+
+    #[test]
+    fn stable_token_as_sats_clamps_extreme_decimals_and_truncates_subsat_values() {
+        assert_eq!(
+            stable_token_as_sats(u64::MAX, MAX_TOKEN_DECIMALS_U64 + 1, Some(1.0)),
+            184_467_440
+        );
+        assert_eq!(stable_token_as_sats(1, 6, Some(100_000.0)), 0);
+    }
+}

--- a/coincube-gui/src/app/breez_spark/client.rs
+++ b/coincube-gui/src/app/breez_spark/client.rs
@@ -1140,7 +1140,8 @@ fn make_spark_event_stream(
 
 #[cfg(test)]
 mod stderr_relay_tests {
-    use super::{embedded_level, strip_ansi};
+    use super::{embedded_level, strip_ansi, SparkClientError};
+    use coincube_spark_protocol::ErrorKind;
     use tracing::Level;
 
     #[test]
@@ -1174,6 +1175,41 @@ mod stderr_relay_tests {
     }
 
     #[test]
+    fn embedded_level_requires_an_exact_uppercase_level_token() {
+        assert_eq!(embedded_level("ts INFORMATION spark::x: ok"), None);
+        assert_eq!(embedded_level("ts info spark::x: ok"), None);
+        assert_eq!(embedded_level("ts WARN spark::x: ok"), Some(Level::WARN));
+    }
+
+    #[test]
+    fn embedded_level_accepts_every_structured_level_before_the_message() {
+        assert_eq!(
+            embedded_level("ts TRACE spark::x: verbose"),
+            Some(Level::TRACE)
+        );
+        assert_eq!(
+            embedded_level("ts DEBUG spark::x: detail"),
+            Some(Level::DEBUG)
+        );
+        assert_eq!(embedded_level("ts INFO spark::x: ok"), Some(Level::INFO));
+        assert_eq!(
+            embedded_level("ts WARN spark::x: careful"),
+            Some(Level::WARN)
+        );
+        assert_eq!(
+            embedded_level("ts ERROR spark::x: boom"),
+            Some(Level::ERROR)
+        );
+    }
+
+    #[test]
+    fn embedded_level_ignores_level_like_punctuation_and_key_value_pairs() {
+        assert_eq!(embedded_level("ts INFO:spark::x: ok"), None);
+        assert_eq!(embedded_level("ts level=INFO spark::x: ok"), None);
+        assert_eq!(embedded_level("ts [INFO] spark::x: ok"), None);
+    }
+
+    #[test]
     fn strips_ansi_colour_codes() {
         let raw =
             "\x1b[2m2026-06-13T07:08:38Z\x1b[0m \x1b[32m INFO\x1b[0m \x1b[2mspark::x\x1b[0m: ok";
@@ -1183,5 +1219,36 @@ mod stderr_relay_tests {
         assert!(clean.contains("spark::x"));
         // Level is still detectable post-strip.
         assert_eq!(embedded_level(&clean), Some(Level::INFO));
+    }
+
+    #[test]
+    fn strips_multi_parameter_ansi_sequences_without_touching_text() {
+        let clean = strip_ansi("plain \x1b[31;1mERROR\x1b[0m spark::x: boom");
+        assert_eq!(clean, "plain ERROR spark::x: boom");
+        assert_eq!(embedded_level(&clean), Some(Level::ERROR));
+    }
+
+    #[test]
+    fn client_errors_display_the_layer_that_failed() {
+        assert_eq!(
+            SparkClientError::Config("missing key".to_string()).to_string(),
+            "Spark config error: missing key"
+        );
+        assert_eq!(
+            SparkClientError::BridgeUnavailable("child exited".to_string()).to_string(),
+            "Spark bridge subprocess unavailable: child exited"
+        );
+        assert_eq!(
+            SparkClientError::BridgeError {
+                kind: ErrorKind::NotConnected,
+                message: "bridge offline".to_string(),
+            }
+            .to_string(),
+            "Spark bridge returned NotConnected: bridge offline"
+        );
+        assert_eq!(
+            SparkClientError::Protocol("wrong payload".to_string()).to_string(),
+            "Spark protocol error: wrong payload"
+        );
     }
 }

--- a/coincube-gui/src/app/breez_spark/config.rs
+++ b/coincube-gui/src/app/breez_spark/config.rs
@@ -72,3 +72,38 @@ impl std::fmt::Display for SparkConfigError {
 }
 
 impl std::error::Error for SparkConfigError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn for_network_maps_bitcoin_and_regtest_to_protocol_networks() {
+        let mainnet_dir = std::path::PathBuf::from("/tmp/spark-mainnet");
+        let mainnet =
+            SparkConfig::for_network(bitcoin::Network::Bitcoin, mainnet_dir.clone()).unwrap();
+        assert_eq!(mainnet.api_key, env!("BREEZ_API_KEY"));
+        assert!(matches!(mainnet.network, ProtocolNetwork::Mainnet));
+        assert_eq!(mainnet.storage_dir, mainnet_dir);
+
+        let regtest_dir = std::path::PathBuf::from("/tmp/spark-regtest");
+        let regtest =
+            SparkConfig::for_network(bitcoin::Network::Regtest, regtest_dir.clone()).unwrap();
+        assert_eq!(regtest.api_key, env!("BREEZ_API_KEY"));
+        assert!(matches!(regtest.network, ProtocolNetwork::Regtest));
+        assert_eq!(regtest.storage_dir, regtest_dir);
+    }
+
+    #[test]
+    fn for_network_rejects_testnet_and_signet() {
+        for network in [bitcoin::Network::Testnet, bitcoin::Network::Signet] {
+            let err = SparkConfig::for_network(network, std::path::PathBuf::from("/tmp/spark"))
+                .unwrap_err();
+            assert!(matches!(err, SparkConfigError::UnsupportedNetwork(n) if n == network));
+            assert_eq!(
+                err.to_string(),
+                format!("Spark wallet is not supported on {} network", network)
+            );
+        }
+    }
+}

--- a/coincube-gui/src/app/breez_spark/mod.rs
+++ b/coincube-gui/src/app/breez_spark/mod.rs
@@ -138,3 +138,56 @@ impl From<SparkClientError> for SparkLoadError {
         Self::Client(value)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coincube_spark_protocol::ErrorKind;
+
+    #[tokio::test]
+    async fn load_spark_client_rejects_unsupported_networks_before_loading_signer() {
+        let fingerprint = Fingerprint::from([0xaa, 0xbb, 0xcc, 0xdd]);
+        let datadir = std::path::Path::new("/this/path/should/not/be/read");
+
+        for network in [Network::Testnet, Network::Signet] {
+            let err = load_spark_client(datadir, network, fingerprint, "pin")
+                .await
+                .unwrap_err();
+            assert!(matches!(
+                err,
+                SparkLoadError::NetworkNotSupported(n) if n == network
+            ));
+        }
+    }
+
+    #[test]
+    fn load_errors_keep_actionable_context_in_display_strings() {
+        let fingerprint = Fingerprint::from([0xaa, 0xbb, 0xcc, 0xdd]);
+
+        assert_eq!(
+            SparkLoadError::NetworkNotSupported(Network::Testnet).to_string(),
+            "Spark wallet is not supported on testnet network"
+        );
+        assert_eq!(
+            SparkLoadError::SignerNotFound(fingerprint).to_string(),
+            "Spark wallet signer not found for fingerprint: aabbccdd"
+        );
+        assert_eq!(
+            SparkLoadError::SignerError("bad pin".to_string()).to_string(),
+            "Spark signer error: bad pin"
+        );
+        assert_eq!(
+            SparkLoadError::Config("missing key".to_string()).to_string(),
+            "Spark config error: missing key"
+        );
+
+        let client = SparkClientError::BridgeError {
+            kind: ErrorKind::BadRequest,
+            message: "invalid handle".to_string(),
+        };
+        assert_eq!(
+            SparkLoadError::from(client).to_string(),
+            "Spark client error: Spark bridge returned BadRequest: invalid handle"
+        );
+    }
+}

--- a/coincube-gui/src/app/state/spark/esplora.rs
+++ b/coincube-gui/src/app/state/spark/esplora.rs
@@ -57,6 +57,16 @@ pub fn is_supported(network: Network) -> bool {
     esplora_base(network).is_some()
 }
 
+fn confirmation_count(status: &TxStatus, tip_height: u32) -> u32 {
+    if !status.confirmed {
+        return 0;
+    }
+    status
+        .block_height
+        .map(|h| tip_height.saturating_sub(h).saturating_add(1))
+        .unwrap_or(1)
+}
+
 /// Fetch the current confirmation count for each `(txid, vout)` against
 /// the given network's Esplora.
 ///
@@ -118,14 +128,7 @@ pub async fn fetch_confirmations(
         {
             Ok(resp) => match resp.json::<TxStatus>().await {
                 Ok(status) => {
-                    let confs = if status.confirmed {
-                        status
-                            .block_height
-                            .map(|h| tip_height.saturating_sub(h).saturating_add(1))
-                            .unwrap_or(1)
-                    } else {
-                        0
-                    };
+                    let confs = confirmation_count(&status, tip_height);
                     out.insert((txid, vout), confs);
                 }
                 Err(e) => tracing::warn!("esplora: status decode failed for {txid}: {e}"),
@@ -135,4 +138,77 @@ pub async fn fetch_confirmations(
     }
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn support_matrix_only_enables_mainnet_esplora() {
+        assert!(is_supported(Network::Bitcoin));
+        assert!(!is_supported(Network::Regtest));
+        assert!(!is_supported(Network::Testnet));
+        assert!(!is_supported(Network::Signet));
+    }
+
+    #[test]
+    fn confirmation_count_tracks_confirmed_mempool_and_missing_height_cases() {
+        assert_eq!(
+            confirmation_count(
+                &TxStatus {
+                    confirmed: true,
+                    block_height: Some(98),
+                },
+                100,
+            ),
+            3
+        );
+        assert_eq!(
+            confirmation_count(
+                &TxStatus {
+                    confirmed: false,
+                    block_height: None,
+                },
+                100,
+            ),
+            0
+        );
+        assert_eq!(
+            confirmation_count(
+                &TxStatus {
+                    confirmed: true,
+                    block_height: None,
+                },
+                100,
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn confirmation_count_saturates_for_inconsistent_tip_data() {
+        assert_eq!(
+            confirmation_count(
+                &TxStatus {
+                    confirmed: true,
+                    block_height: Some(101),
+                },
+                100,
+            ),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_confirmations_short_circuits_without_network_for_empty_or_unsupported_inputs() {
+        assert!(fetch_confirmations(Network::Bitcoin, Vec::new())
+            .await
+            .is_empty());
+        assert!(
+            fetch_confirmations(Network::Regtest, vec![("txid".to_string(), 0)])
+                .await
+                .is_empty()
+        );
+    }
 }

--- a/coincube-gui/src/app/state/spark/mod.rs
+++ b/coincube-gui/src/app/state/spark/mod.rs
@@ -105,3 +105,65 @@ pub(crate) fn unified_spark_balance_sats(
 pub(crate) fn reference_btc_usd_price(cache: &Cache) -> Option<f64> {
     cache.btc_usd_price
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coincube_spark_protocol::StableBalanceSnapshot;
+
+    fn stable_balance(balance: u64, decimals: u32) -> StableBalanceSnapshot {
+        StableBalanceSnapshot {
+            balance,
+            decimals,
+            ticker: "USDB".to_string(),
+        }
+    }
+
+    #[test]
+    fn reference_btc_usd_price_reads_cache_usd_price() {
+        let mut cache = Cache::default();
+        assert_eq!(reference_btc_usd_price(&cache), None);
+
+        cache.btc_usd_price = Some(63_000.0);
+        assert_eq!(reference_btc_usd_price(&cache), Some(63_000.0));
+    }
+
+    #[test]
+    fn unified_spark_balance_uses_btc_balance_without_reference_price() {
+        let cache = Cache::default();
+        let stable = stable_balance(2_500_000, 6);
+
+        assert_eq!(
+            unified_spark_balance_sats(42_000, Some(&stable), &cache),
+            42_000
+        );
+    }
+
+    #[test]
+    fn unified_spark_balance_folds_stable_balance_using_usd_reference_price() {
+        let cache = Cache {
+            btc_usd_price: Some(50_000.0),
+            ..Cache::default()
+        };
+        let stable = stable_balance(2_500_000, 6);
+
+        assert_eq!(
+            unified_spark_balance_sats(123, Some(&stable), &cache),
+            5_123
+        );
+    }
+
+    #[test]
+    fn unified_spark_balance_saturates_when_stable_value_overflows() {
+        let cache = Cache {
+            btc_usd_price: Some(100_000.0),
+            ..Cache::default()
+        };
+        let stable = stable_balance(1_000_000, 6);
+
+        assert_eq!(
+            unified_spark_balance_sats(u64::MAX - 2, Some(&stable), &cache),
+            u64::MAX
+        );
+    }
+}

--- a/coincube-gui/src/app/state/spark/overview.rs
+++ b/coincube-gui/src/app/state/spark/overview.rs
@@ -435,4 +435,85 @@ mod tests {
         assert_eq!(row.token_display.as_deref(), Some("1.58 USDB"));
         assert!(row.fiat_amount.is_some());
     }
+
+    #[test]
+    fn explicit_payment_description_is_preserved() {
+        let mut summary = payment("Receive", "Completed", "deposit", 21_000);
+        summary.description = Some("Savings refill".to_string());
+
+        let row = payment_summary_to_recent_tx(&summary, None);
+
+        assert_eq!(row.description, "Savings refill");
+        assert_eq!(row.method, SparkPaymentMethod::OnChainBitcoin);
+    }
+
+    #[test]
+    fn data_loaded_sets_snapshot_and_keeps_only_five_recent_rows() {
+        let mut panel = SparkOverview::new(None);
+        panel.loading = true;
+        panel.error = Some("old error".to_string());
+
+        let payments: Vec<_> = (0..7)
+            .map(|i| {
+                let mut p = payment("Receive", "Completed", "spark", 1_000 + i);
+                p.id = format!("payment-{i}");
+                p
+            })
+            .collect();
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            Message::View(view::Message::SparkOverview(
+                view::SparkOverviewMessage::DataLoaded {
+                    balance: Amount::from_sat(123_456),
+                    stable_balance: Some(coincube_spark_protocol::StableBalanceSnapshot {
+                        balance: 2_500_000,
+                        decimals: 6,
+                        ticker: "USDB".to_string(),
+                    }),
+                    recent_payments: payments,
+                },
+            )),
+        );
+
+        assert!(!panel.loading);
+        assert_eq!(panel.error, None);
+        let snapshot = panel.snapshot.as_ref().expect("snapshot loaded");
+        assert_eq!(snapshot.balance_sats, 123_456);
+        assert_eq!(
+            snapshot.stable_balance.as_ref().map(|s| s.balance),
+            Some(2_500_000)
+        );
+        assert_eq!(panel.recent_transactions.len(), 5);
+        assert_eq!(panel.recent_transactions[0].id, "payment-0");
+        assert_eq!(panel.recent_transactions[4].id, "payment-4");
+    }
+
+    #[test]
+    fn error_and_stable_balance_messages_update_local_state() {
+        let mut panel = SparkOverview::new(None);
+        panel.loading = true;
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            Message::View(view::Message::SparkOverview(
+                view::SparkOverviewMessage::Error("bridge offline".to_string()),
+            )),
+        );
+
+        assert!(!panel.loading);
+        assert_eq!(panel.error.as_deref(), Some("bridge offline"));
+
+        let _ = panel.update(
+            None,
+            &Cache::default(),
+            Message::View(view::Message::SparkOverview(
+                view::SparkOverviewMessage::StableBalanceLoaded(true),
+            )),
+        );
+
+        assert_eq!(panel.stable_balance_active, Some(true));
+    }
 }

--- a/coincube-gui/src/app/state/spark/receive.rs
+++ b/coincube-gui/src/app/state/spark/receive.rs
@@ -843,6 +843,8 @@ mod tests {
     use crate::app::message::Message as AppMessage;
     use crate::app::state::State;
     use crate::app::view::{Message as ViewMessage, SparkReceiveMessage};
+    use coincube_core::miniscript::bitcoin::Network;
+    use coincube_spark_protocol::{PaymentSummary, StableBalanceSnapshot};
 
     fn receive_ok(payment_request: &str) -> ReceivePaymentOk {
         ReceivePaymentOk {
@@ -861,13 +863,41 @@ mod tests {
         }
     }
 
-    fn update(panel: &mut SparkReceive, msg: SparkReceiveMessage) {
+    fn payment(id: &str, amount_sat: i64) -> PaymentSummary {
+        PaymentSummary {
+            id: id.to_string(),
+            amount_sat,
+            fees_sat: 12,
+            token_amount: None,
+            token_decimals: None,
+            token_ticker: None,
+            timestamp: 1_700_000_000,
+            status: "completed".to_string(),
+            direction: "receive".to_string(),
+            method: "spark".to_string(),
+            description: None,
+        }
+    }
+
+    fn stable_balance(balance: u64, decimals: u32) -> StableBalanceSnapshot {
+        StableBalanceSnapshot {
+            balance,
+            decimals,
+            ticker: "USDB".to_string(),
+        }
+    }
+
+    fn update_with_cache(panel: &mut SparkReceive, cache: &Cache, msg: SparkReceiveMessage) {
         let _task = State::update(
             panel,
             None,
-            &Cache::default(),
+            cache,
             AppMessage::View(ViewMessage::SparkReceive(msg)),
         );
+    }
+
+    fn update(panel: &mut SparkReceive, msg: SparkReceiveMessage) {
+        update_with_cache(panel, &Cache::default(), msg);
     }
 
     #[test]
@@ -1226,6 +1256,7 @@ mod tests {
     fn claim_result_messages_update_claim_error_state() {
         let mut panel = SparkReceive::new(None);
 
+        panel.claim_error = Some("old claim error".to_string());
         update(
             &mut panel,
             SparkReceiveMessage::ClaimDepositRequested {
@@ -1234,6 +1265,7 @@ mod tests {
             },
         );
         assert!(panel.claiming.is_none());
+        assert_eq!(panel.claim_error.as_deref(), Some("old claim error"));
 
         panel.claiming = Some(("tx".to_string(), 0));
         update(
@@ -1271,6 +1303,38 @@ mod tests {
     }
 
     #[test]
+    fn balance_loaded_folds_stable_balance_using_cache_price() {
+        let mut panel = SparkReceive::new(None);
+        let cache = Cache {
+            btc_usd_price: Some(50_000.0),
+            ..Cache::default()
+        };
+
+        update_with_cache(
+            &mut panel,
+            &cache,
+            SparkReceiveMessage::BalanceLoaded(Some((123, Some(stable_balance(2_500_000, 6))))),
+        );
+
+        assert_eq!(panel.balance_sats, 5_123);
+    }
+
+    #[test]
+    fn payments_loaded_keeps_only_five_recent_rows() {
+        let mut panel = SparkReceive::new(None);
+        let payments: Vec<_> = (0..7)
+            .map(|i| payment(&format!("payment-{i}"), 1_000 + i))
+            .collect();
+
+        update(&mut panel, SparkReceiveMessage::PaymentsLoaded(payments));
+
+        assert_eq!(panel.recent_transactions.len(), 5);
+        assert_eq!(panel.recent_transactions[0].id, "payment-0");
+        assert_eq!(panel.recent_transactions[4].id, "payment-4");
+        assert_eq!(panel.recent_transactions[4].amount.to_sat(), 1_004);
+    }
+
+    #[test]
     fn payments_failed_clears_recent_transactions() {
         let mut panel = SparkReceive::new(None);
         panel.recent_transactions.push(SparkRecentTransaction {
@@ -1293,5 +1357,34 @@ mod tests {
         );
 
         assert!(panel.recent_transactions.is_empty());
+    }
+
+    #[test]
+    fn cross_network_selection_without_backend_or_support_is_noop() {
+        let mut panel = SparkReceive::new(None);
+        panel.sender_picker_open = true;
+        let unsupported = Cache {
+            network: Network::Regtest,
+            ..Cache::default()
+        };
+
+        update_with_cache(
+            &mut panel,
+            &unsupported,
+            SparkReceiveMessage::SelectSenderCrossNetwork("usdt:tron".to_string()),
+        );
+
+        assert!(!panel.sender_picker_open);
+        assert!(panel.sideshift_flow.is_none());
+        assert_eq!(panel.method, SparkReceiveMethod::Bolt11);
+
+        update_with_cache(
+            &mut panel,
+            &Cache::default(),
+            SparkReceiveMessage::SelectSenderCrossNetwork("usdt:tron".to_string()),
+        );
+
+        assert!(panel.sideshift_flow.is_none());
+        assert_eq!(panel.method, SparkReceiveMethod::Bolt11);
     }
 }

--- a/coincube-gui/src/app/state/spark/send.rs
+++ b/coincube-gui/src/app/state/spark/send.rs
@@ -1097,6 +1097,50 @@ mod tests {
         assert!(parse_amount_to_sats("abc", BitcoinDisplayUnit::BTC).is_err());
     }
 
+    #[test]
+    fn send_targets_define_picker_order_labels_badges_and_placeholders() {
+        assert_eq!(
+            SparkSendTarget::all(),
+            [
+                SparkSendTarget::Lightning,
+                SparkSendTarget::OnChain,
+                SparkSendTarget::Spark,
+                SparkSendTarget::Usdt,
+                SparkSendTarget::Usdc,
+            ]
+        );
+
+        assert_eq!(SparkSendTarget::Lightning.label(), "Bitcoin");
+        assert_eq!(SparkSendTarget::Lightning.badge(), "Lightning");
+        assert_eq!(
+            SparkSendTarget::Lightning.destination_placeholder(),
+            "Lightning invoice or Lightning address"
+        );
+
+        assert_eq!(SparkSendTarget::OnChain.badge(), "On-chain");
+        assert_eq!(SparkSendTarget::Spark.badge(), "Spark");
+        assert_eq!(SparkSendTarget::Usdt.label(), "USDt");
+        assert_eq!(SparkSendTarget::Usdt.badge(), "Cross-chain");
+        assert_eq!(SparkSendTarget::Usdt.stablecoin(), Some("USDT"));
+        assert_eq!(SparkSendTarget::Usdc.stablecoin(), Some("USDC"));
+        assert!(SparkSendTarget::Usdc.is_stablecoin());
+        assert!(!SparkSendTarget::Spark.is_stablecoin());
+    }
+
+    #[test]
+    fn amount_error_messages_name_the_active_unit() {
+        assert_eq!(amount_unit_word(BitcoinDisplayUnit::BTC), "BTC");
+        assert_eq!(amount_unit_word(BitcoinDisplayUnit::Sats), "sats");
+        assert_eq!(
+            parse_amount_to_sats("", BitcoinDisplayUnit::Sats).unwrap_err(),
+            "Amount must be a whole number of sats."
+        );
+        assert_eq!(
+            parse_amount_to_sats("-1", BitcoinDisplayUnit::BTC).unwrap_err(),
+            "Amount must be a valid BTC value."
+        );
+    }
+
     fn route() -> CrossChainRoute {
         CrossChainRoute {
             provider: "orchestra".to_string(),
@@ -1106,6 +1150,23 @@ mod tests {
             contract_address: None,
             decimals: 6,
             btc_source_supported: true,
+        }
+    }
+
+    fn route_with_asset(asset: &str) -> CrossChainRoute {
+        CrossChainRoute {
+            asset: asset.to_string(),
+            ..route()
+        }
+    }
+
+    fn cross_chain_address(family: &str) -> CrossChainAddress {
+        CrossChainAddress {
+            address: "0xabc".to_string(),
+            family: family.to_string(),
+            contract_address: None,
+            chain_id: None,
+            amount: None,
         }
     }
 
@@ -1267,6 +1328,103 @@ mod tests {
         );
     }
 
+    #[test]
+    fn cross_chain_context_selected_route_obeys_bounds() {
+        let ctx = CrossChainContext {
+            address: cross_chain_address("evm"),
+            routes: vec![route_with_asset("USDT"), route_with_asset("USDC")],
+            selected: 1,
+        };
+        assert_eq!(ctx.selected_route().map(|r| r.asset.as_str()), Some("USDC"));
+
+        let out_of_bounds = CrossChainContext {
+            selected: 99,
+            ..ctx
+        };
+        assert!(out_of_bounds.selected_route().is_none());
+    }
+
+    #[test]
+    fn set_receive_target_clears_the_previous_payment_intent() {
+        let mut panel = failed_panel(cross_chain::RetryPolicy::SafeToRetry);
+        panel.destination_input = "old destination".to_string();
+        panel.amount_input = "123".to_string();
+        panel.receive_picker_open = true;
+
+        let _ = send(
+            &mut panel,
+            SparkSendMessage::SetReceiveTarget(SparkSendTarget::Usdt),
+        );
+
+        assert_eq!(panel.receive_target, SparkSendTarget::Usdt);
+        assert!(!panel.receive_picker_open);
+        assert!(panel.destination_input.is_empty());
+        assert!(panel.amount_input.is_empty());
+        assert!(panel.send_idempotency_key.is_none());
+        assert!(panel.cross_chain_prepare.is_none());
+        assert!(panel.cross_chain.is_none());
+        assert!(matches!(panel.phase, SparkSendPhase::Idle));
+    }
+
+    #[test]
+    fn cross_chain_routes_loaded_filters_to_the_selected_stablecoin() {
+        let mut panel = SparkSend::new(None);
+        panel.receive_target = SparkSendTarget::Usdt;
+
+        let _ = send(
+            &mut panel,
+            SparkSendMessage::CrossChainRoutesLoaded(coincube_spark_protocol::CrossChainRoutesOk {
+                address: Some(cross_chain_address("tron")),
+                routes: vec![
+                    route_with_asset("USDC"),
+                    route_with_asset("USDT"),
+                    route_with_asset("usdt"),
+                ],
+            }),
+        );
+
+        assert!(matches!(panel.phase, SparkSendPhase::CrossChainRoutes));
+        let ctx = panel.cross_chain.as_ref().expect("routes retained");
+        assert_eq!(ctx.address.family, "tron");
+        assert_eq!(ctx.routes.len(), 2);
+        assert!(ctx
+            .routes
+            .iter()
+            .all(|r| r.asset.eq_ignore_ascii_case("USDT")));
+        assert_eq!(ctx.selected, 0);
+    }
+
+    #[test]
+    fn cross_chain_routes_loaded_reports_unrecognized_or_unroutable_destinations() {
+        let mut panel = SparkSend::new(None);
+        panel.receive_target = SparkSendTarget::Usdc;
+
+        let _ = send(
+            &mut panel,
+            SparkSendMessage::CrossChainRoutesLoaded(coincube_spark_protocol::CrossChainRoutesOk {
+                address: None,
+                routes: vec![],
+            }),
+        );
+        assert!(matches!(
+            &panel.phase,
+            SparkSendPhase::Error(msg) if msg.contains("doesn't look like a USDC address")
+        ));
+
+        let _ = send(
+            &mut panel,
+            SparkSendMessage::CrossChainRoutesLoaded(coincube_spark_protocol::CrossChainRoutesOk {
+                address: Some(cross_chain_address("solana")),
+                routes: vec![route_with_asset("USDT")],
+            }),
+        );
+        assert!(matches!(
+            &panel.phase,
+            SparkSendPhase::Error(msg)
+                if msg == "No route can currently send USDC to this solana address."
+        ));
+    }
+
     fn prepared_with_quote(expires_at: &str) -> PrepareSendOk {
         PrepareSendOk {
             handle: "h".to_string(),
@@ -1418,5 +1576,154 @@ mod tests {
         assert!(panel.send_idempotency_key.is_none());
         assert!(panel.cross_chain.is_none());
         assert!(matches!(panel.phase, SparkSendPhase::Idle));
+    }
+
+    #[test]
+    fn receive_picker_open_and_close_are_local_state_only() {
+        let mut panel = SparkSend::new(None);
+
+        let _ = send(&mut panel, SparkSendMessage::OpenReceivePicker);
+        assert!(panel.receive_picker_open);
+        assert!(matches!(panel.phase, SparkSendPhase::Idle));
+        assert_eq!(panel.receive_target, SparkSendTarget::Lightning);
+
+        let _ = send(&mut panel, SparkSendMessage::CloseReceivePicker);
+        assert!(!panel.receive_picker_open);
+        assert!(matches!(panel.phase, SparkSendPhase::Idle));
+        assert_eq!(panel.receive_target, SparkSendTarget::Lightning);
+    }
+
+    #[test]
+    fn advanced_and_slippage_controls_only_update_their_local_fields() {
+        let mut panel = SparkSend::new(None);
+        assert!(!panel.advanced_open);
+
+        let _ = send(&mut panel, SparkSendMessage::ToggleAdvanced);
+        assert!(panel.advanced_open);
+
+        let _ = send(
+            &mut panel,
+            SparkSendMessage::SlippageChanged("250".to_string()),
+        );
+        assert_eq!(panel.slippage_input, "250");
+        assert!(panel.advanced_open);
+        assert!(matches!(panel.phase, SparkSendPhase::Idle));
+
+        let _ = send(&mut panel, SparkSendMessage::ToggleAdvanced);
+        assert!(!panel.advanced_open);
+        assert_eq!(panel.slippage_input, "250");
+    }
+
+    #[test]
+    fn route_selection_updates_valid_indices_and_ignores_out_of_bounds() {
+        let mut panel = SparkSend::new(None);
+        panel.cross_chain = Some(CrossChainContext {
+            address: cross_chain_address("evm"),
+            routes: vec![route_with_asset("USDT"), route_with_asset("USDC")],
+            selected: 0,
+        });
+        panel.phase = SparkSendPhase::CrossChainRoutes;
+
+        let _ = send(&mut panel, SparkSendMessage::CrossChainRouteSelected(1));
+        assert_eq!(panel.cross_chain.as_ref().unwrap().selected, 1);
+
+        let _ = send(&mut panel, SparkSendMessage::CrossChainRouteSelected(99));
+        assert_eq!(
+            panel.cross_chain.as_ref().unwrap().selected,
+            1,
+            "out-of-bounds route selections must leave the current route alone"
+        );
+    }
+
+    #[test]
+    fn quote_request_requires_a_selected_route_before_backend_or_amount_work() {
+        let mut no_context = SparkSend::new(None);
+        let _ = send(&mut no_context, SparkSendMessage::CrossChainQuoteRequested);
+        assert!(matches!(no_context.phase, SparkSendPhase::Idle));
+
+        let mut missing_route = SparkSend::new(None);
+        missing_route.cross_chain = Some(CrossChainContext {
+            address: cross_chain_address("evm"),
+            routes: vec![route()],
+            selected: 99,
+        });
+        missing_route.phase = SparkSendPhase::CrossChainRoutes;
+
+        let _ = send(
+            &mut missing_route,
+            SparkSendMessage::CrossChainQuoteRequested,
+        );
+        assert!(
+            matches!(missing_route.phase, SparkSendPhase::CrossChainRoutes),
+            "without a selected route, quote request must be a no-op"
+        );
+    }
+
+    #[test]
+    fn quote_request_with_a_route_fails_fast_when_backend_is_missing() {
+        let mut panel = SparkSend::new(None);
+        panel.cross_chain = Some(CrossChainContext {
+            address: cross_chain_address("evm"),
+            routes: vec![route()],
+            selected: 0,
+        });
+        panel.amount_input = "1000".to_string();
+
+        let _ = send(&mut panel, SparkSendMessage::CrossChainQuoteRequested);
+        assert!(matches!(
+            &panel.phase,
+            SparkSendPhase::Error(msg) if msg == "Spark backend is not available."
+        ));
+    }
+
+    fn sent_panel_after_method(method: &str) -> SparkSend {
+        let mut panel = failed_panel(cross_chain::RetryPolicy::SafeToRetry);
+        panel.destination_input = "destination".to_string();
+        panel.amount_input = "123".to_string();
+        panel.last_send_method = method.to_string();
+
+        let _ = send(
+            &mut panel,
+            SparkSendMessage::SendSucceeded(SendPaymentOk {
+                payment_id: "payment-id".to_string(),
+                amount_sat: 42_000,
+                fee_sat: 17,
+            }),
+        );
+        panel
+    }
+
+    #[test]
+    fn send_success_clears_the_payment_intent_and_formats_the_sent_amount() {
+        let panel = sent_panel_after_method("BitcoinAddress");
+
+        assert!(matches!(panel.phase, SparkSendPhase::Sent(_)));
+        assert_eq!(panel.sent_amount_display, "42,000 sats");
+        assert!(panel.destination_input.is_empty());
+        assert!(panel.amount_input.is_empty());
+        assert!(panel.send_idempotency_key.is_none());
+        assert!(panel.cross_chain_prepare.is_none());
+        assert!(panel.quote_countdown.is_none());
+        assert!(panel.cross_chain.is_none());
+    }
+
+    #[test]
+    fn send_success_picks_celebration_context_from_the_send_method() {
+        assert_eq!(
+            sent_panel_after_method("BitcoinAddress").sent_celebration_context,
+            "bitcoin-send"
+        );
+        assert_eq!(
+            sent_panel_after_method("Bolt11Invoice").sent_celebration_context,
+            "lightning-send"
+        );
+        assert_eq!(
+            sent_panel_after_method("LnurlPay").sent_celebration_context,
+            "lightning-send"
+        );
+        assert_eq!(
+            sent_panel_after_method("SparkAddress").sent_celebration_context,
+            "spark-send"
+        );
     }
 }

--- a/coincube-gui/src/app/state/spark/settings.rs
+++ b/coincube-gui/src/app/state/spark/settings.rs
@@ -189,3 +189,125 @@ impl State for SparkSettings {
         Task::none()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::state::State;
+    use crate::app::view::{Message as ViewMessage, SparkSettingsMessage};
+
+    fn settings(stable_balance_active: bool, private_mode_enabled: bool) -> GetUserSettingsOk {
+        GetUserSettingsOk {
+            stable_balance_active,
+            private_mode_enabled,
+        }
+    }
+
+    fn update(panel: &mut SparkSettings, msg: SparkSettingsMessage) {
+        let _ = State::update(
+            panel,
+            None,
+            &Cache::default(),
+            Message::View(ViewMessage::SparkSettings(msg)),
+        );
+    }
+
+    #[test]
+    fn new_panel_without_backend_is_unavailable() {
+        let panel = SparkSettings::new(None);
+
+        assert!(panel.backend.is_none());
+        assert!(matches!(panel.status, SparkSettingsStatus::Unavailable));
+        assert_eq!(panel.stable_balance_active, None);
+        assert!(!panel.stable_balance_saving);
+    }
+
+    #[test]
+    fn reload_without_backend_marks_unavailable() {
+        let mut panel = SparkSettings::new(None);
+        panel.status = SparkSettingsStatus::Connected;
+
+        let _ = State::reload(&mut panel, None, None);
+
+        assert!(matches!(panel.status, SparkSettingsStatus::Unavailable));
+    }
+
+    #[test]
+    fn bridge_status_messages_update_status_card_state() {
+        let mut panel = SparkSettings::new(None);
+
+        update(&mut panel, SparkSettingsMessage::BridgeReachable);
+        assert!(matches!(panel.status, SparkSettingsStatus::Connected));
+
+        update(
+            &mut panel,
+            SparkSettingsMessage::BridgeError("bridge exited".to_string()),
+        );
+        assert!(matches!(
+            panel.status,
+            SparkSettingsStatus::Error(ref err) if err == "bridge exited"
+        ));
+    }
+
+    #[test]
+    fn user_settings_loaded_updates_stable_balance_flag() {
+        let mut panel = SparkSettings::new(None);
+
+        update(
+            &mut panel,
+            SparkSettingsMessage::UserSettingsLoaded(settings(true, true)),
+        );
+        assert_eq!(panel.stable_balance_active, Some(true));
+
+        update(
+            &mut panel,
+            SparkSettingsMessage::UserSettingsLoaded(settings(false, false)),
+        );
+        assert_eq!(panel.stable_balance_active, Some(false));
+    }
+
+    #[test]
+    fn stable_balance_toggle_without_backend_is_ignored() {
+        let mut panel = SparkSettings::new(None);
+        panel.stable_balance_active = Some(false);
+
+        update(&mut panel, SparkSettingsMessage::StableBalanceToggled(true));
+
+        assert_eq!(panel.stable_balance_active, Some(false));
+        assert!(!panel.stable_balance_saving);
+    }
+
+    #[test]
+    fn stable_balance_save_success_commits_state_and_clears_saving() {
+        let mut panel = SparkSettings::new(None);
+        panel.stable_balance_active = Some(false);
+        panel.stable_balance_saving = true;
+
+        update(
+            &mut panel,
+            SparkSettingsMessage::StableBalanceSaved(Ok(true)),
+        );
+
+        assert_eq!(panel.stable_balance_active, Some(true));
+        assert!(!panel.stable_balance_saving);
+    }
+
+    #[test]
+    fn stable_balance_save_error_rolls_back_optimistic_state() {
+        let mut panel = SparkSettings::new(None);
+        panel.stable_balance_active = Some(true);
+        panel.stable_balance_saving = true;
+
+        update(
+            &mut panel,
+            SparkSettingsMessage::StableBalanceSaved(Err("sdk rejected toggle".to_string())),
+        );
+
+        assert_eq!(panel.stable_balance_active, Some(false));
+        assert!(!panel.stable_balance_saving);
+        assert!(matches!(
+            panel.status,
+            SparkSettingsStatus::Error(ref err) if err == "sdk rejected toggle"
+        ));
+    }
+}

--- a/coincube-gui/src/app/state/spark/sideshift_receive.rs
+++ b/coincube-gui/src/app/state/spark/sideshift_receive.rs
@@ -32,7 +32,7 @@ use crate::app::wallets::SparkBackend;
 use crate::services::coincube::CoincubeClient;
 use crate::services::sideshift::{
     deposit_options, validate_refund_address, DepositOption, ShiftResponse, ShiftStatusKind,
-    SideshiftClient,
+    SideshiftClient, SideshiftNetwork,
 };
 
 use view::SparkSideshiftReceiveMessage as Msg;
@@ -274,7 +274,7 @@ impl SparkSideshiftReceiveFlow {
                     // Changing chains invalidates the refund address — it was
                     // for the *old* origin chain, and silently carrying it over
                     // is exactly how a refund goes to the wrong network.
-                    if option.network != self.selected.network {
+                    if deposit_selection_clears_refund(self.selected, option) {
                         self.refund_address.clear();
                         self.refund_error = None;
                     }
@@ -287,11 +287,7 @@ impl SparkSideshiftReceiveFlow {
             Msg::RefundAddressEdited(value) => {
                 self.refund_address = value.clone();
                 // Validate as they type, but don't nag on an empty field.
-                self.refund_error = if value.trim().is_empty() {
-                    None
-                } else {
-                    validate_refund_address(self.selected.network, value).err()
-                };
+                self.refund_error = refund_address_edit_error(self.selected.network, value);
                 Task::none()
             }
 
@@ -375,14 +371,7 @@ impl SparkSideshiftReceiveFlow {
                     // string) once a deposit is detected. Keep the latest so the
                     // view can show how much bitcoin is arriving. Parse it exactly
                     // (BTC → sats) rather than via f64, which rounds.
-                    let settle_sat = status.settle_amount.as_deref().and_then(|s| {
-                        coincube_core::miniscript::bitcoin::Amount::from_str_in(
-                            s.trim(),
-                            coincube_core::miniscript::bitcoin::Denomination::Bitcoin,
-                        )
-                        .ok()
-                        .map(|a| a.to_sat())
-                    });
+                    let settle_sat = parse_btc_settle_amount_sats(status.settle_amount.as_deref());
                     if settle_sat.is_some() {
                         self.settle_amount_sat = settle_sat;
                     }
@@ -501,6 +490,18 @@ fn arrival_belongs_to_this_shift(
         )
 }
 
+fn deposit_selection_clears_refund(current: DepositOption, next: DepositOption) -> bool {
+    current.network != next.network
+}
+
+fn refund_address_edit_error(network: SideshiftNetwork, value: &str) -> Option<String> {
+    if value.trim().is_empty() {
+        None
+    } else {
+        validate_refund_address(network, value).err()
+    }
+}
+
 fn nothing_sent_yet(detail: &str) -> String {
     format!(
         "{}. Nothing has been sent — try again.",
@@ -519,6 +520,17 @@ fn bare_bitcoin_address(payment_request: &str) -> String {
         .next()
         .unwrap_or(payment_request)
         .to_string()
+}
+
+fn parse_btc_settle_amount_sats(value: Option<&str>) -> Option<u64> {
+    value.and_then(|s| {
+        coincube_core::miniscript::bitcoin::Amount::from_str_in(
+            s.trim(),
+            coincube_core::miniscript::bitcoin::Denomination::Bitcoin,
+        )
+        .ok()
+        .map(|a| a.to_sat())
+    })
 }
 
 #[cfg(test)]
@@ -620,6 +632,43 @@ mod tests {
         assert!(validate_refund_address(solana.network, tron_address).is_err());
     }
 
+    #[test]
+    fn deposit_selection_clears_refund_only_when_the_origin_chain_changes() {
+        let eth_usdt = deposit_option_by_key("usdt:ethereum").unwrap();
+        let eth_usdc = deposit_option_by_key("usdc:ethereum").unwrap();
+        let tron_usdt = deposit_option_by_key("usdt:tron").unwrap();
+
+        assert!(
+            !deposit_selection_clears_refund(eth_usdt, eth_usdc),
+            "same-chain asset changes can keep the refund address"
+        );
+        assert!(
+            deposit_selection_clears_refund(eth_usdt, tron_usdt),
+            "cross-chain changes must clear the refund address"
+        );
+    }
+
+    #[test]
+    fn refund_address_edit_error_is_quiet_for_blank_input_but_validates_nonblank() {
+        assert_eq!(refund_address_edit_error(SideshiftNetwork::Tron, ""), None);
+        assert_eq!(
+            refund_address_edit_error(SideshiftNetwork::Tron, "   "),
+            None
+        );
+        assert_eq!(
+            refund_address_edit_error(SideshiftNetwork::Tron, "TJRyWwFs9wTFGZg3JbrVriFbNfCug5tDeC"),
+            None
+        );
+
+        let err = refund_address_edit_error(
+            SideshiftNetwork::Tron,
+            "0x71C7656EC7ab88b098defB751B7401B5f6d8976F",
+        )
+        .expect("wrong-chain addresses should be rejected");
+        assert!(err.contains("Tron"));
+        assert!(err.contains("lost"));
+    }
+
     /// The affiliate id comes from *our* API (`/api/v1/config/sideshift`), not
     /// from SideShift. Blaming SideShift for a Coincube outage sends whoever
     /// debugs it to a third party that was never contacted, and tells the user
@@ -677,5 +726,18 @@ mod tests {
             bare_bitcoin_address("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"),
             "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
         );
+    }
+
+    #[test]
+    fn settle_amounts_are_parsed_exactly_as_bitcoin_not_floats() {
+        assert_eq!(parse_btc_settle_amount_sats(Some("0.00000001")), Some(1));
+        assert_eq!(
+            parse_btc_settle_amount_sats(Some(" 1.23456789 ")),
+            Some(123_456_789)
+        );
+        assert_eq!(parse_btc_settle_amount_sats(None), None);
+        assert_eq!(parse_btc_settle_amount_sats(Some("")), None);
+        assert_eq!(parse_btc_settle_amount_sats(Some("not btc")), None);
+        assert_eq!(parse_btc_settle_amount_sats(Some("0.000000001")), None);
     }
 }

--- a/coincube-gui/src/app/state/spark/transactions.rs
+++ b/coincube-gui/src/app/state/spark/transactions.rs
@@ -411,3 +411,261 @@ impl State for SparkTransactions {
         Task::none()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::state::State;
+    use crate::app::view::spark::SparkPaymentMethod;
+    use crate::app::view::{Message as ViewMessage, SparkTransactionsMessage};
+    use crate::app::wallets::DomainPaymentStatus;
+
+    fn payment(id: &str, amount_sat: i64) -> PaymentSummary {
+        PaymentSummary {
+            id: id.to_string(),
+            amount_sat,
+            fees_sat: 7,
+            token_amount: None,
+            token_decimals: None,
+            token_ticker: None,
+            timestamp: 1_700_000_000,
+            status: "Completed".to_string(),
+            direction: if amount_sat >= 0 {
+                "Receive".to_string()
+            } else {
+                "Send".to_string()
+            },
+            method: "lightning".to_string(),
+            description: Some(format!("payment {id}")),
+        }
+    }
+
+    fn payments(count: usize) -> Vec<PaymentSummary> {
+        (0..count)
+            .map(|i| payment(&format!("payment-{i}"), (i as i64 + 1) * 1_000))
+            .collect()
+    }
+
+    fn update(panel: &mut SparkTransactions, msg: SparkTransactionsMessage) {
+        let _ = State::update(
+            panel,
+            None,
+            &Cache::default(),
+            Message::View(ViewMessage::SparkTransactions(msg)),
+        );
+    }
+
+    #[test]
+    fn new_panel_starts_empty() {
+        let panel = SparkTransactions::new(None);
+
+        assert!(panel.backend.is_none());
+        assert!(panel.payments.is_empty());
+        assert!(panel.recent_transactions.is_empty());
+        assert!(!panel.loading);
+        assert_eq!(panel.current_page, 0);
+        assert_eq!(panel.pending_page, None);
+        assert_eq!(panel.fetch_token, 0);
+        assert!(!panel.is_last_page);
+        assert!(!panel.processing);
+        assert!(matches!(panel.modal, SparkTransactionsModal::None));
+        assert!(panel.selected_payment.is_none());
+    }
+
+    #[test]
+    fn reload_without_backend_is_noop() {
+        let mut panel = SparkTransactions::new(None);
+        panel.loading = true;
+        panel.error = Some("keep me".to_string());
+
+        let _ = State::reload(&mut panel, None, None);
+
+        assert!(panel.loading);
+        assert_eq!(panel.error.as_deref(), Some("keep me"));
+        assert_eq!(panel.fetch_token, 0);
+    }
+
+    #[test]
+    fn stale_data_response_is_ignored() {
+        let mut panel = SparkTransactions::new(None);
+        panel.fetch_token = 2;
+        panel.loading = true;
+        panel.processing = true;
+        panel.payments = vec![payment("current", 1_000)];
+
+        update(
+            &mut panel,
+            SparkTransactionsMessage::DataLoaded(1, payments(3)),
+        );
+
+        assert!(panel.loading);
+        assert!(panel.processing);
+        assert_eq!(panel.payments.len(), 1);
+        assert_eq!(panel.payments[0].id, "current");
+        assert!(panel.recent_transactions.is_empty());
+    }
+
+    #[test]
+    fn data_loaded_commits_pending_page_and_trims_probe_row() {
+        let mut panel = SparkTransactions::new(None);
+        panel.fetch_token = 9;
+        panel.pending_page = Some(2);
+        panel.loading = true;
+        panel.processing = true;
+        panel.error = Some("old error".to_string());
+
+        update(
+            &mut panel,
+            SparkTransactionsMessage::DataLoaded(9, payments(PAGE_SIZE as usize + 1)),
+        );
+
+        assert!(!panel.loading);
+        assert!(!panel.processing);
+        assert_eq!(panel.current_page, 2);
+        assert_eq!(panel.pending_page, None);
+        assert!(!panel.is_last_page);
+        assert_eq!(panel.payments.len(), PAGE_SIZE as usize);
+        assert_eq!(panel.recent_transactions.len(), PAGE_SIZE as usize);
+        assert_eq!(panel.error, None);
+
+        let first = &panel.recent_transactions[0];
+        assert_eq!(first.id, "payment-0");
+        assert_eq!(first.description, "payment payment-0");
+        assert_eq!(first.amount.to_sat(), 1_000);
+        assert_eq!(first.fees_sat.to_sat(), 7);
+        assert_eq!(first.status, DomainPaymentStatus::Complete);
+        assert_eq!(first.method, SparkPaymentMethod::Lightning);
+    }
+
+    #[test]
+    fn exact_page_marks_last_page() {
+        let mut panel = SparkTransactions::new(None);
+        panel.fetch_token = 3;
+        panel.loading = true;
+
+        update(
+            &mut panel,
+            SparkTransactionsMessage::DataLoaded(3, payments(PAGE_SIZE as usize)),
+        );
+
+        assert!(panel.is_last_page);
+        assert_eq!(panel.payments.len(), PAGE_SIZE as usize);
+    }
+
+    #[test]
+    fn current_error_response_rolls_back_pending_navigation() {
+        let mut panel = SparkTransactions::new(None);
+        panel.fetch_token = 5;
+        panel.current_page = 1;
+        panel.pending_page = Some(2);
+        panel.loading = true;
+        panel.processing = true;
+
+        update(
+            &mut panel,
+            SparkTransactionsMessage::Error(5, "bridge timed out".to_string()),
+        );
+
+        assert!(!panel.loading);
+        assert!(!panel.processing);
+        assert_eq!(panel.current_page, 1);
+        assert_eq!(panel.pending_page, None);
+        assert_eq!(panel.error.as_deref(), Some("bridge timed out"));
+    }
+
+    #[test]
+    fn stale_error_response_is_ignored() {
+        let mut panel = SparkTransactions::new(None);
+        panel.fetch_token = 8;
+        panel.current_page = 1;
+        panel.pending_page = Some(2);
+        panel.loading = true;
+        panel.processing = true;
+
+        update(
+            &mut panel,
+            SparkTransactionsMessage::Error(7, "old timeout".to_string()),
+        );
+
+        assert!(panel.loading);
+        assert!(panel.processing);
+        assert_eq!(panel.pending_page, Some(2));
+        assert_eq!(panel.error, None);
+    }
+
+    #[test]
+    fn select_preselect_and_close_manage_detail_selection() {
+        let mut panel = SparkTransactions::new(None);
+        panel.fetch_token = 1;
+        update(
+            &mut panel,
+            SparkTransactionsMessage::DataLoaded(1, payments(2)),
+        );
+
+        update(&mut panel, SparkTransactionsMessage::Select(1));
+        assert_eq!(
+            panel.selected_payment.as_ref().map(|p| p.id.as_str()),
+            Some("payment-1")
+        );
+
+        let explicit = panel.recent_transactions[0].clone();
+        update(
+            &mut panel,
+            SparkTransactionsMessage::Preselect(explicit.clone()),
+        );
+        assert_eq!(
+            panel.selected_payment.as_ref().map(|p| p.id.as_str()),
+            Some(explicit.id.as_str())
+        );
+
+        let _ = State::update(
+            &mut panel,
+            None,
+            &Cache::default(),
+            Message::View(ViewMessage::Close),
+        );
+        assert!(panel.selected_payment.is_none());
+    }
+
+    #[test]
+    fn export_modal_progress_and_close_are_local_state_only() {
+        let mut panel = SparkTransactions::new(None);
+        panel.modal = SparkTransactionsModal::Export {
+            state: ImportExportState::Started,
+        };
+
+        let _ = State::update(
+            &mut panel,
+            None,
+            &Cache::default(),
+            Message::View(ViewMessage::ImportExport(ImportExportMessage::Progress(
+                crate::export::Progress::Ended,
+            ))),
+        );
+        assert!(matches!(
+            panel.modal,
+            SparkTransactionsModal::Export {
+                state: ImportExportState::Ended
+            }
+        ));
+
+        let _ = State::update(
+            &mut panel,
+            None,
+            &Cache::default(),
+            Message::View(ViewMessage::ImportExport(ImportExportMessage::Close)),
+        );
+        assert!(matches!(panel.modal, SparkTransactionsModal::None));
+
+        panel.modal = SparkTransactionsModal::Export {
+            state: ImportExportState::Started,
+        };
+        let _ = State::update(
+            &mut panel,
+            None,
+            &Cache::default(),
+            Message::View(ViewMessage::ImportExport(ImportExportMessage::Path(None))),
+        );
+        assert!(matches!(panel.modal, SparkTransactionsModal::None));
+    }
+}

--- a/coincube-gui/src/app/view/nav/spark.rs
+++ b/coincube-gui/src/app/view/nav/spark.rs
@@ -34,3 +34,78 @@ pub fn items(_ctx: &NavContext) -> Vec<SubItem> {
         ),
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx<'a>(status: &'a crate::app::ConnectionStatus) -> NavContext<'a> {
+        NavContext {
+            has_vault: false,
+            has_p2p: false,
+            network: coincube_core::miniscript::bitcoin::Network::Bitcoin,
+            p2p_test_coordinator: false,
+            marketplace_flags: crate::app::features::MarketplaceServerFlags::OFF,
+            liquid_gate: crate::app::features::LiquidGate::HIDDEN,
+            cube_name: "test cube",
+            lightning_address: None,
+            avatar: None,
+            theme_mode: coincube_ui::theme::palette::ThemeMode::default(),
+            connect_authenticated: false,
+            connect_stream_status: status,
+        }
+    }
+
+    #[test]
+    fn spark_secondary_nav_items_keep_expected_order_and_routes() {
+        let status = crate::app::ConnectionStatus::default();
+        let items = items(&ctx(&status));
+
+        let labels: Vec<_> = items.iter().map(|item| item.label).collect();
+        assert_eq!(
+            labels,
+            ["Overview", "Send", "Receive", "Transactions", "Settings"]
+        );
+        assert_eq!(items[0].route, Menu::Spark(SparkSubMenu::Overview));
+        assert_eq!(items[1].route, Menu::Spark(SparkSubMenu::Send));
+        assert_eq!(items[2].route, Menu::Spark(SparkSubMenu::Receive));
+        assert_eq!(
+            items[3].route,
+            Menu::Spark(SparkSubMenu::Transactions(None))
+        );
+        assert_eq!(
+            items[4].route,
+            Menu::Spark(SparkSubMenu::Settings(Some(SparkSettingsOption::General)))
+        );
+    }
+
+    #[test]
+    fn spark_secondary_nav_matchers_group_payload_variants() {
+        let status = crate::app::ConnectionStatus::default();
+        let items = items(&ctx(&status));
+        let txid = "0000000000000000000000000000000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+
+        assert!((items[0].matches)(&Menu::Spark(SparkSubMenu::Overview)));
+        assert!(!(items[0].matches)(&Menu::Spark(SparkSubMenu::Send)));
+
+        assert!((items[3].matches)(&Menu::Spark(
+            SparkSubMenu::Transactions(None)
+        )));
+        assert!((items[3].matches)(&Menu::Spark(
+            SparkSubMenu::Transactions(Some(txid))
+        )));
+        assert!(!(items[3].matches)(&Menu::Spark(SparkSubMenu::Receive)));
+
+        assert!((items[4].matches)(&Menu::Spark(SparkSubMenu::Settings(
+            None
+        ))));
+        assert!((items[4].matches)(&Menu::Spark(SparkSubMenu::Settings(
+            Some(SparkSettingsOption::LightningAddress)
+        ))));
+        assert!(!(items[4].matches)(&Menu::Cube(
+            crate::app::menu::CubeSubMenu::Overview
+        )));
+    }
+}

--- a/coincube-gui/src/app/view/spark/last_tx.rs
+++ b/coincube-gui/src/app/view/spark/last_tx.rs
@@ -20,6 +20,7 @@ use iced::{
     Background, Length,
 };
 
+use coincube_core::miniscript::bitcoin::Amount;
 use coincube_ui::component::empty_placeholder;
 
 use crate::app::view::spark::{SparkPaymentMethod, SparkRecentTransaction};
@@ -57,11 +58,7 @@ pub fn last_transactions_section<'a, M: 'a + Clone + 'static>(
             SparkPaymentMethod::StableBalance => asset_network_logo("btc", "spark", 40.0),
         };
 
-        let display_amount = if tx.is_incoming {
-            tx.amount
-        } else {
-            tx.amount + tx.fees_sat
-        };
+        let display_amount = row_display_amount(tx);
 
         let mut item = TransactionListItem::new(direction, &display_amount, bitcoin_unit)
             .with_custom_icon(tx_icon)
@@ -165,4 +162,43 @@ pub fn last_transactions_section<'a, M: 'a + Clone + 'static>(
         )
         .push(Space::new().height(Length::Fixed(40.0)))
         .into()
+}
+
+fn row_display_amount(tx: &SparkRecentTransaction) -> Amount {
+    if tx.is_incoming {
+        tx.amount
+    } else {
+        tx.amount + tx.fees_sat
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tx(is_incoming: bool, amount_sat: u64, fees_sat: u64) -> SparkRecentTransaction {
+        SparkRecentTransaction {
+            id: "payment".to_string(),
+            description: "Spark transfer".to_string(),
+            time_ago: "just now".to_string(),
+            timestamp: 1_700_000_000,
+            amount: Amount::from_sat(amount_sat),
+            fees_sat: Amount::from_sat(fees_sat),
+            fiat_amount: None,
+            is_incoming,
+            status: DomainPaymentStatus::Complete,
+            method: SparkPaymentMethod::Spark,
+            token_display: None,
+        }
+    }
+
+    #[test]
+    fn row_display_amount_keeps_incoming_net_amount() {
+        assert_eq!(row_display_amount(&tx(true, 5_000, 21)).to_sat(), 5_000);
+    }
+
+    #[test]
+    fn row_display_amount_adds_outgoing_fees() {
+        assert_eq!(row_display_amount(&tx(false, 5_000, 21)).to_sat(), 5_021);
+    }
 }

--- a/coincube-gui/src/app/view/spark/overview.rs
+++ b/coincube-gui/src/app/view/spark/overview.rs
@@ -190,24 +190,7 @@ fn connected_view<'a>(
     // the small "pending" indicators underneath the total. Skip
     // token-display rows so a USDB conversion entry doesn't get
     // counted as pending sats.
-    let pending_outgoing_sats: u64 = recent
-        .iter()
-        .filter(|t| {
-            !t.is_incoming
-                && t.token_display.is_none()
-                && matches!(t.status, DomainPaymentStatus::Pending)
-        })
-        .map(|t| (t.amount + t.fees_sat).to_sat())
-        .sum();
-    let pending_incoming_sats: u64 = recent
-        .iter()
-        .filter(|t| {
-            t.is_incoming
-                && t.token_display.is_none()
-                && matches!(t.status, DomainPaymentStatus::Pending)
-        })
-        .map(|t| t.amount.to_sat())
-        .sum();
+    let (pending_outgoing_sats, pending_incoming_sats) = pending_btc_sats(recent);
 
     // ── Unified portfolio card ─────────────────────────────────────────
     let total_col = Column::new()
@@ -314,11 +297,7 @@ fn connected_view<'a>(
                 }
             };
 
-            let display_amount = if tx.is_incoming {
-                tx.amount
-            } else {
-                tx.amount + tx.fees_sat
-            };
+            let display_amount = row_display_amount(tx);
 
             let mut item = TransactionListItem::new(direction, &display_amount, bitcoin_unit)
                 .with_custom_icon(tx_icon)
@@ -435,6 +414,37 @@ fn connected_view<'a>(
     content.into()
 }
 
+fn pending_btc_sats(recent: &[SparkRecentTransaction]) -> (u64, u64) {
+    let pending_outgoing_sats = recent
+        .iter()
+        .filter(|t| {
+            !t.is_incoming
+                && t.token_display.is_none()
+                && matches!(t.status, DomainPaymentStatus::Pending)
+        })
+        .map(|t| row_display_amount(t).to_sat())
+        .sum();
+    let pending_incoming_sats = recent
+        .iter()
+        .filter(|t| {
+            t.is_incoming
+                && t.token_display.is_none()
+                && matches!(t.status, DomainPaymentStatus::Pending)
+        })
+        .map(|t| row_display_amount(t).to_sat())
+        .sum();
+
+    (pending_outgoing_sats, pending_incoming_sats)
+}
+
+fn row_display_amount(tx: &SparkRecentTransaction) -> Amount {
+    if tx.is_incoming {
+        tx.amount
+    } else {
+        tx.amount + tx.fees_sat
+    }
+}
+
 fn stable_badge<'a>() -> Element<'a, SparkOverviewMessage> {
     Container::new(
         text("Stable")
@@ -486,4 +496,120 @@ fn placeholder<'a, T: Into<Element<'a, SparkOverviewMessage>>>(
             ..Default::default()
         })
         .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tx(
+        id: &str,
+        is_incoming: bool,
+        status: DomainPaymentStatus,
+        amount_sat: u64,
+        fees_sat: u64,
+        token_display: Option<&str>,
+    ) -> SparkRecentTransaction {
+        SparkRecentTransaction {
+            id: id.to_string(),
+            description: id.to_string(),
+            time_ago: "just now".to_string(),
+            timestamp: 1_700_000_000,
+            amount: Amount::from_sat(amount_sat),
+            fees_sat: Amount::from_sat(fees_sat),
+            fiat_amount: None,
+            is_incoming,
+            status,
+            method: if token_display.is_some() {
+                SparkPaymentMethod::StableBalance
+            } else {
+                SparkPaymentMethod::Spark
+            },
+            token_display: token_display.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn pending_btc_sats_counts_pending_incoming_and_outgoing_totals() {
+        let rows = vec![
+            tx(
+                "incoming",
+                true,
+                DomainPaymentStatus::Pending,
+                1_000,
+                12,
+                None,
+            ),
+            tx(
+                "outgoing",
+                false,
+                DomainPaymentStatus::Pending,
+                2_000,
+                34,
+                None,
+            ),
+        ];
+
+        assert_eq!(pending_btc_sats(&rows), (2_034, 1_000));
+    }
+
+    #[test]
+    fn pending_btc_sats_skips_completed_failed_and_token_rows() {
+        let rows = vec![
+            tx(
+                "complete",
+                true,
+                DomainPaymentStatus::Complete,
+                1_000,
+                0,
+                None,
+            ),
+            tx(
+                "failed",
+                false,
+                DomainPaymentStatus::Failed,
+                2_000,
+                40,
+                None,
+            ),
+            tx(
+                "token",
+                true,
+                DomainPaymentStatus::Pending,
+                999_999,
+                0,
+                Some("1.23 USDB"),
+            ),
+        ];
+
+        assert_eq!(pending_btc_sats(&rows), (0, 0));
+    }
+
+    #[test]
+    fn row_display_amount_adds_fees_only_for_outgoing_rows() {
+        assert_eq!(
+            row_display_amount(&tx(
+                "incoming",
+                true,
+                DomainPaymentStatus::Pending,
+                100,
+                9,
+                None
+            ))
+            .to_sat(),
+            100
+        );
+        assert_eq!(
+            row_display_amount(&tx(
+                "outgoing",
+                false,
+                DomainPaymentStatus::Pending,
+                100,
+                9,
+                None
+            ))
+            .to_sat(),
+            109
+        );
+    }
 }

--- a/coincube-gui/src/app/view/spark/receive.rs
+++ b/coincube-gui/src/app/view/spark/receive.rs
@@ -356,11 +356,11 @@ fn deposit_row<'a>(
 /// error stays in the panel state; this just keeps the row from
 /// blowing up vertically.
 fn short_error(err: &str) -> String {
-    const MAX: usize = 60;
-    if err.len() <= MAX {
+    const MAX_CHARS: usize = 60;
+    if err.chars().count() <= MAX_CHARS {
         err.to_string()
     } else {
-        format!("{}…", &err[..MAX])
+        format!("{}…", err.chars().take(MAX_CHARS).collect::<String>())
     }
 }
 
@@ -794,4 +794,74 @@ fn kv_row<'a>(label: &'a str, value: String) -> Element<'a, Message> {
                 .push(p1_regular(value)),
         )
         .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_error_leaves_short_and_boundary_length_errors_unchanged() {
+        let short = "bridge unavailable";
+        assert_eq!(short_error(short), short);
+
+        let boundary = "x".repeat(60);
+        assert_eq!(short_error(&boundary), boundary);
+    }
+
+    #[test]
+    fn short_error_truncates_long_ascii_errors() {
+        let err = format!("{}tail", "x".repeat(60));
+
+        assert_eq!(short_error(&err), format!("{}…", "x".repeat(60)));
+    }
+
+    #[test]
+    fn short_error_truncates_on_char_boundaries() {
+        let err = format!("{}⚡tail", "x".repeat(59));
+
+        assert_eq!(short_error(&err), format!("{}⚡…", "x".repeat(59)));
+    }
+
+    #[test]
+    fn bitcoin_rail_display_labels_are_stable() {
+        assert_eq!(
+            rail_display(SparkReceiveMethod::Bolt11),
+            ("lightning", "Lightning")
+        );
+        assert_eq!(
+            rail_display(SparkReceiveMethod::OnchainBitcoin),
+            ("bitcoin", "On-chain")
+        );
+        assert_eq!(rail_display(SparkReceiveMethod::Spark), ("spark", "Spark"));
+    }
+
+    #[test]
+    fn cross_network_asset_display_names_are_stable() {
+        assert_eq!(asset_display_name("usdt"), "USDt");
+        assert_eq!(asset_display_name("usdc"), "USDC");
+        assert_eq!(asset_display_name("eth"), "Ether");
+        assert_eq!(asset_display_name("sol"), "Solana");
+        assert_eq!(asset_display_name("trx"), "Tron");
+        assert_eq!(asset_display_name("doge"), "doge");
+    }
+
+    #[test]
+    fn selector_card_border_only_highlights_on_hover() {
+        let theme = theme::Theme::default();
+        let active = card_button_style(&theme, iced::widget::button::Status::Active);
+        let hovered = card_button_style(&theme, iced::widget::button::Status::Hovered);
+
+        assert_eq!(active.border.color, color::TRANSPARENT);
+        assert_eq!(hovered.border.color, color::ORANGE);
+    }
+
+    #[test]
+    fn selected_picker_row_uses_orange_border_in_both_themes() {
+        for theme in [theme::Theme::dark(), theme::Theme::light()] {
+            let style = picker_row_selected(&theme);
+            assert_eq!(style.border.color, color::ORANGE);
+            assert_eq!(style.border.width, 1.0);
+        }
+    }
 }

--- a/coincube-gui/src/app/view/spark/send.rs
+++ b/coincube-gui/src/app/view/spark/send.rs
@@ -817,6 +817,21 @@ mod tests {
     }
 
     #[test]
+    fn conversion_fee_is_asset_only_with_non_positive_prices() {
+        for price in [Some(0.0), Some(-1.0)] {
+            let s = conversion_fee_display(97_921, 6, "USDT", price, BitcoinDisplayUnit::Sats);
+            assert_eq!(s, "0.097921 USDT");
+        }
+    }
+
+    #[test]
+    fn conversion_fee_uses_the_selected_bitcoin_display_unit() {
+        // 0.097921 USDT at $65,000/BTC = 150 sats, rendered in BTC mode.
+        let s = conversion_fee_display(97_921, 6, "USDT", Some(65_000.0), BitcoinDisplayUnit::BTC);
+        assert_eq!(s, "0.097921 USDT (≈ 0.00 000 150 BTC)");
+    }
+
+    #[test]
     fn conversion_fee_shows_the_hint_for_a_sub_one_sat_fee_when_priced() {
         // A tiny fee rounds to 0 sats, but with a price known the hint should
         // still show — the old `sats == 0` gate wrongly suppressed it.

--- a/coincube-gui/src/app/view/spark/settings/lightning_address.rs
+++ b/coincube-gui/src/app/view/spark/settings/lightning_address.rs
@@ -47,29 +47,22 @@ pub fn lightning_address_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, Conn
         .lightning_address
         .as_ref()
         .and_then(|la| la.lightning_address.clone())
-        .map(|mut a| {
-            if !a.contains('@') {
-                a.push_str(LN_ADDRESS_DOMAIN);
-            }
-            a
-        });
+        .map(|a| normalize_lightning_address(&a));
     let has_address = current_address.is_some();
-    let current_username = current_address
-        .as_deref()
-        .and_then(|a| a.split('@').next())
-        .map(|u| u.to_string());
+    let current_username = current_address.as_deref().and_then(lightning_username);
 
     let card_content: Element<ConnectCubeMessage> = if has_address && state.ln_editing {
         // Edit mode: in-place rename form on the claimed-address card.
         let address = current_address.clone().unwrap_or_default();
         let username = &state.ln_username_input;
-        let format_ok = state.ln_username_error.is_none() && !username.is_empty();
-        let available = state.ln_username_available == Some(true);
-        let differs = current_username
-            .as_deref()
-            .map(|u| u != username.as_str())
-            .unwrap_or(true);
-        let can_change = format_ok && available && differs && !state.ln_changing;
+        let differs = lightning_username_differs(current_username.as_deref(), username);
+        let can_change = can_change_lightning_address(
+            username,
+            state.ln_username_error.as_deref(),
+            state.ln_username_available,
+            current_username.as_deref(),
+            state.ln_changing,
+        );
 
         let status: Element<ConnectCubeMessage> = if state.ln_checking {
             text::p2_regular("Checking…").color(color::GREY_3).into()
@@ -247,9 +240,12 @@ pub fn lightning_address_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, Conn
     } else {
         // Claim form
         let username = &state.ln_username_input;
-        let is_valid = state.ln_username_error.is_none() && !username.is_empty();
-        let is_available = state.ln_username_available == Some(true);
-        let can_claim = is_valid && is_available && !state.ln_claiming;
+        let can_claim = can_claim_lightning_address(
+            username,
+            state.ln_username_error.as_deref(),
+            state.ln_username_available,
+            state.ln_claiming,
+        );
 
         // Status indicator
         let status: Element<ConnectCubeMessage> = if state.ln_checking {
@@ -396,5 +392,126 @@ pub fn lightning_address_ux<'a>(state: &'a ConnectCubePanel) -> Element<'a, Conn
             .into()
     } else {
         body
+    }
+}
+
+fn normalize_lightning_address(address: &str) -> String {
+    if address.contains('@') {
+        address.to_string()
+    } else {
+        format!("{address}{LN_ADDRESS_DOMAIN}")
+    }
+}
+
+fn lightning_username(address: &str) -> Option<String> {
+    address.split('@').next().map(str::to_string)
+}
+
+fn lightning_username_differs(current_username: Option<&str>, proposed: &str) -> bool {
+    current_username
+        .map(|current| current != proposed)
+        .unwrap_or(true)
+}
+
+fn can_claim_lightning_address(
+    username: &str,
+    username_error: Option<&str>,
+    username_available: Option<bool>,
+    claiming: bool,
+) -> bool {
+    !username.is_empty()
+        && username_error.is_none()
+        && username_available == Some(true)
+        && !claiming
+}
+
+fn can_change_lightning_address(
+    username: &str,
+    username_error: Option<&str>,
+    username_available: Option<bool>,
+    current_username: Option<&str>,
+    changing: bool,
+) -> bool {
+    can_claim_lightning_address(username, username_error, username_available, changing)
+        && lightning_username_differs(current_username, username)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_lightning_address_adds_domain_only_for_bare_usernames() {
+        assert_eq!(
+            normalize_lightning_address("founder"),
+            "founder@coincube.io"
+        );
+        assert_eq!(
+            normalize_lightning_address("founder@example.com"),
+            "founder@example.com"
+        );
+    }
+
+    #[test]
+    fn lightning_username_extracts_the_local_part() {
+        assert_eq!(
+            lightning_username("founder@coincube.io").as_deref(),
+            Some("founder")
+        );
+        assert_eq!(lightning_username("founder").as_deref(), Some("founder"));
+    }
+
+    #[test]
+    fn claim_eligibility_requires_valid_available_idle_username() {
+        assert!(can_claim_lightning_address(
+            "founder",
+            None,
+            Some(true),
+            false
+        ));
+        assert!(!can_claim_lightning_address("", None, Some(true), false));
+        assert!(!can_claim_lightning_address(
+            "founder",
+            Some("bad username"),
+            Some(true),
+            false
+        ));
+        assert!(!can_claim_lightning_address(
+            "founder",
+            None,
+            Some(false),
+            false
+        ));
+        assert!(!can_claim_lightning_address(
+            "founder",
+            None,
+            Some(true),
+            true
+        ));
+    }
+
+    #[test]
+    fn change_eligibility_also_requires_a_different_username() {
+        assert!(can_change_lightning_address(
+            "newname",
+            None,
+            Some(true),
+            Some("oldname"),
+            false
+        ));
+        assert!(!can_change_lightning_address(
+            "oldname",
+            None,
+            Some(true),
+            Some("oldname"),
+            false
+        ));
+        assert!(!can_change_lightning_address(
+            "newname",
+            None,
+            Some(true),
+            Some("oldname"),
+            true
+        ));
     }
 }

--- a/coincube-gui/src/app/view/spark/settings/mod.rs
+++ b/coincube-gui/src/app/view/spark/settings/mod.rs
@@ -108,25 +108,15 @@ fn stable_balance_card<'a>(
     saving: bool,
     spark_available: bool,
 ) -> Element<'a, Message> {
-    let status_line: Element<'_, Message> = match (active, spark_available) {
-        (_, false) => p2_regular("Spark bridge unavailable — toggle disabled.").into(),
-        (None, true) => p2_regular("Loading…").into(),
-        (Some(true), true) => p2_regular("Stable Balance is ON").into(),
-        (Some(false), true) => p2_regular("Stable Balance is OFF").into(),
-    };
+    let status_line: Element<'_, Message> =
+        p2_regular(stable_balance_status_text(active, spark_available)).into();
 
-    let can_toggle = spark_available && active.is_some() && !saving;
-    let target = active.unwrap_or(false);
-    let (button_label, next_state) = if target {
-        ("Turn off", false)
-    } else {
-        ("Turn on", true)
-    };
-    let toggle_btn = button::primary(None, button_label).width(Length::Fixed(140.0));
-    let toggle_btn: Element<'_, Message> = if can_toggle {
+    let toggle = stable_balance_toggle_state(active, saving, spark_available);
+    let toggle_btn = button::primary(None, toggle.button_label).width(Length::Fixed(140.0));
+    let toggle_btn: Element<'_, Message> = if toggle.can_toggle {
         toggle_btn
             .on_press(Message::SparkSettings(
-                SparkSettingsMessage::StableBalanceToggled(next_state),
+                SparkSettingsMessage::StableBalanceToggled(toggle.next_state),
             ))
             .into()
     } else {
@@ -159,16 +149,73 @@ fn stable_balance_card<'a>(
     .into()
 }
 
+fn stable_balance_status_text(active: Option<bool>, spark_available: bool) -> &'static str {
+    match (active, spark_available) {
+        (_, false) => "Spark bridge unavailable — toggle disabled.",
+        (None, true) => "Loading…",
+        (Some(true), true) => "Stable Balance is ON",
+        (Some(false), true) => "Stable Balance is OFF",
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct StableBalanceToggleState {
+    button_label: &'static str,
+    next_state: bool,
+    can_toggle: bool,
+}
+
+fn stable_balance_toggle_state(
+    active: Option<bool>,
+    saving: bool,
+    spark_available: bool,
+) -> StableBalanceToggleState {
+    let can_toggle = spark_available && active.is_some() && !saving;
+    let target = active.unwrap_or(false);
+    let (button_label, next_state) = if target {
+        ("Turn off", false)
+    } else {
+        ("Turn on", true)
+    };
+    StableBalanceToggleState {
+        button_label,
+        next_state,
+        can_toggle,
+    }
+}
+
 /// Small live diagnostic card — shows whether the Spark bridge
 /// subprocess is reachable. Green check for a healthy round-trip,
 /// red X for an error, a neutral dot while loading.
 fn bridge_status_card<'a>(status: &SparkSettingsStatus) -> Element<'a, Message> {
-    let (indicator_char, indicator_color, headline, detail): (
-        &'static str,
-        iced::Color,
-        &'static str,
-        String,
-    ) = match status {
+    let (indicator_char, indicator_color, headline, detail) = bridge_status_copy(status);
+
+    Container::new(
+        Column::new()
+            .spacing(8)
+            .push(h4_bold("Bridge status"))
+            .push(
+                Row::new()
+                    .spacing(8)
+                    .align_y(Alignment::Center)
+                    .push(iced::widget::text(indicator_char).size(18).style(
+                        move |_: &theme::Theme| iced::widget::text::Style {
+                            color: Some(indicator_color),
+                        },
+                    ))
+                    .push(p1_regular(headline)),
+            )
+            .push(p2_regular(detail)),
+    )
+    .padding(12)
+    .style(theme::card::simple)
+    .into()
+}
+
+fn bridge_status_copy(
+    status: &SparkSettingsStatus,
+) -> (&'static str, iced::Color, &'static str, String) {
+    match status {
         SparkSettingsStatus::Loading => (
             "●",
             color::GREY_3,
@@ -201,26 +248,74 @@ fn bridge_status_card<'a>(status: &SparkSettingsStatus) -> Element<'a, Message> 
              failed to spawn."
                 .to_string(),
         ),
-    };
+    }
+}
 
-    Container::new(
-        Column::new()
-            .spacing(8)
-            .push(h4_bold("Bridge status"))
-            .push(
-                Row::new()
-                    .spacing(8)
-                    .align_y(Alignment::Center)
-                    .push(iced::widget::text(indicator_char).size(18).style(
-                        move |_: &theme::Theme| iced::widget::text::Style {
-                            color: Some(indicator_color),
-                        },
-                    ))
-                    .push(p1_regular(headline)),
-            )
-            .push(p2_regular(detail)),
-    )
-    .padding(12)
-    .style(theme::card::simple)
-    .into()
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stable_balance_status_text_covers_loading_on_off_and_unavailable() {
+        assert_eq!(
+            stable_balance_status_text(None, false),
+            "Spark bridge unavailable — toggle disabled."
+        );
+        assert_eq!(stable_balance_status_text(None, true), "Loading…");
+        assert_eq!(
+            stable_balance_status_text(Some(true), true),
+            "Stable Balance is ON"
+        );
+        assert_eq!(
+            stable_balance_status_text(Some(false), true),
+            "Stable Balance is OFF"
+        );
+    }
+
+    #[test]
+    fn stable_balance_toggle_state_only_enables_when_loaded_available_and_idle() {
+        assert_eq!(
+            stable_balance_toggle_state(Some(true), false, true),
+            StableBalanceToggleState {
+                button_label: "Turn off",
+                next_state: false,
+                can_toggle: true,
+            }
+        );
+        assert_eq!(
+            stable_balance_toggle_state(Some(false), false, true),
+            StableBalanceToggleState {
+                button_label: "Turn on",
+                next_state: true,
+                can_toggle: true,
+            }
+        );
+        assert!(!stable_balance_toggle_state(None, false, true).can_toggle);
+        assert!(!stable_balance_toggle_state(Some(true), true, true).can_toggle);
+        assert!(!stable_balance_toggle_state(Some(true), false, false).can_toggle);
+    }
+
+    #[test]
+    fn bridge_status_copy_names_loading_connected_error_and_unavailable() {
+        let loading = bridge_status_copy(&SparkSettingsStatus::Loading);
+        assert_eq!(loading.0, "●");
+        assert_eq!(loading.1, color::GREY_3);
+        assert_eq!(loading.2, "Checking bridge…");
+
+        let connected = bridge_status_copy(&SparkSettingsStatus::Connected);
+        assert_eq!(connected.0, "✓");
+        assert_eq!(connected.1, color::GREEN);
+        assert_eq!(connected.2, "Connected");
+
+        let error = bridge_status_copy(&SparkSettingsStatus::Error("boom".to_string()));
+        assert_eq!(error.0, "✗");
+        assert_eq!(error.1, color::RED);
+        assert_eq!(error.2, "Disconnected");
+        assert!(error.3.contains("boom"));
+
+        let unavailable = bridge_status_copy(&SparkSettingsStatus::Unavailable);
+        assert_eq!(unavailable.0, "✗");
+        assert_eq!(unavailable.1, color::RED);
+        assert_eq!(unavailable.2, "Unavailable");
+    }
 }

--- a/coincube-gui/src/app/view/spark/sideshift_receive.rs
+++ b/coincube-gui/src/app/view/spark/sideshift_receive.rs
@@ -230,20 +230,10 @@ fn active_body(
                 | ShiftStatusKind::Settled
         ) {
             if let Some(sats) = flow.settle_amount_sat() {
-                let settled = matches!(status, ShiftStatusKind::Settled);
                 col = col.push(
-                    text(format!(
-                        "{}{} {}",
-                        if settled { "" } else { "≈ " },
-                        Amount::from_sat(sats).to_formatted_string_with_unit(bitcoin_unit),
-                        if matches!(bitcoin_unit, BitcoinDisplayUnit::BTC) {
-                            "BTC"
-                        } else {
-                            "SATS"
-                        },
-                    ))
-                    .size(P1_SIZE)
-                    .bold(),
+                    text(settle_amount_display(sats, status, bitcoin_unit))
+                        .size(P1_SIZE)
+                        .bold(),
                 );
             }
         }
@@ -291,17 +281,9 @@ fn arrived_body(
 
     if let Some(sats) = flow.arrived_amount_sat() {
         col = col.push(
-            text(format!(
-                "{} {}",
-                Amount::from_sat(sats).to_formatted_string_with_unit(bitcoin_unit),
-                if matches!(bitcoin_unit, BitcoinDisplayUnit::BTC) {
-                    "BTC"
-                } else {
-                    "SATS"
-                },
-            ))
-            .size(H4_SIZE)
-            .bold(),
+            text(arrived_amount_display(sats, bitcoin_unit))
+                .size(H4_SIZE)
+                .bold(),
         );
     }
 
@@ -337,6 +319,36 @@ fn spark_shift_guidance(status: &ShiftStatusKind) -> &'static str {
              wallet automatically after about 3 confirmations — ~30 minutes."
         }
         other => other.guidance(),
+    }
+}
+
+fn settle_amount_display(
+    sats: u64,
+    status: &ShiftStatusKind,
+    bitcoin_unit: BitcoinDisplayUnit,
+) -> String {
+    let settled = matches!(status, ShiftStatusKind::Settled);
+    format!(
+        "{}{} {}",
+        if settled { "" } else { "≈ " },
+        Amount::from_sat(sats).to_formatted_string_with_unit(bitcoin_unit),
+        bitcoin_unit_label(bitcoin_unit),
+    )
+}
+
+fn arrived_amount_display(sats: u64, bitcoin_unit: BitcoinDisplayUnit) -> String {
+    format!(
+        "{} {}",
+        Amount::from_sat(sats).to_formatted_string_with_unit(bitcoin_unit),
+        bitcoin_unit_label(bitcoin_unit),
+    )
+}
+
+fn bitcoin_unit_label(bitcoin_unit: BitcoinDisplayUnit) -> &'static str {
+    if matches!(bitcoin_unit, BitcoinDisplayUnit::BTC) {
+        "BTC"
+    } else {
+        "SATS"
     }
 }
 
@@ -426,4 +438,128 @@ fn error_body(error: Option<&str>) -> Element<'_, Msg> {
                 .width(Length::Fixed(160.0)),
         )
         .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn settled_guidance_uses_spark_confirming_copy() {
+        let spark_copy = spark_shift_guidance(&ShiftStatusKind::Settled);
+        let shared_copy = ShiftStatusKind::Settled.guidance();
+
+        assert_ne!(spark_copy, shared_copy);
+        assert!(spark_copy.contains("arriving on-chain"));
+        assert!(spark_copy.contains("automatically"));
+        assert!(spark_copy.contains("3 confirmations"));
+        assert!(!spark_copy.contains("has arrived"));
+    }
+
+    #[test]
+    fn non_settled_guidance_delegates_to_shared_status_copy() {
+        for status in [
+            ShiftStatusKind::Waiting,
+            ShiftStatusKind::Pending,
+            ShiftStatusKind::Processing,
+            ShiftStatusKind::Settling,
+            ShiftStatusKind::Expired,
+            ShiftStatusKind::Review,
+            ShiftStatusKind::Refunding,
+            ShiftStatusKind::Refunded,
+            ShiftStatusKind::Error,
+        ] {
+            assert_eq!(spark_shift_guidance(&status), status.guidance());
+        }
+    }
+
+    #[test]
+    fn status_badges_distinguish_arriving_review_and_done_states() {
+        let (settled_label, settled_color) = status_badge(&ShiftStatusKind::Settled);
+        assert_eq!(settled_label, "Bitcoin arriving");
+        assert_eq!(settled_color, color::ORANGE);
+
+        let (review_label, review_color) = status_badge(&ShiftStatusKind::Review);
+        assert_eq!(review_label, "On hold for review");
+        assert_eq!(review_color, color::RED);
+
+        let (refunded_label, refunded_color) = status_badge(&ShiftStatusKind::Refunded);
+        assert_eq!(refunded_label, "Refunded");
+        assert_eq!(refunded_color, color::GREY_3);
+
+        let (unknown_label, unknown_color) =
+            status_badge(&ShiftStatusKind::Unknown("future".to_string()));
+        assert_eq!(unknown_label, "Checking…");
+        assert_eq!(unknown_color, color::GREY_3);
+    }
+
+    #[test]
+    fn status_badges_cover_waiting_in_flight_and_failed_states() {
+        for status in [ShiftStatusKind::Pending, ShiftStatusKind::Processing] {
+            let (label, color) = status_badge(&status);
+            assert_eq!(label, "Deposit detected");
+            assert_eq!(color, color::ORANGE);
+        }
+
+        assert_eq!(
+            status_badge(&ShiftStatusKind::Waiting),
+            ("Waiting for deposit", color::GREY_3)
+        );
+        assert_eq!(
+            status_badge(&ShiftStatusKind::Settling),
+            ("Settling…", color::ORANGE)
+        );
+        assert_eq!(
+            status_badge(&ShiftStatusKind::Expired),
+            ("Expired", color::RED)
+        );
+        assert_eq!(
+            status_badge(&ShiftStatusKind::Refunding),
+            ("Refunding…", color::ORANGE)
+        );
+        assert_eq!(
+            status_badge(&ShiftStatusKind::Error),
+            ("Failed", color::RED)
+        );
+    }
+
+    #[test]
+    fn settle_amount_display_is_approx_until_settled_and_uses_selected_unit() {
+        assert_eq!(
+            settle_amount_display(
+                123_456_789,
+                &ShiftStatusKind::Processing,
+                BitcoinDisplayUnit::BTC
+            ),
+            "≈ 1.23 456 789 BTC"
+        );
+        assert_eq!(
+            settle_amount_display(
+                123_456_789,
+                &ShiftStatusKind::Settled,
+                BitcoinDisplayUnit::BTC
+            ),
+            "1.23 456 789 BTC"
+        );
+        assert_eq!(
+            settle_amount_display(
+                123_456_789,
+                &ShiftStatusKind::Pending,
+                BitcoinDisplayUnit::Sats
+            ),
+            "≈ 123,456,789 SATS"
+        );
+    }
+
+    #[test]
+    fn arrived_amount_display_is_never_approximate() {
+        assert_eq!(
+            arrived_amount_display(42_000, BitcoinDisplayUnit::Sats),
+            "42,000 SATS"
+        );
+        assert_eq!(
+            arrived_amount_display(42_000, BitcoinDisplayUnit::BTC),
+            "0.00 042 000 BTC"
+        );
+    }
 }

--- a/coincube-gui/src/app/view/spark/transactions.rs
+++ b/coincube-gui/src/app/view/spark/transactions.rs
@@ -297,28 +297,8 @@ pub fn transaction_detail_view<'a>(
         SparkPaymentMethod::Spark => asset_network_logo::<Message>("btc", "spark", 56.0),
         SparkPaymentMethod::StableBalance => asset_network_logo::<Message>("btc", "spark", 56.0),
     };
-    let method_text = match tx.method {
-        SparkPaymentMethod::Lightning => "Lightning payment",
-        SparkPaymentMethod::OnChainBitcoin => {
-            if is_incoming {
-                "On-chain deposit"
-            } else {
-                "On-chain withdrawal"
-            }
-        }
-        SparkPaymentMethod::Spark => "Spark transfer",
-        SparkPaymentMethod::StableBalance => "Stable Balance",
-    };
-    let status_text = match tx.status {
-        DomainPaymentStatus::Complete => "Completed",
-        DomainPaymentStatus::Pending => "Pending",
-        DomainPaymentStatus::Failed => "Failed",
-        DomainPaymentStatus::TimedOut => "Timed out",
-        DomainPaymentStatus::Created => "Created",
-        DomainPaymentStatus::Refundable => "Refundable",
-        DomainPaymentStatus::RefundPending => "Refund pending",
-        DomainPaymentStatus::WaitingFeeAcceptance => "Awaiting fee",
-    };
+    let method_text = payment_method_text(tx.method, is_incoming);
+    let status_text = payment_status_text(tx.status);
     let date_text = format_timestamp(tx.timestamp).unwrap_or_else(|| "Unknown".to_string());
     let fiat_str = total_fiat
         .as_ref()
@@ -404,6 +384,34 @@ pub fn transaction_detail_view<'a>(
         .into()
 }
 
+fn payment_method_text(method: SparkPaymentMethod, is_incoming: bool) -> &'static str {
+    match method {
+        SparkPaymentMethod::Lightning => "Lightning payment",
+        SparkPaymentMethod::OnChainBitcoin => {
+            if is_incoming {
+                "On-chain deposit"
+            } else {
+                "On-chain withdrawal"
+            }
+        }
+        SparkPaymentMethod::Spark => "Spark transfer",
+        SparkPaymentMethod::StableBalance => "Stable Balance",
+    }
+}
+
+fn payment_status_text(status: DomainPaymentStatus) -> &'static str {
+    match status {
+        DomainPaymentStatus::Complete => "Completed",
+        DomainPaymentStatus::Pending => "Pending",
+        DomainPaymentStatus::Failed => "Failed",
+        DomainPaymentStatus::TimedOut => "Timed out",
+        DomainPaymentStatus::Created => "Created",
+        DomainPaymentStatus::Refundable => "Refundable",
+        DomainPaymentStatus::RefundPending => "Refund pending",
+        DomainPaymentStatus::WaitingFeeAcceptance => "Awaiting fee",
+    }
+}
+
 fn detail_back_button() -> Element<'static, Message> {
     button::secondary(None, "< Back")
         .width(Length::Fixed(150.0))
@@ -414,3 +422,50 @@ fn detail_back_button() -> Element<'static, Message> {
 // `Amount` is kept in scope for future use (e.g. the detail pane).
 #[allow(dead_code)]
 fn _keep_amount_in_scope(_: Amount) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payment_method_text_names_directional_onchain_rows() {
+        assert_eq!(
+            payment_method_text(SparkPaymentMethod::Lightning, true),
+            "Lightning payment"
+        );
+        assert_eq!(
+            payment_method_text(SparkPaymentMethod::OnChainBitcoin, true),
+            "On-chain deposit"
+        );
+        assert_eq!(
+            payment_method_text(SparkPaymentMethod::OnChainBitcoin, false),
+            "On-chain withdrawal"
+        );
+        assert_eq!(
+            payment_method_text(SparkPaymentMethod::Spark, false),
+            "Spark transfer"
+        );
+        assert_eq!(
+            payment_method_text(SparkPaymentMethod::StableBalance, true),
+            "Stable Balance"
+        );
+    }
+
+    #[test]
+    fn payment_status_text_covers_every_domain_status() {
+        use DomainPaymentStatus::*;
+
+        for (status, label) in [
+            (Created, "Created"),
+            (Pending, "Pending"),
+            (Complete, "Completed"),
+            (Failed, "Failed"),
+            (TimedOut, "Timed out"),
+            (Refundable, "Refundable"),
+            (RefundPending, "Refund pending"),
+            (WaitingFeeAcceptance, "Awaiting fee"),
+        ] {
+            assert_eq!(payment_status_text(status), label);
+        }
+    }
+}

--- a/coincube-spark-protocol/src/lib.rs
+++ b/coincube-spark-protocol/src/lib.rs
@@ -1029,6 +1029,8 @@ pub enum Frame {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
 
     /// The exact `prepare_send` response (USDT on Solana) that used to fail to
     /// parse with "u128 is not supported": its `estimated_out` / `fee_amount`
@@ -1149,5 +1151,217 @@ mod tests {
             !json.contains("amount"),
             "None amount must be omitted: {json}"
         );
+    }
+
+    #[test]
+    fn request_frames_use_snake_case_method_tags_and_expected_params() {
+        let set_stable = Frame::Request(Request {
+            id: 7,
+            method: Method::SetStableBalance(SetStableBalanceParams { enabled: true }),
+        });
+        assert_eq!(
+            serde_json::to_value(set_stable).expect("serialize"),
+            json!({
+                "type": "request",
+                "id": 7,
+                "method": "set_stable_balance",
+                "params": { "enabled": true }
+            })
+        );
+
+        let receive_spark = Frame::Request(Request {
+            id: 8,
+            method: Method::ReceiveSpark,
+        });
+        assert_eq!(
+            serde_json::to_value(receive_spark).expect("serialize"),
+            json!({
+                "type": "request",
+                "id": 8,
+                "method": "receive_spark"
+            })
+        );
+    }
+
+    #[test]
+    fn response_helpers_emit_ok_and_error_envelopes() {
+        assert_eq!(
+            serde_json::to_value(Frame::Response(Response::ok(
+                11,
+                OkPayload::SetStableBalance {}
+            )))
+            .expect("serialize ok"),
+            json!({
+                "type": "response",
+                "id": 11,
+                "ok": {
+                    "kind": "set_stable_balance",
+                    "data": {}
+                }
+            })
+        );
+
+        assert_eq!(
+            serde_json::to_value(Frame::Response(Response::err(
+                12,
+                ErrorKind::BadRequest,
+                "bad frame"
+            )))
+            .expect("serialize err"),
+            json!({
+                "type": "response",
+                "id": 12,
+                "err": {
+                    "kind": "bad_request",
+                    "message": "bad frame"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn events_default_missing_optional_payload_fields() {
+        let parsed: Frame = serde_json::from_value(json!({
+            "type": "event",
+            "event": "payment_succeeded",
+            "payload": {
+                "id": "payment-1",
+                "amount_sat": 42
+            }
+        }))
+        .expect("event parses");
+        let Frame::Event(Event::PaymentSucceeded {
+            id,
+            amount_sat,
+            bolt11,
+        }) = parsed
+        else {
+            panic!("expected payment succeeded event");
+        };
+        assert_eq!(id, "payment-1");
+        assert_eq!(amount_sat, 42);
+        assert_eq!(bolt11, None);
+
+        assert_eq!(
+            serde_json::to_value(Frame::Event(Event::DepositsChanged)).expect("serialize"),
+            json!({
+                "type": "event",
+                "event": "deposits_changed"
+            })
+        );
+    }
+
+    #[test]
+    fn payment_summary_defaults_keep_old_list_payments_frames_parsing() {
+        let payment: PaymentSummary = serde_json::from_value(json!({
+            "id": "payment-1",
+            "amount_sat": 21,
+            "timestamp": 1_700_000_000u64,
+            "status": "completed",
+            "direction": "receive"
+        }))
+        .expect("legacy payment summary parses");
+
+        assert_eq!(payment.fees_sat, 0);
+        assert_eq!(payment.token_amount, None);
+        assert_eq!(payment.token_decimals, None);
+        assert_eq!(payment.token_ticker, None);
+        assert_eq!(payment.method, "");
+        assert_eq!(payment.description, None);
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct OptionalAmountProbe {
+        #[serde(with = "super::opt_u128_dec")]
+        amount: Option<u128>,
+    }
+
+    #[test]
+    fn optional_u128_codec_accepts_null_and_serializes_none_as_null() {
+        let parsed: OptionalAmountProbe =
+            serde_json::from_value(json!({ "amount": null })).expect("null parses as None");
+        assert_eq!(parsed, OptionalAmountProbe { amount: None });
+
+        let encoded =
+            serde_json::to_value(OptionalAmountProbe { amount: None }).expect("serialize None");
+        assert_eq!(encoded, json!({ "amount": null }));
+    }
+
+    #[test]
+    fn u128_codecs_reject_non_numeric_json_with_useful_errors() {
+        let err = serde_json::from_value::<Frame>(json!({
+            "type": "response",
+            "id": 1,
+            "ok": {
+                "kind": "prepare_send",
+                "data": {
+                    "handle": "h",
+                    "amount_sat": 1,
+                    "fee_sat": 0,
+                    "method": "CrossChainAddress",
+                    "cross_chain": {
+                        "route": {
+                            "provider": "boltz",
+                            "chain": "Solana",
+                            "asset": "USDT",
+                            "decimals": 6,
+                            "btc_source_supported": true
+                        },
+                        "estimated_out": true,
+                        "fee_amount": "1",
+                        "source_transfer_fee_sats": 0,
+                        "expires_at": "1784180130",
+                        "retry_safe": true
+                    }
+                }
+            }
+        }))
+        .expect_err("bool is not a u128");
+        assert!(
+            err.to_string()
+                .contains("a u128 as a decimal string or a JSON integer"),
+            "{err}"
+        );
+
+        let err = serde_json::from_value::<OptionalAmountProbe>(json!({ "amount": false }))
+            .expect_err("bool is not an optional u128");
+        assert!(
+            err.to_string()
+                .contains("a u128 as a decimal string or a JSON integer"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn u128_codec_accepts_positive_signed_integers_and_rejects_negative() {
+        let frame = json!({
+            "type": "response",
+            "id": 79,
+            "ok": {
+                "kind": "prepare_send",
+                "data": {
+                    "handle": "h",
+                    "amount_sat": 10173,
+                    "fee_sat": 43,
+                    "method": "CrossChainAddress",
+                    "cross_chain": {
+                        "route": {
+                            "provider": "boltz",
+                            "chain": "Solana",
+                            "asset": "USDT",
+                            "decimals": 6,
+                            "btc_source_supported": true
+                        },
+                        "estimated_out": 42,
+                        "fee_amount": -1,
+                        "source_transfer_fee_sats": 43,
+                        "expires_at": "1784180130",
+                        "retry_safe": true
+                    }
+                }
+            }
+        });
+        let err = serde_json::from_value::<Frame>(frame).expect_err("negative u128 rejected");
+        assert!(err.to_string().contains("out of range"), "{err}");
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are overwhelmingly tests and small extractions; the only user-visible fix is safer error-string truncation in the receive view.
> 
> **Overview**
> Adds broad **unit and state-machine tests** across the Spark wallet stack (Breez client/config/load, Esplora confirmations, panel state for overview/send/receive/transactions/settings, SideShift receive, nav, and view formatting).
> 
> Several **small refactors** pull inline logic into pure helpers so behavior can be asserted without UI (`confirmation_count`, transaction row amounts/pending totals, Lightning address eligibility, stable-balance settings copy, SideShift refund/settle parsing, payment detail labels).
> 
> **Notable behavior tweak:** `short_error` in receive view now truncates by **Unicode character count** instead of byte length, avoiding broken display on multi-byte errors.
> 
> **Protocol crate:** additional serde tests for request/response/event frames, legacy `PaymentSummary` defaults, and `u128` JSON codec edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ce14d0b2e067c4099b246cfaf25aad7eaa55332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->