### PR TITLE
fix: trigger 423 DURESS_LOCKED on decoy recovery kit password

### DIFF
--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -1294,10 +1294,18 @@ impl CoincubeClient {
     /// `GET /api/v1/connect/cubes/{cube_id}/recovery-kit` (Approach C, dual-password).
     ///
     /// Distinct from [`get_recovery_kit`](Self::get_recovery_kit): the password
-    /// hash gates which envelope (regular vs. duress) the server returns, and a
-    /// duress password yields `423 DURESS_LOCKED` rather than a kit. The hash is
-    /// sent in the `X-CRK-Password-Hash` header rather than the query string so
-    /// it never lands in access logs.
+    /// gates which envelope (regular vs. duress) the server returns, and a
+    /// duress password yields `423 DURESS_LOCKED` rather than a kit.
+    ///
+    /// IMPORTANT: despite the `crk_password_hash` / `X-CRK-Password-Hash`
+    /// naming, the value carried here is the **raw** CRK password, not a hash.
+    /// The server stores each candidate as an argon2id PHC string with a random
+    /// salt (see [`hash_duress_secret`](crate::services::duress::enroll::hash_duress_secret)),
+    /// so it can only tell a regular password from the duress one by running
+    /// `argon2::verify` on the plaintext. Pre-hashing here would produce a
+    /// fresh-salt digest that can never match the stored one, silently breaking
+    /// duress — do NOT "fix" this by hashing. The value rides in a header rather
+    /// than the query string so it never lands in access logs.
     ///
     /// NOTE: the exact transport is pinned by Connect API Phase 4; the header
     /// name here is provisional and revisited in Phase 7.
@@ -1307,7 +1315,10 @@ impl CoincubeClient {
         crk_password_hash: &str,
     ) -> Result<RecoveryKit, super::DownloadError> {
         use super::DownloadError;
-        let url = format!("{}/api/v1/connect/cubes/{}/recovery-kit", self.base_url, cube_id);
+        let url = format!(
+            "{}/api/v1/connect/cubes/{}/recovery-kit",
+            self.base_url, cube_id
+        );
         let res = self
             .client
             .get(&url)
@@ -1329,6 +1340,9 @@ impl CoincubeClient {
                 Err(DownloadError::from_locked_body(&body))
             }
             404 => Err(DownloadError::NotFound),
+            429 => Err(DownloadError::RateLimited {
+                retry_after: parse_retry_after(res.headers()),
+            }),
             400 | 401 | 403 | 422 => Err(DownloadError::Invalid),
             other => Err(DownloadError::Other(CoincubeError::Unsuccessful(
                 crate::services::http::NotSuccessResponseInfo {
@@ -3518,7 +3532,7 @@ mod duress_tests {
         let server = MockServer::start();
         let mock = server.mock(|when, then| {
             when.method(MockMethod::GET)
-                .path("/api/v1/cubes/42/recovery-kit")
+                .path("/api/v1/connect/cubes/42/recovery-kit")
                 .header("X-CRK-Password-Hash", "regular-hash");
             then.status(200)
                 .header("content-type", "application/json")
@@ -3551,7 +3565,7 @@ mod duress_tests {
         let server = MockServer::start();
         server.mock(|when, then| {
             when.method(MockMethod::GET)
-                .path("/api/v1/cubes/42/recovery-kit");
+                .path("/api/v1/connect/cubes/42/recovery-kit");
             then.status(423)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -3583,7 +3597,7 @@ mod duress_tests {
         let server = MockServer::start();
         server.mock(|when, then| {
             when.method(MockMethod::GET)
-                .path("/api/v1/cubes/42/recovery-kit");
+                .path("/api/v1/connect/cubes/42/recovery-kit");
             then.status(423)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -3615,7 +3629,7 @@ mod duress_tests {
         let server = MockServer::start();
         server.mock(|when, then| {
             when.method(MockMethod::GET)
-                .path("/api/v1/cubes/42/recovery-kit");
+                .path("/api/v1/connect/cubes/42/recovery-kit");
             then.status(403)
                 .header("content-type", "application/json")
                 .json_body(json!({ "error": { "code": "WRONG_PASSWORD" } }));
@@ -3627,6 +3641,28 @@ mod duress_tests {
             .await
             .expect_err("expected invalid");
         assert!(matches!(err, DownloadError::Invalid), "got {:?}", err);
+    }
+
+    #[tokio::test]
+    async fn download_kit_429_parses_retry_after() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(429).header("Retry-After", "17");
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .download_recovery_kit(42, "regular-hash")
+            .await
+            .expect_err("expected rate limit");
+        match err {
+            DownloadError::RateLimited { retry_after } => {
+                assert_eq!(retry_after, std::time::Duration::from_secs(17));
+            }
+            other => panic!("expected RateLimited, got {:?}", other),
+        }
     }
 }
 

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -1307,7 +1307,7 @@ impl CoincubeClient {
         crk_password_hash: &str,
     ) -> Result<RecoveryKit, super::DownloadError> {
         use super::DownloadError;
-        let url = format!("{}/api/v1/cubes/{}/recovery-kit", self.base_url, cube_id);
+        let url = format!("{}/api/v1/connect/cubes/{}/recovery-kit", self.base_url, cube_id);
         let res = self
             .client
             .get(&url)

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -1297,32 +1297,46 @@ impl CoincubeClient {
     /// gates which envelope (regular vs. duress) the server returns, and a
     /// duress password yields `423 DURESS_LOCKED` rather than a kit.
     ///
-    /// IMPORTANT: despite the `crk_password_hash` / `X-CRK-Password-Hash`
-    /// naming, the value carried here is the **raw** CRK password, not a hash.
-    /// The server stores each candidate as an argon2id PHC string with a random
+    /// IMPORTANT: despite the `X-CRK-Password-Hash` header name (fixed by the
+    /// Connect API contract), the value carried here is the **raw** CRK
+    /// password, not a hash — hence the `crk_password` parameter name. The
+    /// server stores each candidate as an argon2id PHC string with a random
     /// salt (see [`hash_duress_secret`](crate::services::duress::enroll::hash_duress_secret)),
     /// so it can only tell a regular password from the duress one by running
     /// `argon2::verify` on the plaintext. Pre-hashing here would produce a
     /// fresh-salt digest that can never match the stored one, silently breaking
     /// duress — do NOT "fix" this by hashing. The value rides in a header rather
-    /// than the query string so it never lands in access logs.
+    /// than the query string so it never lands in access logs, and is marked
+    /// sensitive below so cooperating logging/tracing layers redact it and
+    /// HTTP/2 keeps it out of the HPACK compression table.
     ///
     /// NOTE: the exact transport is pinned by Connect API Phase 4; the header
     /// name here is provisional and revisited in Phase 7.
     pub async fn download_recovery_kit(
         &self,
         cube_id: u64,
-        crk_password_hash: &str,
+        crk_password: &str,
     ) -> Result<RecoveryKit, super::DownloadError> {
         use super::DownloadError;
         let url = format!(
             "{}/api/v1/connect/cubes/{}/recovery-kit",
             self.base_url, cube_id
         );
+        // Carry the raw password as a *sensitive* header value (see the note
+        // above): hyper omits sensitive headers from the HTTP/2 HPACK table,
+        // and any logging/tracing layer that honours `is_sensitive` redacts it.
+        let mut crk_header =
+            reqwest::header::HeaderValue::from_str(crk_password).map_err(|_| {
+                DownloadError::Other(CoincubeError::Api(
+                    "recovery kit password contains characters that cannot be sent in a header"
+                        .to_string(),
+                ))
+            })?;
+        crk_header.set_sensitive(true);
         let res = self
             .client
             .get(&url)
-            .header("X-CRK-Password-Hash", crk_password_hash)
+            .header("X-CRK-Password-Hash", crk_header)
             .send()
             .await
             .map_err(|e| DownloadError::Other(e.into()))?;
@@ -3660,6 +3674,67 @@ mod duress_tests {
         match err {
             DownloadError::RateLimited { retry_after } => {
                 assert_eq!(retry_after, std::time::Duration::from_secs(17));
+            }
+            other => panic!("expected RateLimited, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn download_kit_404_maps_to_not_found() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(404);
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .download_recovery_kit(42, "regular-hash")
+            .await
+            .expect_err("expected not found");
+        assert!(matches!(err, DownloadError::NotFound), "got {:?}", err);
+    }
+
+    #[tokio::test]
+    async fn download_kit_429_missing_retry_after_defaults_to_60s() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(429);
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .download_recovery_kit(42, "regular-hash")
+            .await
+            .expect_err("expected rate limit");
+        match err {
+            DownloadError::RateLimited { retry_after } => {
+                assert_eq!(retry_after, std::time::Duration::from_secs(60));
+            }
+            other => panic!("expected RateLimited, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn download_kit_429_malformed_retry_after_defaults_to_60s() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(429).header("Retry-After", "not-a-number");
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = client
+            .download_recovery_kit(42, "regular-hash")
+            .await
+            .expect_err("expected rate limit");
+        match err {
+            DownloadError::RateLimited { retry_after } => {
+                assert_eq!(retry_after, std::time::Duration::from_secs(60));
             }
             other => panic!("expected RateLimited, got {:?}", other),
         }

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -1291,7 +1291,7 @@ impl CoincubeClient {
         Ok(resp.data)
     }
 
-    /// `GET /api/v1/cubes/{cube_id}/recovery-kit` (Approach C, dual-password).
+    /// `GET /api/v1/connect/cubes/{cube_id}/recovery-kit` (Approach C, dual-password).
     ///
     /// Distinct from [`get_recovery_kit`](Self::get_recovery_kit): the password
     /// hash gates which envelope (regular vs. duress) the server returns, and a

--- a/coincube-gui/src/services/coincube/client.rs
+++ b/coincube-gui/src/services/coincube/client.rs
@@ -1328,7 +1328,8 @@ impl CoincubeClient {
                 let body = res.text().await.unwrap_or_default();
                 Err(DownloadError::from_locked_body(&body))
             }
-            400 | 401 | 403 | 404 | 422 => Err(DownloadError::Invalid),
+            404 => Err(DownloadError::NotFound),
+            400 | 401 | 403 | 422 => Err(DownloadError::Invalid),
             other => Err(DownloadError::Other(CoincubeError::Unsuccessful(
                 crate::services::http::NotSuccessResponseInfo {
                     status_code: other,

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -1835,8 +1835,10 @@ pub enum DownloadError {
     TrustedDeviceDelay {
         available_at: Option<chrono::DateTime<chrono::Utc>>,
     },
-    /// Wrong password / malformed request (4xx other than 423).
+    /// Wrong password / malformed request (4xx other than 423/404).
     Invalid,
+    /// `404 Not Found` — no kit exists for this cube.
+    NotFound,
     /// Network, 5xx, or parse failure.
     Other(CoincubeError),
 }
@@ -1851,6 +1853,7 @@ impl std::fmt::Display for DownloadError {
                 write!(f, "Recovery kit download is delayed on new devices.")
             }
             DownloadError::Invalid => write!(f, "Incorrect recovery kit password."),
+            DownloadError::NotFound => write!(f, "Recovery kit not found."),
             DownloadError::Other(e) => write!(f, "{}", e),
         }
     }

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -1835,12 +1835,13 @@ pub enum DownloadError {
     TrustedDeviceDelay {
         available_at: Option<chrono::DateTime<chrono::Utc>>,
     },
-    /// Wrong password / malformed request (4xx other than 423/404/429).
+    /// Wrong password / malformed request (`400`, `401`, `403`, or `422`).
     Invalid,
     /// `404 Not Found` — no kit exists for this cube.
     NotFound,
     /// `429 Too Many Requests` — the caller should back off. `retry_after`
-    /// is the parsed `Retry-After` duration (defaults to 60s when absent).
+    /// is the parsed `Retry-After` duration (defaults to 60s when the header
+    /// is missing or malformed).
     RateLimited { retry_after: std::time::Duration },
     /// Network, 5xx, or parse failure.
     Other(CoincubeError),

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -1835,10 +1835,13 @@ pub enum DownloadError {
     TrustedDeviceDelay {
         available_at: Option<chrono::DateTime<chrono::Utc>>,
     },
-    /// Wrong password / malformed request (4xx other than 423/404).
+    /// Wrong password / malformed request (4xx other than 423/404/429).
     Invalid,
     /// `404 Not Found` — no kit exists for this cube.
     NotFound,
+    /// `429 Too Many Requests` — the caller should back off. `retry_after`
+    /// is the parsed `Retry-After` duration (defaults to 60s when absent).
+    RateLimited { retry_after: std::time::Duration },
     /// Network, 5xx, or parse failure.
     Other(CoincubeError),
 }
@@ -1854,6 +1857,9 @@ impl std::fmt::Display for DownloadError {
             }
             DownloadError::Invalid => write!(f, "Incorrect recovery kit password."),
             DownloadError::NotFound => write!(f, "Recovery kit not found."),
+            DownloadError::RateLimited { retry_after } => {
+                write!(f, "Rate limited — try again in {}s.", retry_after.as_secs())
+            }
             DownloadError::Other(e) => write!(f, "{}", e),
         }
     }

--- a/coincube-gui/src/services/recovery/restore.rs
+++ b/coincube-gui/src/services/recovery/restore.rs
@@ -200,7 +200,9 @@ pub async fn fetch_and_decrypt_kit(
     cube_id: u64,
     password: &Zeroizing<String>,
 ) -> Result<DecryptedKit, RestoreError> {
-    let kit = client.download_recovery_kit(cube_id, password.as_str()).await?;
+    let kit = client
+        .download_recovery_kit(cube_id, password.as_str())
+        .await?;
 
     // Empty strings on the wire mean "this half wasn't uploaded."
     // Treat them the same as `None` here so the caller can pattern-
@@ -779,6 +781,74 @@ mod integration_tests {
         mock.assert();
         assert!(matches!(err, RestoreError::BadPasswordOrCorrupt));
     }
+
+    #[tokio::test]
+    async fn fetch_and_decrypt_kit_423_duress_locked_maps_to_typed_variant() {
+        // Approach C headline case: entering the *duress* CRK password makes
+        // the server withhold the kit with `423 DURESS_LOCKED`. This must reach
+        // the UI as the typed `DuressLocked` variant (carrying `unlock_at`), not
+        // a generic error, so the cryptic-but-deniable cue renders.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(423)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "error": {
+                        "code": "DURESS_LOCKED",
+                        "unlockAt": "2026-06-10T00:00:00Z"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = fetch_and_decrypt_kit(&client, 42, &pw("duress password"))
+            .await
+            .expect_err("expected DuressLocked");
+        mock.assert();
+        match err {
+            RestoreError::DuressLocked { unlock_at } => {
+                assert_eq!(
+                    unlock_at.expect("unlock_at present").to_rfc3339(),
+                    "2026-06-10T00:00:00+00:00"
+                );
+            }
+            other => panic!("expected DuressLocked, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_and_decrypt_kit_423_trusted_device_delay_maps_to_typed_variant() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(MockMethod::GET)
+                .path("/api/v1/connect/cubes/42/recovery-kit");
+            then.status(423)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "error": {
+                        "code": "TRUSTED_DEVICE_DELAY",
+                        "availableAt": "2026-06-11T00:00:00Z"
+                    }
+                }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = fetch_and_decrypt_kit(&client, 42, &pw("pw"))
+            .await
+            .expect_err("expected TrustedDeviceDelay");
+        mock.assert();
+        match err {
+            RestoreError::TrustedDeviceDelay { available_at } => {
+                assert_eq!(
+                    available_at.expect("available_at present").to_rfc3339(),
+                    "2026-06-11T00:00:00+00:00"
+                );
+            }
+            other => panic!("expected TrustedDeviceDelay, got {:?}", other),
+        }
+    }
 }
 impl From<crate::services::coincube::DownloadError> for RestoreError {
     fn from(e: crate::services::coincube::DownloadError) -> Self {
@@ -790,6 +860,7 @@ impl From<crate::services::coincube::DownloadError> for RestoreError {
             }
             DownloadError::Invalid => Self::Api("Invalid request".to_string()),
             DownloadError::NotFound => Self::NotFound,
+            DownloadError::RateLimited { retry_after } => Self::RateLimited { retry_after },
             DownloadError::Other(e) => Self::from(e),
         }
     }

--- a/coincube-gui/src/services/recovery/restore.rs
+++ b/coincube-gui/src/services/recovery/restore.rs
@@ -200,7 +200,7 @@ pub async fn fetch_and_decrypt_kit(
     cube_id: u64,
     password: &Zeroizing<String>,
 ) -> Result<DecryptedKit, RestoreError> {
-    let kit = client.get_recovery_kit(cube_id).await?;
+    let kit = client.download_recovery_kit(cube_id, password.as_str()).await?;
 
     // Empty strings on the wire mean "this half wasn't uploaded."
     // Treat them the same as `None` here so the caller can pattern-
@@ -778,5 +778,18 @@ mod integration_tests {
             .expect_err("expected BadPasswordOrCorrupt");
         mock.assert();
         assert!(matches!(err, RestoreError::BadPasswordOrCorrupt));
+    }
+}
+impl From<crate::services::coincube::DownloadError> for RestoreError {
+    fn from(e: crate::services::coincube::DownloadError) -> Self {
+        use crate::services::coincube::DownloadError;
+        match e {
+            DownloadError::DuressLocked { unlock_at } => Self::DuressLocked { unlock_at },
+            DownloadError::TrustedDeviceDelay { available_at } => {
+                Self::TrustedDeviceDelay { available_at }
+            }
+            DownloadError::Invalid => Self::Api("Invalid request".to_string()),
+            DownloadError::Other(e) => Self::from(e),
+        }
     }
 }

--- a/coincube-gui/src/services/recovery/restore.rs
+++ b/coincube-gui/src/services/recovery/restore.rs
@@ -789,6 +789,7 @@ impl From<crate::services::coincube::DownloadError> for RestoreError {
                 Self::TrustedDeviceDelay { available_at }
             }
             DownloadError::Invalid => Self::Api("Invalid request".to_string()),
+            DownloadError::NotFound => Self::NotFound,
             DownloadError::Other(e) => Self::from(e),
         }
     }


### PR DESCRIPTION
This commit fixes the Duress CRK Password lockout trigger which was previously failing to trip the backend's duress flag because the password hash was not being sent during kit decryption.

Changes:

Updated fetch_and_decrypt_kit in restore.rs to use the new download_recovery_kit API client method instead of get_recovery_kit, ensuring the X-CRK-Password-Hash header is sent to the server. Implemented From for RestoreError to correctly map DownloadError::DuressLocked and other specific download errors to the UI layer. Fixed a routing typo in download_recovery_kit (client.rs) where the endpoint URL was missing the /connect segment, causing the request to 404 and return a generic Invalid request error to the user. Fixes: fetch_and_decrypt_kit uses standard GET; Duress CRK Password fails to trigger 423 DURESS_LOCKED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated recovery kit downloads to use the current connection-scoped endpoint.
  * Added user-facing, typed handling for missing kits (404) and rate limiting (429), including the server-provided retry cooldown.
  * Improved restore flow error mapping so duress lock and trusted-device delay produce the correct typed restore errors.
  * Recovery flow now correctly uses the provided password when fetching the recovery kit.
* **Tests**
  * Expanded recovery-kit and restore integration tests for 429 `Retry-After` parsing and 404 mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->