### PR TITLE
Issue/coin 415

### DIFF
--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -378,7 +378,6 @@ pub fn validate_local_backups_for_duress() -> Result<(), String> {
     Ok(())
 }
 
-
 /// State for the Contacts section within ConnectAccountPanel.
 pub struct ContactsState {
     pub step: ContactsStep,

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -342,6 +342,43 @@ pub fn duress_tier1_gate_blocked(cubes: Option<&[DuressCube]>) -> bool {
     cubes.is_none_or(duress_gate_blocked)
 }
 
+/// Validation check for local backups of ALL local Cubes. Before allowing a user
+/// to enable Duress Mode (which arms a duress PIN on every Cube on this device),
+/// we must ensure that all Cubes have proper backups.
+pub fn validate_local_backups_for_duress() -> Result<(), String> {
+    let dir = crate::dir::CoincubeDirectory::active()
+        .map_err(|e| format!("Failed to read active directory: {}", e))?;
+    // Duress only protects mainnet cubes; testnet backups are irrelevant.
+    let net_dir = dir.network_directory(crate::daemon::model::Network::Bitcoin);
+    let settings = crate::app::settings::Settings::from_file(&net_dir)
+        .map_err(|e| format!("Failed to read settings: {}", e))?;
+
+    for cube in settings.cubes {
+        let is_passkey = cube.is_passkey_cube();
+        let has_vault = cube.vault_wallet_id.is_some();
+
+        if is_passkey && !has_vault {
+            continue; // Nothing to back up
+        }
+
+        if !is_passkey && !cube.backed_up {
+            return Err(format!(
+                "The Seed Phrase for your Cube '{}' must be backed up before enabling Duress Mode.",
+                cube.name
+            ));
+        }
+
+        if has_vault && !cube.has_recovery_kit() {
+            return Err(format!(
+                "The Vault Wallet Descriptor for your Cube '{}' must be backed up before enabling Duress Mode.",
+                cube.name
+            ));
+        }
+    }
+    Ok(())
+}
+
+
 /// State for the Contacts section within ConnectAccountPanel.
 pub struct ContactsState {
     pub step: ContactsStep,
@@ -2716,6 +2753,12 @@ impl ConnectAccountPanel {
 
             // ── Enrollment wizard (Phases 2 & 8) ──
             DuressMessage::StartEnrollment => {
+                if let Err(msg) = validate_local_backups_for_duress() {
+                    self.error = Some(msg);
+                    return iced::Task::none();
+                }
+                self.error = None;
+
                 let entitled = self
                     .plan
                     .as_ref()
@@ -2761,6 +2804,12 @@ impl ConnectAccountPanel {
                 return self.reload_duress_cubes();
             }
             DuressMessage::StartEnrollmentWithoutCrk => {
+                if let Err(msg) = validate_local_backups_for_duress() {
+                    self.error = Some(msg);
+                    return iced::Task::none();
+                }
+                self.error = None;
+
                 // Tier 2 — Connect, no recovery kit: same as Tier 1 minus the
                 // CRK-password step (see `enroll_steps`), and always behind the
                 // backup-acknowledgement gate (no recovery kit by definition).

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -2922,6 +2922,10 @@ impl ConnectAccountPanel {
                 if e.submitting {
                     return iced::Task::none();
                 }
+                if let Err(msg) = validate_local_backups_for_duress() {
+                    e.error = Some(msg);
+                    return iced::Task::none();
+                }
                 if let Err(msg) = validate_enroll_step(e) {
                     e.error = Some(msg);
                     return iced::Task::none();

--- a/coincube-gui/src/services/duress/enroll.rs
+++ b/coincube-gui/src/services/duress/enroll.rs
@@ -52,6 +52,7 @@ const DURESS_CODE_BITS: usize = 128;
 /// default.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DuressDelay {
+    M2,
     #[default]
     H24,
     H48,
@@ -62,7 +63,8 @@ pub enum DuressDelay {
 
 impl DuressDelay {
     /// All choices in display order; the first is the default (24h).
-    pub const ALL: [DuressDelay; 5] = [
+    pub const ALL: [DuressDelay; 6] = [
+        DuressDelay::M2,
         DuressDelay::H24,
         DuressDelay::H48,
         DuressDelay::D7,
@@ -74,6 +76,7 @@ impl DuressDelay {
     /// `unlock_delay_minutes`.
     pub fn minutes(self) -> u32 {
         match self {
+            DuressDelay::M2 => 2,
             DuressDelay::H24 => 24 * 60,
             DuressDelay::H48 => 48 * 60,
             DuressDelay::D7 => 7 * 24 * 60,
@@ -84,6 +87,7 @@ impl DuressDelay {
 
     pub fn label(self) -> &'static str {
         match self {
+            DuressDelay::M2 => "2m",
             DuressDelay::H24 => "24h",
             DuressDelay::H48 => "48h",
             DuressDelay::D7 => "7d",
@@ -270,7 +274,7 @@ mod tests {
         assert_eq!(DuressDelay::H24.minutes(), 1440);
         assert_eq!(DuressDelay::D90.minutes(), 129_600);
         assert_eq!(DuressDelay::default(), DuressDelay::H24);
-        assert_eq!(DuressDelay::ALL.len(), 5);
+        assert_eq!(DuressDelay::ALL.len(), 6);
     }
 
     #[test]

--- a/coincube-gui/src/services/duress/enroll.rs
+++ b/coincube-gui/src/services/duress/enroll.rs
@@ -52,7 +52,6 @@ const DURESS_CODE_BITS: usize = 128;
 /// default.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DuressDelay {
-    M2,
     #[default]
     H24,
     H48,
@@ -63,8 +62,7 @@ pub enum DuressDelay {
 
 impl DuressDelay {
     /// All choices in display order; the first is the default (24h).
-    pub const ALL: [DuressDelay; 6] = [
-        DuressDelay::M2,
+    pub const ALL: [DuressDelay; 5] = [
         DuressDelay::H24,
         DuressDelay::H48,
         DuressDelay::D7,
@@ -76,7 +74,6 @@ impl DuressDelay {
     /// `unlock_delay_minutes`.
     pub fn minutes(self) -> u32 {
         match self {
-            DuressDelay::M2 => 2,
             DuressDelay::H24 => 24 * 60,
             DuressDelay::H48 => 48 * 60,
             DuressDelay::D7 => 7 * 24 * 60,
@@ -87,7 +84,6 @@ impl DuressDelay {
 
     pub fn label(self) -> &'static str {
         match self {
-            DuressDelay::M2 => "2m",
             DuressDelay::H24 => "24h",
             DuressDelay::H48 => "48h",
             DuressDelay::D7 => "7d",
@@ -274,7 +270,7 @@ mod tests {
         assert_eq!(DuressDelay::H24.minutes(), 1440);
         assert_eq!(DuressDelay::D90.minutes(), 129_600);
         assert_eq!(DuressDelay::default(), DuressDelay::H24);
-        assert_eq!(DuressDelay::ALL.len(), 6);
+        assert_eq!(DuressDelay::ALL.len(), 5);
     }
 
     #[test]


### PR DESCRIPTION
Data Integrity: Enforce local backup validation before Duress Mode enrollment

Previously, a user could fully set up and enable Duress Mode on a local Cube without backing up their Seed Phrase or Vault Wallet Descriptor. This contradicted the fundamental requirement that users must secure their assets before opting into a destructive action like Duress Mode.

This update introduces a strict validation check prior to launching the Duress enrollment wizard. It verifies that all local mainnet Cubes have their Seed Phrase backed up, and any configured Vaults have a backed up Wallet Descriptor. If a required backup is missing, the enrollment is blocked and an inline error is displayed in the Connect Account Panel guiding the user to complete their backups first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prerequisite checks for local backups before starting duress enrollment.
  * Display clear user-facing errors when a Cube is missing required backup or recovery kit components.
  * Prevents duress enrollment from proceeding when local backup prerequisites are incomplete, including on initial start and at submission time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->