### PR TITLE
Fix multi-sig ordering issue

### DIFF
--- a/coincube-gui/src/app/message.rs
+++ b/coincube-gui/src/app/message.rs
@@ -89,6 +89,13 @@ pub enum Message {
     Signed(Fingerprint, Result<Psbt, Error>),
     WalletUpdated(Result<Arc<Wallet>, Error>),
     Updated(Result<(), Error>),
+    /// UI-only signal to recompute collected signatures and re-evaluate the
+    /// Sign picker's close/broadcast state after an in-memory PSBT merge —
+    /// distinct from `Updated(Ok)`, which additionally marks the spend tx as
+    /// persisted (`saved = true`). Emitted speculatively by the Keychain flow
+    /// before/independent of the `update_spend_tx` round-trip, so it must not
+    /// imply a successful save.
+    Reconcile,
     Saved(Result<(), Error>),
     Verified(Fingerprint, Result<(), Error>),
     StartRescan(Result<(), Error>),

--- a/coincube-gui/src/app/state/vault/keychain_sign.rs
+++ b/coincube-gui/src/app/state/vault/keychain_sign.rs
@@ -526,13 +526,20 @@ impl KeychainSignModal {
             .any(|p| p.signed_psbt_merged && !p.signed_psbt_persisted)
     }
 
-    /// True while any pending session's `update_spend_tx` persist callback is
-    /// still in flight (dispatched, not yet returned). Manual dismissal keeps
-    /// the hidden modal mounted while this holds so the callback can land and
-    /// mark the row Failed on error. Unlike `has_persistence_pending`, a persist
-    /// that already *failed* is not in flight, so dismissal doesn't hang on it.
-    pub fn has_persistence_in_flight(&self) -> bool {
-        self.pending.iter().any(|p| p.signed_psbt_persisting)
+    /// True while any pending session has an async signed-PSBT capture still in
+    /// flight — either a `GetSigningSession` fetch (`signed_psbt_fetching`) or an
+    /// `update_spend_tx` persist (`signed_psbt_persisting`) that was dispatched
+    /// and hasn't returned. Manual dismissal keeps the hidden modal mounted while
+    /// this holds so the fetch can merge and the persist callback can land (and
+    /// mark the row Failed on error) instead of being dropped. A `Completed`
+    /// session whose fetch is still running looks status-drained, so keying
+    /// dismissal off status alone would silently lose its signature. Unlike
+    /// `has_persistence_pending`, an op that already *failed* is no longer in
+    /// flight, so dismissal doesn't hang on it.
+    pub fn has_capture_in_flight(&self) -> bool {
+        self.pending
+            .iter()
+            .any(|p| p.signed_psbt_fetching || p.signed_psbt_persisting)
     }
 
     /// True while any pending session is non-terminal. After
@@ -562,12 +569,13 @@ impl KeychainSignModal {
     /// existing `Phase::AllDone` + `Message::Updated(Ok)` close path
     /// that the panel already drives `self.modal = None` from.
     fn close_if_dismissed_and_drained(&mut self) -> Task<Message> {
-        // A merged row is terminal-by-status (Completed) while its persist
-        // callback is still in flight — don't tear down until it returns, so a
-        // `Persisted(Err)` can still mark the row Failed.
-        let persisting = self.has_persistence_in_flight();
+        // A `Completed` row can still have an in-flight fetch or persist callback
+        // (it is terminal-by-status but not yet captured) — don't tear down until
+        // that async op returns, so the fetch can merge and a `Persisted(Err)`
+        // can still mark the row Failed.
+        let capturing = self.has_capture_in_flight();
         if self.dismissed
-            && !persisting
+            && !capturing
             && !self.pending.is_empty()
             && self
                 .pending
@@ -2289,7 +2297,7 @@ mod tests {
         modal.pending[0].signed_psbt_persisting = true;
 
         // Both gates hold while the persist is in flight.
-        assert!(modal.has_persistence_in_flight());
+        assert!(modal.has_capture_in_flight());
         assert!(modal.has_persistence_pending());
 
         // User cancels/dismisses. `close_if_dismissed_and_drained` (the update
@@ -2306,13 +2314,40 @@ mod tests {
         // merged-but-unsaved (so threshold teardown would stay blocked).
         modal.pending[0].status = PendingSessionStatus::Failed;
         modal.pending[0].signed_psbt_persisting = false;
-        assert!(!modal.has_persistence_in_flight());
+        assert!(!modal.has_capture_in_flight());
         assert!(
             modal.has_persistence_pending(),
             "a failed persist still blocks threshold teardown until retry"
         );
 
         // With the callback resolved, the dismissed modal can finally drain.
+        let _ = modal.close_if_dismissed_and_drained();
+        assert!(matches!(modal.phase, Phase::AllDone));
+    }
+
+    #[test]
+    fn dismissal_waits_for_in_flight_fetch_of_a_completed_session() {
+        // A SessionCompleted event sets status=Completed AND dispatches the
+        // GetSigningSession fetch (signed_psbt_fetching=true) *before* the merge.
+        // Dismissing in that window must NOT drop the modal — otherwise the
+        // returning fetch lands on nothing and the signature is lost even though
+        // the signer already signed.
+        let mut modal = modal();
+        modal.pending.push(pending(PendingSessionStatus::Completed));
+        modal.pending[0].signed_psbt_fetching = true; // fetch dispatched, not merged yet
+
+        assert!(modal.has_capture_in_flight());
+
+        modal.mark_dismissed();
+        let _ = modal.close_if_dismissed_and_drained();
+        assert!(
+            !matches!(modal.phase, Phase::AllDone),
+            "dismissed modal must wait for the in-flight signed-PSBT fetch of a Completed session"
+        );
+
+        // Fetch resolves (flag cleared); with nothing else in flight it drains.
+        modal.pending[0].signed_psbt_fetching = false;
+        assert!(!modal.has_capture_in_flight());
         let _ = modal.close_if_dismissed_and_drained();
         assert!(matches!(modal.phase, Phase::AllDone));
     }

--- a/coincube-gui/src/app/state/vault/keychain_sign.rs
+++ b/coincube-gui/src/app/state/vault/keychain_sign.rs
@@ -893,18 +893,29 @@ impl KeychainSignModal {
         // We prune a *clone* and merge the returned signatures back into the
         // full `tx.psbt`, so the stored PSBT keeps all its derivations — this
         // mirrors the hardware-wallet (BitBox02) handling in `sign_psbt`.
-        let psbt_to_sign = self
+        let psbt_to_sign = match self
             .wallet
             .main_descriptor
             .prune_bip32_derivs_last_avail(self.psbt.clone())
-            .unwrap_or_else(|e| {
+        {
+            Ok(psbt) => psbt,
+            Err(e) => {
+                // Never fall back to sending the unpruned PSBT: the remote
+                // signer could then sign a key from the wrong spending path,
+                // producing a signature that can't satisfy this spend. Abort the
+                // session (mark it Failed for retry) instead.
                 tracing::warn!(
                     target: "coincube_gui::signing",
                     error = %e,
-                    "Could not prune PSBT to the spending path; sending unpruned"
+                    "Could not prune PSBT to the spending path; aborting signing session"
                 );
-                self.psbt.clone()
-            });
+                if let Some(entry) = self.pending.get_mut(index) {
+                    entry.status = PendingSessionStatus::Failed;
+                    entry.error = Some(format!("Could not prepare PSBT for signing: {e}"));
+                }
+                return Task::none();
+            }
+        };
         let psbt_bytes = psbt_to_sign.serialize();
         let vault_id = self.vault_id.unwrap_or(0).to_string();
         let descriptor_id = self.descriptor_id.clone();
@@ -2370,7 +2381,10 @@ mod tests {
             let _ = modal.poll_pending_sessions();
             assert!(
                 !modal.pending[0].signed_psbt_fetching,
-                "captured/given-up session ({status:?}, merged={merged}, persisted={persisted}) must not poll"
+                "captured/given-up session ({:?}, merged={}, persisted={}) must not poll",
+                status,
+                merged,
+                persisted
             );
         }
     }

--- a/coincube-gui/src/app/state/vault/keychain_sign.rs
+++ b/coincube-gui/src/app/state/vault/keychain_sign.rs
@@ -1052,14 +1052,20 @@ impl KeychainSignModal {
             EventType::SessionApproved => entry.status = PendingSessionStatus::Approved,
             EventType::SignatureSubmitted => {
                 entry.status = PendingSessionStatus::PartiallySigned;
-                if !entry.signed_psbt_fetching && !entry.signed_psbt_persisted {
+                if !entry.signed_psbt_fetching
+                    && !entry.signed_psbt_merged
+                    && !entry.signed_psbt_persisted
+                {
                     entry.signed_psbt_fetching = true;
                     fetch_session_id = Some(event.session_id.clone());
                 }
             }
             EventType::SessionCompleted => {
                 entry.status = PendingSessionStatus::Completed;
-                if !entry.signed_psbt_fetching && !entry.signed_psbt_persisted {
+                if !entry.signed_psbt_fetching
+                    && !entry.signed_psbt_merged
+                    && !entry.signed_psbt_persisted
+                {
                     entry.signed_psbt_fetching = true;
                     fetch_session_id = Some(event.session_id.clone());
                 }
@@ -1290,11 +1296,13 @@ impl KeychainSignModal {
             // Skip sessions that are finished, cancelled by the user (cancel
             // RPC may still be in flight, so status isn't `Cancelled` yet),
             // not yet created, already being fetched (event path or a
-            // previous tick), or already captured.
+            // previous tick), already merged (persist may still be in flight),
+            // or already captured.
             if entry.status.is_terminal()
                 || entry.cancel_requested
                 || entry.session_id.is_empty()
                 || entry.signed_psbt_fetching
+                || entry.signed_psbt_merged
                 || entry.signed_psbt_persisted
             {
                 continue;
@@ -1540,11 +1548,17 @@ impl Modal for KeychainSignModal {
         // Poll pending signing sessions as a fallback for realtime
         // `SessionEvent`s that never arrive (gRPC stream flapping/superseded,
         // vault-scope mismatch, …). Active only while we have at least one
-        // non-terminal session whose signature hasn't yet been captured —
-        // so it self-stops once everyone has signed (or the flow ends).
+        // non-terminal session whose signature hasn't yet been fetched — once
+        // merged we're waiting on the local persist, not the remote, so a
+        // merged-but-not-yet-persisted row must not keep polling (it would
+        // re-fetch and re-persist the same signature). It self-stops once
+        // everyone has signed (or the flow ends).
         let needs_poll = matches!(self.phase, Phase::Sessions)
             && self.pending.iter().any(|p| {
-                !p.status.is_terminal() && !p.signed_psbt_persisted && !p.session_id.is_empty()
+                !p.status.is_terminal()
+                    && !p.signed_psbt_merged
+                    && !p.signed_psbt_persisted
+                    && !p.session_id.is_empty()
             });
         if needs_poll {
             iced::time::every(std::time::Duration::from_secs(SESSION_POLL_INTERVAL_SECS))
@@ -2168,6 +2182,32 @@ mod tests {
         modal.pending[0].status = PendingSessionStatus::Completed;
         modal.pending[0].signed_psbt_persisted = true;
         assert!(!modal.has_persistence_pending());
+    }
+
+    #[test]
+    fn poll_does_not_refetch_a_merged_but_unpersisted_row() {
+        // A non-terminal row whose signature is already merged (persist still
+        // in flight) must not be re-fetched — doing so would run a second
+        // GetSigningSession + update_spend_tx for the same session. The network
+        // work in `poll_pending_sessions` is lazy, so calling it here only
+        // exercises the synchronous skip/mark logic.
+        let mut modal = modal();
+        modal
+            .pending
+            .push(pending(PendingSessionStatus::PartiallySigned));
+
+        // Baseline: an un-merged, non-terminal row *is* polled (marks fetching).
+        let _ = modal.poll_pending_sessions();
+        assert!(modal.pending[0].signed_psbt_fetching);
+
+        // Merged-but-unpersisted: reset the fetch flag and confirm poll skips it.
+        modal.pending[0].signed_psbt_fetching = false;
+        modal.pending[0].signed_psbt_merged = true;
+        let _ = modal.poll_pending_sessions();
+        assert!(
+            !modal.pending[0].signed_psbt_fetching,
+            "merged row must not be re-fetched by a poll tick"
+        );
     }
 
     #[test]

--- a/coincube-gui/src/app/state/vault/keychain_sign.rs
+++ b/coincube-gui/src/app/state/vault/keychain_sign.rs
@@ -2382,9 +2382,7 @@ mod tests {
             assert!(
                 !modal.pending[0].signed_psbt_fetching,
                 "captured/given-up session ({:?}, merged={}, persisted={}) must not poll",
-                status,
-                merged,
-                persisted
+                status, merged, persisted
             );
         }
     }

--- a/coincube-gui/src/app/state/vault/keychain_sign.rs
+++ b/coincube-gui/src/app/state/vault/keychain_sign.rs
@@ -121,6 +121,13 @@ pub struct PendingSession {
     /// `SIGNATURE_SUBMITTED` and `SESSION_COMPLETED` can both ask for the
     /// signed PSBT; this prevents duplicate fetch/persist races.
     pub signed_psbt_fetching: bool,
+    /// True once this session's signed PSBT has been merged into the local
+    /// `SpendTx` in memory, until that merge is durably persisted
+    /// (`signed_psbt_persisted`). While set-but-not-persisted the picker must
+    /// not close on threshold: the daemon lacks the signature it would
+    /// broadcast, and a persist failure needs the row to stay visible so it
+    /// can be marked Failed and retried. Reset on retry.
+    pub signed_psbt_merged: bool,
 }
 
 /// View-friendly mirror of the gRPC `SessionStatus` enum, plus a
@@ -477,6 +484,18 @@ impl KeychainSignModal {
                 .all(|p| p.status.is_terminal_success() && p.signed_psbt_persisted)
     }
 
+    /// True while any pending session has its signed PSBT merged into the
+    /// local `SpendTx` but not yet durably persisted — persist in flight *or*
+    /// a persist that failed. Threshold-based modal teardown must wait for
+    /// these: closing on the in-memory merge alone would drop the modal (and
+    /// the daemon would lack a signature it needs to broadcast) before a
+    /// persist failure could mark the row Failed for retry.
+    pub fn has_persistence_pending(&self) -> bool {
+        self.pending
+            .iter()
+            .any(|p| p.signed_psbt_merged && !p.signed_psbt_persisted)
+    }
+
     /// True while any pending session is non-terminal. After
     /// `cancel_all()`, such entries still depend on the modal staying
     /// mounted: empty-`session_id` rows are cancelled later by
@@ -786,6 +805,7 @@ impl KeychainSignModal {
                 cancel_requested: false,
                 signed_psbt_persisted: false,
                 signed_psbt_fetching: false,
+                signed_psbt_merged: false,
             });
         }
 
@@ -815,6 +835,7 @@ impl KeychainSignModal {
         entry.cancel_requested = false;
         entry.signed_psbt_persisted = false;
         entry.signed_psbt_fetching = false;
+        entry.signed_psbt_merged = false;
 
         let psbt_bytes = self.psbt.serialize();
         let vault_id = self.vault_id.unwrap_or(0).to_string();
@@ -1091,14 +1112,15 @@ impl KeychainSignModal {
             // `Persisted { Ok }` arm performs this transition instead.
             self.phase = Phase::AllDone;
         }
-        // Any status change reconciles the panel: the sole recompute/close
-        // authority lives in the panel's `Message::Updated(Ok)` arm, so
-        // re-emit it on every event — even when this one started no fetch
-        // (e.g. it raced a poll that already holds the fetch) and not all
-        // sessions are done yet. Without this a merged signature can sit
-        // uncounted (badge stuck below threshold, modal never closing) until
-        // some unrelated message happens to trigger a reconcile.
-        Task::done(Message::Updated(Ok(())))
+        // Any status change reconciles the panel: the recompute/close
+        // authority lives in `PsbtState`, so emit a UI-only `Reconcile` on
+        // every event — even when this one started no fetch (e.g. it raced a
+        // poll that already holds the fetch) and not all sessions are done yet.
+        // Without this a merged signature can sit uncounted (badge stuck below
+        // threshold, modal never closing) until some unrelated message happens
+        // to trigger a reconcile. `Reconcile` (not `Updated(Ok)`) because no
+        // save occurred here — persist success is signalled by `Persisted`.
+        Task::done(Message::Reconcile)
     }
 
     /// Merge the signed PSBT returned by `GetSigningSession` into the
@@ -1220,6 +1242,11 @@ impl KeychainSignModal {
             "Merging signed PSBT from session into local SpendTx"
         );
         super::psbt::merge_signatures_pub(&mut tx.psbt, &signed_psbt);
+        // Mark the row merged-but-not-yet-persisted so threshold-close waits
+        // for the persist (or its failure) below.
+        if let Some(entry) = self.pending.iter_mut().find(|p| p.session_id == session_id) {
+            entry.signed_psbt_merged = true;
+        }
         // Persist the merged PSBT so a restart picks it up. Carry the
         // session_id through so a persistence failure marks the right
         // row instead of being silently swallowed by the panel's
@@ -1242,9 +1269,11 @@ impl KeychainSignModal {
         );
         // The signature is already merged into `tx.psbt`; reconcile the panel's
         // count/badge/close decision now rather than waiting on the persist
-        // round-trip (`Persisted { Ok }` also re-emits this, but a slow or
-        // failed persist must not strand a merged signature uncounted).
-        Task::batch([persist, Task::done(Message::Updated(Ok(())))])
+        // round-trip (`Persisted { Ok }` re-emits `Updated(Ok)` on real save
+        // success). `Reconcile` is UI-only — it must not mark the tx saved,
+        // since this persist may still fail — but it must not strand a merged
+        // signature uncounted either.
+        Task::batch([persist, Task::done(Message::Reconcile)])
     }
 
     /// Poll `GetSigningSession` for every live, identified pending signer.
@@ -1999,6 +2028,7 @@ mod tests {
             cancel_requested: false,
             signed_psbt_persisted: false,
             signed_psbt_fetching: false,
+            signed_psbt_merged: false,
         }
     }
 
@@ -2115,6 +2145,29 @@ mod tests {
         modal.pending[0].signed_psbt_persisted = false;
         let _ = modal.close_if_dismissed_and_drained();
         assert!(matches!(modal.phase, Phase::AllDone));
+    }
+
+    #[test]
+    fn persistence_pending_tracks_merged_but_unsaved_rows() {
+        let mut modal = modal();
+        modal.pending.push(pending(PendingSessionStatus::Completed));
+
+        // Terminal-success alone is not persistence-pending: nothing merged.
+        assert!(!modal.has_persistence_pending());
+
+        // Merged but not yet persisted — threshold close must wait.
+        modal.pending[0].signed_psbt_merged = true;
+        assert!(modal.has_persistence_pending());
+
+        // A persist that *failed* still leaves the sig unsaved: keep blocking
+        // so the row can be marked Failed rather than closing the modal.
+        modal.pending[0].status = PendingSessionStatus::Failed;
+        assert!(modal.has_persistence_pending());
+
+        // Once durably persisted, no longer pending.
+        modal.pending[0].status = PendingSessionStatus::Completed;
+        modal.pending[0].signed_psbt_persisted = true;
+        assert!(!modal.has_persistence_pending());
     }
 
     #[test]

--- a/coincube-gui/src/app/state/vault/keychain_sign.rs
+++ b/coincube-gui/src/app/state/vault/keychain_sign.rs
@@ -128,6 +128,24 @@ pub struct PendingSession {
     /// broadcast, and a persist failure needs the row to stay visible so it
     /// can be marked Failed and retried. Reset on retry.
     pub signed_psbt_merged: bool,
+    /// True while this session's `update_spend_tx` persist callback is
+    /// in flight — set when the persist is dispatched, cleared when it
+    /// returns (Ok *or* Err). Distinct from `signed_psbt_merged`: a failed
+    /// persist stays "merged but unsaved" (blocking threshold teardown) yet is
+    /// no longer "in flight", so manual dismissal — which only waits for active
+    /// persistence — can proceed instead of hanging on the failed row.
+    pub signed_psbt_persisting: bool,
+}
+
+impl PendingSession {
+    /// True once this session's signed PSBT has been merged into the local
+    /// `SpendTx` (in memory) or durably persisted. The retry gates stop
+    /// fetching a session only once its signature is captured — reaching
+    /// `Completed` status alone is not enough, since the fetch+merge can lag
+    /// (or miss) the `SESSION_COMPLETED` event.
+    fn signature_captured(&self) -> bool {
+        self.signed_psbt_merged || self.signed_psbt_persisted
+    }
 }
 
 /// View-friendly mirror of the gRPC `SessionStatus` enum, plus a
@@ -168,6 +186,18 @@ impl PendingSessionStatus {
 
     pub fn is_terminal_success(&self) -> bool {
         matches!(self, Self::Completed)
+    }
+
+    /// True only for the *give-up* terminal states — the session failed or was
+    /// abandoned and its signature will never arrive. Distinct from
+    /// `is_terminal()`, which also counts `Completed`: a `Completed` session
+    /// whose signed PSBT hasn't been fetched+merged yet must keep being
+    /// retried, so fetch/poll retry gates key off this, not `is_terminal()`.
+    pub fn is_give_up(&self) -> bool {
+        matches!(
+            self,
+            Self::Rejected | Self::Cancelled | Self::Expired | Self::Failed
+        )
     }
 
     pub fn from_proto(status: ProtoSessionStatus) -> Self {
@@ -496,6 +526,15 @@ impl KeychainSignModal {
             .any(|p| p.signed_psbt_merged && !p.signed_psbt_persisted)
     }
 
+    /// True while any pending session's `update_spend_tx` persist callback is
+    /// still in flight (dispatched, not yet returned). Manual dismissal keeps
+    /// the hidden modal mounted while this holds so the callback can land and
+    /// mark the row Failed on error. Unlike `has_persistence_pending`, a persist
+    /// that already *failed* is not in flight, so dismissal doesn't hang on it.
+    pub fn has_persistence_in_flight(&self) -> bool {
+        self.pending.iter().any(|p| p.signed_psbt_persisting)
+    }
+
     /// True while any pending session is non-terminal. After
     /// `cancel_all()`, such entries still depend on the modal staying
     /// mounted: empty-`session_id` rows are cancelled later by
@@ -523,7 +562,12 @@ impl KeychainSignModal {
     /// existing `Phase::AllDone` + `Message::Updated(Ok)` close path
     /// that the panel already drives `self.modal = None` from.
     fn close_if_dismissed_and_drained(&mut self) -> Task<Message> {
+        // A merged row is terminal-by-status (Completed) while its persist
+        // callback is still in flight — don't tear down until it returns, so a
+        // `Persisted(Err)` can still mark the row Failed.
+        let persisting = self.has_persistence_in_flight();
         if self.dismissed
+            && !persisting
             && !self.pending.is_empty()
             && self
                 .pending
@@ -806,6 +850,7 @@ impl KeychainSignModal {
                 signed_psbt_persisted: false,
                 signed_psbt_fetching: false,
                 signed_psbt_merged: false,
+                signed_psbt_persisting: false,
             });
         }
 
@@ -836,8 +881,31 @@ impl KeychainSignModal {
         entry.signed_psbt_persisted = false;
         entry.signed_psbt_fetching = false;
         entry.signed_psbt_merged = false;
+        entry.signed_psbt_persisting = false;
 
-        let psbt_bytes = self.psbt.serialize();
+        // Prune the PSBT's BIP32 derivations to the active spending path before
+        // sending it to the remote signer. The Keychain signs a single key at a
+        // time; if the PSBT advertises this signer's fingerprint on more than
+        // one spending path (e.g. both the primary `multi(...)` key at `/0;1/*`
+        // and the recovery `pkh(...)` key at `/2;3/*`), the phone can sign the
+        // wrong-path key, which then cannot satisfy the path this transaction
+        // actually spends. Pruning leaves only the keys for the current path.
+        // We prune a *clone* and merge the returned signatures back into the
+        // full `tx.psbt`, so the stored PSBT keeps all its derivations — this
+        // mirrors the hardware-wallet (BitBox02) handling in `sign_psbt`.
+        let psbt_to_sign = self
+            .wallet
+            .main_descriptor
+            .prune_bip32_derivs_last_avail(self.psbt.clone())
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    target: "coincube_gui::signing",
+                    error = %e,
+                    "Could not prune PSBT to the spending path; sending unpruned"
+                );
+                self.psbt.clone()
+            });
+        let psbt_bytes = psbt_to_sign.serialize();
         let vault_id = self.vault_id.unwrap_or(0).to_string();
         let descriptor_id = self.descriptor_id.clone();
         let tokens = self.tokens.clone();
@@ -1069,6 +1137,10 @@ impl KeychainSignModal {
                     entry.signed_psbt_fetching = true;
                     fetch_session_id = Some(event.session_id.clone());
                 }
+                // If the fetch is skipped here (already fetching/merged/
+                // persisted) and the in-flight fetch never lands the signature,
+                // the poll fallback re-fetches this `Completed` row until it is
+                // captured.
             }
             EventType::SessionRejected => {
                 entry.status = PendingSessionStatus::Rejected;
@@ -1155,12 +1227,12 @@ impl KeychainSignModal {
         let resp = match result {
             Ok(r) => r,
             Err(e) => {
-                if e.auth {
-                    self.error = Some(e.message);
-                    self.phase = Phase::AllDone;
-                    return Task::none();
-                }
                 if let Some(entry) = self.pending.iter_mut().find(|p| p.session_id == session_id) {
+                    // Always clear the in-flight flag — otherwise the poll/
+                    // event fetch guards keep skipping this row and it can
+                    // never be retried. (Auth errors are no exception: a stale
+                    // token clears on the next attempt via the interceptor, and
+                    // one row's failure must not force-close the whole modal.)
                     entry.signed_psbt_fetching = false;
                     // A transient failure on a background *poll* must not
                     // fail the session — the realtime event or the next
@@ -1248,10 +1320,12 @@ impl KeychainSignModal {
             "Merging signed PSBT from session into local SpendTx"
         );
         super::psbt::merge_signatures_pub(&mut tx.psbt, &signed_psbt);
-        // Mark the row merged-but-not-yet-persisted so threshold-close waits
-        // for the persist (or its failure) below.
+        // Mark the row merged-but-not-yet-persisted (blocks threshold close
+        // until saved or retried) and persist-in-flight (keeps a dismissed
+        // modal mounted until the callback below returns).
         if let Some(entry) = self.pending.iter_mut().find(|p| p.session_id == session_id) {
             entry.signed_psbt_merged = true;
+            entry.signed_psbt_persisting = true;
         }
         // Persist the merged PSBT so a restart picks it up. Carry the
         // session_id through so a persistence failure marks the right
@@ -1293,17 +1367,19 @@ impl KeychainSignModal {
         let desktop_device_id = self.desktop_device_id.clone();
         let mut tasks = Vec::new();
         for entry in self.pending.iter_mut() {
-            // Skip sessions that are finished, cancelled by the user (cancel
-            // RPC may still be in flight, so status isn't `Cancelled` yet),
-            // not yet created, already being fetched (event path or a
-            // previous tick), already merged (persist may still be in flight),
-            // or already captured.
-            if entry.status.is_terminal()
+            // Skip sessions that gave up (rejected/cancelled/expired/failed),
+            // were cancelled by the user (cancel RPC may still be in flight, so
+            // status isn't `Cancelled` yet), not yet created, already being
+            // fetched (event path or a previous tick), already merged (persist
+            // may still be in flight), or already captured. NOTE: `Completed`
+            // is deliberately NOT a skip — a `Completed` session whose signed
+            // PSBT hasn't been fetched+merged yet must keep being polled until
+            // its signature actually lands (`is_give_up`, not `is_terminal`).
+            if entry.status.is_give_up()
                 || entry.cancel_requested
                 || entry.session_id.is_empty()
                 || entry.signed_psbt_fetching
-                || entry.signed_psbt_merged
-                || entry.signed_psbt_persisted
+                || entry.signature_captured()
             {
                 continue;
             }
@@ -1495,6 +1571,7 @@ impl KeychainSignModal {
                             self.pending.iter_mut().find(|p| p.session_id == session_id)
                         {
                             entry.signed_psbt_persisted = true;
+                            entry.signed_psbt_persisting = false;
                         }
                         if self.check_all_done() {
                             self.phase = Phase::AllDone;
@@ -1514,6 +1591,11 @@ impl KeychainSignModal {
                         {
                             entry.status = PendingSessionStatus::Failed;
                             entry.signed_psbt_fetching = false;
+                            // Persist callback returned — no longer in flight.
+                            // `signed_psbt_merged` stays set so threshold close
+                            // remains blocked (row is Failed, awaiting retry),
+                            // but dismissal need not wait on it any longer.
+                            entry.signed_psbt_persisting = false;
                             entry.error = Some(format!("Failed to persist signed PSBT: {}", e));
                         }
                     }
@@ -1547,18 +1629,16 @@ impl Modal for KeychainSignModal {
     fn subscription(&self) -> Subscription<Message> {
         // Poll pending signing sessions as a fallback for realtime
         // `SessionEvent`s that never arrive (gRPC stream flapping/superseded,
-        // vault-scope mismatch, …). Active only while we have at least one
-        // non-terminal session whose signature hasn't yet been fetched — once
-        // merged we're waiting on the local persist, not the remote, so a
-        // merged-but-not-yet-persisted row must not keep polling (it would
-        // re-fetch and re-persist the same signature). It self-stops once
-        // everyone has signed (or the flow ends).
+        // vault-scope mismatch, …), or that announce `SESSION_COMPLETED` before
+        // the signed PSBT was actually fetched+merged. Active while any session
+        // hasn't given up (rejected/cancelled/expired/failed) and its signature
+        // isn't captured yet — `Completed` alone does NOT stop it, otherwise a
+        // completed-but-unfetched signature would be stranded with no retry.
+        // Once captured we wait on the local persist, not the remote, so a
+        // merged row stops polling. It self-stops once everyone has signed.
         let needs_poll = matches!(self.phase, Phase::Sessions)
             && self.pending.iter().any(|p| {
-                !p.status.is_terminal()
-                    && !p.signed_psbt_merged
-                    && !p.signed_psbt_persisted
-                    && !p.session_id.is_empty()
+                !p.status.is_give_up() && !p.signature_captured() && !p.session_id.is_empty()
             });
         if needs_poll {
             iced::time::every(std::time::Duration::from_secs(SESSION_POLL_INTERVAL_SECS))
@@ -2043,6 +2123,7 @@ mod tests {
             signed_psbt_persisted: false,
             signed_psbt_fetching: false,
             signed_psbt_merged: false,
+            signed_psbt_persisting: false,
         }
     }
 
@@ -2185,6 +2266,47 @@ mod tests {
     }
 
     #[test]
+    fn dismissal_waits_for_in_flight_persist_then_closes_on_persisted_err() {
+        // Cancel during persistence, followed by Persisted(Err): the dismissed
+        // modal must stay mounted until the persist callback returns, so the
+        // failure can mark the row Failed instead of landing on a dropped modal.
+        let mut modal = modal();
+        modal.pending.push(pending(PendingSessionStatus::Completed));
+        // Signature merged; `update_spend_tx` dispatched, callback not back yet
+        // (the state `on_session_fetched` leaves behind).
+        modal.pending[0].signed_psbt_merged = true;
+        modal.pending[0].signed_psbt_persisting = true;
+
+        // Both gates hold while the persist is in flight.
+        assert!(modal.has_persistence_in_flight());
+        assert!(modal.has_persistence_pending());
+
+        // User cancels/dismisses. `close_if_dismissed_and_drained` (the update
+        // choke point) must NOT tear down while the callback is outstanding,
+        // even though the row's status (Completed) is terminal.
+        modal.mark_dismissed();
+        let _ = modal.close_if_dismissed_and_drained();
+        assert!(
+            !matches!(modal.phase, Phase::AllDone),
+            "dismissed modal must wait for the in-flight persist callback"
+        );
+
+        // Persisted(Err) lands: row Failed, no longer in flight, but still
+        // merged-but-unsaved (so threshold teardown would stay blocked).
+        modal.pending[0].status = PendingSessionStatus::Failed;
+        modal.pending[0].signed_psbt_persisting = false;
+        assert!(!modal.has_persistence_in_flight());
+        assert!(
+            modal.has_persistence_pending(),
+            "a failed persist still blocks threshold teardown until retry"
+        );
+
+        // With the callback resolved, the dismissed modal can finally drain.
+        let _ = modal.close_if_dismissed_and_drained();
+        assert!(matches!(modal.phase, Phase::AllDone));
+    }
+
+    #[test]
     fn poll_does_not_refetch_a_merged_but_unpersisted_row() {
         // A non-terminal row whose signature is already merged (persist still
         // in flight) must not be re-fetched — doing so would run a second
@@ -2208,6 +2330,49 @@ mod tests {
             !modal.pending[0].signed_psbt_fetching,
             "merged row must not be re-fetched by a poll tick"
         );
+    }
+
+    #[test]
+    fn poll_retries_a_completed_but_uncaptured_session() {
+        // The core regression: a session that reached `Completed` (e.g. the
+        // stream event landed before the signed PSBT was fetched) but whose
+        // signature is NOT captured must keep being polled — `Completed` is
+        // terminal, but retries key off `is_give_up`/`signature_captured`, not
+        // `is_terminal`. Without this the signature is stranded forever.
+        let mut modal = modal();
+        modal.pending.push(pending(PendingSessionStatus::Completed));
+        // session_id is set by `pending()`, no capture flags, not fetching.
+        assert!(!modal.pending[0].signature_captured());
+
+        let _ = modal.poll_pending_sessions();
+        assert!(
+            modal.pending[0].signed_psbt_fetching,
+            "a Completed-but-uncaptured session must be re-fetched by the poll"
+        );
+    }
+
+    #[test]
+    fn poll_skips_captured_and_given_up_sessions() {
+        // Captured (merged OR persisted) and give-up terminals must NOT poll.
+        for (status, merged, persisted) in [
+            (PendingSessionStatus::Completed, true, false), // merged
+            (PendingSessionStatus::Completed, false, true), // persisted
+            (PendingSessionStatus::Failed, false, false),
+            (PendingSessionStatus::Rejected, false, false),
+            (PendingSessionStatus::Cancelled, false, false),
+            (PendingSessionStatus::Expired, false, false),
+        ] {
+            let mut modal = modal();
+            modal.pending.push(pending(status));
+            modal.pending[0].signed_psbt_merged = merged;
+            modal.pending[0].signed_psbt_persisted = persisted;
+
+            let _ = modal.poll_pending_sessions();
+            assert!(
+                !modal.pending[0].signed_psbt_fetching,
+                "captured/given-up session ({status:?}, merged={merged}, persisted={persisted}) must not poll"
+            );
+        }
     }
 
     #[test]

--- a/coincube-gui/src/app/state/vault/keychain_sign.rs
+++ b/coincube-gui/src/app/state/vault/keychain_sign.rs
@@ -1090,13 +1090,15 @@ impl KeychainSignModal {
             // fetch+merge — `check_all_done` is still false here and the
             // `Persisted { Ok }` arm performs this transition instead.
             self.phase = Phase::AllDone;
-            // `SessionCompleted` produces no follow-up message on its
-            // own, and the panel's `Message::Updated(Ok)` arm is the
-            // sole place that closes this modal — so without this
-            // re-emit the modal would stay stuck on "Closing…".
-            return Task::done(Message::Updated(Ok(())));
         }
-        Task::none()
+        // Any status change reconciles the panel: the sole recompute/close
+        // authority lives in the panel's `Message::Updated(Ok)` arm, so
+        // re-emit it on every event — even when this one started no fetch
+        // (e.g. it raced a poll that already holds the fetch) and not all
+        // sessions are done yet. Without this a merged signature can sit
+        // uncounted (badge stuck below threshold, modal never closing) until
+        // some unrelated message happens to trigger a reconcile.
+        Task::done(Message::Updated(Ok(())))
     }
 
     /// Merge the signed PSBT returned by `GetSigningSession` into the
@@ -1224,7 +1226,7 @@ impl KeychainSignModal {
         // generic `Message::Updated(Err)` path.
         let merged = tx.psbt.clone();
         let daemon = daemon.clone();
-        Task::perform(
+        let persist = Task::perform(
             async move {
                 daemon
                     .update_spend_tx(&merged)
@@ -1237,7 +1239,12 @@ impl KeychainSignModal {
                     result,
                 })
             },
-        )
+        );
+        // The signature is already merged into `tx.psbt`; reconcile the panel's
+        // count/badge/close decision now rather than waiting on the persist
+        // round-trip (`Persisted { Ok }` also re-emits this, but a slow or
+        // failed persist must not strand a merged signature uncounted).
+        Task::batch([persist, Task::done(Message::Updated(Ok(())))])
     }
 
     /// Poll `GetSigningSession` for every live, identified pending signer.

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -154,7 +154,14 @@ impl PsbtState {
         let close = match self.modal.as_mut() {
             Some(PsbtModal::Sign(sign)) => {
                 sign.set_counted_signers(counted);
-                self.tx.path_ready().is_some() || sign.should_close_after_dismiss()
+                // Threshold close waits for any Keychain signature that is
+                // merged in memory but not yet durably persisted — otherwise a
+                // slow or failing persist would tear the picker down before the
+                // daemon holds the signature it must broadcast (and before the
+                // failing row could be marked Failed). Dismissal-driven close
+                // has its own drain gate and is unaffected.
+                (self.tx.path_ready().is_some() && !sign.keychain_persistence_pending())
+                    || sign.should_close_after_dismiss()
             }
             _ => false,
         };
@@ -405,6 +412,14 @@ impl PsbtState {
                         return Task::done(Message::View(view::Message::ShowError(err_msg)));
                     }
                 };
+            }
+            Message::Reconcile => {
+                // UI-only: recompute collected signatures and maybe close the
+                // picker after an in-memory merge. Unlike `Updated(Ok)` this
+                // does NOT set `saved` — the persist may still be in flight or
+                // may fail, and marking the tx saved here would wrongly enable
+                // Export/Delete on a never-persisted spend.
+                return self.reconcile_and_maybe_close();
             }
             Message::Updated(Ok(_)) => {
                 self.saved = true;
@@ -1111,6 +1126,16 @@ impl SignModal {
         self.signed = counted;
     }
 
+    /// True while the nested Keychain flow has a signature merged into the
+    /// PSBT but not yet durably persisted. The picker must not close on
+    /// threshold until this resolves, so a persist failure can mark the row
+    /// Failed instead of tearing the modal down on an unsaved signature.
+    pub fn keychain_persistence_pending(&self) -> bool {
+        self.keychain
+            .as_ref()
+            .is_some_and(|k| k.has_persistence_pending())
+    }
+
     /// Best-effort cancel of any keychain sessions still in flight, used when
     /// the picker is about to close because the threshold was met so those
     /// sessions don't outlive it server-side.
@@ -1233,18 +1258,17 @@ impl SignModal {
                     .iter()
                     .enumerate()
                     .find(|(_, p)| p.fingerprint == fp)
-                    .map(|(i, p)| {
-                        (
-                            i,
-                            p.status,
-                            p.status.is_terminal_success() && p.signed_psbt_persisted,
-                        )
-                    })
+                    .map(|(i, p)| (i, p.status))
             });
         let kind = self.signing_key_kind(fp, master_fp, kc.is_some());
 
-        // Signature already collected (local or keychain).
-        if self.signed.contains(&fp) || kc.map(|(_, _, s)| s).unwrap_or(false) {
+        // Signature already collected. `self.signed` is the single source of
+        // truth — it mirrors the signers actually counted in the merged PSBT
+        // (refreshed by `set_counted_signers` on every reconcile), so the row
+        // and the "X of N collected" badge can't disagree. No persistence-based
+        // shortcut: a Keychain response only counts once its signature is merged
+        // and counted, which is exactly what puts the key into `self.signed`.
+        if self.signed.contains(&fp) {
             return (kind, St::Signed);
         }
         // Inactive spending path — nothing here can sign this transaction.
@@ -1298,7 +1322,7 @@ impl SignModal {
             }
         }
         // A Connect-resolved Keychain signer.
-        if let Some((idx, status, _)) = kc {
+        if let Some((idx, status)) = kc {
             return match status {
                 PendingSessionStatus::Idle => (Kind::Keychain, St::Available(Act::Keychain)),
                 PendingSessionStatus::Rejected

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -1094,9 +1094,10 @@ impl SignModal {
         };
         let cancel = k.cancel_all();
         // Keep the hidden modal mounted while sessions still need draining OR a
-        // persist callback is in flight — the latter so a `Persisted(Err)` can
-        // still mark its row Failed instead of landing on a dropped modal.
-        let keep = k.has_undrained_sessions() || k.has_persistence_in_flight();
+        // signed-PSBT capture (fetch or persist) is in flight — so a `Completed`
+        // session's fetch can still merge and a `Persisted(Err)` can still mark
+        // its row Failed instead of landing on a dropped modal.
+        let keep = k.has_undrained_sessions() || k.has_capture_in_flight();
         if keep {
             k.mark_dismissed();
             self.display_modal = false;
@@ -1105,14 +1106,14 @@ impl SignModal {
     }
 
     /// True once the picker was dismissed (hidden) and its keychain sessions
-    /// have all drained *and* no persist callback is still in flight — the
-    /// signal the panel uses to finally drop it.
+    /// have all drained *and* no signed-PSBT capture (fetch or persist) is still
+    /// in flight — the signal the panel uses to finally drop it.
     pub fn should_close_after_dismiss(&self) -> bool {
         !self.display_modal
             && self
                 .keychain
                 .as_ref()
-                .is_none_or(|k| !k.has_undrained_sessions() && !k.has_persistence_in_flight())
+                .is_none_or(|k| !k.has_undrained_sessions() && !k.has_capture_in_flight())
     }
 
     /// True when this picker offers Keychain signing but the nested flow
@@ -1272,13 +1273,20 @@ impl SignModal {
             });
         let kind = self.signing_key_kind(fp, master_fp, kc.is_some());
 
+        // A resolved Keychain session in a give-up state (rejected / expired /
+        // failed — including a *persist* failure) must fall through to the Retry
+        // branch below, even if its signature is transiently counted in
+        // `self.signed`. A failed `update_spend_tx` leaves the signature
+        // merged-but-unsaved, so rendering it Signed would hide the Retry
+        // affordance and overstate the durable "X of N collected" count.
+        let kc_needs_retry = matches!(kc, Some((_, status)) if status.is_give_up());
         // Signature already collected. `self.signed` is the single source of
         // truth — it mirrors the signers actually counted in the merged PSBT
         // (refreshed by `set_counted_signers` on every reconcile), so the row
         // and the "X of N collected" badge can't disagree. No persistence-based
         // shortcut: a Keychain response only counts once its signature is merged
         // and counted, which is exactly what puts the key into `self.signed`.
-        if self.signed.contains(&fp) {
+        if self.signed.contains(&fp) && !kc_needs_retry {
             return (kind, St::Signed);
         }
         // Inactive spending path — nothing here can sign this transaction.

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -1723,39 +1723,43 @@ async fn sign_psbt(
     hw: std::sync::Arc<dyn async_hwi::HWI + Send + Sync>,
     mut psbt: Psbt,
 ) -> Result<Psbt, Error> {
-    // The BitBox02 is only going to produce a signature for a single key in the Script. In order
-    // to make sure it doesn't sign for a public key from another spending path we remove the BIP32
-    // derivation for the other paths.
-    if matches!(hw.device_kind(), async_hwi::DeviceKind::BitBox02) {
-        // We need to make sure we don't prune the BIP32 derivations from the original PSBT (which
-        // would end up being updated in the daemon's database and erase the previously unpruned
-        // one). To this end we create a new, pruned, psbt we use for signing and then merge its
-        // signatures back into the original PSBT.
-        let mut pruned_psbt = wallet
-            .main_descriptor
-            .prune_bip32_derivs_last_avail(psbt.clone())
-            .map_err(Error::Desc)?;
-        hw.sign_tx(&mut pruned_psbt).await.map_err(Error::from)?;
-        for (i, psbt_in) in psbt.inputs.iter_mut().enumerate() {
-            if let Some(pruned_psbt_in) = pruned_psbt.inputs.get_mut(i) {
-                psbt_in
-                    .partial_sigs
-                    .append(&mut pruned_psbt_in.partial_sigs);
-                if let Some(tap_key_sig) = pruned_psbt_in.tap_key_sig {
-                    psbt_in.tap_key_sig = Some(tap_key_sig);
-                }
-                psbt_in
-                    .tap_script_sigs
-                    .append(&mut pruned_psbt_in.tap_script_sigs);
-            } else {
-                log::error!(
-                    "Not all PSBT inputs are present in the pruned psbt. Pruned psbt: '{}'.",
-                    &pruned_psbt
-                );
+    // Sign against a copy pruned to the active spending path. Some signers
+    // (e.g. the BitBox02) only produce a signature for a single key per Script,
+    // so an unpruned PSBT — in which a signer's key appears on more than one
+    // spending path (a primary `multi(...)` key and a recovery `pkh(...)` key) —
+    // can lead them to sign the wrong path's key, which then can't satisfy the
+    // path this transaction actually spends. Pruning removes the BIP32
+    // derivations for the inactive paths so every signer signs the right key(s).
+    // Applied to all devices, not just the BitBox02, so a future single-key
+    // signer is safe by construction; multi-key signers are unaffected (they
+    // just sign the active-path key instead of also signing an unused
+    // recovery-path key).
+    //
+    // We prune a *clone* and merge the returned signatures back into the
+    // original PSBT, so its full derivations are preserved in the daemon's
+    // stored copy.
+    let mut pruned_psbt = wallet
+        .main_descriptor
+        .prune_bip32_derivs_last_avail(psbt.clone())
+        .map_err(Error::Desc)?;
+    hw.sign_tx(&mut pruned_psbt).await.map_err(Error::from)?;
+    for (i, psbt_in) in psbt.inputs.iter_mut().enumerate() {
+        if let Some(pruned_psbt_in) = pruned_psbt.inputs.get_mut(i) {
+            psbt_in
+                .partial_sigs
+                .append(&mut pruned_psbt_in.partial_sigs);
+            if let Some(tap_key_sig) = pruned_psbt_in.tap_key_sig {
+                psbt_in.tap_key_sig = Some(tap_key_sig);
             }
+            psbt_in
+                .tap_script_sigs
+                .append(&mut pruned_psbt_in.tap_script_sigs);
+        } else {
+            log::error!(
+                "Not all PSBT inputs are present in the pruned psbt. Pruned psbt: '{}'.",
+                &pruned_psbt
+            );
         }
-    } else {
-        hw.sign_tx(&mut psbt).await.map_err(Error::from)?;
     }
     Ok(psbt)
 }

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -460,8 +460,14 @@ impl PsbtState {
                     } else {
                         self.tx.spend_amount
                     };
-                    let amount_display =
-                        display_amount.to_formatted_string_with_unit(cache.bitcoin_unit);
+                    // Include the unit label ("SATS" / "BTC") so the success
+                    // screen reads e.g. "149,794 SATS has been sent successfully"
+                    // rather than a bare number.
+                    let amount_display = format!(
+                        "{} {}",
+                        display_amount.to_formatted_string_with_unit(cache.bitcoin_unit),
+                        cache.bitcoin_unit.label(),
+                    );
                     self.modal = Some(PsbtModal::Broadcast(BroadcastModal {
                         conflicting_txids,
                         broadcast: false,
@@ -1087,7 +1093,10 @@ impl SignModal {
             return (Task::none(), false);
         };
         let cancel = k.cancel_all();
-        let keep = k.has_undrained_sessions();
+        // Keep the hidden modal mounted while sessions still need draining OR a
+        // persist callback is in flight — the latter so a `Persisted(Err)` can
+        // still mark its row Failed instead of landing on a dropped modal.
+        let keep = k.has_undrained_sessions() || k.has_persistence_in_flight();
         if keep {
             k.mark_dismissed();
             self.display_modal = false;
@@ -1096,13 +1105,14 @@ impl SignModal {
     }
 
     /// True once the picker was dismissed (hidden) and its keychain sessions
-    /// have all drained — the signal the panel uses to finally drop it.
+    /// have all drained *and* no persist callback is still in flight — the
+    /// signal the panel uses to finally drop it.
     pub fn should_close_after_dismiss(&self) -> bool {
         !self.display_modal
             && self
                 .keychain
                 .as_ref()
-                .is_none_or(|k| !k.has_undrained_sessions())
+                .is_none_or(|k| !k.has_undrained_sessions() && !k.has_persistence_in_flight())
     }
 
     /// True when this picker offers Keychain signing but the nested flow

--- a/coincube-gui/src/app/state/vault/psbt.rs
+++ b/coincube-gui/src/app/state/vault/psbt.rs
@@ -133,6 +133,45 @@ impl PsbtState {
         self.modal = None;
     }
 
+    /// Single authority for reflecting collected signatures. Recomputes
+    /// `tx.sigs` from the authoritative merged `tx.psbt`, refreshes the Sign
+    /// picker's per-key "Signed" set from the *counted* signers (so a row can
+    /// never show Signed without being counted), and closes the picker once a
+    /// spending path is satisfied (or it was dismissed and its Keychain
+    /// sessions drained). Idempotent — safe to call after every signature
+    /// merge, decoupled from the persist round-trip.
+    fn reconcile_and_maybe_close(&mut self) -> Task<Message> {
+        if let Ok(sigs) = self
+            .wallet
+            .main_descriptor
+            .partial_spend_info(&self.tx.psbt)
+        {
+            self.tx.sigs = sigs;
+        }
+        // Derive the picker's "Signed" indicator from the counted signers so
+        // the per-key rows and the "X of N collected" badge can't diverge.
+        let counted = self.tx.signers();
+        let close = match self.modal.as_mut() {
+            Some(PsbtModal::Sign(sign)) => {
+                sign.set_counted_signers(counted);
+                self.tx.path_ready().is_some() || sign.should_close_after_dismiss()
+            }
+            _ => false,
+        };
+        if close {
+            // Best-effort: cancel any Keychain sessions still in flight so they
+            // don't outlive the closed picker.
+            let extra = if let Some(PsbtModal::Sign(sign)) = self.modal.as_mut() {
+                sign.cancel_keychain_if_active()
+            } else {
+                Task::none()
+            };
+            self.modal = None;
+            return extra;
+        }
+        Task::none()
+    }
+
     pub fn subscription(&self) -> Subscription<Message> {
         if let Some(modal) = &self.modal {
             modal.as_ref().subscription()
@@ -370,45 +409,15 @@ impl PsbtState {
             Message::Updated(Ok(_)) => {
                 self.saved = true;
                 if let Some(modal) = self.modal.as_mut() {
+                    // Let the modal run its own side-effects (e.g. Keychain
+                    // bookkeeping), then reconcile the collected signatures and
+                    // decide whether to close. The recompute/close/close-after-
+                    // dismiss logic lives in `reconcile_and_maybe_close` so
+                    // every merge site (local sign, Keychain merge, dismissal
+                    // drain) drives the same idempotent path regardless of
+                    // persist ordering.
                     let cmd = modal.as_mut().update(daemon.clone(), message, &mut self.tx);
-                    // Recompute path_ready / sigs against the newly merged
-                    // PSBT so the close decision below — and the outer view's
-                    // Sign→Broadcast swap — reflect the just-added signature.
-                    // The signature may have come from a local device
-                    // (`SignModal`'s own Updated arm) or a Keychain session
-                    // (which re-emits `Updated(Ok)` through here after its
-                    // merge+persist), so recompute unconditionally.
-                    if let Ok(sigs) = self
-                        .wallet
-                        .main_descriptor
-                        .partial_spend_info(&self.tx.psbt)
-                    {
-                        self.tx.sigs = sigs;
-                    }
-                    // Close the unified picker only when the spending path
-                    // threshold is met, or when it was dismissed mid-flight
-                    // and its Keychain sessions have finished draining. A
-                    // single local/keychain signature that doesn't meet the
-                    // threshold keeps the picker open so more signers can be
-                    // added.
-                    let close = match modal {
-                        PsbtModal::Sign(sign) => {
-                            self.tx.path_ready().is_some() || sign.should_close_after_dismiss()
-                        }
-                        _ => false,
-                    };
-                    if close {
-                        // Best-effort: cancel any Keychain sessions still in
-                        // flight so they don't outlive the closed picker.
-                        let extra = if let PsbtModal::Sign(sign) = modal {
-                            sign.cancel_keychain_if_active()
-                        } else {
-                            Task::none()
-                        };
-                        self.modal = None;
-                        return Task::batch([cmd, extra]);
-                    }
-                    return cmd;
+                    return Task::batch([cmd, self.reconcile_and_maybe_close()]);
                 }
             }
             Message::BroadcastModal(res) => match res {
@@ -1094,6 +1103,14 @@ impl SignModal {
         self.keychain = keychain;
     }
 
+    /// Replace the per-key "Signed" set with the authoritative signers counted
+    /// from the merged PSBT (`SpendTx::signers()`). Called on every reconcile so
+    /// a row can only read Signed once its signature is actually counted — the
+    /// optimistic `signed.insert` on local-sign return is corrected here.
+    pub fn set_counted_signers(&mut self, counted: HashSet<Fingerprint>) {
+        self.signed = counted;
+    }
+
     /// Best-effort cancel of any keychain sessions still in flight, used when
     /// the picker is about to close because the threshold was met so those
     /// sessions don't outlive it server-side.
@@ -1505,9 +1522,18 @@ impl Modal for SignModal {
                         self.signed.insert(fingerprint);
                         let daemon = daemon.clone();
                         merge_signatures(&mut tx.psbt, &psbt);
+                        // Persist the *merged* PSBT (not the lone single-signer
+                        // result) so the daemon's stored copy always matches the
+                        // desktop's in-memory set. Otherwise a later re-read of
+                        // the tx from the daemon (list refresh / reopen) can
+                        // surface a partially-signed psbt and drop signatures
+                        // collected earlier in the same session.
+                        let merged = tx.psbt.clone();
                         if self.is_saved {
                             return Task::perform(
-                                async move { daemon.update_spend_tx(&psbt).await.map_err(|e| e.into()) },
+                                async move {
+                                    daemon.update_spend_tx(&merged).await.map_err(|e| e.into())
+                                },
                                 Message::Updated,
                             );
                         // If the spend transaction was never saved before, then both the psbt and
@@ -1521,7 +1547,7 @@ impl Modal for SignModal {
                             }
                             return Task::perform(
                                 async move {
-                                    daemon.update_spend_tx(&psbt).await?;
+                                    daemon.update_spend_tx(&merged).await?;
                                     daemon.update_labels(&labels).await.map_err(|e| e.into())
                                 },
                                 Message::Updated,
@@ -1817,6 +1843,70 @@ mod tests {
         };
         let (modal, _task) = build_keychain_if_ready(&ready, &wallet, &psbt);
         assert!(modal.is_some());
+    }
+
+    #[test]
+    fn counted_signers_drive_the_signed_row_state() {
+        use view::vault::psbt::SigningKeyState;
+
+        // Regression: a per-key row must read "Signed" only when its signature
+        // is actually counted (present in the merged PSBT / `tx.sigs`), never
+        // from an optimistic flag alone. `reconcile_and_maybe_close` feeds the
+        // counted set here via `set_counted_signers`.
+        let mut modal = SignModal::new(
+            HashSet::new(),
+            Arc::new(wallet()),
+            CoincubeDirectory::new(PathBuf::new()),
+            Network::Signet,
+            false,
+            None,
+            None,
+            false,
+        );
+
+        let signer = fingerprint("f714c228");
+        let other = fingerprint("2522f23c");
+
+        let primary_before = modal
+            .signing_paths()
+            .into_iter()
+            .find(|p| p.is_primary)
+            .unwrap();
+        let row_before = primary_before
+            .keys
+            .iter()
+            .find(|r| r.fingerprint == signer)
+            .expect("signer is a primary key");
+        assert!(
+            !matches!(row_before.state, SigningKeyState::Signed),
+            "uncounted key must not render as Signed"
+        );
+
+        modal.set_counted_signers(HashSet::from([signer]));
+
+        let primary_after = modal
+            .signing_paths()
+            .into_iter()
+            .find(|p| p.is_primary)
+            .unwrap();
+        let signer_row = primary_after
+            .keys
+            .iter()
+            .find(|r| r.fingerprint == signer)
+            .unwrap();
+        assert!(
+            matches!(signer_row.state, SigningKeyState::Signed),
+            "counted key must render as Signed"
+        );
+        let other_row = primary_after
+            .keys
+            .iter()
+            .find(|r| r.fingerprint == other)
+            .unwrap();
+        assert!(
+            !matches!(other_row.state, SigningKeyState::Signed),
+            "uncounted key must stay un-Signed"
+        );
     }
 
     #[tokio::test]

--- a/coincube-gui/src/app/state/vault/psbts.rs
+++ b/coincube-gui/src/app/state/vault/psbts.rs
@@ -86,6 +86,17 @@ impl State for PsbtsPanel {
                     self.wallet.apply_spend_tx_overrides(&mut txs);
                     self.spend_txs = txs;
                     if let Some(tx) = &self.selected_tx {
+                        // Never rebuild the open PSBT panel while a modal is up:
+                        // a `PsbtState::new` here resets `modal` to `None` and
+                        // replaces `tx.psbt` with the daemon's copy, dropping an
+                        // in-progress Sign session (and its in-flight Keychain
+                        // sessions) and re-exposing only the signatures persisted
+                        // so far. The signing flow keeps the merged psbt in
+                        // memory and persists it itself, so a refresh has nothing
+                        // to add here.
+                        if tx.modal.is_some() {
+                            return Task::none();
+                        }
                         if let Some(tx) = self.spend_txs.iter().find(|spend_tx| {
                             spend_tx.psbt.unsigned_tx.compute_txid()
                                 == tx.tx.psbt.unsigned_tx.compute_txid()
@@ -190,5 +201,66 @@ impl State for PsbtsPanel {
 impl From<PsbtsPanel> for Box<dyn State> {
     fn from(s: PsbtsPanel) -> Box<dyn State> {
         Box::new(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{daemon::client::Coincubed, utils::mock::Daemon as MockDaemon};
+    use coincube_core::{
+        descriptors::CoincubeDescriptor,
+        miniscript::bitcoin::{secp256k1::Secp256k1, Network, Psbt},
+    };
+    use std::str::FromStr;
+
+    const DESC: &str = "wsh(or_d(multi(2,[f714c228/48'/1'/0'/2']tpubDEwJnTwfKoMvu8AXXBPydBVWDpzNP5tatjjZ56q4TQioGL7iL9xzTbMoCCQ3tfGihtff7vtR4xsjcRuhZ7HWARVAkGZ1HZcpBhVdou76k7j/<0;1>/*,[2522f23c/48'/1'/0'/2']tpubDEoTU4bDW1EXN1rnLXnRfue1a7DeqjJcs39PkEeLcVXhVKzCnFo9yQX2EeeXJ6kh4hgbz5o9v7YAc1EE97AEJpJbKNmDxE3ZQo4msGPSp2J/<0;1>/*),and_v(v:thresh(1,pkh([f714c228/48'/1'/0'/2']tpubDEwJnTwfKoMvu8AXXBPydBVWDpzNP5tatjjZ56q4TQioGL7iL9xzTbMoCCQ3tfGihtff7vtR4xsjcRuhZ7HWARVAkGZ1HZcpBhVdou76k7j/<2;3>/*),a:pkh([2522f23c/48'/1'/0'/2']tpubDEoTU4bDW1EXN1rnLXnRfue1a7DeqjJcs39PkEeLcVXhVKzCnFo9yQX2EeeXJ6kh4hgbz5o9v7YAc1EE97AEJpJbKNmDxE3ZQo4msGPSp2J/<2;3>/*)),older(65535))))#9s8ekrce";
+
+    // Unsigned PSBT spending a Coincube coin under `DESC` (mirrors the fixture
+    // used by the psbt panel tests).
+    const UNSIGNED_PSBT: &str = "cHNidP8BAIkCAAAAAc0x/jtWvFugrl8zc34KVIlWCugXT6JNtgir6UqX+Vv6AQAAAAD9////AkBCDwAAAAAAIgAgtQu/fA/8rQhJ0I6wUoBDO0vNa3lgsEpEIj7rTOMnBcXuIEkBAAAAACIAIOdCiXh7yL2V/f6S6KMTOzgqKkqyIXgmFuwDnmXbIiosAAAAAAABAP04AQIAAAAAAQKYYriMs/PtSqm6LPNWWFYskTL6nWZegJdwxYcVCRn8vwEAAAAA/f///87D7dkdgMd1Laj/v6xspNRtrQXGP+8BPFMLqkeBb6MRAQAAAAD9////AuGQDgAAAAAAIlEg7DgdNxI7WybaPUZXcMCh+uN1E4X8E5DzJIlj83S+tIMQZFgBAAAAACIAIJZAn7j5iOen7xo2sKzjMc24llTZIuS+RpdwcLHtE6ufAUCksqYUJBbHB9x8eHdoRvRqiGzG4wQXpmY96vh14zAJEM2CS/oZaNVC4Wj8rY2cdjAvZj9dlVZFPbOxx9g5tFxUAUA24s2KJ7sjSHUAcUSd4yqRK/G3CZM8qhkhyHhGDSS0zZvZaIcgoqOPe23gH32wAI9Aax1gJUDv4kKOqOx64ltg9BADAAEBKxBkWAEAAAAAIgAglkCfuPmI56fvGjawrOMxzbiWVNki5L5Gl3Bwse0Tq58BBYZSIQIeYxzruE4/cvi6zbRmB1asJO0bMfUutoH0bpubw1zAZSEDLZSmORZKW/k5A+4QxJR2/H+vcV8U0WPX9SvS+MRMffNSrnNkdqkUmNf1mL657o/oxxnHkIrtdNkbge+IrGt2qRSIigBO15eaB9dj93ihNpAX9HHDuoisbJNRiAP//wCyaCIGAh5jHOu4Tj9y+LrNtGYHVqwk7Rsx9S62gfRum5vDXMBlHPcUwigwAACAAQAAgAAAAIACAACAAAAAAAAAAAAiBgIr7HqsyKEvERWQsmsv6FleMuXThpI77+TVkQ3TSOOLURz3FMIoMAAAgAEAAIAAAACAAgAAgAIAAAAAAAAAIgYDLZSmORZKW/k5A+4QxJR2/H+vcV8U0WPX9SvS+MRMffMcJSLyPDAAAIABAACAAAAAgAIAAIAAAAAAAAAAACIGA/h0pUXGHq1+kSuTYVTO8RHKfQLJlhfNtm+qdcIIr09jHCUi8jwwAACAAQAAgAAAAIACAACAAgAAAAAAAAAAIgICGAO/4xFiX/S5DXTV6uARFTcMwP1hto8BtPkdn3gIjf0c9xTCKDAAAIABAACAAAAAgAIAAIACAAAAAgAAACICAuNOSbsNRv31XkF2ygwCOuCnsJNRLhV0isJ/VRdj1k7IHPcUwigwAACAAQAAgAAAAIACAACAAAAAAAIAAAAiAgOpBJHEchNOeXuQwuLHlwOfkAyfoGvrYfb4pCFLKEPw2hwlIvI8MAAAgAEAAIAAAACAAgAAgAIAAAACAAAAIgIDyLkJiZTjLCysDOQotYs9us5CEYev4kyTYW2uL2r5H1McJSLyPDAAAIABAACAAAAAgAIAAIAAAAAAAgAAAAAiAgIlvGBvHRPmmVP6sn9g/akW2VJAvbJagMnZ/24gLdITsxz3FMIoMAAAgAEAAIAAAACAAgAAgAMAAAADAAAAIgIDNmVQOMMezQgABjk1zjfc3I2eKFJ4xLqT55jG4BP4p0Ec9xTCKDAAAIABAACAAAAAgAIAAIABAAAAAwAAACICA4Subm7T6yYCMWLgDtMy92hOgjanJefukbCOSVEHlX0IHCUi8jwwAACAAQAAgAAAAIACAACAAQAAAAMAAAAiAgPpsETw12nxLEM6OSOPfxp4YYj8NtRcLdqBpi3S4/BTuRwlIvI8MAAAgAEAAIAAAACAAgAAgAMAAAADAAAAAA==";
+
+    fn spend_tx() -> SpendTx {
+        let desc = CoincubeDescriptor::from_str(DESC).unwrap();
+        let psbt = Psbt::from_str(UNSIGNED_PSBT).unwrap();
+        let secp = Secp256k1::verification_only();
+        SpendTx::new(None, psbt, vec![], &desc, &secp, Network::Signet)
+    }
+
+    // Regression: a background `SpendTxs` refresh must NOT rebuild the open
+    // PSBT panel while a modal is up — doing so drops the in-progress Sign
+    // session (and its in-flight Keychain sessions) and re-exposes only the
+    // signatures persisted so far.
+    #[test]
+    fn spendtxs_refresh_preserves_an_open_modal() {
+        let wallet = Arc::new(Wallet::new(CoincubeDescriptor::from_str(DESC).unwrap()));
+        let tx = spend_tx();
+
+        let mut panel = PsbtsPanel::new(wallet.clone());
+        panel.preselect(tx.clone());
+        // Simulate an open Sign session by attaching a modal to the panel.
+        panel.selected_tx.as_mut().unwrap().modal =
+            Some(psbt::PsbtModal::Save(psbt::SaveModal::default()));
+
+        // The daemon must never be hit on this path (we return before using it);
+        // an empty mock enforces that.
+        let daemon: Arc<dyn Daemon + Sync + Send> =
+            Arc::new(Coincubed::new(MockDaemon::new(vec![]).run()));
+
+        let _ = panel.update(
+            Some(daemon),
+            &Cache::default(),
+            Message::SpendTxs(Ok(vec![tx])),
+        );
+
+        assert!(
+            panel
+                .selected_tx
+                .as_ref()
+                .expect("selected tx retained")
+                .modal
+                .is_some(),
+            "open modal must survive a background SpendTxs refresh"
+        );
     }
 }

--- a/coincube-ui/src/component/amount.rs
+++ b/coincube-ui/src/component/amount.rs
@@ -21,6 +21,17 @@ impl std::fmt::Display for BitcoinDisplayUnit {
     }
 }
 
+impl BitcoinDisplayUnit {
+    /// The uppercase label shown next to an amount ("BTC" / "SATS"), matching
+    /// how amounts render throughout the UI.
+    pub fn label(&self) -> &'static str {
+        match self {
+            BitcoinDisplayUnit::BTC => "BTC",
+            BitcoinDisplayUnit::Sats => "SATS",
+        }
+    }
+}
+
 pub trait DisplayAmount {
     fn to_formatted_string(&self) -> String;
     fn to_formatted_string_with_unit(&self, unit: BitcoinDisplayUnit) -> String;
@@ -221,10 +232,7 @@ fn render_amount<'a, T: 'a>(
     unit: BitcoinDisplayUnit,
 ) -> Row<'a, T> {
     let spacing = if size > P1_SIZE { 10 } else { 5 };
-    let unit_text = match unit {
-        BitcoinDisplayUnit::BTC => "BTC",
-        BitcoinDisplayUnit::Sats => "SATS",
-    };
+    let unit_text = unit.label();
 
     let (before, after) = match split_at_first_non_zero(amount.clone()) {
         Some((b, a)) => (b, a),
@@ -254,10 +262,7 @@ fn render_unconfirmed_amount<'a, T: 'a>(
     unit: BitcoinDisplayUnit,
 ) -> Row<'a, T> {
     let spacing = if size > P1_SIZE { 10 } else { 5 };
-    let unit_text = match unit {
-        BitcoinDisplayUnit::BTC => "BTC",
-        BitcoinDisplayUnit::Sats => "SATS",
-    };
+    let unit_text = unit.label();
 
     Row::with_children(vec![
         text(amount).size(size).color(color::GREY_3).into(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes core PSBT signing, merge, persist, and modal lifecycle for multi-sig and Keychain flows; mistakes could lose signatures, close the UI before save, or broadcast with incomplete/wrong-path sigs.
> 
> **Overview**
> Fixes multi-sig / multi-path wallets where signers could attach signatures to the **wrong descriptor path** (primary vs recovery) and where the Sign picker could show stale counts, close too early, or drop in-flight Keychain work.
> 
> **Spending-path PSBT pruning** — Before Keychain `CreateSigningSession` and for **all** hardware wallets (not only BitBox02), the PSBT sent to the signer is a **pruned clone** of the active spending path; signatures merge back into the full stored PSBT. Prune failure aborts the Keychain session instead of sending an unpruned PSBT.
> 
> **Reconciliation & close gates** — Adds UI-only `Message::Reconcile` and central `reconcile_and_maybe_close` so signature counts, per-key **Signed** state (`set_counted_signers`), and threshold close stay aligned with the in-memory merged PSBT **without** setting `saved`. Keychain rows track **merged vs persisted** (`signed_psbt_merged`, `signed_psbt_persisting`); the picker waits on `has_persistence_pending` / `has_capture_in_flight` before auto-close or dismiss-drain. Polling uses `is_give_up` / `signature_captured()` so **Completed** sessions keep retrying until the signed PSBT is actually captured.
> 
> **Other hardening** — Local/hardware persist uses the **merged** PSBT; background `SpendTxs` refresh no longer rebuilds an open PSBT panel (preserves modals/sessions); broadcast success copy includes **SATS/BTC** via `BitcoinDisplayUnit::label()`. Regression tests cover poll/retry, dismissal during fetch/persist, counted-signer UI, and modal preservation on refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2bd201683c6d49d8043c1b082944e47120842fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “Signed” status and signature counters by separating in-memory reconciliation from true persistence, avoiding premature completion.
  * Prevented unnecessary fetches for already-merged signatures and refined give-up/retry logic for keychain signing until persistence finishes.
  * Kept signing modals open during background refreshes and updated auto-close/dismiss behavior to wait for in-flight capture/persist.
  * Updated broadcast amount display to include explicit units (“SATS”/“BTC”).
* **Tests**
  * Added regression coverage for counted-signer “Signed” rendering, preserving open modals during refresh, and persistence-pending close/dismiss behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->