### PR TITLE
Recovery Key Fixes

### DIFF
--- a/coincube-gui/src/app/state/vault/signers.rs
+++ b/coincube-gui/src/app/state/vault/signers.rs
@@ -359,6 +359,7 @@ mod tests {
             owner_email: String::new(),
             is_own_key: false,
             used_by_vault: false,
+            recovery_role: String::new(),
         }
     }
 

--- a/coincube-gui/src/installer/connect_vault.rs
+++ b/coincube-gui/src/installer/connect_vault.rs
@@ -13,10 +13,12 @@
 //!   only matters for those.
 //! - **Role** defaults to `Keyholder` for every member. Refinement into
 //!   Beneficiary/Observer is a follow-up.
-//! - **Failure UX**: the W9 409 (`KEY_ALREADY_USED_IN_VAULT`) rolls
-//!   back the just-created vault so the user can restart with a clean
-//!   slate; other errors leave the partial vault in place and surface a
-//!   retry-able warning.
+//! - **Failure UX**: the W9 409 (`KEY_ALREADY_USED_IN_VAULT`) and the
+//!   I2 409 (`KEY_IS_RECOVERY_RECIPIENT`) both roll back the just-created
+//!   vault — W9 so the user can restart with a clean slate, I2 because a
+//!   retry can't help (the sealed descriptor still holds the recovery
+//!   key, so it must be rebuilt first). Other errors leave the partial
+//!   vault in place and surface a retry-able warning.
 
 use crate::services::coincube::{
     AddVaultMemberRequest, CoincubeClient, ConnectVaultResponse, CreateConnectVaultRequest,
@@ -46,6 +48,12 @@ pub enum ConnectVaultError {
     /// back before the error surfaced, so the user can restart. Carries
     /// the offending `key_id` for the dialog.
     KeyAlreadyUsedInVault { key_id: u64 },
+    /// I2 409 `KEY_IS_RECOVERY_RECIPIENT`. The descriptor was sealed with
+    /// a recovery key, which can never be a Vault signer. Like W9 the
+    /// vault shell is rolled back first, but retrying is useless here —
+    /// the descriptor itself must be rebuilt without the recovery key.
+    /// Carries the offending `key_id` for the dialog.
+    KeyIsRecoveryRecipient { key_id: u64 },
     /// Any other failure (network, backend 5xx, partial success). The
     /// caller gets a message suitable for display.
     Other(String),
@@ -61,6 +69,15 @@ impl std::fmt::Display for ConnectVaultError {
                     "Key #{} is already used in another Vault. A key can \
                      only participate in one Vault. Remove it from this \
                      configuration and pick a different key.",
+                    key_id
+                )
+            }
+            Self::KeyIsRecoveryRecipient { key_id } => {
+                write!(
+                    f,
+                    "Key #{} is a recovery key and can't be a Vault signer. \
+                     Rebuild the Vault descriptor without the recovery key, \
+                     then try again.",
                     key_id
                 )
             }
@@ -119,7 +136,7 @@ pub async fn create_connect_vault(
         .await
         .map_err(|e| ConnectVaultError::Other(format!("Failed to create Connect vault: {}", e)))?;
 
-    // 3. Fan out member rows. On W9 409, roll back and bail.
+    // 3. Fan out member rows. On the W9 or I2 409, roll back and bail.
     let mut members_added = 0usize;
     for payload in &members {
         let req = AddVaultMemberRequest {
@@ -146,6 +163,26 @@ pub async fn create_connect_vault(
                     );
                 }
                 return Err(ConnectVaultError::KeyAlreadyUsedInVault {
+                    key_id: payload.key_id,
+                });
+            }
+            Err(e) if e.is_key_is_recovery_recipient() => {
+                // I2 backstop: the descriptor was sealed with a recovery
+                // key, which can never fan out into a signer. Unlike W9,
+                // retrying is hopeless — the sealed descriptor still
+                // contains the recovery key — so we roll the partial
+                // vault back (same best-effort delete as W9) and surface a
+                // distinct "rebuild the descriptor" error. PR 2 should make
+                // this unreachable from a current build, but stale desktops
+                // and future pickers keep it worth having.
+                if let Err(rollback_err) = client.delete_connect_vault(cube.id).await {
+                    tracing::warn!(
+                        "I2 rollback failed to delete vault {}: {}",
+                        vault.id,
+                        rollback_err
+                    );
+                }
+                return Err(ConnectVaultError::KeyIsRecoveryRecipient {
                     key_id: payload.key_id,
                 });
             }
@@ -385,6 +422,103 @@ mod tests {
         assert!(
             matches!(err, ConnectVaultError::KeyAlreadyUsedInVault { key_id: 99 }),
             "expected W9 error with key_id=99, got: {:?}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn i2_409_recovery_recipient_rolls_back_vault_and_surfaces_key_id() {
+        let server = MockServer::start();
+
+        let register = server.mock(|when, then| {
+            when.method(Method::POST).path("/api/v1/connect/cubes");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 42,
+                        "uuid": "abc-uuid",
+                        "name": "My Cube",
+                        "network": "mainnet",
+                        "lightningAddress": null,
+                        "bolt12Offer": null,
+                        "status": "active"
+                    }
+                }));
+        });
+
+        let create_vault = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/vault");
+            then.status(201)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": {
+                        "id": 5,
+                        "cubeId": 42,
+                        "timelockDays": 180,
+                        "timelockExpiresAt": "2026-10-15T00:00:00Z",
+                        "lastResetAt": "2026-04-18T00:00:00Z",
+                        "status": "active",
+                        "members": [],
+                        "createdAt": "2026-04-18T00:00:00Z",
+                        "updatedAt": "2026-04-18T00:00:00Z"
+                    }
+                }));
+        });
+
+        // I2 guard: 409 with the recovery-recipient code.
+        let add_member = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/vault/members");
+            then.status(409)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": false,
+                    "error": {
+                        "code": "KEY_IS_RECOVERY_RECIPIENT",
+                        "message": "This key is a recovery key and cannot be a Vault signer"
+                    }
+                }));
+        });
+
+        let rollback = server.mock(|when, then| {
+            when.method(Method::DELETE)
+                .path("/api/v1/connect/cubes/42/vault");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": true,
+                    "data": { "deleted": true }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = create_connect_vault(
+            Some(client),
+            Some("abc-uuid".to_string()),
+            Some("My Cube".to_string()),
+            "mainnet".to_string(),
+            vec![sample_member("deadbeef", 99, None)],
+            Some(180),
+        )
+        .await
+        .expect_err("expected I2 409 error");
+
+        register.assert();
+        create_vault.assert();
+        add_member.assert();
+        // The partial vault is rolled back, exactly like W9 — retrying can't
+        // help, so we don't strand a vault the descriptor can never fan out.
+        rollback.assert();
+        assert!(
+            matches!(
+                err,
+                ConnectVaultError::KeyIsRecoveryRecipient { key_id: 99 }
+            ),
+            "expected I2 error with key_id=99, got: {:?}",
             err
         );
     }

--- a/coincube-gui/src/installer/step/descriptor/editor/key.rs
+++ b/coincube-gui/src/installer/step/descriptor/editor/key.rs
@@ -1070,6 +1070,17 @@ impl SelectKeySource {
     }
 
     fn on_select_keychain_key(&mut self, resolved: ResolvedCubeKey) -> Task<Message> {
+        // I2 backstop: an owner-self recovery key restores this Cube but must
+        // never be a Vault signer. The row is rendered disabled, but view state
+        // can lag a re-fetch, so refuse it here too — sealing a descriptor with
+        // it would only be rejected by the server's I2 guard later (PR 3).
+        if resolved.raw.is_owner_self_recovery() {
+            self.error = Some(
+                "This is a recovery key — it restores this Cube but can never be a Vault signer."
+                    .to_string(),
+            );
+            return Task::none();
+        }
         let fingerprint_str = &resolved.raw.fingerprint;
         let xpub_str = &resolved.raw.xpub;
         let derivation_str = &resolved.raw.derivation_path;
@@ -1258,7 +1269,11 @@ impl SelectKeySource {
             let key_reused = candidate_fp.is_some_and(|fp| self.key_placed_elsewhere(fp));
             // W9 pre-check: reject keys that another Vault already claims.
             let used_elsewhere = rk.raw.used_by_vault;
-            let disabled = owner_blocked || key_reused || used_elsewhere;
+            // I2: the owner-self recovery key restores this Cube but is never a
+            // signer. Show it — it teaches the model — but disabled, and let
+            // its caption win over the reuse/selection reasons below.
+            let is_recovery = rk.raw.is_owner_self_recovery();
+            let disabled = is_recovery || owner_blocked || key_reused || used_elsewhere;
             let fp_short: String = rk.raw.fingerprint.chars().take(8).collect();
             let fingerprint = Some(format!("#{}", fp_short));
             let msg = if disabled {
@@ -1269,10 +1284,13 @@ impl SelectKeySource {
                     Self::route(SelectKeySourceMessage::SelectKeychainKey(rk_clone.clone()))
                 })
             };
-            // Surface the most specific reason when several apply: a key
-            // claimed by another Vault reports that first, then an exact
-            // reuse in this quorum, then the owner being placed elsewhere.
-            let warning = if used_elsewhere {
+            // Surface the most specific reason when several apply: the recovery
+            // caption first (it's the whole point of the row), then a key
+            // claimed by another Vault, then an exact reuse in this quorum,
+            // then the owner being placed elsewhere.
+            let warning = if is_recovery {
+                Some("Recovery key — restores this Cube, never signs".to_string())
+            } else if used_elsewhere {
                 Some("Used by another Vault".to_string())
             } else if key_reused {
                 Some("Already used in this Vault".to_string())
@@ -2693,6 +2711,7 @@ mod tests {
             owner_email: format!("owner{owner_id}@example.com"),
             is_own_key: true,
             used_by_vault: false,
+            recovery_role: String::new(),
         }
     }
 
@@ -2703,6 +2722,14 @@ mod tests {
                 primary_owner_id: owner_id,
             },
         }
+    }
+
+    /// A resolved owner-self recovery key — the `recoveryRole: "owner-self"`
+    /// annotation the API stamps on the Cube's recovery recipient (PR 2).
+    fn resolved_recovery_key(id: u64, fingerprint: &str, owner_id: u64) -> ResolvedCubeKey {
+        let mut rk = resolved_key(id, fingerprint, owner_id);
+        rk.raw.recovery_role = "owner-self".to_string();
+        rk
     }
 
     fn keychain_key(fingerprint: Fingerprint, owner_id: u64, key_id: u64) -> Key {
@@ -2917,5 +2944,36 @@ mod tests {
             collision_picker.error.as_deref(),
             Some("A different key with the same master fingerprint is already in this Vault.")
         );
+    }
+
+    #[test]
+    fn owner_self_recovery_key_selection_is_a_no_op() {
+        // I2: an owner-self recovery key restores the Cube but can never be a
+        // Vault signer. The view renders it disabled; the submit-side backstop
+        // must refuse it too — an otherwise-valid key (right network, no
+        // conflicts) is rejected purely on the recovery annotation, with no
+        // selection made and no step advance.
+        let mut picker = empty_picker();
+        let _ = picker.on_select_keychain_key(resolved_recovery_key(1, "8a550171", 7));
+        assert!(
+            matches!(picker.selected_key, SelectedKey::None),
+            "a recovery key must not be selected"
+        );
+        assert_eq!(
+            picker.step,
+            Step::Grid,
+            "selection must not advance the step"
+        );
+        assert_eq!(
+            picker.error.as_deref(),
+            Some("This is a recovery key — it restores this Cube but can never be a Vault signer.")
+        );
+
+        // The same key without the annotation is accepted — proving the refusal
+        // keys off `recoveryRole` alone, not some other property of the fixture.
+        let mut ok_picker = empty_picker();
+        let _ = ok_picker.on_select_keychain_key(resolved_key(1, "8a550171", 7));
+        assert!(matches!(ok_picker.selected_key, SelectedKey::New(_)));
+        assert_eq!(ok_picker.step, Step::Details);
     }
 }

--- a/coincube-gui/src/installer/step/mod.rs
+++ b/coincube-gui/src/installer/step/mod.rs
@@ -256,6 +256,22 @@ impl Step for Final {
                     ));
                     return Task::perform(async move {}, |_| Message::RedeemNextKey);
                 }
+                Err(ConnectVaultError::KeyIsRecoveryRecipient { key_id }) => {
+                    // I2: the descriptor was sealed with a recovery key,
+                    // which can never be a Vault signer. The partial vault
+                    // was rolled back upstream. Unlike W9, a plain retry
+                    // won't help — the descriptor must be rebuilt without
+                    // the recovery key — so the copy says exactly that. The
+                    // local install still stands, so continue with redemption.
+                    self.warning = Some(format!(
+                        "This key (#{}) is a recovery key and can't be a Vault \
+                         signer. Your local wallet is installed; rebuild the \
+                         Vault descriptor without the recovery key, then restart \
+                         the Vault Builder to create the Connect vault.",
+                        key_id
+                    ));
+                    return Task::perform(async move {}, |_| Message::RedeemNextKey);
+                }
                 Err(ConnectVaultError::Other(msg)) => {
                     // Transient / unexpected failure. Warn but continue
                     // — the local wallet is already persisted, and the

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -2526,7 +2526,8 @@ mod cube_member_tests {
                             "ownerUserId": 99,
                             "ownerEmail": "alice@example.com",
                             "isOwnKey": false,
-                            "usedByVault": true
+                            "usedByVault": true,
+                            "recoveryRole": "owner-self"
                         }
                     ]
                 }));
@@ -2546,6 +2547,9 @@ mod cube_member_tests {
         assert_eq!(k.owner_email, "alice@example.com");
         assert!(!k.is_own_key);
         assert!(k.used_by_vault);
+        // The recovery annotation (PR 2) round-trips and the helper reads it.
+        assert_eq!(k.recovery_role, "owner-self");
+        assert!(k.is_owner_self_recovery());
         // Legacy fields default out.
         assert_eq!(k.primary_owner_id, 0);
     }
@@ -2597,6 +2601,10 @@ mod cube_member_tests {
         assert!(k.owner_email.is_empty());
         assert!(!k.is_own_key);
         assert!(!k.used_by_vault);
+        // A pre-annotation backend omits `recoveryRole`; it defaults to empty
+        // and the key is treated as a normal signer (PR 2 back-compat).
+        assert!(k.recovery_role.is_empty());
+        assert!(!k.is_owner_self_recovery());
     }
 
     #[tokio::test]
@@ -2751,6 +2759,55 @@ mod cube_member_tests {
         assert!(
             !err.is_key_already_used_in_vault(),
             "generic 409 must not match the W9 helper"
+        );
+        assert!(
+            !err.is_key_is_recovery_recipient(),
+            "generic 409 must not match the I2 helper"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_vault_member_409_recovery_recipient_maps_to_helper() {
+        use crate::services::coincube::{AddVaultMemberRequest, VaultMemberRole};
+        // I2 guard: a recovery key can never be a Vault signer. The 409 must
+        // trip the recovery helper and NOT the W9 helper — they drive
+        // different rollback copy in the installer.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/vault/members");
+            then.status(409)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "success": false,
+                    "error": {
+                        "code": "KEY_IS_RECOVERY_RECIPIENT",
+                        "message": "This key is a recovery key and cannot be a Vault signer"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .add_vault_member(
+                42,
+                AddVaultMemberRequest {
+                    contact_id: None,
+                    key_id: Some(99),
+                    role: VaultMemberRole::Keyholder,
+                },
+            )
+            .await
+            .expect_err("expected 409");
+        mock.assert();
+        assert!(
+            err.is_key_is_recovery_recipient(),
+            "is_key_is_recovery_recipient() should match: {}",
+            err
+        );
+        assert!(
+            !err.is_key_already_used_in_vault(),
+            "recovery-recipient 409 must not match the W9 helper"
         );
     }
 

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -754,7 +754,19 @@ pub struct CubeKeyRaw {
     /// Drives the W9 pre-check in the Vault Builder key picker.
     #[serde(default)]
     pub used_by_vault: bool,
+    /// Recovery-recipient annotation: `"owner-self"` when this key backs the
+    /// Cube's owner-self recovery recipient (a key that *restores* the Cube but
+    /// must never be a Vault signer — invariant I2), empty otherwise. On the
+    /// `/keys` endpoint the API only annotates owner-self keys; heir-recipient
+    /// keys are left blank because an heir's key legitimately signs today.
+    /// `#[serde(default)]` so a pre-annotation backend deserialises as before.
+    #[serde(default)]
+    pub recovery_role: String,
 }
+
+/// `recoveryRole` value marking a key as the Cube's owner-self recovery
+/// recipient. Mirrors the API's `models.RecoveryRecipientRoleOwnerSelf`.
+pub const RECOVERY_ROLE_OWNER_SELF: &str = "owner-self";
 
 impl CubeKeyRaw {
     /// Returns the server-supplied `ownerUserId` when present, falling back
@@ -766,6 +778,13 @@ impl CubeKeyRaw {
         } else {
             self.primary_owner_id
         }
+    }
+
+    /// `true` iff this key is the Cube's owner-self recovery key. Such a key
+    /// restores the Cube but can never be a Vault signer (I2), so the picker
+    /// shows it as a disabled row and the selection handler refuses it.
+    pub fn is_owner_self_recovery(&self) -> bool {
+        self.recovery_role == RECOVERY_ROLE_OWNER_SELF
     }
 }
 
@@ -1418,6 +1437,14 @@ pub fn member_joined_after_vault(member_joined_at: &str, vault_created_at: &str)
 /// can match on it when routing 409s.
 pub const ERR_KEY_ALREADY_USED_IN_VAULT: &str = "KEY_ALREADY_USED_IN_VAULT";
 
+/// Error code returned by the backend's I2 guard: 409 from
+/// `POST /connect/cubes/{cubeId}/vault/members` when the key is registered as a
+/// recovery recipient and therefore may never be a Vault signer. Mirrors the
+/// API's `responses.ErrKeyIsRecoveryRecipient`. Retrying is useless — the
+/// sealed descriptor must be rebuilt without the recovery key — so the caller
+/// rolls the just-created vault back (see `installer/connect_vault.rs`).
+pub const ERR_KEY_IS_RECOVERY_RECIPIENT: &str = "KEY_IS_RECOVERY_RECIPIENT";
+
 /// Error code returned by the backend's W16 guard (see
 /// `coincube-api` PR 8): 409 from
 /// `POST /connect/cubes/{cubeId}/vault/members` when `role=keyholder`
@@ -1472,6 +1499,24 @@ impl CoincubeError {
         }
         if let Ok(env) = serde_json::from_str::<ApiErrorResponse>(&info.text) {
             return env.error.code == ERR_KEY_ALREADY_USED_IN_VAULT;
+        }
+        false
+    }
+
+    /// Returns `true` if this error is the I2 "key is a recovery recipient"
+    /// conflict from `POST /connect/cubes/{id}/vault/members` — the key backs a
+    /// recovery recipient and can't be a Vault signer. Drives the vault
+    /// rollback in the installer (a retry can't help; the descriptor must be
+    /// rebuilt without the recovery key).
+    pub fn is_key_is_recovery_recipient(&self) -> bool {
+        let CoincubeError::Unsuccessful(info) = self else {
+            return false;
+        };
+        if info.status_code != 409 {
+            return false;
+        }
+        if let Ok(env) = serde_json::from_str::<ApiErrorResponse>(&info.text) {
+            return env.error.code == ERR_KEY_IS_RECOVERY_RECIPIENT;
         }
         false
     }

--- a/coincube-gui/src/services/connect/grpc/session.rs
+++ b/coincube-gui/src/services/connect/grpc/session.rs
@@ -152,3 +152,52 @@ impl GrpcSessionClient {
         })
     }
 }
+
+/// The two decrypt-relay calls [`crate::services::inheritance::heir::decrypt_envelopes`]
+/// drives, behind a trait so the orchestration can be unit-tested with a
+/// recording mock (asserting every `create_decrypt_request` fires before the
+/// first `get_decrypt_result` poll — the up-front-batching invariant). The
+/// production implementor is [`GrpcSessionClient`], delegating to its inherent
+/// methods; nothing else depends on the trait.
+#[async_trait::async_trait]
+pub trait DecryptRelay {
+    async fn create_decrypt_request(
+        &mut self,
+        request_id: String,
+        cube_id: String,
+        artifact_kind: String,
+        transport_pubkey: Vec<u8>,
+    ) -> Result<(), tonic::Status>;
+
+    async fn get_decrypt_result(
+        &mut self,
+        request_id: String,
+    ) -> Result<DecryptOutcome, tonic::Status>;
+}
+
+#[async_trait::async_trait]
+impl DecryptRelay for GrpcSessionClient {
+    async fn create_decrypt_request(
+        &mut self,
+        request_id: String,
+        cube_id: String,
+        artifact_kind: String,
+        transport_pubkey: Vec<u8>,
+    ) -> Result<(), tonic::Status> {
+        GrpcSessionClient::create_decrypt_request(
+            self,
+            request_id,
+            cube_id,
+            artifact_kind,
+            transport_pubkey,
+        )
+        .await
+    }
+
+    async fn get_decrypt_result(
+        &mut self,
+        request_id: String,
+    ) -> Result<DecryptOutcome, tonic::Status> {
+        GrpcSessionClient::get_decrypt_result(self, request_id).await
+    }
+}

--- a/coincube-gui/src/services/inheritance/heir.rs
+++ b/coincube-gui/src/services/inheritance/heir.rs
@@ -16,7 +16,7 @@ use super::error::EciesError;
 use super::wire::wire_to_envelope;
 use super::{open_with_shared_key, transport_keypair, unwrap_shared_key, SCHEME};
 use crate::services::coincube::InheritanceEnvelopeWire;
-use crate::services::connect::grpc::session::{DecryptOutcome, GrpcSessionClient};
+use crate::services::connect::grpc::session::{DecryptOutcome, DecryptRelay};
 use crate::services::recovery::{DecryptedKit, DescriptorBlob, SeedBlob, BLOB_VERSION};
 
 /// Length of the HKDF-derived symmetric key Keychain returns.
@@ -152,8 +152,16 @@ pub fn assemble(artifacts: Vec<OpenedArtifact>) -> DecryptedKit {
 /// Returns the assembled [`DecryptedKit`] for the existing restore machinery.
 /// `grpc` is the authenticated Connect SessionService client; `cube_id` selects
 /// the recovery key on the heir's Keychain and is bound into each envelope's AAD.
+///
+/// The two envelopes of a Full-Cube restore (seed + descriptor) are brokered as
+/// **one** consent ceremony on the phone: every `create_decrypt_request` fires
+/// in phase 1 — before any result poll — so both `DecryptRequestedEvent`s reach
+/// the Keychain's queue before the owner approves (SPEC-ecies-v1 §4b; master
+/// F1/F2). Sequentially awaiting each request one at a time (the old shape) made
+/// the phone see only one pending request and turned a Full-Cube restore into
+/// two separate approvals.
 pub async fn decrypt_envelopes(
-    grpc: &mut GrpcSessionClient,
+    grpc: &mut impl DecryptRelay,
     cube_id: u64,
     wires: &[InheritanceEnvelopeWire],
 ) -> Result<DecryptedKit, HeirDecryptError> {
@@ -166,16 +174,26 @@ pub async fn decrypt_envelopes(
     // per-request `request_id` keeps each wrap bound to its own request (§4b).
     let transport = transport_keypair();
     let cube_id_str = cube_id.to_string();
-    let mut artifacts = Vec::with_capacity(wires.len());
+
+    // Refuse any scheme we can't open before creating a single request — an
+    // unsupported envelope must not leave a half-created group on the phone.
     for wire in wires {
-        // Refuse a scheme we can't open before round-tripping to Keychain.
         if wire.scheme != SCHEME {
             return Err(HeirDecryptError::Envelope(format!(
                 "unsupported scheme '{}'",
                 wire.scheme
             )));
         }
-        // 1. Broker the decrypt; 2–4. wait for the Keychain's wrapped key.
+    }
+
+    // Phase 1 — create every decrypt request up-front. This loop completes
+    // before any phase-2 wait, so all requests land on the Keychain's queue as
+    // a batch and the phone runs a single ceremony. If any *create* fails we
+    // abort the whole restore here, before prompting for approval, rather than
+    // await a half-created group; the already-created requests fall away via
+    // their TTL, and the phone rejects a group coherently (keychain PR 1).
+    let mut pending = Vec::with_capacity(wires.len());
+    for wire in wires {
         let request_id = uuid::Uuid::new_v4().to_string();
         grpc.create_decrypt_request(
             request_id.clone(),
@@ -185,9 +203,16 @@ pub async fn decrypt_envelopes(
         )
         .await
         .map_err(|s| HeirDecryptError::Keychain(s.message().to_string()))?;
-        let wrapped = await_wrapped_key(grpc, &request_id).await?;
+        pending.push((request_id, wire));
+    }
 
-        // 5. Unwrap `K` with the transport key, then open + parse the envelope.
+    // Phase 2 — await each wrapped key, unwrap it (bound to its own
+    // `request_id`, §4b), then open + parse the envelope. The relay client is
+    // `&mut`-threaded, so these waits stay sequential — that's fine; only the
+    // creates above must be up-front.
+    let mut artifacts = Vec::with_capacity(pending.len());
+    for (request_id, wire) in pending {
+        let wrapped = await_wrapped_key(grpc, &request_id).await?;
         let k = unwrap_shared_key(&transport, &request_id, &wrapped)?;
         artifacts.push(open_blob(wire, &k, cube_id)?);
     }
@@ -200,7 +225,7 @@ pub async fn decrypt_envelopes(
 /// the realtime handler) will later let this resolve promptly instead of at the
 /// poll cadence.
 async fn await_wrapped_key(
-    grpc: &mut GrpcSessionClient,
+    grpc: &mut impl DecryptRelay,
     request_id: &str,
 ) -> Result<Vec<u8>, HeirDecryptError> {
     const POLL_INTERVAL: Duration = Duration::from_secs(2);
@@ -418,5 +443,169 @@ mod tests {
                 other
             ),
         }
+    }
+
+    // ── decrypt_envelopes batching (PR 1) ─────────────────────────────
+    //
+    // The defect these guard against: envelopes were brokered one at a time
+    // (create → await → open, per wire), so the phone only ever saw one
+    // pending request and a Full-Cube restore became two consent ceremonies.
+    // The fix fires every `create_decrypt_request` up-front (phase 1) before
+    // any `get_decrypt_result` poll (phase 2). We assert that ordering with a
+    // recording mock; the poll returning `Rejected` is fine — the call log is
+    // already complete by the first poll, which is exactly what we check.
+
+    #[derive(Debug, Clone, PartialEq)]
+    enum RelayCall {
+        /// A `create_decrypt_request`, tagged with the envelope's artifact kind.
+        Create(String),
+        /// A `get_decrypt_result` poll, tagged with the request id.
+        Get(String),
+    }
+
+    /// Records the order of relay calls and returns a canned poll outcome.
+    struct MockRelay {
+        calls: Vec<RelayCall>,
+        /// 1-based index of a `create` that should fail (simulating a broker
+        /// error mid-batch); `None` means every create succeeds.
+        fail_create_on: Option<usize>,
+        creates_seen: usize,
+        /// What each poll returns. `Rejected` lets phase 2 terminate on the
+        /// first poll without needing a real wrapped key.
+        poll_outcome: DecryptOutcome,
+    }
+
+    impl MockRelay {
+        fn new(poll_outcome: DecryptOutcome) -> Self {
+            Self {
+                calls: Vec::new(),
+                fail_create_on: None,
+                creates_seen: 0,
+                poll_outcome,
+            }
+        }
+
+        fn get_calls(&self) -> usize {
+            self.calls
+                .iter()
+                .filter(|c| matches!(c, RelayCall::Get(_)))
+                .count()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl DecryptRelay for MockRelay {
+        async fn create_decrypt_request(
+            &mut self,
+            _request_id: String,
+            _cube_id: String,
+            artifact_kind: String,
+            _transport_pubkey: Vec<u8>,
+        ) -> Result<(), tonic::Status> {
+            self.creates_seen += 1;
+            self.calls.push(RelayCall::Create(artifact_kind));
+            if self.fail_create_on == Some(self.creates_seen) {
+                return Err(tonic::Status::internal("mock broker failure"));
+            }
+            Ok(())
+        }
+
+        async fn get_decrypt_result(
+            &mut self,
+            request_id: String,
+        ) -> Result<DecryptOutcome, tonic::Status> {
+            self.calls.push(RelayCall::Get(request_id));
+            Ok(self.poll_outcome.clone())
+        }
+    }
+
+    /// Builds a two-envelope (seed + descriptor) escrow set for the batching
+    /// tests — the exact Full-Cube shape the defect regressed on.
+    fn two_envelope_set() -> Vec<InheritanceEnvelopeWire> {
+        let heir = kh(b"batch-heir-seed-vector-000000000000000000000");
+        let khs = vec![KeyholderXpub {
+            key_id: 5,
+            xpub: heir.xpub,
+            account_derivation: "m/48'/0'/0'/2'".to_string(),
+        }];
+        let descriptor_json = serde_json::to_vec(&sample_descriptor_blob()).unwrap();
+        let seed_json = serde_json::to_vec(&sample_seed_blob()).unwrap();
+        build_escrow_set(&khs, CUBE, &descriptor_json, Some(&seed_json)).unwrap()
+    }
+
+    #[tokio::test]
+    async fn two_envelopes_create_both_before_first_poll() {
+        let set = two_envelope_set();
+        assert_eq!(set.len(), 2, "Full-Cube seals seed + descriptor");
+
+        let mut relay = MockRelay::new(DecryptOutcome::Rejected);
+        // The phone rejects on the first poll; we only care about ordering.
+        let res = decrypt_envelopes(&mut relay, CUBE, &set).await;
+        assert!(matches!(res, Err(HeirDecryptError::Rejected)));
+
+        // Both creates must land before any poll — that's what lets the phone
+        // run one ceremony. The first `Get` therefore can't appear until both
+        // `Create`s have.
+        let first_get = relay
+            .calls
+            .iter()
+            .position(|c| matches!(c, RelayCall::Get(_)))
+            .expect("phase 2 polled at least once");
+        assert_eq!(first_get, 2, "the first poll comes after both creates");
+        assert!(
+            matches!(relay.calls[0], RelayCall::Create(_))
+                && matches!(relay.calls[1], RelayCall::Create(_)),
+            "phase 1 issues both creates up-front, got {:?}",
+            relay.calls
+        );
+    }
+
+    #[tokio::test]
+    async fn single_envelope_creates_then_polls() {
+        // Descriptor-only (vault) restore: one create, then poll — unchanged.
+        let heir = kh(b"single-heir-seed-vector-00000000000000000000");
+        let khs = vec![KeyholderXpub {
+            key_id: 7,
+            xpub: heir.xpub,
+            account_derivation: "m/48'/0'/0'/2'".to_string(),
+        }];
+        let descriptor_json = serde_json::to_vec(&sample_descriptor_blob()).unwrap();
+        let set = build_escrow_set(&khs, CUBE, &descriptor_json, None).unwrap();
+        assert_eq!(set.len(), 1);
+
+        let mut relay = MockRelay::new(DecryptOutcome::Rejected);
+        let res = decrypt_envelopes(&mut relay, CUBE, &set).await;
+        assert!(matches!(res, Err(HeirDecryptError::Rejected)));
+        assert_eq!(
+            relay.calls.len(),
+            2,
+            "one create then one poll, got {:?}",
+            relay.calls
+        );
+        assert!(matches!(relay.calls[0], RelayCall::Create(_)));
+        assert!(matches!(relay.calls[1], RelayCall::Get(_)));
+    }
+
+    #[tokio::test]
+    async fn create_failure_on_second_envelope_aborts_without_awaiting_first() {
+        let set = two_envelope_set();
+
+        let mut relay = MockRelay::new(DecryptOutcome::Completed(vec![]));
+        relay.fail_create_on = Some(2); // second create errors mid-batch.
+
+        let res = decrypt_envelopes(&mut relay, CUBE, &set).await;
+        assert!(
+            matches!(res, Err(HeirDecryptError::Keychain(_))),
+            "a create failure surfaces as a Keychain error, got {:?}",
+            res
+        );
+        // The whole restore is abandoned before any approval is awaited: no
+        // poll for the already-created first request.
+        assert_eq!(
+            relay.get_calls(),
+            0,
+            "must not await the first envelope after the second create fails, got {:?}",
+            relay.calls
+        );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes vault member attachment, descriptor key picking, and inheritance decrypt orchestration; behavior is guarded by API error codes and new tests but affects security-sensitive recovery paths.
> 
> **Overview**
> Enforces **invariant I2**: owner-self recovery keys may restore a Cube but must never become Vault signers. Cube keys now deserialize **`recoveryRole`** (`owner-self`) with **`is_owner_self_recovery()`**; the Vault Builder shows those rows disabled with explanatory copy and refuses selection in **`on_select_keychain_key`**. Connect vault creation maps backend **`KEY_IS_RECOVERY_RECIPIENT`** 409s to **`ConnectVaultError::KeyIsRecoveryRecipient`**, rolls back the partial vault (like W9), and the installer Final step warns that the descriptor must be rebuilt—not merely retried.
> 
> **Heir Full-Cube restore** no longer runs decrypt relay create→poll per envelope. **`decrypt_envelopes`** issues every **`create_decrypt_request`** first, then polls results via a testable **`DecryptRelay`** trait on **`GrpcSessionClient`**, so seed + descriptor share one phone consent ceremony.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f0c7d74cd4c1cb6de70d9c68c85d3d5e624c1be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->