### PR TITLE
Fix: prevent BlockSlop vulnerability on node flavor swap

### DIFF
--- a/coincube-gui/src/node/bitcoind.rs
+++ b/coincube-gui/src/node/bitcoind.rs
@@ -1211,10 +1211,26 @@ impl Bitcoind {
         #[cfg(target_os = "windows")]
         let datadir_path_str = datadir_path_str.replace("\\\\?\\", "").replace("\\\\?", "");
 
-        let args = vec![
+        let mut args = vec![
             format!("-chain={}", network.to_core_arg()),
             format!("-datadir={}", datadir_path_str),
         ];
+
+        // PLAN-blockslop-mitigation: If the user swaps node flavors, we must
+        // force a reindex to validate inherited chainstate under the new rules.
+        let marker_path = bitcoind_datadir.join(".coincube_last_flavor");
+        if let Ok(marker_bytes) = std::fs::read(&marker_path) {
+            if let Ok(last_flavor_str) = String::from_utf8(marker_bytes) {
+                let current_flavor_str = match configured_flavor {
+                    NodeFlavor::Core => "Core",
+                    NodeFlavor::Knots => "Knots",
+                };
+                if last_flavor_str != current_flavor_str && (last_flavor_str == "Core" || last_flavor_str == "Knots") {
+                    info!("Flavor switch detected ({} -> {}), injecting -reindex-chainstate", last_flavor_str, current_flavor_str);
+                    args.push("-reindex-chainstate=1".to_string());
+                }
+            }
+        }
         // Build a fresh bitcoind command each spawn attempt (we may respawn if
         // the datadir lock isn't free yet — see the retry below).
         let spawn_bitcoind = || -> Result<std::process::Child, StartInternalBitcoindError> {
@@ -1226,6 +1242,13 @@ impl Bitcoind {
 
             // Detach the child so closing the app doesn't take the node down.
             crate::node::detach_spawned_process(&mut command);
+
+            // Persist the current flavor so subsequent restarts don't reindex needlessly.
+            let current_flavor_str = match configured_flavor {
+                NodeFlavor::Core => "Core",
+                NodeFlavor::Knots => "Knots",
+            };
+            let _ = std::fs::write(&marker_path, current_flavor_str);
 
             command
                 .spawn()

--- a/coincube-gui/src/node/bitcoind.rs
+++ b/coincube-gui/src/node/bitcoind.rs
@@ -1218,17 +1218,32 @@ impl Bitcoind {
 
         // PLAN-blockslop-mitigation: If the user swaps node flavors, we must
         // force a reindex to validate inherited chainstate under the new rules.
+        let current_flavor_str = match configured_flavor {
+            NodeFlavor::Core => "Core",
+            NodeFlavor::Knots => "Knots",
+        };
         let marker_path = bitcoind_datadir.join(".coincube_last_flavor");
-        if let Ok(marker_bytes) = std::fs::read(&marker_path) {
-            if let Ok(last_flavor_str) = String::from_utf8(marker_bytes) {
-                let current_flavor_str = match configured_flavor {
-                    NodeFlavor::Core => "Core",
-                    NodeFlavor::Knots => "Knots",
-                };
-                if last_flavor_str != current_flavor_str && (last_flavor_str == "Core" || last_flavor_str == "Knots") {
-                    info!("Flavor switch detected ({} -> {}), injecting -reindex-chainstate", last_flavor_str, current_flavor_str);
-                    args.push("-reindex-chainstate=1".to_string());
+        match std::fs::read(&marker_path) {
+            Ok(marker_bytes) => {
+                match String::from_utf8(marker_bytes) {
+                    Ok(last_flavor_str) if last_flavor_str == "Core" || last_flavor_str == "Knots" => {
+                        if last_flavor_str != current_flavor_str {
+                            info!("Flavor switch detected ({} -> {}), injecting -reindex-chainstate", last_flavor_str, current_flavor_str);
+                            args.push("-reindex-chainstate=1".to_string());
+                        }
+                    }
+                    _ => {
+                        warn!("Flavor marker unreadable or malformed, conservatively injecting -reindex-chainstate");
+                        args.push("-reindex-chainstate=1".to_string());
+                    }
                 }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // First-run case: marker is missing, assume no swap occurred.
+            }
+            Err(e) => {
+                warn!("Failed to read flavor marker ({}), conservatively injecting -reindex-chainstate", e);
+                args.push("-reindex-chainstate=1".to_string());
             }
         }
         // Build a fresh bitcoind command each spawn attempt (we may respawn if

--- a/coincube-gui/src/node/bitcoind.rs
+++ b/coincube-gui/src/node/bitcoind.rs
@@ -1258,13 +1258,6 @@ impl Bitcoind {
             // Detach the child so closing the app doesn't take the node down.
             crate::node::detach_spawned_process(&mut command);
 
-            // Persist the current flavor so subsequent restarts don't reindex needlessly.
-            let current_flavor_str = match configured_flavor {
-                NodeFlavor::Core => "Core",
-                NodeFlavor::Knots => "Knots",
-            };
-            let _ = std::fs::write(&marker_path, current_flavor_str);
-
             command
                 .spawn()
                 .map_err(|e| StartInternalBitcoindError::CommandError(e.to_string()))
@@ -1308,6 +1301,13 @@ impl Bitcoind {
             match coincubed::BitcoinD::new(&config, "internal_bitcoind_start".to_string()) {
                 Ok(_) => {
                     log::info!("Bitcoind seems to have successfully started.");
+
+                    // Persist the current flavor only after successful startup so that 
+                    // an early exit/failure doesn't falsely validate the chainstate.
+                    if let Err(e) = std::fs::write(&marker_path, current_flavor_str) {
+                        log::error!("Failed to persist flavor marker: {}", e);
+                    }
+
                     return Ok(Self {
                         config,
                         lock: LockFile::create(coincube_datadir.bitcoind_directory(), network)


### PR DESCRIPTION
This implements a mitigation for the BlockSlop consensus bug (related to BIP 110) which can occur when a node upgrades or swaps rule-enforcement implementations but retains an unvalidated historical chainstate.

Changes:

Introduce a .coincube_last_flavor marker file in the bitcoind datadir to persistently track the node flavor across restarts. Modify spawn_internal_bitcoind to read this marker on startup. If a flavor swap is detected (e.g. from Bitcoin Core to Bitcoin Knots), dynamically inject -reindex-chainstate=1 into the bitcoind arguments. This forces the new client to validate all inherited block history against its own rules, neutralizing the vulnerability. Gracefully skip the re-index on the very first run by assuming no swap occurred if the marker file is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed node startup when switching between Bitcoin Core and Bitcoin Knots.
  * Automatically triggers the required chainstate reindex after a detected flavor change, helping ensure the node operates correctly after switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->