### PR TITLE
Duress work

### DIFF
--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -2207,7 +2207,7 @@ impl ConnectAccountPanel {
         // never drops its secrets unzeroized.
         self.clear_duress_enroll();
         self.duress_enroll = Some(DuressEnrollState {
-            step: enroll_steps()[0],
+            step: ENROLL_STEPS[0],
             duress_pin: String::new(),
             duress_pin_confirm: String::new(),
             all_clear: String::new(),
@@ -2805,7 +2805,9 @@ impl ConnectAccountPanel {
 
                 // Generate this device's duress code ONCE: its hash goes to the
                 // server, the same plaintext is persisted (encrypted) locally.
-                let code = enroll::generate_duress_code();
+                // Held in `Zeroizing` so the local plaintext is scrubbed on drop
+                // — on normal completion and on every early-return below.
+                let code = zeroize::Zeroizing::new(enroll::generate_duress_code());
 
                 // Enroll on the server FIRST. The duress PIN + code are persisted
                 // locally only after a successful EnrollResult, so a server
@@ -2813,13 +2815,13 @@ impl ConnectAccountPanel {
                 // code for that success handler. Zeroize any code stashed by a
                 // prior submit (retry) before replacing it, so the superseded
                 // plaintext doesn't linger.
-                if let Some(mut old) = e.pending_code.replace(code.clone()) {
+                if let Some(mut old) = e.pending_code.replace((*code).clone()) {
                     zeroize::Zeroize::zeroize(&mut old);
                 }
                 let all_clear_hash = enroll::hash_duress_secret(&e.all_clear);
                 // Single path always collects the account-level duress
                 // recovery-kit password (Approach C).
-                let crk_hash = Some(enroll::hash_duress_secret(&e.crk_password));
+                let crk_hash = enroll::hash_duress_secret(&e.crk_password);
                 let code_hash = enroll::hash_duress_secret(&code);
                 let delay_minutes = e.delay.minutes();
 
@@ -2832,13 +2834,12 @@ impl ConnectAccountPanel {
                     }
                 };
                 let crk_hash = match crk_hash {
-                    Some(Ok(h)) => Some(h),
-                    Some(Err(_)) => {
+                    Ok(h) => Some(h),
+                    Err(_) => {
                         e.error = Some("Failed to hash credentials.".to_string());
                         e.submitting = false;
                         return iced::Task::none();
                     }
-                    None => None,
                 };
                 // A stable device fingerprint is required so the server can
                 // recognise this desktop. If it can't be resolved, fail the
@@ -4522,29 +4523,24 @@ fn device_fingerprint() -> Result<String, String> {
 /// account-level duress recovery-kit password → unlock delay → confirm. Duress
 /// is paid + behind the hard Recovery-Kit gate, so there is no tier branching
 /// and no self-attestation step.
-fn enroll_steps() -> Vec<DuressEnrollStep> {
-    use DuressEnrollStep::*;
-    vec![
-        SetDuressPin,
-        SetAllClear,
-        SetCrkPassword,
-        PickDelay,
-        Confirm,
-    ]
-}
+const ENROLL_STEPS: [DuressEnrollStep; 5] = [
+    DuressEnrollStep::SetDuressPin,
+    DuressEnrollStep::SetAllClear,
+    DuressEnrollStep::SetCrkPassword,
+    DuressEnrollStep::PickDelay,
+    DuressEnrollStep::Confirm,
+];
 
 fn next_enroll_step(cur: DuressEnrollStep) -> DuressEnrollStep {
-    let steps = enroll_steps();
-    match steps.iter().position(|s| *s == cur) {
-        Some(i) if i + 1 < steps.len() => steps[i + 1],
+    match ENROLL_STEPS.iter().position(|s| *s == cur) {
+        Some(i) if i + 1 < ENROLL_STEPS.len() => ENROLL_STEPS[i + 1],
         _ => cur,
     }
 }
 
 fn prev_enroll_step(cur: DuressEnrollStep) -> DuressEnrollStep {
-    let steps = enroll_steps();
-    match steps.iter().position(|s| *s == cur) {
-        Some(i) if i > 0 => steps[i - 1],
+    match ENROLL_STEPS.iter().position(|s| *s == cur) {
+        Some(i) if i > 0 => ENROLL_STEPS[i - 1],
         _ => cur,
     }
 }
@@ -4613,8 +4609,8 @@ mod duress_enroll_tests {
         // Duress is paid + behind the hard Recovery-Kit gate, so there is one
         // path: no tier branching, no self-attestation step.
         assert_eq!(
-            enroll_steps(),
-            vec![
+            ENROLL_STEPS,
+            [
                 DuressEnrollStep::SetDuressPin,
                 DuressEnrollStep::SetAllClear,
                 DuressEnrollStep::SetCrkPassword,
@@ -5156,10 +5152,11 @@ mod duress_enroll_tests {
     }
 
     #[test]
-    fn submit_enrollment_rechecks_the_vault_gate_for_tier1() {
+    fn submit_enrollment_rechecks_the_vault_gate() {
         // The gate is enforced at StartEnrollment, but state can change while
         // the wizard is open (a mid-wizard Vault creation invalidates the
-        // checklist). SubmitEnrollment must re-check for Tier-1 and refuse.
+        // checklist). SubmitEnrollment must re-check the single gated path and
+        // refuse.
         let mut panel = ConnectAccountPanel::new();
         panel.duress_enroll = Some(state(DuressEnrollStep::Confirm));
 

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -555,36 +555,12 @@ pub enum ConnectFlowStep {
     },
 }
 
-/// Which credentials the enrollment wizard collects, derived from the account's
-/// duress entitlement (and, for sovereign, the absence of Connect).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum EnrollTier {
-    /// Connect + recovery kit: full flow incl. the account-level duress CRK
-    /// password (Approach C).
-    Tier1,
-    /// Connect, no recovery kit: same as Tier 1 minus the CRK password, with a
-    /// BIG warning that recovery depends on the seed-phrase backup.
-    Tier2,
-    /// No Connect: local-only wipe; the wizard opens with a Connect-
-    /// encouragement screen and a type-to-confirm friction step.
-    Sovereign,
-}
-
-/// Steps of the duress enrollment wizard. Sovereign opens at `Encourage`;
-/// Connect tiers skip straight to `SetDuressPin` (or `BackupAck` when the gate
-/// applies). `SetCrkPassword` is Tier 1 only.
+/// Steps of the duress enrollment wizard. Duress is a paid (Pro/Estate) feature,
+/// gated behind a complete, server-verified Recovery Kit for every Vault Cube
+/// (the hard gate — `duress_tier1_gate_blocked`), so there is a single
+/// enrollment path with no tier branching and no self-attestation step.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DuressEnrollStep {
-    /// Sovereign Step 0 — Connect-encouragement (primary CTA "Sign up for
-    /// Connect", secondary "Continue without Connect").
-    Encourage,
-    /// Mandated backup-acknowledgement gate — type the exact, case-sensitive
-    /// [`BACKUP_ACK_PHRASE`] before duress can be armed. Shown when any Cube a
-    /// duress wipe would destroy lacks a Cube Recovery Kit, or when the user is
-    /// sovereign (no server-side recovery at all). Skipped when every protected
-    /// Cube is backed up (Tier 1). Was the sovereign-only "I have my seed-phrase
-    /// backup" friction step.
-    BackupAck,
     SetDuressPin,
     SetAllClear,
     SetCrkPassword,
@@ -592,19 +568,10 @@ pub enum DuressEnrollStep {
     Confirm,
 }
 
-/// The exact phrase a user must type, character-for-character, at the
-/// [`DuressEnrollStep::BackupAck`] gate before duress can be armed. Naming both
-/// destroyed artifacts — the Master Seed Phrase(s) and the Vault Wallet
-/// Descriptor(s) — and the funds consequence is deliberate (Robert, 2026-06-30):
-/// the match is strict, case-sensitive, with no whitespace normalization, so
-/// the user can't pass by paraphrase, a checkbox, or muscle memory.
-pub const BACKUP_ACK_PHRASE: &str = "I understand my Cubes will be permanently destroyed (along with access to any funds held within) if I activate duress without my own external backup of the Master Seed Phrases and Vault Wallet Descriptors.";
-
 /// In-flight enrollment wizard state (Phases 2 & 8). `None` on the panel when
 /// the wizard isn't open.
 #[derive(Debug)]
 pub struct DuressEnrollState {
-    pub tier: EnrollTier,
     pub step: DuressEnrollStep,
     pub duress_pin: String,
     /// Re-entry of `duress_pin` so a memorized typo is caught at enrollment.
@@ -612,34 +579,17 @@ pub struct DuressEnrollState {
     pub all_clear: String,
     pub crk_password: String,
     pub delay: crate::services::duress::enroll::DuressDelay,
-    /// Typed input for the mandated backup-acknowledgement gate
-    /// ([`DuressEnrollStep::BackupAck`]). Must exactly (case-sensitively) equal
-    /// [`BACKUP_ACK_PHRASE`] before enrollment can proceed.
-    pub backup_ack: String,
-    /// Whether this enrollment must pass the backup-acknowledgement gate. Set at
-    /// `open_enroll_wizard` time: always for sovereign and Tier 2, and for Tier 1
-    /// only when some protected Cube lacks a recovery kit (or the per-Cube state
-    /// is unknown — fail toward showing the warning).
-    pub require_backup_ack: bool,
     pub memorized: bool,
     pub submitting: bool,
     pub error: Option<String>,
     /// This device's generated duress code, held between SubmitEnrollment and a
-    /// successful server EnrollResult. For Connect tiers the code is NOT
-    /// persisted locally until the server confirms enrollment, so a server
-    /// failure can't leave a half-armed duress PIN on disk.
+    /// successful server EnrollResult. The code is NOT persisted locally until
+    /// the server confirms enrollment, so a server failure can't leave a
+    /// half-armed duress PIN on disk.
     pub pending_code: Option<String>,
 }
 
 impl DuressEnrollState {
-    /// Whether the backup-acknowledgement gate's typed input is an exact,
-    /// case-sensitive match for [`BACKUP_ACK_PHRASE`]. Drives the disabled state
-    /// of the wizard's advance button on the [`DuressEnrollStep::BackupAck`]
-    /// step, so it can't be cleared by a paraphrase or near-miss.
-    pub fn backup_ack_satisfied(&self) -> bool {
-        self.backup_ack == BACKUP_ACK_PHRASE
-    }
-
     /// Scrubs the in-memory secret fields (PINs, passphrases, and the generated
     /// duress code) so they don't linger on the heap after the wizard is torn
     /// down — e.g. on logout, where the rest of the session is reset.
@@ -649,7 +599,6 @@ impl DuressEnrollState {
         self.duress_pin_confirm.zeroize();
         self.all_clear.zeroize();
         self.crk_password.zeroize();
-        self.backup_ack.zeroize();
         if let Some(code) = self.pending_code.as_mut() {
             code.zeroize();
         }
@@ -889,6 +838,18 @@ impl ConnectAccountPanel {
                 .unwrap_or(false)
     }
 
+    /// True when the account's plan includes Duress Mode (the paid `duress`
+    /// entitlement, set by the server for Pro and Estate). Gates the entire
+    /// duress enrollment surface — the panel CTA, the checklist fetch, and the
+    /// server-state fetch — so a Free account never reaches enrollment. The
+    /// codebase gates on this entitlement bool, not a `PlanTier` name check.
+    pub fn is_duress_entitled(&self) -> bool {
+        self.plan
+            .as_ref()
+            .map(|p| p.entitlements.duress)
+            .unwrap_or(false)
+    }
+
     /// True when the account carries the Estate-only `duress_alerts`
     /// entitlement. Gates both the Emergency-contacts data load and the
     /// management UI (non-entitled accounts get the locked affordance).
@@ -928,12 +889,7 @@ impl ConnectAccountPanel {
     /// them, so the fetch would be wasted). Best-effort: a failed fetch
     /// leaves the list empty and the screen falls back to generic copy.
     pub fn reload_duress_cubes(&mut self) -> iced::Task<Message> {
-        let entitled = self
-            .plan
-            .as_ref()
-            .map(|p| p.entitlements.duress)
-            .unwrap_or(false);
-        if !entitled {
+        if !self.is_duress_entitled() {
             return iced::Task::none();
         }
         // Bump the load token so any older in-flight fetch is discarded when it
@@ -964,12 +920,7 @@ impl ConnectAccountPanel {
     /// flow. No-op for accounts without the duress entitlement. Best-effort:
     /// a failed fetch leaves the state `None` and the setup flow is shown.
     pub fn reload_duress_state(&mut self) -> iced::Task<Message> {
-        let entitled = self
-            .plan
-            .as_ref()
-            .map(|p| p.entitlements.duress)
-            .unwrap_or(false);
-        if !entitled {
+        if !self.is_duress_entitled() {
             return iced::Task::none();
         }
         // Refresh the authoritative LOCAL arm signal (whether THIS device wrote
@@ -2248,50 +2199,25 @@ impl ConnectAccountPanel {
         iced::Task::none()
     }
 
-    /// Opens the duress enrollment wizard for `tier`, resetting all inputs. The
-    /// starting step and whether the mandated backup-acknowledgement gate
-    /// applies are both derived here from `tier` and the per-Cube recovery-kit
-    /// state. Shared by the Tier 1 / Tier 2 / Sovereign entry points.
-    fn open_enroll_wizard(&mut self, tier: EnrollTier) {
+    /// Opens the duress enrollment wizard, resetting all inputs. Duress is a
+    /// paid feature behind a hard, server-verified Recovery-Kit gate, so there
+    /// is a single enrollment path and the wizard always opens at `SetDuressPin`.
+    fn open_enroll_wizard(&mut self) {
         // Scrub any wizard already in flight before replacing it, so re-opening
         // never drops its secrets unzeroized.
         self.clear_duress_enroll();
-        let require_backup_ack = self.compute_require_backup_ack(tier);
-        // The wizard opens at the first step of the tier's (gate-aware) sequence
-        // — `Encourage` for sovereign, `BackupAck` when a Connect tier gates, or
-        // `SetDuressPin` for a fully-backed-up Tier 1.
-        let step = enroll_steps(tier, require_backup_ack)[0];
         self.duress_enroll = Some(DuressEnrollState {
-            tier,
-            step,
+            step: enroll_steps()[0],
             duress_pin: String::new(),
             duress_pin_confirm: String::new(),
             all_clear: String::new(),
             crk_password: String::new(),
             delay: crate::services::duress::enroll::DuressDelay::default(),
-            backup_ack: String::new(),
-            require_backup_ack,
             memorized: false,
             submitting: false,
             error: None,
             pending_code: None,
         });
-    }
-
-    /// Whether this enrollment must pass the mandated backup-acknowledgement
-    /// gate ([`DuressEnrollStep::BackupAck`]). Always for sovereign (no
-    /// server-side recovery) and Tier 2 (Connect, explicitly no recovery kit);
-    /// for Tier 1 only when some Cube a duress wipe would destroy still lacks a
-    /// recovery kit. When the per-Cube state hasn't loaded (`None`), fail toward
-    /// showing the gate — over-warning is safe, silently skipping it isn't.
-    fn compute_require_backup_ack(&self, tier: EnrollTier) -> bool {
-        match tier {
-            EnrollTier::Sovereign | EnrollTier::Tier2 => true,
-            EnrollTier::Tier1 => self
-                .duress_cubes
-                .as_ref()
-                .is_none_or(|cubes| cubes.iter().any(|c| !c.has_recovery_kit)),
-        }
     }
 
     /// Tears down all session state: bumps `session_generation` (so any
@@ -2716,62 +2642,40 @@ impl ConnectAccountPanel {
 
             // ── Enrollment wizard (Phases 2 & 8) ──
             DuressMessage::StartEnrollment => {
-                let entitled = self
-                    .plan
-                    .as_ref()
-                    .map(|p| p.entitlements.duress)
-                    .unwrap_or(false);
-                // Entitled (signed-in) users default to Tier 1, which collects
-                // the account-level duress recovery-kit password — that password
-                // covers current AND future Cubes, so it's safe to collect even
-                // before a CRK exists. A user who explicitly has no recovery kit
-                // takes the Tier 2 path via StartEnrollmentWithoutCrk. Non-
-                // Connect users get the sovereign encouragement flow.
-                // The hard vault gate (PLAN-duress-vault-gate PR 2). The CTA is
+                // Duress is a paid (Pro/Estate) feature. The view hides the CTA
+                // for un-entitled accounts; re-check here as a defensive backstop
+                // so a stale view can never open the wizard without entitlement.
+                if !self.is_duress_entitled() {
+                    return iced::Task::none();
+                }
+                // The hard vault gate (PLAN-duress-vault-gate). The CTA is
                 // rendered disabled while blocked, but re-check here as a
                 // belt-and-suspenders backstop: a stale view (kit status that
-                // landed after the last paint) could still fire this. Only
-                // gates the Tier-1 (with-CRK) path — the Tier-2 bypass and the
-                // sovereign flow are deliberately never gated.
+                // landed after the last paint) could still fire this. With the
+                // Tier-2 bypass and the Sovereign path removed, this gate is the
+                // single hard requirement for enrollment.
                 //
                 // Fail closed when the checklist hasn't loaded (`None`): an
-                // unverified fleet must not open Tier-1 enrollment (master I7 /
-                // Resolved decision 4) — `duress_tier1_gate_blocked` returns
-                // true for `None`. Reload so the checklist (and any retry
-                // affordance) becomes current instead of silently proceeding.
-                if entitled {
-                    if duress_tier1_gate_blocked(self.duress_cubes.as_deref()) {
-                        // No-op: gate blocked (or fleet not yet verified). A
-                        // fresh reload keeps the checklist current.
-                        return self.reload_duress_cubes();
-                    }
-                    self.open_enroll_wizard(EnrollTier::Tier1);
-                    // Kick a fresh checklist fetch as the user commits to
-                    // enrolling. The cached list the gate just read could be
-                    // briefly stale (a routine reload keeps the prior list in
-                    // place while its refetch is in flight); firing one now
-                    // guarantees the `SubmitEnrollment` re-check runs against
-                    // current completeness by the time the wizard is finished.
+                // unverified fleet must not open enrollment (master I7 / Resolved
+                // decision 4) — `duress_tier1_gate_blocked` returns true for
+                // `None`. Reload so the checklist (and any retry affordance)
+                // becomes current instead of silently proceeding.
+                if duress_tier1_gate_blocked(self.duress_cubes.as_deref()) {
+                    // No-op: gate blocked (or fleet not yet verified). A fresh
+                    // reload keeps the checklist current.
                     return self.reload_duress_cubes();
-                } else {
-                    self.open_enroll_wizard(EnrollTier::Sovereign);
                 }
+                self.open_enroll_wizard();
+                // Kick a fresh checklist fetch as the user commits to enrolling.
+                // The cached list the gate just read could be briefly stale (a
+                // routine reload keeps the prior list in place while its refetch
+                // is in flight); firing one now guarantees the `SubmitEnrollment`
+                // re-check runs against current completeness by the time the
+                // wizard is finished.
+                return self.reload_duress_cubes();
             }
             DuressMessage::ReloadCubes => {
                 return self.reload_duress_cubes();
-            }
-            DuressMessage::StartEnrollmentWithoutCrk => {
-                // Tier 2 — Connect, no recovery kit: same as Tier 1 minus the
-                // CRK-password step (see `enroll_steps`), and always behind the
-                // backup-acknowledgement gate (no recovery kit by definition).
-                self.open_enroll_wizard(EnrollTier::Tier2);
-            }
-            DuressMessage::SignUpForConnect => {
-                self.clear_duress_enroll();
-                self.step = ConnectFlowStep::Register {
-                    email: String::new(),
-                    loading: false,
-                };
             }
             DuressMessage::CancelEnrollment => {
                 // Ignore cancel while a server enroll_duress is in flight:
@@ -2810,11 +2714,6 @@ impl ConnectAccountPanel {
                     e.delay = d;
                 }
             }
-            DuressMessage::BackupAckChanged(v) => {
-                if let Some(e) = &mut self.duress_enroll {
-                    e.backup_ack = v;
-                }
-            }
             DuressMessage::MemorizedToggled(v) => {
                 if let Some(e) = &mut self.duress_enroll {
                     e.memorized = v;
@@ -2823,7 +2722,7 @@ impl ConnectAccountPanel {
             DuressMessage::EnrollBack => {
                 if let Some(e) = &mut self.duress_enroll {
                     e.error = None;
-                    e.step = prev_enroll_step(e.tier, e.require_backup_ack, e.step);
+                    e.step = prev_enroll_step(e.step);
                 }
             }
             DuressMessage::EnrollNext => {
@@ -2832,7 +2731,7 @@ impl ConnectAccountPanel {
                         e.error = Some(msg);
                     } else {
                         e.error = None;
-                        e.step = next_enroll_step(e.tier, e.require_backup_ack, e.step);
+                        e.step = next_enroll_step(e.step);
                     }
                 }
             }
@@ -2842,13 +2741,12 @@ impl ConnectAccountPanel {
                 // the wizard is open — a mid-session Vault creation calls
                 // `invalidate_duress_cubes` and expects the gate to stay closed
                 // until the new Vault's kit is complete. Re-check at the actual
-                // commit for Tier-1 (Tier-2 bypass and Sovereign are never
-                // gated), mirroring the PIN-collision pre-flight below: surface
-                // the block on the wizard and refresh the checklist, without
-                // firing the enroll. Fails closed on an invalidated/unloaded
-                // checklist (`None`), which is exactly the mid-wizard-Vault case.
-                let tier = self.duress_enroll.as_ref().map(|e| e.tier);
-                if tier == Some(EnrollTier::Tier1)
+                // commit (the single hard-gated path), mirroring the
+                // PIN-collision pre-flight below: surface the block on the wizard
+                // and refresh the checklist, without firing the enroll. Fails
+                // closed on an invalidated/unloaded checklist (`None`), which is
+                // exactly the mid-wizard-Vault case.
+                if self.duress_enroll.is_some()
                     && duress_tier1_gate_blocked(self.duress_cubes.as_deref())
                 {
                     if let Some(e) = &mut self.duress_enroll {
@@ -2903,45 +2801,25 @@ impl ConnectAccountPanel {
                 }
                 e.submitting = true;
                 e.error = None;
-                let tier = e.tier;
                 let gen = self.session_generation;
 
                 // Generate this device's duress code ONCE: its hash goes to the
                 // server, the same plaintext is persisted (encrypted) locally.
                 let code = enroll::generate_duress_code();
 
-                if tier == EnrollTier::Sovereign {
-                    // No Connect call — local wipe + cryptic only. Persist now.
-                    // The cached state is flipped to "enrolled" only once persist
-                    // succeeds (via `EnrollmentPersisted`), so a failed persist
-                    // doesn't leave a false "enabled" view with no Cube armed.
-                    let duress_pin = e.duress_pin.clone();
-                    self.clear_duress_enroll();
-                    return iced::Task::done(Message::CompleteDuressEnrollment(
-                        crate::app::message::DuressEnrollmentPayload {
-                            duress_pin: zeroize::Zeroizing::new(duress_pin),
-                            duress_code: zeroize::Zeroizing::new(code),
-                            account_id: None,
-                            gen,
-                        },
-                    ));
-                }
-
-                // Connect tiers: enroll on the server FIRST. The duress PIN +
-                // code are persisted locally only after a successful
-                // EnrollResult, so a server failure can't leave a half-armed
-                // duress PIN on disk. Stash the code for that success handler.
-                // Zeroize any code stashed by a prior submit (retry) before
-                // replacing it, so the superseded plaintext doesn't linger.
+                // Enroll on the server FIRST. The duress PIN + code are persisted
+                // locally only after a successful EnrollResult, so a server
+                // failure can't leave a half-armed duress PIN on disk. Stash the
+                // code for that success handler. Zeroize any code stashed by a
+                // prior submit (retry) before replacing it, so the superseded
+                // plaintext doesn't linger.
                 if let Some(mut old) = e.pending_code.replace(code.clone()) {
                     zeroize::Zeroize::zeroize(&mut old);
                 }
                 let all_clear_hash = enroll::hash_duress_secret(&e.all_clear);
-                let crk_hash = if tier == EnrollTier::Tier1 {
-                    Some(enroll::hash_duress_secret(&e.crk_password))
-                } else {
-                    None
-                };
+                // Single path always collects the account-level duress
+                // recovery-kit password (Approach C).
+                let crk_hash = Some(enroll::hash_duress_secret(&e.crk_password));
                 let code_hash = enroll::hash_duress_secret(&code);
                 let delay_minutes = e.delay.minutes();
 
@@ -3007,7 +2885,7 @@ impl ConnectAccountPanel {
                         // Clone the forwarded secrets into the Zeroizing payload,
                         // then scrub the wizard via the shared helper — this path
                         // must not drop the leftover fields (all_clear, CRK
-                        // password, backup_ack) unzeroized.
+                        // password) unzeroized.
                         let payload = self.duress_enroll.as_ref().map(|e| {
                             crate::app::message::DuressEnrollmentPayload {
                                 duress_pin: zeroize::Zeroizing::new(e.duress_pin.clone()),
@@ -4200,7 +4078,10 @@ fn load_duress_cubes(client: &CoincubeClient, generation: u64, seq: u64) -> iced
                 }
             }))
             .await;
-            Some(rows)
+            // Fold in local mainnet Cubes the server list omits (unregistered /
+            // `remote_synced == false`): armed by duress but invisible to the
+            // server-driven gate. Fail closed on them (`append_local_only_rows`).
+            Some(append_local_only_rows(rows, &local))
         },
         move |cubes| {
             Message::View(view::Message::ConnectAccount(
@@ -4219,6 +4100,9 @@ fn load_duress_cubes(client: &CoincubeClient, generation: u64, seq: u64) -> iced
 struct LocalCubeShape {
     /// Local `CubeSettings.id`, which equals the server Cube `uuid`.
     uuid: String,
+    /// Local `CubeSettings.name`, used to label a local-only Cube in the
+    /// checklist when it has no server row to borrow a name from.
+    name: String,
     has_vault: bool,
     is_passkey: bool,
 }
@@ -4254,10 +4138,49 @@ fn load_local_cube_shapes() -> Vec<LocalCubeShape> {
         .iter()
         .map(|c| LocalCubeShape {
             uuid: c.id.clone(),
+            name: c.name.clone(),
             has_vault: c.vault_wallet_id.is_some(),
             is_passkey: c.is_passkey_cube(),
         })
         .collect()
+}
+
+/// Append synthetic checklist rows for local mainnet Cubes that are **not**
+/// present in the server-derived `rows` — e.g. a Cube created on this device but
+/// not yet registered with Connect (`remote_synced == false`), which
+/// `list_cubes` therefore omits. Duress arming iterates local `settings.cubes`
+/// (all Cubes, all networks — see `persist_duress_enrollment`), so such a Cube
+/// **is** wiped, yet the server-driven gate never sees it: a fail-open hole.
+///
+/// Each synthetic row carries `halves: None` → completeness `Unknown`, so
+/// [`DuressCube::blocks_gate`] fails **closed** for any local-only Vault Cube
+/// (vaultless Cubes stay non-blocking per master invariant I2). The Cube also
+/// surfaces in the checklist so the user can see what to finish. Pure (no I/O)
+/// so it is unit-testable independently of the async `load_duress_cubes`.
+fn append_local_only_rows(mut rows: Vec<DuressCube>, local: &[LocalCubeShape]) -> Vec<DuressCube> {
+    for l in local {
+        let already_listed = rows
+            .iter()
+            .any(|r| r.uuid.as_deref() == Some(l.uuid.as_str()));
+        if already_listed {
+            continue;
+        }
+        rows.push(DuressCube {
+            // Sentinel: no server record exists for this Cube, so there is no
+            // server id and no per-cube kit-status fetch. `halves` is already
+            // `None`, so `server_id` is never used to address the server here.
+            server_id: 0,
+            uuid: Some(l.uuid.clone()),
+            name: l.name.clone(),
+            has_recovery_kit: false,
+            // Status unknowable (not on Connect) → fails the gate closed.
+            halves: None,
+            has_vault: Some(l.has_vault),
+            is_passkey: Some(l.is_passkey),
+            local: true,
+        });
+    }
+    rows
 }
 
 /// Fetch server-side duress state (enrolled / active) for the Duress intro
@@ -4595,51 +4518,31 @@ fn device_fingerprint() -> Result<String, String> {
         .map_err(|e| format!("device fingerprint unavailable: {e}"))
 }
 
-/// The ordered steps for a tier. Sovereign opens with the Connect
-/// encouragement + friction confirm; Connect tiers skip those. `SetCrkPassword`
-/// is Tier 1 only.
-/// The ordered steps for `tier`, with the mandated backup-acknowledgement gate
-/// spliced in when `require_backup_ack` is set. The gate sits right after the
-/// sovereign `Encourage` screen, or at the very front for Connect tiers (which
-/// have no `Encourage` screen).
-fn enroll_steps(tier: EnrollTier, require_backup_ack: bool) -> Vec<DuressEnrollStep> {
+/// The single ordered enrollment sequence: duress PIN → all-clear passphrase →
+/// account-level duress recovery-kit password → unlock delay → confirm. Duress
+/// is paid + behind the hard Recovery-Kit gate, so there is no tier branching
+/// and no self-attestation step.
+fn enroll_steps() -> Vec<DuressEnrollStep> {
     use DuressEnrollStep::*;
-    let mut steps = match tier {
-        EnrollTier::Tier1 => vec![
-            SetDuressPin,
-            SetAllClear,
-            SetCrkPassword,
-            PickDelay,
-            Confirm,
-        ],
-        EnrollTier::Tier2 => vec![SetDuressPin, SetAllClear, PickDelay, Confirm],
-        EnrollTier::Sovereign => vec![Encourage, SetDuressPin, Confirm],
-    };
-    if require_backup_ack {
-        let pos = usize::from(matches!(tier, EnrollTier::Sovereign));
-        steps.insert(pos, BackupAck);
-    }
-    steps
+    vec![
+        SetDuressPin,
+        SetAllClear,
+        SetCrkPassword,
+        PickDelay,
+        Confirm,
+    ]
 }
 
-fn next_enroll_step(
-    tier: EnrollTier,
-    require_backup_ack: bool,
-    cur: DuressEnrollStep,
-) -> DuressEnrollStep {
-    let steps = enroll_steps(tier, require_backup_ack);
+fn next_enroll_step(cur: DuressEnrollStep) -> DuressEnrollStep {
+    let steps = enroll_steps();
     match steps.iter().position(|s| *s == cur) {
         Some(i) if i + 1 < steps.len() => steps[i + 1],
         _ => cur,
     }
 }
 
-fn prev_enroll_step(
-    tier: EnrollTier,
-    require_backup_ack: bool,
-    cur: DuressEnrollStep,
-) -> DuressEnrollStep {
-    let steps = enroll_steps(tier, require_backup_ack);
+fn prev_enroll_step(cur: DuressEnrollStep) -> DuressEnrollStep {
+    let steps = enroll_steps();
     match steps.iter().position(|s| *s == cur) {
         Some(i) if i > 0 => steps[i - 1],
         _ => cur,
@@ -4651,16 +4554,6 @@ fn prev_enroll_step(
 fn validate_enroll_step(e: &DuressEnrollState) -> Result<(), String> {
     use crate::services::duress::enroll;
     match e.step {
-        DuressEnrollStep::Encourage => Ok(()),
-        DuressEnrollStep::BackupAck => {
-            // Strict, case-sensitive, no whitespace normalization — the gate
-            // can't be passed by paraphrase or a near-miss.
-            if e.backup_ack == BACKUP_ACK_PHRASE {
-                Ok(())
-            } else {
-                Err("Type the confirmation phrase exactly to continue.".to_string())
-            }
-        }
         DuressEnrollStep::SetDuressPin => {
             enroll::validate_duress_pin(&e.duress_pin, &e.duress_pin_confirm)
         }
@@ -4684,19 +4577,14 @@ mod duress_enroll_tests {
     use super::*;
     use crate::services::coincube::OwnerSelfRecoverySummary;
 
-    fn state(tier: EnrollTier, step: DuressEnrollStep) -> DuressEnrollState {
+    fn state(step: DuressEnrollStep) -> DuressEnrollState {
         DuressEnrollState {
-            tier,
             step,
             duress_pin: String::new(),
             duress_pin_confirm: String::new(),
             all_clear: String::new(),
             crk_password: String::new(),
             delay: crate::services::duress::enroll::DuressDelay::default(),
-            backup_ack: String::new(),
-            // Default the tests to "gate on" so a `BackupAck` step is always
-            // reachable; individual gate-inclusion tests set this explicitly.
-            require_backup_ack: true,
             memorized: false,
             submitting: false,
             error: None,
@@ -4706,11 +4594,10 @@ mod duress_enroll_tests {
 
     #[test]
     fn zeroize_secrets_clears_all_sensitive_fields() {
-        let mut s = state(EnrollTier::Tier1, DuressEnrollStep::Confirm);
+        let mut s = state(DuressEnrollStep::Confirm);
         s.duress_pin = "8765".to_string();
         s.all_clear = "correct horse battery".to_string();
         s.crk_password = "a-long-crk-password".to_string();
-        s.backup_ack = BACKUP_ACK_PHRASE.to_string();
         s.pending_code = Some("deadbeefcafebabe".to_string());
 
         s.zeroize_secrets();
@@ -4718,14 +4605,27 @@ mod duress_enroll_tests {
         assert!(s.duress_pin.is_empty());
         assert!(s.all_clear.is_empty());
         assert!(s.crk_password.is_empty());
-        assert!(s.backup_ack.is_empty());
         assert!(s.pending_code.as_deref().unwrap_or("").is_empty());
     }
 
     #[test]
-    fn tier1_step_order_no_gate() {
-        // Fully-backed-up Tier 1 (gate skipped) keeps the original sequence.
-        let mut s = DuressEnrollStep::SetDuressPin;
+    fn enroll_is_a_single_fixed_sequence() {
+        // Duress is paid + behind the hard Recovery-Kit gate, so there is one
+        // path: no tier branching, no self-attestation step.
+        assert_eq!(
+            enroll_steps(),
+            vec![
+                DuressEnrollStep::SetDuressPin,
+                DuressEnrollStep::SetAllClear,
+                DuressEnrollStep::SetCrkPassword,
+                DuressEnrollStep::PickDelay,
+                DuressEnrollStep::Confirm,
+            ]
+        );
+    }
+
+    #[test]
+    fn enroll_step_order_walks_the_sequence_and_saturates() {
         let order = [
             DuressEnrollStep::SetDuressPin,
             DuressEnrollStep::SetAllClear,
@@ -4733,55 +4633,24 @@ mod duress_enroll_tests {
             DuressEnrollStep::PickDelay,
             DuressEnrollStep::Confirm,
         ];
+        let mut s = DuressEnrollStep::SetDuressPin;
         for expected in &order[1..] {
-            s = next_enroll_step(EnrollTier::Tier1, false, s);
+            s = next_enroll_step(s);
             assert_eq!(s, *expected);
         }
-        // Saturates at the end.
+        // Saturates at both ends.
         assert_eq!(
-            next_enroll_step(EnrollTier::Tier1, false, DuressEnrollStep::Confirm),
+            next_enroll_step(DuressEnrollStep::Confirm),
             DuressEnrollStep::Confirm
         );
-    }
-
-    #[test]
-    fn tier1_gate_prepends_backup_ack() {
-        // A Tier 1 with a Cube lacking a recovery kit opens at the gate, then
-        // flows into the normal sequence.
-        let steps = enroll_steps(EnrollTier::Tier1, true);
-        assert_eq!(steps[0], DuressEnrollStep::BackupAck);
         assert_eq!(
-            next_enroll_step(EnrollTier::Tier1, true, DuressEnrollStep::BackupAck),
+            prev_enroll_step(DuressEnrollStep::SetDuressPin),
             DuressEnrollStep::SetDuressPin
         );
-        // Back from the gate saturates (it's the first step).
+        // Backward step.
         assert_eq!(
-            prev_enroll_step(EnrollTier::Tier1, true, DuressEnrollStep::BackupAck),
-            DuressEnrollStep::BackupAck
-        );
-    }
-
-    #[test]
-    fn tier2_always_gates_and_skips_crk_password() {
-        let steps = enroll_steps(EnrollTier::Tier2, true);
-        assert_eq!(steps[0], DuressEnrollStep::BackupAck);
-        assert!(!steps.contains(&DuressEnrollStep::SetCrkPassword));
-        assert_eq!(
-            next_enroll_step(EnrollTier::Tier2, true, DuressEnrollStep::SetAllClear),
+            prev_enroll_step(DuressEnrollStep::Confirm),
             DuressEnrollStep::PickDelay
-        );
-    }
-
-    #[test]
-    fn sovereign_opens_with_encourage_then_gate() {
-        // Sovereign always gates; the gate sits right after the Encourage screen.
-        assert_eq!(
-            enroll_steps(EnrollTier::Sovereign, true)[0],
-            DuressEnrollStep::Encourage
-        );
-        assert_eq!(
-            next_enroll_step(EnrollTier::Sovereign, true, DuressEnrollStep::Encourage),
-            DuressEnrollStep::BackupAck
         );
     }
 
@@ -4850,25 +4719,61 @@ mod duress_enroll_tests {
         );
     }
 
+    fn local_shape(uuid: &str, has_vault: bool) -> LocalCubeShape {
+        LocalCubeShape {
+            uuid: uuid.to_string(),
+            name: uuid.to_string(),
+            has_vault,
+            is_passkey: false,
+        }
+    }
+
     #[test]
-    fn require_backup_ack_gating() {
-        let mut panel = ConnectAccountPanel::new();
+    fn append_local_only_rows_fails_closed_on_unregistered_vault_cube() {
+        // A local mainnet Vault Cube absent from the server list (unregistered /
+        // remote_synced == false) is armed by duress but invisible to the
+        // server-driven gate. It must be folded in as an Unknown row so the gate
+        // fails closed.
+        let server = vec![duress_cube("on-server", true)];
+        let rows = append_local_only_rows(server, &[local_shape("local-only", true)]);
+        assert_eq!(rows.len(), 2);
+        let added = rows
+            .iter()
+            .find(|r| r.uuid.as_deref() == Some("local-only"))
+            .expect("local-only cube folded in");
+        assert!(added.local);
+        assert_eq!(added.halves, None, "unknown status → fails closed");
+        assert!(added.blocks_gate(), "unregistered Vault Cube must block");
+        assert!(duress_gate_blocked(&rows));
+    }
 
-        // Sovereign and Tier 2 always gate, regardless of cube state.
-        assert!(panel.compute_require_backup_ack(EnrollTier::Sovereign));
-        assert!(panel.compute_require_backup_ack(EnrollTier::Tier2));
+    #[test]
+    fn append_local_only_rows_leaves_vaultless_cube_non_blocking() {
+        // A vaultless local-only Cube never blocks (master invariant I2).
+        let rows = append_local_only_rows(Vec::new(), &[local_shape("seed-only", false)]);
+        assert_eq!(rows.len(), 1);
+        assert!(!rows[0].blocks_gate());
+        assert!(!duress_gate_blocked(&rows));
+    }
 
-        // Tier 1 with unknown cube state (not yet loaded) → fail toward the gate.
-        panel.duress_cubes = None;
-        assert!(panel.compute_require_backup_ack(EnrollTier::Tier1));
+    #[test]
+    fn append_local_only_rows_does_not_duplicate_a_server_cube() {
+        // A local Cube already present on the server (matched by uuid) is not
+        // re-added — the server row, with its real kit status, wins.
+        let server = vec![duress_cube("dup", true)];
+        let rows = append_local_only_rows(server, &[local_shape("dup", false)]);
+        assert_eq!(rows.len(), 1);
+        assert!(
+            rows[0].halves.is_some(),
+            "kept the server row, not a synthetic Unknown"
+        );
+    }
 
-        // Tier 1 with every cube backed up → skip the gate.
-        panel.duress_cubes = Some(vec![duress_cube("A", true), duress_cube("B", true)]);
-        assert!(!panel.compute_require_backup_ack(EnrollTier::Tier1));
-
-        // Tier 1 with any cube lacking a recovery kit → gate.
-        panel.duress_cubes = Some(vec![duress_cube("A", true), duress_cube("B", false)]);
-        assert!(panel.compute_require_backup_ack(EnrollTier::Tier1));
+    #[test]
+    fn append_local_only_rows_noop_on_empty_local() {
+        let server = vec![duress_cube("a", true), duress_cube("b", true)];
+        let rows = append_local_only_rows(server, &[]);
+        assert_eq!(rows.len(), 2);
     }
 
     #[test]
@@ -5058,11 +4963,13 @@ mod duress_enroll_tests {
     fn merge_vault_shape_precedence_local_over_server() {
         let local_vault = LocalCubeShape {
             uuid: "u".into(),
+            name: "u".into(),
             has_vault: true,
             is_passkey: false,
         };
         let local_vaultless = LocalCubeShape {
             uuid: "u".into(),
+            name: "u".into(),
             has_vault: false,
             is_passkey: true,
         };
@@ -5254,7 +5161,7 @@ mod duress_enroll_tests {
         // the wizard is open (a mid-wizard Vault creation invalidates the
         // checklist). SubmitEnrollment must re-check for Tier-1 and refuse.
         let mut panel = ConnectAccountPanel::new();
-        panel.duress_enroll = Some(state(EnrollTier::Tier1, DuressEnrollStep::Confirm));
+        panel.duress_enroll = Some(state(DuressEnrollStep::Confirm));
 
         // A Vault Cube with an incomplete kit is now in the checklist.
         panel.duress_cubes = Some(vec![DuressCube {
@@ -5273,7 +5180,7 @@ mod duress_enroll_tests {
 
         // Fail-closed on an invalidated (None) checklist too — the exact
         // mid-wizard-Vault-creation case.
-        panel.duress_enroll = Some(state(EnrollTier::Tier1, DuressEnrollStep::Confirm));
+        panel.duress_enroll = Some(state(DuressEnrollStep::Confirm));
         panel.invalidate_duress_cubes();
         let _ = panel.update_duress(DuressMessage::SubmitEnrollment);
         let e = panel.duress_enroll.as_ref().expect("wizard stays open");
@@ -5326,7 +5233,7 @@ mod duress_enroll_tests {
         // PIN entered twice passes the step. Collision with a real Cube PIN is
         // enforced at persist time (`persist_duress_enrollment`), where Cube
         // PIN hashes are available.
-        let mut s = state(EnrollTier::Tier1, DuressEnrollStep::SetDuressPin);
+        let mut s = state(DuressEnrollStep::SetDuressPin);
         assert!(validate_enroll_step(&s).is_err());
         s.duress_pin = "1235".to_string();
         // Confirmation still empty → mismatch.
@@ -5336,46 +5243,8 @@ mod duress_enroll_tests {
     }
 
     #[test]
-    fn backup_ack_requires_exact_case_sensitive_phrase() {
-        let mut s = state(EnrollTier::Sovereign, DuressEnrollStep::BackupAck);
-        // Near-misses keep the gate closed: empty, a paraphrase, the old phrase,
-        // a case change, and trailing/leading whitespace (no normalization).
-        for near_miss in [
-            "",
-            "nope",
-            "I have my seed-phrase backup",
-            &BACKUP_ACK_PHRASE.to_lowercase(),
-            &format!("{BACKUP_ACK_PHRASE} "),
-            &format!(" {BACKUP_ACK_PHRASE}"),
-            &BACKUP_ACK_PHRASE.replace('.', ""),
-        ] {
-            s.backup_ack = near_miss.to_string();
-            assert!(
-                validate_enroll_step(&s).is_err(),
-                "near-miss should keep the gate closed: {:?}",
-                near_miss
-            );
-            assert!(!s.backup_ack_satisfied());
-        }
-        // The exact, character-for-character phrase passes.
-        s.backup_ack = BACKUP_ACK_PHRASE.to_string();
-        assert!(validate_enroll_step(&s).is_ok());
-        assert!(s.backup_ack_satisfied());
-    }
-
-    #[test]
-    fn backup_ack_phrase_names_both_artifacts() {
-        // The mandated phrase must name both destroyed artifacts and the funds
-        // consequence (snapshot of the spec wording).
-        assert!(BACKUP_ACK_PHRASE.contains("Master Seed Phrases"));
-        assert!(BACKUP_ACK_PHRASE.contains("Vault Wallet Descriptors"));
-        assert!(BACKUP_ACK_PHRASE.contains("permanently destroyed"));
-        assert!(BACKUP_ACK_PHRASE.contains("funds"));
-    }
-
-    #[test]
     fn confirm_requires_memorized_checkbox() {
-        let mut s = state(EnrollTier::Tier1, DuressEnrollStep::Confirm);
+        let mut s = state(DuressEnrollStep::Confirm);
         assert!(validate_enroll_step(&s).is_err());
         s.memorized = true;
         assert!(validate_enroll_step(&s).is_ok());

--- a/coincube-gui/src/app/state/connect/mod.rs
+++ b/coincube-gui/src/app/state/connect/mod.rs
@@ -85,8 +85,8 @@ pub use account::{
     cube_backup_completeness, duress_gate_blocked, duress_tier1_gate_blocked, AddToCubeDialog,
     CheckoutPhase, CheckoutState, ConnectAccountPanel, ConnectFlowStep, ContactsState,
     ContactsStep, CubeBackupCompleteness, DuressContactsState, DuressContactsStep, DuressCube,
-    DuressDisableState, DuressEnrollState, DuressEnrollStep, DuressGateStatus, EnrollTier,
-    InviteCubeOption, PlanLifecycle, BACKUP_ACK_PHRASE,
+    DuressDisableState, DuressEnrollState, DuressEnrollStep, DuressGateStatus, InviteCubeOption,
+    PlanLifecycle,
 };
 pub use cube::ConnectCubePanel;
 pub use cube_members::ConnectCubeMembersState;

--- a/coincube-gui/src/app/view/connect/duress_contacts.rs
+++ b/coincube-gui/src/app/view/connect/duress_contacts.rs
@@ -111,6 +111,12 @@ fn locked_card<'a>() -> Element<'a, ConnectAccountMessage> {
                 )
                 .color(color::GREY_3),
             )
+            .push(iced::widget::Space::new().height(Length::Fixed(14.0)))
+            .push(
+                button::primary(None, "View plans")
+                    .width(Length::Fixed(160.0))
+                    .on_press(ConnectAccountMessage::OpenPlanBilling),
+            )
             .padding(20)
             .spacing(0),
     )

--- a/coincube-gui/src/app/view/connect/duress_enroll.rs
+++ b/coincube-gui/src/app/view/connect/duress_enroll.rs
@@ -14,9 +14,7 @@ use coincube_ui::{
 };
 use iced::Length;
 
-use crate::app::state::connect::{
-    DuressDisableState, DuressEnrollState, DuressEnrollStep, EnrollTier, BACKUP_ACK_PHRASE,
-};
+use crate::app::state::connect::{DuressDisableState, DuressEnrollState, DuressEnrollStep};
 use crate::app::view::{ConnectAccountMessage, DuressMessage};
 use crate::services::duress::enroll::{DuressDelay, MIN_ALL_CLEAR_LEN};
 
@@ -185,12 +183,11 @@ pub fn disable_ux(state: &DuressDisableState) -> Element<'_, ConnectAccountMessa
 // Phases 2 & 8 — enrollment wizard
 // =============================================================================
 
-/// The multi-step enrollment wizard. Tier-aware: sovereign opens with the
-/// Connect-encouragement screen, Connect tiers start at the duress-PIN step.
+/// The multi-step enrollment wizard: duress PIN → all-clear passphrase → duress
+/// recovery-kit password → unlock delay → confirm. Single path — duress is a
+/// paid feature behind the hard, server-verified Recovery-Kit gate.
 pub fn enroll_ux(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
     let body = match state.step {
-        DuressEnrollStep::Encourage => encourage_step(),
-        DuressEnrollStep::BackupAck => backup_ack_step(state),
         DuressEnrollStep::SetDuressPin => duress_pin_step(state),
         DuressEnrollStep::SetAllClear => all_clear_step(state),
         DuressEnrollStep::SetCrkPassword => crk_password_step(state),
@@ -208,126 +205,42 @@ pub fn enroll_ux(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage
         col = col.push(text::p2_regular(err.clone()).color(color::RED));
     }
 
-    // Navigation row. `Encourage` is special (its own CTAs); every other step
-    // gets Back + (Next | Complete enrollment).
-    if !matches!(state.step, DuressEnrollStep::Encourage) {
-        let is_last = matches!(state.step, DuressEnrollStep::Confirm);
-        let primary = if is_last {
-            if state.submitting {
-                button::primary(None, "Enrolling…").width(Length::Fixed(200.0))
-            } else {
-                button::primary(None, "Complete enrollment")
-                    .width(Length::Fixed(200.0))
-                    .on_press(msg(DuressMessage::SubmitEnrollment))
-            }
+    // Navigation row: Back + (Next | Complete enrollment).
+    let is_last = matches!(state.step, DuressEnrollStep::Confirm);
+    let primary = if is_last {
+        if state.submitting {
+            button::primary(None, "Enrolling…").width(Length::Fixed(200.0))
         } else {
-            // On the backup-acknowledgement gate, "Next" stays disabled until
-            // the phrase is an exact, case-sensitive match — no paraphrase, no
-            // checkbox shortcut. Every other step advances freely (its own
-            // validation runs on press).
-            let ready =
-                !matches!(state.step, DuressEnrollStep::BackupAck) || state.backup_ack_satisfied();
-            button::primary(None, "Next")
-                .width(Length::Fixed(120.0))
-                .on_press_maybe(ready.then(|| msg(DuressMessage::EnrollNext)))
-        };
-        col = col.push(
-            Row::new()
-                .spacing(12)
-                .push(
-                    button::secondary(None, "Back")
-                        .width(Length::Fixed(120.0))
-                        .on_press(msg(DuressMessage::EnrollBack)),
-                )
-                .push(iced::widget::Space::new().width(Length::Fill))
-                .push(
-                    // Disabled while submitting: cancelling mid-enroll would
-                    // zeroize the duress secrets before the server result lands.
-                    button::transparent(None, "Cancel").on_press_maybe(
-                        (!state.submitting).then(|| msg(DuressMessage::CancelEnrollment)),
-                    ),
-                )
-                .push(primary),
-        );
-    }
+            button::primary(None, "Complete enrollment")
+                .width(Length::Fixed(200.0))
+                .on_press(msg(DuressMessage::SubmitEnrollment))
+        }
+    } else {
+        // Each step advances freely; its own validation runs on press.
+        button::primary(None, "Next")
+            .width(Length::Fixed(120.0))
+            .on_press(msg(DuressMessage::EnrollNext))
+    };
+    col = col.push(
+        Row::new()
+            .spacing(12)
+            .push(
+                button::secondary(None, "Back")
+                    .width(Length::Fixed(120.0))
+                    .on_press(msg(DuressMessage::EnrollBack)),
+            )
+            .push(iced::widget::Space::new().width(Length::Fill))
+            .push(
+                // Disabled while submitting: cancelling mid-enroll would
+                // zeroize the duress secrets before the server result lands.
+                button::transparent(None, "Cancel").on_press_maybe(
+                    (!state.submitting).then(|| msg(DuressMessage::CancelEnrollment)),
+                ),
+            )
+            .push(primary),
+    );
 
     col.width(Length::Fill).into()
-}
-
-fn encourage_step<'a>() -> Element<'a, ConnectAccountMessage> {
-    card(
-        Column::new()
-            .push(
-                text::p1_bold("We recommend setting up Connect before enabling duress mode.")
-                    .style(theme::text::primary),
-            )
-            .push(
-                text::p2_regular("Connect makes duress mode safer and more forgiving:")
-                    .color(color::GREY_3),
-            )
-            .push(
-                text::p2_regular(
-                    "• Cube Recovery Kit — restore after a wipe with no paper seed phrase.\n\
-                 • All-clear passphrase — undo an accidental or coerced activation from a \
-                 trusted device. Sovereign duress has no all-clear.\n\
-                 • Lockout window (24h–90d) — buys you time to reach a trusted device.\n\
-                 • Cross-device signaling — the Keychain signer auto-refuses during duress.\n\
-                 • Trusted-device delay on new-device downloads.",
-                )
-                .color(color::GREY_3),
-            )
-            .push(iced::widget::Space::new().height(Length::Fixed(12.0)))
-            .push(
-                button::primary(None, "Sign up for Connect")
-                    .width(Length::Fixed(240.0))
-                    .on_press(msg(DuressMessage::SignUpForConnect)),
-            )
-            .push(
-                button::transparent(None, "Continue without Connect (advanced)")
-                    .on_press(msg(DuressMessage::EnrollNext)),
-            ),
-    )
-}
-
-fn backup_ack_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
-    // Name BOTH destroyed artifacts explicitly — the Master Seed Phrase(s) AND
-    // the Vault Wallet Descriptor(s) — and the funds consequence. A duress wipe
-    // without a Cube Recovery Kit is only reversible from the user's own
-    // external backup of both.
-    let mut col = Column::new()
-        .push(text::p1_bold("No recovery without your own backup").style(theme::text::warning))
-        .push(
-            text::p2_regular(
-                "Activating duress permanently destroys every Cube on this device. Without a \
-                 Cube Recovery Kit, the only way back is your OWN external backup of BOTH your \
-                 Master Seed Phrase(s) AND your Vault Wallet Descriptor(s). If you don't have \
-                 both, the wipe is irreversible and any funds held in those Cubes are gone — \
-                 there is no server-side recovery path.",
-            )
-            .color(color::GREY_3),
-        )
-        .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
-        .push(text::p2_regular("Type the following exactly to continue:").color(color::GREY_3))
-        .push(text::p2_bold(BACKUP_ACK_PHRASE).style(theme::text::primary))
-        .push(
-            TextInput::new("Type the confirmation phrase exactly", &state.backup_ack)
-                .on_input(|v| msg(DuressMessage::BackupAckChanged(v)))
-                .padding(15),
-        );
-
-    // Connect tiers: keep the recommended path one tap away. Cancelling returns
-    // to the Duress panel, where the per-Cube recovery-kit checklist lives.
-    // Sovereign has no recovery kit, so there's no off-ramp to offer.
-    if state.tier != EnrollTier::Sovereign {
-        col = col
-            .push(iced::widget::Space::new().height(Length::Fixed(8.0)))
-            .push(
-                button::secondary(None, "Set up a Recovery Kit first")
-                    .on_press(msg(DuressMessage::CancelEnrollment)),
-            );
-    }
-
-    card(col)
 }
 
 fn duress_pin_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
@@ -448,18 +361,14 @@ fn delay_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
 }
 
 fn confirm_step(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage> {
-    // Every tier sets a duress PIN; only Connect tiers collect an all-clear
-    // passphrase, and only Tier 1 a recovery-kit password. Sovereign never
-    // creates an all-clear, so don't tell it to memorize one.
-    let mut creds = Column::new()
+    // The single enrollment path always collects all three credentials: a
+    // duress PIN, an all-clear passphrase, and the account-level duress
+    // recovery-kit password.
+    let creds = Column::new()
         .spacing(4)
-        .push(text::p2_regular("• Duress PIN").color(color::GREY_3));
-    if state.tier != EnrollTier::Sovereign {
-        creds = creds.push(text::p2_regular("• All-clear passphrase").color(color::GREY_3));
-    }
-    if state.tier == EnrollTier::Tier1 {
-        creds = creds.push(text::p2_regular("• Duress recovery-kit password").color(color::GREY_3));
-    }
+        .push(text::p2_regular("• Duress PIN").color(color::GREY_3))
+        .push(text::p2_regular("• All-clear passphrase").color(color::GREY_3))
+        .push(text::p2_regular("• Duress recovery-kit password").color(color::GREY_3));
 
     card(
         Column::new()

--- a/coincube-gui/src/app/view/connect/duress_enroll.rs
+++ b/coincube-gui/src/app/view/connect/duress_enroll.rs
@@ -225,9 +225,14 @@ pub fn enroll_ux(state: &DuressEnrollState) -> Element<'_, ConnectAccountMessage
         Row::new()
             .spacing(12)
             .push(
+                // Inert on the first step: there is no previous step to return
+                // to (matches the Cancel affordance's disabled pattern).
                 button::secondary(None, "Back")
                     .width(Length::Fixed(120.0))
-                    .on_press(msg(DuressMessage::EnrollBack)),
+                    .on_press_maybe(
+                        (!matches!(state.step, DuressEnrollStep::SetDuressPin))
+                            .then(|| msg(DuressMessage::EnrollBack)),
+                    ),
             )
             .push(iced::widget::Space::new().width(Length::Fill))
             .push(

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -1620,25 +1620,25 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
         return duress_contacts::form_ux(state);
     }
 
-    let entitled = state
-        .plan
-        .as_ref()
-        .map(|p| p.entitlements.duress)
-        .unwrap_or(false);
-
     let mut col = Column::new()
         .push(text::h4_bold("Duress Mode").style(theme::text::primary))
         .push(iced::widget::Space::new().height(Length::Fixed(15.0)));
 
-    if !entitled {
+    if !state.is_duress_entitled() {
         return col
             .push(
                 container(
                     Column::new()
+                        .spacing(12)
                         .push(text::p1_regular(
                             "Duress mode is available on Pro and Estate plans. Upgrade your \
                              Connect plan to enable it.",
                         ))
+                        .push(
+                            button::primary(None, "View plans")
+                                .width(Length::Fixed(160.0))
+                                .on_press(ConnectAccountMessage::OpenPlanBilling),
+                        )
                         .padding(20),
                 )
                 .style(card_style)
@@ -1895,18 +1895,18 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
         });
 
         col = col.push(iced::widget::Space::new().height(Length::Fixed(16.0)));
-        // The hard vault gate (PLAN-duress-vault-gate PR 2): Tier-1 enrollment
-        // is blocked while any Vault Cube in the checklist has an incomplete
-        // (or unverifiable) Recovery Kit — a duress wipe of such a Cube would
-        // be irreversible. The Tier-2 bypass below is deliberately never gated.
+        // The hard vault gate (PLAN-duress-vault-gate): enrollment is blocked
+        // while any Vault Cube in the checklist has an incomplete (or
+        // unverifiable) Recovery Kit — a duress wipe of such a Cube would be
+        // irreversible. This is now the single hard requirement: there is no
+        // "advanced" bypass and no sovereign path.
         //
         // Fail closed on an unloaded checklist (`None`): until the cube list +
         // kit statuses land we can't confirm every Vault Cube is safe, so the
         // CTA stays disabled rather than opening a fail-open window before the
         // fetch completes (master I7 / Resolved decision 4). A failed fetch
-        // also leaves `None`, so it stays blocked with the bypass as the
-        // offline escape hatch. An empty (loaded) list is `Some([])` → not
-        // blocked.
+        // also leaves `None`, so it stays blocked. An empty (loaded) list is
+        // `Some([])` → not blocked.
         let cubes_loaded = state.duress_cubes.is_some();
         let gate_blocked = duress_tier1_gate_blocked(state.duress_cubes.as_deref());
         if gate_blocked {
@@ -1933,15 +1933,6 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
                     )),
             );
         }
-        // Tier 2 (Connect, no recovery kit) — the plan's Task 2.1 secondary
-        // path. The panel can't see per-Cube CRK state, so the user picks:
-        // this skips the duress recovery-kit password step. Deliberately
-        // reachable in every blocked state — the vault gate never hides it.
-        col = col.push(
-            button::transparent(None, "Continue without a recovery kit (advanced)").on_press(
-                ConnectAccountMessage::Duress(DuressMessage::StartEnrollmentWithoutCrk),
-            ),
-        );
     }
 
     // Emergency contacts (Estate Notifications — PR 1). Rendered below the

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -221,6 +221,11 @@ pub enum Message {
     /// prompt. The Pane intercepts it and focuses the Home tab on its
     /// Connect section.
     OpenConnectSignIn,
+    /// Bubbles up from a paid-feature locked card outside the Connect page
+    /// (e.g. Settings → Vault Recovery Alerts) when the user clicks "View
+    /// plans". The Pane intercepts it and focuses the Home tab on its
+    /// Connect → Plan & Billing section. Mirrors [`OpenConnectSignIn`].
+    OpenPlanBilling,
     /// Remote duress activation arrived over the gRPC stream (Phase 7b). The
     /// tab shell intercepts this and locks the running app into the cryptic
     /// "Duress Mode Activated" screen — WITHOUT wiping (remote activation can
@@ -1551,16 +1556,9 @@ pub enum DuressMessage {
     FinishRecovery,
 
     // ── Enrollment wizard (Phases 2 & 8) ──
-    /// Begin enrollment. Entitled users start at Tier 1 (with the account-level
-    /// duress recovery-kit password); non-Connect users get the sovereign flow.
+    /// Begin enrollment. Duress is a paid (Pro/Estate) feature behind a hard,
+    /// server-verified Recovery-Kit gate — a single enrollment path, no tiers.
     StartEnrollment,
-    /// Begin enrollment WITHOUT a recovery kit (Tier 2 — the plan's Task 2.1
-    /// "Continue without recovery kit (advanced)"). Skips the CRK-password step.
-    /// Only offered to entitled users, since the panel can't see per-Cube CRK
-    /// state to auto-select the tier.
-    StartEnrollmentWithoutCrk,
-    /// Sovereign "Sign up for Connect" CTA → the Register flow.
-    SignUpForConnect,
     CancelEnrollment,
     EnrollBack,
     EnrollNext,
@@ -1569,11 +1567,6 @@ pub enum DuressMessage {
     AllClearChanged(String),
     CrkPasswordChanged(String),
     DelaySelected(crate::services::duress::enroll::DuressDelay),
-    /// The mandated backup-acknowledgement gate's typed-confirmation input
-    /// (formerly `SovereignConfirmChanged`). The gate now covers the Tier-2
-    /// (Connect, no CRK) and any-Cube-without-a-recovery-kit paths too, not
-    /// just sovereign — see [`crate::app::state::connect::DuressEnrollStep`].
-    BackupAckChanged(String),
     MemorizedToggled(bool),
     SubmitEnrollment,
     EnrollResult(Result<(), String>, u64),
@@ -1646,7 +1639,6 @@ impl std::fmt::Debug for DuressMessage {
             DuressPinConfirmChanged(_) => write!(f, "DuressPinConfirmChanged(<redacted>)"),
             AllClearChanged(_) => write!(f, "AllClearChanged(<redacted>)"),
             CrkPasswordChanged(_) => write!(f, "CrkPasswordChanged(<redacted>)"),
-            BackupAckChanged(_) => write!(f, "BackupAckChanged(<redacted>)"),
             DisablePinChanged(_) => write!(f, "DisablePinChanged(<redacted>)"),
             // Non-sensitive — `ClearResult`/`EnrollResult` carry only an error
             // string (no secret), so they format normally.
@@ -1655,8 +1647,6 @@ impl std::fmt::Debug for DuressMessage {
             ForgotAllClear => write!(f, "ForgotAllClear"),
             FinishRecovery => write!(f, "FinishRecovery"),
             StartEnrollment => write!(f, "StartEnrollment"),
-            StartEnrollmentWithoutCrk => write!(f, "StartEnrollmentWithoutCrk"),
-            SignUpForConnect => write!(f, "SignUpForConnect"),
             CancelEnrollment => write!(f, "CancelEnrollment"),
             EnrollBack => write!(f, "EnrollBack"),
             EnrollNext => write!(f, "EnrollNext"),
@@ -2361,7 +2351,6 @@ mod duress_message_debug_tests {
             DuressMessage::DuressPinConfirmChanged(CANARY.to_string()),
             DuressMessage::AllClearChanged(CANARY.to_string()),
             DuressMessage::CrkPasswordChanged(CANARY.to_string()),
-            DuressMessage::BackupAckChanged(CANARY.to_string()),
             DuressMessage::DisablePinChanged(CANARY.to_string()),
         ];
         for msg in &sensitive {

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -177,13 +177,20 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
 
     // Locked affordance for non-Estate accounts.
     if !ra.entitled {
-        body = body.push(
-            text(
-                "Recovery alerts are part of the Estate plan. Upgrade your Connect plan to \
-                 enable chain monitoring and keyholder alerts.",
+        body = body
+            .push(
+                text(
+                    "Recovery alerts are part of the Estate plan. Upgrade your Connect plan to \
+                     enable chain monitoring and keyholder alerts.",
+                )
+                .size(13),
             )
-            .size(13),
-        );
+            .push(Space::new().height(Length::Fixed(12.0)))
+            .push(
+                button::primary(None, "View plans")
+                    .width(Length::Fixed(160.0))
+                    .on_press(Message::OpenPlanBilling),
+            );
         return card::simple(body).width(Length::Fill).into();
     }
 

--- a/coincube-gui/src/gui/pane.rs
+++ b/coincube-gui/src/gui/pane.rs
@@ -89,6 +89,33 @@ impl Pane {
         task.map(move |msg| Message::Tab(id, msg))
     }
 
+    /// Focus an existing Home tab (or spawn one) and route it to `nav`. Shared
+    /// by the OpenConnectSignIn / OpenPlanBilling handlers, which differ only in
+    /// the Connect sub-section `nav` targets.
+    fn focus_home_tab_with(&mut self, nav: crate::home::Message, cfg: &Config) -> Task<Message> {
+        let home_tab = self
+            .tabs
+            .iter()
+            .enumerate()
+            .find(|(_, t)| matches!(&t.state, tab::State::Home(_)))
+            .map(|(i, t)| (i, t.id));
+        if let Some((idx, tab_id)) = home_tab {
+            self.focused_tab = idx;
+            return Task::done(Message::Tab(tab_id, tab::Message::Launch(nav)));
+        }
+        // No Home tab open — spawn one and queue the navigation against its id
+        // so it lands on the target Connect section rather than the default view.
+        let add_task = self.add_tab(cfg);
+        let new_tab_id = self.tabs.last().map(|t| t.id);
+        if let Some(tab_id) = new_tab_id {
+            return Task::batch([
+                add_task,
+                Task::done(Message::Tab(tab_id, tab::Message::Launch(nav))),
+            ]);
+        }
+        add_task
+    }
+
     pub fn close_tab(&mut self, i: usize) {
         if let Some(mut tab) = self.remove_tab(i) {
             tab.stop();
@@ -205,63 +232,23 @@ impl Pane {
                 }
             }
             Message::View(ViewMessage::OpenConnectSignIn) => {
-                // Find an existing Home tab and focus it; if none is
-                // open, create one. Either way, route it to the
-                // Connect overview so the user lands on the login form.
-                let home_tab = self
-                    .tabs
-                    .iter()
-                    .enumerate()
-                    .find(|(_, t)| matches!(&t.state, tab::State::Home(_)))
-                    .map(|(i, t)| (i, t.id));
+                // Focus/spawn a Home tab and land on Connect → Overview so the
+                // user reaches the login form.
                 let nav = crate::home::Message::View(crate::home::ViewMessage::GoToSection(
                     crate::home::HomeSection::Connect(crate::app::menu::ConnectSubMenu::Overview),
                 ));
-                if let Some((idx, tab_id)) = home_tab {
-                    self.focused_tab = idx;
-                    return Task::done(Message::Tab(tab_id, tab::Message::Launch(nav)));
-                }
-                // No Home tab open — spawn one and queue the
-                // navigation against its id so it lands on Connect →
-                // Overview rather than the default Cubes view.
-                let add_task = self.add_tab(cfg);
-                let new_tab_id = self.tabs.last().map(|t| t.id);
-                if let Some(tab_id) = new_tab_id {
-                    return Task::batch([
-                        add_task,
-                        Task::done(Message::Tab(tab_id, tab::Message::Launch(nav))),
-                    ]);
-                }
-                return add_task;
+                return self.focus_home_tab_with(nav, cfg);
             }
             Message::View(ViewMessage::OpenPlanBilling) => {
-                // Mirror OpenConnectSignIn, but land on Connect → Plan & Billing
-                // so a paid-feature "View plans" CTA outside the Connect page
-                // (e.g. Settings → Vault Recovery Alerts) routes to the picker.
-                let home_tab = self
-                    .tabs
-                    .iter()
-                    .enumerate()
-                    .find(|(_, t)| matches!(&t.state, tab::State::Home(_)))
-                    .map(|(i, t)| (i, t.id));
+                // Focus/spawn a Home tab and land on Connect → Plan & Billing,
+                // for a paid-feature "View plans" CTA outside the Connect page
+                // (e.g. Settings → Vault Recovery Alerts).
                 let nav = crate::home::Message::View(crate::home::ViewMessage::GoToSection(
                     crate::home::HomeSection::Connect(
                         crate::app::menu::ConnectSubMenu::PlanBilling,
                     ),
                 ));
-                if let Some((idx, tab_id)) = home_tab {
-                    self.focused_tab = idx;
-                    return Task::done(Message::Tab(tab_id, tab::Message::Launch(nav)));
-                }
-                let add_task = self.add_tab(cfg);
-                let new_tab_id = self.tabs.last().map(|t| t.id);
-                if let Some(tab_id) = new_tab_id {
-                    return Task::batch([
-                        add_task,
-                        Task::done(Message::Tab(tab_id, tab::Message::Launch(nav))),
-                    ]);
-                }
-                return add_task;
+                return self.focus_home_tab_with(nav, cfg);
             }
         }
 

--- a/coincube-gui/src/gui/pane.rs
+++ b/coincube-gui/src/gui/pane.rs
@@ -30,6 +30,10 @@ pub enum ViewMessage {
     /// handler focuses an existing Home tab and routes it to its
     /// Connect overview so the user can sign in.
     OpenConnectSignIn,
+    /// Bubbled from a tab whose paid-feature locked card emitted
+    /// [`crate::app::view::Message::OpenPlanBilling`]. The handler focuses an
+    /// existing Home tab and routes it to Connect → Plan & Billing.
+    OpenPlanBilling,
     /// Bubbled from the Home tab on its auth-success edge. The
     /// handler broadcasts a `ConnectAccountMessage::Init` to every
     /// open Cube tab so those panels re-read the shared keyring
@@ -157,6 +161,9 @@ impl Pane {
                             tab::Message::OpenConnectSignIn => {
                                 Task::done(Message::View(ViewMessage::OpenConnectSignIn))
                             }
+                            tab::Message::OpenPlanBilling => {
+                                Task::done(Message::View(ViewMessage::OpenPlanBilling))
+                            }
                             tab::Message::ConnectSignedIn => {
                                 Task::done(Message::View(ViewMessage::ConnectSignedIn))
                             }
@@ -217,6 +224,35 @@ impl Pane {
                 // No Home tab open — spawn one and queue the
                 // navigation against its id so it lands on Connect →
                 // Overview rather than the default Cubes view.
+                let add_task = self.add_tab(cfg);
+                let new_tab_id = self.tabs.last().map(|t| t.id);
+                if let Some(tab_id) = new_tab_id {
+                    return Task::batch([
+                        add_task,
+                        Task::done(Message::Tab(tab_id, tab::Message::Launch(nav))),
+                    ]);
+                }
+                return add_task;
+            }
+            Message::View(ViewMessage::OpenPlanBilling) => {
+                // Mirror OpenConnectSignIn, but land on Connect → Plan & Billing
+                // so a paid-feature "View plans" CTA outside the Connect page
+                // (e.g. Settings → Vault Recovery Alerts) routes to the picker.
+                let home_tab = self
+                    .tabs
+                    .iter()
+                    .enumerate()
+                    .find(|(_, t)| matches!(&t.state, tab::State::Home(_)))
+                    .map(|(i, t)| (i, t.id));
+                let nav = crate::home::Message::View(crate::home::ViewMessage::GoToSection(
+                    crate::home::HomeSection::Connect(
+                        crate::app::menu::ConnectSubMenu::PlanBilling,
+                    ),
+                ));
+                if let Some((idx, tab_id)) = home_tab {
+                    self.focused_tab = idx;
+                    return Task::done(Message::Tab(tab_id, tab::Message::Launch(nav)));
+                }
                 let add_task = self.add_tab(cfg);
                 let new_tab_id = self.tabs.last().map(|t| t.id);
                 if let Some(tab_id) = new_tab_id {

--- a/coincube-gui/src/gui/tab.rs
+++ b/coincube-gui/src/gui/tab.rs
@@ -418,6 +418,11 @@ pub enum Message {
     /// (Spark → Settings → Lightning Address, Cube → Settings →
     /// Avatar / Members).
     OpenConnectSignIn,
+    /// Bubbles up to the pane so it can focus the Home tab on its Connect →
+    /// Plan & Billing section — fired when the user clicks "View plans" on a
+    /// paid-feature locked card outside the Connect page (Settings → Vault
+    /// Recovery Alerts).
+    OpenPlanBilling,
     /// Bubbles up to the pane on a Home-tab login edge so it can
     /// broadcast a session re-check to every open Cube tab.
     ConnectSignedIn,
@@ -1303,6 +1308,12 @@ impl Tab {
                         } else {
                             init_task
                         }
+                    }
+                    app::Message::View(app::view::Message::OpenPlanBilling) => {
+                        // Pure navigation: bubble to the pane so it focuses the
+                        // Home tab on Connect → Plan & Billing (the "View plans"
+                        // CTA on a paid-feature locked card outside Connect).
+                        Task::done(Message::OpenPlanBilling)
                     }
                     m => app.update(m).map(Message::Run),
                 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes security-sensitive duress enrollment and gating behavior (removed bypass/sovereign paths, stricter checklist), though the net effect is fail-closed; incorrect gate or local-merge logic could block enrollment or miss a wipeable Cube.
> 
> **Overview**
> **Duress enrollment is collapsed to one paid Connect path** — no Tier 1/2/Sovereign branching, no “continue without recovery kit,” no sovereign-only local enroll, and no type-to-confirm backup acknowledgement wizard. Enrollment always runs the same five steps (duress PIN → all-clear → account CRK password → delay → confirm) and always posts to the server with a CRK password hash.
> 
> **Gating is tightened and centralized:** `is_duress_entitled()` backs start/fetch paths; start and submit both require the existing vault recovery-kit gate with no bypass. The duress cube checklist now **merges local-only mainnet Cubes** missing from Connect’s server list as unknown-status rows so unregistered Vault Cubes still **fail the gate closed**.
> 
> **Upgrade UX:** locked Duress, Emergency Contacts, and Vault Recovery Alerts surfaces gain **View plans**, routed via new `OpenPlanBilling` bubbling (pane focuses Home → Connect → Plan & Billing), with shared `focus_home_tab_with` for sign-in vs billing navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db66fd4076dcca2f2f96b05effa8c57fef992829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streamlined duress enrollment wizard with a consistent five-step flow.
  * Added “View plans” buttons to locked Emergency Contacts and Recovery Alerts sections.
  * Added navigation directly to Connect → Plan & Billing from upgrade prompts.

* **Improvements**
  * Strengthened duress eligibility and vault checklist requirements.
  * Improved handling of locally configured cubes missing from checklist results.
  * Simplified enrollment confirmation and credential guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->