### PR TITLE
Core <> Knots Migration

### DIFF
--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -2272,13 +2272,21 @@ impl App {
             subscriptions.push(self.panels.spark_receive.sideshift_poll_subscription());
         }
 
-        // Stream the pending internal bitcoind's debug.log for UpdateTip lines.
-        if let Some(pending_cfg) = self
-            .daemon
-            .as_ref()
-            .and_then(|d| d.config())
-            .and_then(|c| c.pending_bitcoind.clone())
-        {
+        // Stream the internal bitcoind's debug.log for UpdateTip lines.
+        //
+        // Prefer a pending node (one being set up or switched to), but fall back to
+        // the active managed node: a chain repair after a Core↔Knots swap reconnects
+        // blocks on a node that is already live, with nothing pending, and until now
+        // that progress was invisible.
+        if let Some(pending_cfg) = self.daemon.as_ref().and_then(|d| d.config()).and_then(|c| {
+            c.pending_bitcoind.clone().or_else(|| {
+                match c.bitcoin_backend.as_ref() {
+                    Some(coincubed::config::BitcoinBackend::Bitcoind(cfg)) => Some(cfg.clone()),
+                    // Electrum/Esplora backends have no debug.log to tail.
+                    _ => None,
+                }
+            })
+        }) {
             let internal_datadir = internal_bitcoind_datadir(&self.cache.datadir_path);
             let is_internal = match &pending_cfg.rpc_auth {
                 BitcoindRpcAuth::CookieFile(path) => path.starts_with(&internal_datadir),

--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -760,10 +760,11 @@ impl State for BitcoindSettingsState {
                         };
                         let cfg = settings.bitcoind_config.clone();
                         let network = cache.network;
+                        let coincube_datadir = cache.datadir_path.clone();
                         return Task::perform(
                             async move {
                                 tokio::task::spawn_blocking(move || {
-                                    repair_managed_node_chain(&cfg, network)
+                                    repair_managed_node_chain(&coincube_datadir, &cfg, network)
                                 })
                                 .await
                                 .unwrap_or_else(|e| Err(e.to_string()))
@@ -1238,13 +1239,18 @@ fn write_internal_bitcoind_config(
 /// reconnect many blocks and outlast the RPC socket timeout, so we return as soon
 /// as the request is away and let the node get on with it. Progress shows up in
 /// the usual sync indicators.
-fn repair_managed_node_chain(cfg: &BitcoindConfig, network: Network) -> Result<String, String> {
+fn repair_managed_node_chain(
+    coincube_datadir: &CoincubeDirectory,
+    cfg: &BitcoindConfig,
+    network: Network,
+) -> Result<String, String> {
     let anchor_height = crate::node::revalidate::rdts_anchor_height(network).ok_or_else(|| {
         "BIP-110 isn't deployed on this network, so there is nothing to repair.".to_string()
     })?;
     let bitcoind = coincubed::BitcoinD::new(cfg, "repair_node_chain".to_string())
         .map_err(|e| format!("Could not reach the managed node: {e}"))?;
     crate::node::revalidate::execute(
+        coincube_datadir,
         &bitcoind,
         crate::node::revalidate::RevalidationPlan::ClearFailureFlags { anchor_height },
     )?;

--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -749,6 +749,33 @@ impl State for BitcoindSettingsState {
                     NodeSettingsMessage::CopyToClipboard(value) => {
                         return clipboard::write(value);
                     }
+                    NodeSettingsMessage::RepairNodeChain => {
+                        // Manual counterpart to the automatic check in
+                        // `Bitcoind::maybe_start`. Idempotent and non-destructive:
+                        // `reconsiderblock` only clears rejection flags and lets the
+                        // node re-activate the most-work chain, so the worst case is
+                        // that it does nothing.
+                        let Some(settings) = self.bitcoind_settings.as_ref() else {
+                            return Task::none();
+                        };
+                        let cfg = settings.bitcoind_config.clone();
+                        let network = cache.network;
+                        return Task::perform(
+                            async move {
+                                tokio::task::spawn_blocking(move || {
+                                    repair_managed_node_chain(&cfg, network)
+                                })
+                                .await
+                                .unwrap_or_else(|e| Err(e.to_string()))
+                            },
+                            |res| match res {
+                                Ok(msg) => {
+                                    Message::View(view::Message::ShowToast(log::Level::Info, msg))
+                                }
+                                Err(e) => Message::View(view::Message::ShowError(e)),
+                            },
+                        );
+                    }
                     NodeSettingsMessage::RestartNodeToApply => {
                         // Restart the managed node now so freshly-toggled
                         // inbound-over-Tor settings take effect, reusing the setup
@@ -1039,6 +1066,29 @@ impl State for BitcoindSettingsState {
                     );
                 }
 
+                // "Chain repair": manual `reconsiderblock` at the BIP-110 anchor.
+                // Managed node, mainnet only (that's where RDTS is deployed), and
+                // hidden during a setup/flavour switch. The automatic check on node
+                // start covers the normal case; this is the escape hatch for when
+                // the state that drives it has been lost.
+                if crate::node::revalidate::rdts_anchor_height(cache.network).is_some()
+                    && self.pending_node_setup.is_none()
+                    && self
+                        .bitcoind_settings
+                        .as_ref()
+                        .and_then(|s| s.managed_flavor)
+                        .is_some()
+                    && matches!(
+                        self.full_config
+                            .as_ref()
+                            .and_then(|c| c.bitcoin_backend.as_ref()),
+                        Some(BitcoinBackend::Bitcoind(_))
+                    )
+                {
+                    setting_panels
+                        .push(view::vault::settings::chain_repair_section().map(map_node_msg));
+                }
+
                 // "Node resources": prune target + mempool cap for the internal
                 // managed node. All networks (unlike inbound-Tor), the managed
                 // node only, and hidden during a setup/flavour switch/restart.
@@ -1180,6 +1230,27 @@ fn write_internal_bitcoind_config(
 /// installed from those bytes. Returns the `BitcoindConfig` and the live
 /// `Bitcoind` handle (which keeps the lock file alive) to be stored by the
 /// caller.
+/// Clear the block-index rejection flags below the BIP-110 anchor on the managed
+/// node, so it can follow the most-work chain again.
+///
+/// Blocking (opens an RPC connection), so callers must run it off the UI thread.
+/// The `reconsiderblock` itself is fire-and-forget: re-activating the chain can
+/// reconnect many blocks and outlast the RPC socket timeout, so we return as soon
+/// as the request is away and let the node get on with it. Progress shows up in
+/// the usual sync indicators.
+fn repair_managed_node_chain(cfg: &BitcoindConfig, network: Network) -> Result<String, String> {
+    let anchor_height = crate::node::revalidate::rdts_anchor_height(network).ok_or_else(|| {
+        "BIP-110 isn't deployed on this network, so there is nothing to repair.".to_string()
+    })?;
+    let bitcoind = coincubed::BitcoinD::new(cfg, "repair_node_chain".to_string())
+        .map_err(|e| format!("Could not reach the managed node: {e}"))?;
+    crate::node::revalidate::execute(
+        &bitcoind,
+        crate::node::revalidate::RevalidationPlan::ClearFailureFlags { anchor_height },
+    )?;
+    Ok("Asked the node to re-check its chain. This may take a few minutes.".to_string())
+}
+
 fn configure_and_start_internal_bitcoind(
     coincube_datadir: CoincubeDirectory,
     network: Network,
@@ -2293,6 +2364,28 @@ mod tests {
             node_message(view::NodeSettingsMessage::CancelFlavorSwitch),
         );
         assert_eq!(state.pending_flavor_switch, None);
+
+        // Selecting the flavour the node already runs raises no confirmation:
+        // there is nothing to switch, so the modal must not appear.
+        let _ = state.update(
+            Some(daemon.clone()),
+            &cache,
+            edit_message(view::SettingsEditMessage::SwitchManagedFlavor(
+                NodeFlavor::Core,
+            )),
+        );
+        assert_eq!(state.pending_flavor_switch, None);
+
+        // The chain-repair escape hatch dispatches its work to a blocking task and
+        // must not disturb any settings state on the way (in particular it must not
+        // open a flavour-switch modal or a node-setup panel).
+        let _ = state.update(
+            Some(daemon.clone()),
+            &cache,
+            node_message(view::NodeSettingsMessage::RepairNodeChain),
+        );
+        assert_eq!(state.pending_flavor_switch, None);
+        assert!(state.pending_node_setup.is_none());
 
         let _ = state.update(
             Some(daemon.clone()),

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -559,6 +559,13 @@ pub enum NodeSettingsMessage {
     ConfirmFlavorSwitch,
     /// Dismiss the flavour-switch confirmation without switching.
     CancelFlavorSwitch,
+    /// Ask the managed node to reconsider the blocks below the BIP-110 anchor.
+    ///
+    /// The manual escape hatch for a node left following a chain with less work
+    /// than one it knows about — normally repaired automatically on start, but the
+    /// automatic path depends on state that can be lost (a datadir moved between
+    /// machines, a wiped sidecar). The call is idempotent and never destructive.
+    RepairNodeChain,
     /// Restart the managed node now so freshly-changed inbound-over-Tor settings
     /// take effect (they otherwise apply only on the next node start).
     RestartNodeToApply,

--- a/coincube-gui/src/app/view/vault/settings/mod.rs
+++ b/coincube-gui/src/app/view/vault/settings/mod.rs
@@ -676,10 +676,12 @@ pub fn chain_repair_section<'a>() -> Element<'a, NodeSettingsMessage> {
 ///   shared block index. Those marks persist across the swap, so without it Core
 ///   would keep following the chain Knots chose rather than the one with the most
 ///   work. That can change which transactions are confirmed.
-/// * Switching **to Knots** starts enforcing the stricter rules from now on, but
-///   does not re-check history that Core already accepted. Doing so requires
-///   rewinding the chain, which is not implemented yet — so we say so plainly
-///   rather than implying a guarantee we don't provide.
+/// * Switching **to Knots** starts enforcing the stricter rules *and* rewinds the
+///   chain to the BIP-110 anchor so blocks Core accepted are replayed under them.
+///   That takes hours and parks every Vault's poller while it runs, so the copy
+///   has to set both expectations. It also cannot reach below `pruneheight` —
+///   coverage is bounded by what the node still stores — so the copy says that too
+///   rather than implying the whole chain was verified.
 fn flavor_switch_chain_note(target: NodeFlavor) -> &'static str {
     match target {
         NodeFlavor::Core => {
@@ -2465,8 +2467,9 @@ mod tests {
 
     // The two directions are not symmetric, and the copy must not imply they are:
     // switching to Core can change which chain the node follows, while switching to
-    // Knots enforces from now on WITHOUT re-checking history it already accepted.
-    // Overstating the latter would promise a guarantee Phase 1 does not deliver.
+    // Knots re-checks the recent blocks the node still stores. The Knots copy has to
+    // mention both halves — the re-check and the pruning bound — because claiming
+    // the re-check without its limit would promise coverage we cannot deliver.
     #[test]
     fn flavor_switch_copy_is_direction_specific() {
         let to_core = flavor_switch_chain_note(NodeFlavor::Core);

--- a/coincube-gui/src/app/view/vault/settings/mod.rs
+++ b/coincube-gui/src/app/view/vault/settings/mod.rs
@@ -579,6 +579,10 @@ pub fn bitcoind<'a>(
 /// Switching restarts the shared node and may download the other client, so we
 /// gate it behind an explicit confirm. Rendered as a modal body by
 /// `BitcoindSettingsState::view`.
+///
+/// The second paragraph is direction-specific because the two swaps have
+/// genuinely different consequences for the chain the node follows — see
+/// [`flavor_switch_chain_note`].
 pub fn flavor_switch_confirm<'a>(target: NodeFlavor) -> Element<'a, NodeSettingsMessage> {
     card::modal(
         Column::new()
@@ -601,6 +605,11 @@ pub fn flavor_switch_confirm<'a>(target: NodeFlavor) -> Element<'a, NodeSettings
                 .style(theme::text::secondary),
             )
             .push(
+                text(flavor_switch_chain_note(target))
+                    .size(14)
+                    .style(theme::text::secondary),
+            )
+            .push(
                 Row::new()
                     .spacing(10)
                     .push(
@@ -617,6 +626,74 @@ pub fn flavor_switch_confirm<'a>(target: NodeFlavor) -> Element<'a, NodeSettings
     )
     .width(Length::Fixed(500.0))
     .into()
+}
+
+/// "Chain repair" card: a manual `reconsiderblock` at the BIP-110 anchor.
+///
+/// Bitcoin Knots records its rejections in the block index, and those marks
+/// persist when the datadir is later opened by Bitcoin Core — which would
+/// otherwise keep following the chain Knots chose rather than the one with the
+/// most work. The app repairs that automatically whenever the node starts, so this
+/// button only matters when the state driving that check has been lost (a datadir
+/// carried between machines, a wiped sidecar). Safe to press at any time: the call
+/// is idempotent and clears flags rather than discarding anything.
+pub fn chain_repair_section<'a>() -> Element<'a, NodeSettingsMessage> {
+    card::simple(Container::new(
+        Column::new()
+            .spacing(15)
+            .push(
+                Row::new()
+                    .push(badge::badge(icon::bitcoin_icon()))
+                    .push(text("Chain repair").bold())
+                    .spacing(20)
+                    .align_y(Alignment::Center),
+            )
+            .push(
+                text(
+                    "If your node is stuck behind a chain it knows has more work — \
+                     usually after switching between Bitcoin Knots and Bitcoin Core — \
+                     this asks it to re-check those blocks. Nothing is deleted, and \
+                     it's safe to run more than once.",
+                )
+                .size(14)
+                .style(theme::text::secondary),
+            )
+            .push(
+                button::secondary(None, "Re-check chain")
+                    .on_press(NodeSettingsMessage::RepairNodeChain),
+            ),
+    ))
+    .width(Length::Fill)
+    .into()
+}
+
+/// What switching *to* `target` means for the chain the node follows.
+///
+/// These are not symmetric. Bitcoin Knots can enforce BIP-110 (RDTS) and Bitcoin
+/// Core cannot, so:
+///
+/// * Switching **to Core** may have to undo rejections Knots recorded in the
+///   shared block index. Those marks persist across the swap, so without it Core
+///   would keep following the chain Knots chose rather than the one with the most
+///   work. That can change which transactions are confirmed.
+/// * Switching **to Knots** starts enforcing the stricter rules from now on, but
+///   does not re-check history that Core already accepted. Doing so requires
+///   rewinding the chain, which is not implemented yet — so we say so plainly
+///   rather than implying a guarantee we don't provide.
+fn flavor_switch_chain_note(target: NodeFlavor) -> &'static str {
+    match target {
+        NodeFlavor::Core => {
+            "Core doesn't enforce BIP-110. If Knots had rejected any blocks, your node \
+             will re-check them and may switch to a different chain, so some recent \
+             transactions could change confirmation state."
+        }
+        NodeFlavor::Knots => {
+            "Knots will enforce BIP-110. Your node will also re-check the recent blocks \
+             it still stores against the new rules, which can take a few hours; Vaults \
+             pause updating until it finishes. Blocks older than that were already \
+             pruned and can't be re-checked."
+        }
+    }
 }
 
 pub fn electrum_edit<'a>(
@@ -2383,6 +2460,26 @@ mod tests {
         let _ = inbound_tor_section(false, true, true, false, false, false, None);
         let _ = inbound_tor_section(true, true, true, true, true, true, Some(&stats));
         let _ = inbound_tor_section(true, false, false, true, false, true, Some(&stats));
+        let _ = chain_repair_section();
+    }
+
+    // The two directions are not symmetric, and the copy must not imply they are:
+    // switching to Core can change which chain the node follows, while switching to
+    // Knots enforces from now on WITHOUT re-checking history it already accepted.
+    // Overstating the latter would promise a guarantee Phase 1 does not deliver.
+    #[test]
+    fn flavor_switch_copy_is_direction_specific() {
+        let to_core = flavor_switch_chain_note(NodeFlavor::Core);
+        let to_knots = flavor_switch_chain_note(NodeFlavor::Knots);
+        assert_ne!(to_core, to_knots);
+        assert!(
+            to_core.contains("different chain"),
+            "switching to Core must warn that the followed chain may change"
+        );
+        assert!(
+            to_knots.contains("re-check") && to_knots.contains("pruned"),
+            "switching to Knots must say history is re-checked AND that pruning bounds it"
+        );
     }
 
     #[test]

--- a/coincube-gui/src/node/bitcoind.rs
+++ b/coincube-gui/src/node/bitcoind.rs
@@ -1183,6 +1183,7 @@ impl Bitcoind {
                 crate::node::revalidate::reconcile_after_start(
                     coincube_datadir,
                     &running,
+                    &config,
                     network,
                     running_flavor,
                 );
@@ -1290,6 +1291,7 @@ impl Bitcoind {
                     crate::node::revalidate::reconcile_after_start(
                         coincube_datadir,
                         &started,
+                        &config,
                         network,
                         observed_flavor,
                     );

--- a/coincube-gui/src/node/bitcoind.rs
+++ b/coincube-gui/src/node/bitcoind.rs
@@ -1177,6 +1177,15 @@ impl Bitcoind {
                 .unwrap_or(configured_flavor);
             if running_flavor == configured_flavor {
                 info!("Internal bitcoind is already running ({running_flavor:?})");
+                // Reconcile here too: this vault may be attaching to a node another
+                // vault swapped the flavour of, so this is a start path like any
+                // other. `running_flavor` is read from the node's own subversion.
+                crate::node::revalidate::reconcile_after_start(
+                    coincube_datadir,
+                    &running,
+                    network,
+                    running_flavor,
+                );
                 return Ok(Bitcoind {
                     config,
                     lock: LockFile::create(coincube_datadir.bitcoind_directory(), network)
@@ -1268,8 +1277,22 @@ impl Bitcoind {
                 }
             }
             match coincubed::BitcoinD::new(&config, "internal_bitcoind_start".to_string()) {
-                Ok(_) => {
+                Ok(started) => {
                     log::info!("Bitcoind seems to have successfully started.");
+                    // Ask the node what it actually is rather than trusting
+                    // `configured_flavor`: `select_managed_bitcoind_exe` falls back to
+                    // the other flavour's binary when the preferred one isn't
+                    // installed, so the two can legitimately disagree.
+                    let observed_flavor = started
+                        .subversion()
+                        .map(|sv| NodeFlavor::from_subversion(&sv))
+                        .unwrap_or(configured_flavor);
+                    crate::node::revalidate::reconcile_after_start(
+                        coincube_datadir,
+                        &started,
+                        network,
+                        observed_flavor,
+                    );
                     return Ok(Self {
                         config,
                         lock: LockFile::create(coincube_datadir.bitcoind_directory(), network)

--- a/coincube-gui/src/node/mod.rs
+++ b/coincube-gui/src/node/mod.rs
@@ -3,6 +3,7 @@ use coincubed::config::BitcoinBackend;
 pub mod bitcoind;
 pub mod electrum;
 pub mod esplora;
+pub mod revalidate;
 pub mod tor;
 
 /// Configure `command` so its spawned child is detached from this process:

--- a/coincube-gui/src/node/revalidate.rs
+++ b/coincube-gui/src/node/revalidate.rs
@@ -108,17 +108,20 @@ pub struct ChainFacts {
     pub current_flavor: NodeFlavor,
     /// Blocks validated toward the best known tip.
     pub blocks: i32,
-    /// Whether the RDTS deployment is locked in or active on this node.
-    pub deployment_live: bool,
+    /// Highest block on ANY branch the node knows of, including ones it rejected or
+    /// has headers for but never downloaded. Compared against [`Self::blocks`] this
+    /// is what tells us the node is following less work than it knows about.
+    pub best_known_height: i32,
+    /// Whether we have positive evidence the RDTS deployment will never activate.
+    ///
+    /// Note the polarity: this is set only on proof of failure, never on absence of
+    /// proof. Bitcoin Core does not define the deployment at all, so a Knots → Core
+    /// swap can only ever see "no such deployment" — and treating that as "not live"
+    /// made the entire repair unreachable on the very node that needs it.
+    pub rdts_abandoned: bool,
     /// How much history the node still stores. Nothing at or below the prune height
     /// can be disconnected — the data needed to do so is gone.
     pub prune_state: coincubed::PruneState,
-    /// Whether the node knows of a branch with more work than the one it follows
-    /// (see [`needs_reconsider`]).
-    ///
-    /// This is what keeps the ledger from being load-bearing: a swap we failed to
-    /// record still shows up here as an observable symptom.
-    pub node_stranded: bool,
 }
 
 /// Why no remediation is needed.
@@ -126,12 +129,13 @@ pub struct ChainFacts {
 pub enum SkipReason {
     /// RDTS isn't deployed on this network (regtest, signet, …).
     NoDeploymentOnNetwork,
-    /// The deployment has not locked in, so no rule is being enforced and the two
-    /// flavours cannot yet disagree.
-    DeploymentNotLive,
-    /// The chain has not reached the first height at which the flavours can
-    /// diverge. Until mainnet passes 961,632 this is the universal answer.
-    TipBelowAnchor,
+    /// The deployment timed out without activating, so its rules will never be
+    /// enforced and nothing can diverge over them.
+    DeploymentAbandoned,
+    /// No branch the node knows of reaches past the first height at which the
+    /// flavours can diverge. Until mainnet passes 961,632 this is the universal
+    /// answer.
+    NothingAboveAnchor,
     /// The node follows the best chain it knows of and did not just come from
     /// Knots. Nothing to clear.
     NothingToClear,
@@ -186,13 +190,20 @@ pub fn plan(facts: ChainFacts) -> RevalidationPlan {
     let Some(anchor_height) = rdts_anchor_height(facts.network) else {
         return RevalidationPlan::Skip(SkipReason::NoDeploymentOnNetwork);
     };
-    if !facts.deployment_live {
-        return RevalidationPlan::Skip(SkipReason::DeploymentNotLive);
+    if facts.rdts_abandoned {
+        return RevalidationPlan::Skip(SkipReason::DeploymentAbandoned);
     }
-    // Nothing above the anchor exists yet, so nothing can have diverged.
-    if facts.blocks <= anchor_height {
-        return RevalidationPlan::Skip(SkipReason::TipBelowAnchor);
+    // Measured against the best branch the node knows of, not the one it follows: a
+    // node parked at the anchor because it rejected the block above it has an active
+    // tip of exactly `anchor_height`, and gating on that would refuse to repair the
+    // very first rejection.
+    if facts.best_known_height <= anchor_height {
+        return RevalidationPlan::Skip(SkipReason::NothingAboveAnchor);
     }
+
+    // The node is following less work than it knows about. Kept as an observation
+    // rather than a stored flag so a swap we failed to record still surfaces.
+    let node_stranded = facts.best_known_height > facts.blocks;
 
     match facts.current_flavor {
         NodeFlavor::Core => {
@@ -201,7 +212,7 @@ pub fn plan(facts: ChainFacts) -> RevalidationPlan {
             // through the installer, a lost or corrupt sidecar, a datadir moved
             // between machines.
             let came_from_knots = facts.previous_flavor == Some(NodeFlavor::Knots);
-            if came_from_knots || facts.node_stranded {
+            if came_from_knots || node_stranded {
                 RevalidationPlan::ClearFailureFlags { anchor_height }
             } else {
                 RevalidationPlan::Skip(SkipReason::NothingToClear)
@@ -415,25 +426,19 @@ fn write_atomically(path: &Path, contents: &[u8]) -> io::Result<()> {
 // The stateless check
 // ---------------------------------------------------------------------------
 
-/// Whether the node is stranded off the best chain it knows about, and so needs a
-/// `reconsiderblock`.
+/// The highest block on any branch the node knows of, `getchaintips`-wide.
 ///
-/// This is the backstop that makes the ledger non-load-bearing: it asks only "is
-/// our active tip the most-work chain the node has headers for?", which is true of
-/// a healthy node regardless of history.
+/// Includes branches it rejected and ones it only has headers for. Comparing this
+/// against the active tip is the backstop that makes the flavour ledger
+/// non-load-bearing: it asks "is the node following the most work it knows about?",
+/// which a healthy node satisfies regardless of history.
 ///
 /// Deliberately **not** keyed on a branch's status being `"invalid"`. A node that
 /// rejects a block stops downloading that branch, so the honest most-work chain
 /// commonly shows up as `headers-only` rather than `invalid` — gating on
 /// `"invalid"` would miss exactly the stranded case this exists to catch.
-pub fn needs_reconsider(tips: &[coincubed::ChainTipEntry]) -> bool {
-    let Some(active_height) = tips.iter().find(|t| t.is_active()).map(|t| t.height) else {
-        return false;
-    };
-    // Any other branch reaching higher than our active tip means the node knows of
-    // more work than it is following.
-    tips.iter()
-        .any(|t| !t.is_active() && t.height > active_height)
+pub fn best_known_height(tips: &[coincubed::ChainTipEntry]) -> Option<i32> {
+    tips.iter().map(|t| t.height).max()
 }
 
 /// Observe how the managed node came up, record it, and remediate if the flavour
@@ -463,14 +468,12 @@ pub fn reconcile_after_start(
     // below an invalidated block and will not move until we release it.
     resume_pending_rewind(coincube_datadir, bitcoind);
 
-    // Record what we saw first. If the remediation below fails we would otherwise
-    // never record it, and retry the same failing path on every single startup;
-    // the stranded check is what catches the case regardless.
     let previous_flavor = ManagedNodeState::load(coincube_datadir).last_run_flavor;
-    ManagedNodeState::record_run(coincube_datadir, observed_flavor);
 
-    // Networks without the deployment cost us nothing: no RPCs at all.
+    // Networks without an anchor cost us nothing: no RPCs at all. Nothing can be
+    // planned there, so the flavour record is safe to advance immediately.
     if rdts_anchor_height(network).is_none() {
+        ManagedNodeState::record_run(coincube_datadir, observed_flavor);
         return;
     }
 
@@ -481,15 +484,18 @@ pub fn reconcile_after_start(
             return;
         }
     };
-    let deployment_live = bitcoind
+    // Absence is not evidence of failure. Core does not define this deployment at
+    // all, so on a Knots → Core swap the only honest reading of `None` is "this
+    // binary can't tell us", and the height gate decides instead.
+    let rdts_abandoned = bitcoind
         .deployment_status(RDTS_DEPLOYMENT)
-        .map(|d| d.is_live())
+        .map(|d| d.has_failed())
         .unwrap_or(false);
-    let node_stranded = match bitcoind.chain_tips() {
-        Ok(tips) => needs_reconsider(&tips),
+    let best_known = match bitcoind.chain_tips() {
+        Ok(tips) => best_known_height(&tips).unwrap_or(status.blocks),
         Err(e) => {
             warn!("could not read chain tips for the RDTS flavour check: {e}");
-            false
+            status.blocks
         }
     };
 
@@ -498,26 +504,39 @@ pub fn reconcile_after_start(
         previous_flavor,
         current_flavor: observed_flavor,
         blocks: status.blocks,
-        deployment_live,
+        best_known_height: best_known.max(status.blocks),
+        rdts_abandoned,
         prune_state: status.prune_state,
-        node_stranded,
     });
     match plan {
         RevalidationPlan::Skip(reason) => {
             tracing::debug!("No RDTS revalidation needed ({reason:?}).");
+            ManagedNodeState::record_run(coincube_datadir, observed_flavor);
         }
         RevalidationPlan::ClearFailureFlags { .. } => {
+            // Idempotent and cheap, so advancing the record is safe even if it fails:
+            // a node still following less work than it knows about is caught again by
+            // the height comparison on the next start, with no reliance on the ledger.
             if let Err(e) = execute(bitcoind, plan) {
                 warn!("RDTS revalidation failed: {e}");
             }
+            ManagedNodeState::record_run(coincube_datadir, observed_flavor);
         }
         RevalidationPlan::ReplayUnderRdts {
             floor_height,
             target_height,
         } => {
+            // Deliberately do NOT record the flavour here. The Core → Knots branch is
+            // the one case with no stateless backstop — a Knots node legitimately
+            // trailing the majority chain must never be "repaired" — so the ledger is
+            // the only thing that can trigger a retry. Advancing it before the replay
+            // succeeded would turn any transient failure into a permanent skip, since
+            // the next start would see Knots → Knots. The replay thread records it on
+            // success instead.
             spawn_replay(
                 coincube_datadir.clone(),
                 config.clone(),
+                observed_flavor,
                 floor_height,
                 target_height,
             );
@@ -537,22 +556,23 @@ pub fn reconcile_after_start(
 fn spawn_replay(
     coincube_datadir: CoincubeDirectory,
     config: coincubed::config::BitcoindConfig,
+    observed_flavor: NodeFlavor,
     floor_height: i32,
     target_height: i32,
 ) {
-    // The maintenance flag is held for the whole replay, so it doubles as a cheap
-    // "one at a time" check: several Vaults can start against the same shared node
-    // at once and must not each kick off their own rewind of it. Best-effort, not a
-    // lock — the flag is set by the thread we are about to spawn, so two calls
-    // landing in the same instant can still both get through. The durable rewind
-    // record is what keeps that recoverable, and the work is idempotent besides.
-    if coincubed::managed_node_maintenance() {
+    // Claim maintenance here, not inside the thread, and hand the guard over. Several
+    // Vaults can attach to the one shared node in the same instant; a check followed
+    // by a set would let two of them each start rewinding it. The guard's Drop
+    // releases on every exit path, including a spawn that never happens.
+    let Some(guard) = coincubed::MaintenanceGuard::try_acquire() else {
         info!("A chain replay is already running; not starting another.");
         return;
-    }
+    };
     let spawned = thread::Builder::new()
         .name("rdts-replay".to_string())
         .spawn(move || {
+            // Held for the whole replay; released when this closure returns.
+            let _guard = guard;
             let bitcoind = match coincubed::BitcoinD::new(&config, "rdts_replay".to_string()) {
                 Ok(bitcoind) => bitcoind,
                 Err(e) => {
@@ -560,10 +580,14 @@ fn spawn_replay(
                     return;
                 }
             };
-            if let Err(e) =
-                execute_replay(&coincube_datadir, &bitcoind, floor_height, target_height)
-            {
-                warn!("RDTS replay failed: {e}");
+            match execute_replay(&coincube_datadir, &bitcoind, floor_height, target_height) {
+                // Only now has the swap actually been dealt with, so only now may the
+                // ledger advance. Leaving it behind on failure is what makes the next
+                // start retry, instead of seeing Knots → Knots and skipping forever —
+                // this direction has no stateless backstop, because a Knots node
+                // legitimately trailing the majority chain must never be "repaired".
+                Ok(()) => ManagedNodeState::record_run(&coincube_datadir, observed_flavor),
+                Err(e) => warn!("RDTS replay failed: {e}"),
             }
         });
     if let Err(e) = spawned {
@@ -578,6 +602,14 @@ fn spawn_replay(
 /// persistent and nothing in the node records that we were mid-operation.
 /// Idempotent, so running it when there is nothing to finish costs one RPC.
 pub fn resume_pending_rewind(coincube_datadir: &CoincubeDirectory, bitcoind: &coincubed::BitcoinD) {
+    // A replay running right now has a rewind recorded and a half-disconnected chain.
+    // Another Vault attaching at that moment must not mistake it for a crash: issuing
+    // `reconsiderblock` would cut the live replay off mid-disconnect and clear the
+    // record out from under it, leaving the chain half-rewound with nothing to
+    // finish it.
+    if coincubed::managed_node_maintenance() {
+        return;
+    }
     // `try_load`, not `load`: an unreadable sidecar must not read as "nothing
     // pending". If a rewind really is in flight, defaulting here would leave the
     // node parked below the invalidated block with nothing left to release it, and
@@ -688,7 +720,6 @@ pub fn execute_replay(
         );
     }
 
-    let _maintenance = coincubed::MaintenanceGuard::new();
     info!(
         "Rewinding the managed node to height {floor_height} so Knots can re-check blocks \
          {first_divergent}..{target_height} under BIP-110."
@@ -799,12 +830,19 @@ mod tests {
             current_flavor: to,
             // Comfortably past the anchor, so the height gate isn't what's under test.
             blocks: RDTS_ANCHOR_MAINNET + 5_000,
-            deployment_live: true,
+            best_known_height: RDTS_ANCHOR_MAINNET + 5_000,
+            rdts_abandoned: false,
             // Unpruned unless a test says otherwise, so the prune floor isn't a
             // hidden variable in the cases that aren't about it.
             prune_state: coincubed::PruneState::NotPruned,
-            node_stranded: false,
         }
+    }
+
+    /// The node follows less work than it knows about — a rejected or headers-only
+    /// branch sits `above` blocks higher than its active tip.
+    fn stranded_by(mut f: ChainFacts, above: i32) -> ChainFacts {
+        f.best_known_height = f.blocks + above;
+        f
     }
 
     #[test]
@@ -818,9 +856,9 @@ mod tests {
     #[test]
     fn networks_without_an_anchor_are_skipped() {
         for network in [Network::Regtest, Network::Signet, Network::Testnet4] {
-            let mut f = facts(network, NodeFlavor::Knots, NodeFlavor::Core);
+            let f = facts(network, NodeFlavor::Knots, NodeFlavor::Core);
             // Even a stranded node: we have no defensible height to act from.
-            f.node_stranded = true;
+            let f = stranded_by(f, 10);
             assert_eq!(
                 plan(f),
                 RevalidationPlan::Skip(SkipReason::NoDeploymentOnNetwork),
@@ -828,16 +866,33 @@ mod tests {
         }
     }
 
-    // The runtime gate. Until RDTS locks in, both flavours enforce the same rules,
-    // so no swap can strand the node and this must stay entirely inert.
+    // The runtime gate rules out only a deployment that will never activate.
     #[test]
-    fn a_dormant_deployment_is_skipped() {
-        let mut f = facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Core);
-        f.deployment_live = false;
-        f.node_stranded = true;
+    fn an_abandoned_deployment_is_skipped() {
+        let mut f = stranded_by(
+            facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Core),
+            10,
+        );
+        f.rdts_abandoned = true;
         assert_eq!(
             plan(f),
-            RevalidationPlan::Skip(SkipReason::DeploymentNotLive)
+            RevalidationPlan::Skip(SkipReason::DeploymentAbandoned)
+        );
+    }
+
+    // Bitcoin Core does not define `reduced_data` at all, so after a Knots -> Core
+    // swap the deployment lookup can only ever come back empty. Reading that as
+    // "not live" made the entire repair unreachable on the one node that needs it,
+    // so absence must fall through to the height gate rather than short-circuit.
+    #[test]
+    fn a_missing_deployment_entry_does_not_block_the_repair() {
+        let f = facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Core);
+        assert!(!f.rdts_abandoned, "absence must not be recorded as failure");
+        assert_eq!(
+            plan(f),
+            RevalidationPlan::ClearFailureFlags {
+                anchor_height: RDTS_ANCHOR_MAINNET
+            },
         );
     }
 
@@ -845,13 +900,18 @@ mod tests {
     // node answers today. Shipping before activation is what lets the ledger be
     // seeded correctly on every install before divergence is possible at all.
     #[test]
-    fn a_tip_below_the_anchor_is_skipped() {
+    fn a_chain_below_the_anchor_is_skipped() {
         let mut f = facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Core);
         f.blocks = RDTS_ANCHOR_MAINNET;
-        assert_eq!(plan(f), RevalidationPlan::Skip(SkipReason::TipBelowAnchor));
+        f.best_known_height = RDTS_ANCHOR_MAINNET;
+        assert_eq!(
+            plan(f),
+            RevalidationPlan::Skip(SkipReason::NothingAboveAnchor)
+        );
 
         // One block into the mandatory-signalling window, divergence is possible.
         f.blocks = RDTS_ANCHOR_MAINNET + 1;
+        f.best_known_height = RDTS_ANCHOR_MAINNET + 1;
         assert_eq!(
             plan(f),
             RevalidationPlan::ClearFailureFlags {
@@ -883,9 +943,11 @@ mod tests {
     // switch, lost sidecar, datadir moved between machines).
     #[test]
     fn a_stranded_core_node_is_repaired_without_any_ledger() {
-        let mut f = facts(Network::Bitcoin, NodeFlavor::Core, NodeFlavor::Core);
+        let mut f = stranded_by(
+            facts(Network::Bitcoin, NodeFlavor::Core, NodeFlavor::Core),
+            10,
+        );
         f.previous_flavor = None;
-        f.node_stranded = true;
         assert_eq!(
             plan(f),
             RevalidationPlan::ClearFailureFlags {
@@ -899,17 +961,38 @@ mod tests {
     // its flags would re-validate and re-reject the same blocks on every startup.
     #[test]
     fn a_stranded_knots_node_is_never_repaired() {
-        let mut f = facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Knots);
-        f.node_stranded = true;
+        let f = stranded_by(
+            facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Knots),
+            10,
+        );
         assert_eq!(plan(f), RevalidationPlan::Skip(SkipReason::NothingToClear));
 
         // Not even right after a Core -> Knots swap. That swap does trigger work,
         // but it must be a replay under RDTS — never a "repair" that clears the
         // rejections and drags the node back onto the chain the user just opted out
         // of following.
-        let mut f = facts(Network::Bitcoin, NodeFlavor::Core, NodeFlavor::Knots);
-        f.node_stranded = true;
+        let f = stranded_by(
+            facts(Network::Bitcoin, NodeFlavor::Core, NodeFlavor::Knots),
+            10,
+        );
         assert!(matches!(plan(f), RevalidationPlan::ReplayUnderRdts { .. }));
+    }
+
+    // The first rejection is the whole point. A Knots node that rejected the block
+    // at the start of the mandatory-signalling window sits at exactly the anchor,
+    // with a higher branch it refuses to follow. Gating on the active tip alone
+    // declined to repair it after a swap to Core.
+    #[test]
+    fn a_node_parked_exactly_at_the_anchor_is_still_repaired() {
+        let mut f = facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Core);
+        f.blocks = RDTS_ANCHOR_MAINNET;
+        f.best_known_height = RDTS_ANCHOR_MAINNET + 1;
+        assert_eq!(
+            plan(f),
+            RevalidationPlan::ClearFailureFlags {
+                anchor_height: RDTS_ANCHOR_MAINNET
+            },
+        );
     }
 
     // Core -> Knots on an unpruned node: rewind all the way to the anchor, which is
@@ -1005,8 +1088,10 @@ mod tests {
     // Knots node must not re-run it every time.
     #[test]
     fn a_restarting_knots_node_does_not_replay() {
-        let mut f = facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Knots);
-        f.node_stranded = true;
+        let f = stranded_by(
+            facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Knots),
+            10,
+        );
         assert_eq!(plan(f), RevalidationPlan::Skip(SkipReason::NothingToClear));
 
         let mut f = facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Knots);
@@ -1058,25 +1143,24 @@ mod tests {
     }
 
     #[test]
-    fn a_healthy_node_needs_no_reconsider() {
-        assert!(!needs_reconsider(&[
-            tip(100, "active"),
-            tip(98, "valid-fork")
-        ]));
-        // No active tip at all (shouldn't happen) must not read as stranded.
-        assert!(!needs_reconsider(&[]));
-    }
+    fn best_known_height_spans_every_branch() {
+        assert_eq!(
+            best_known_height(&[tip(100, "active"), tip(98, "valid-fork")]),
+            Some(100)
+        );
+        assert_eq!(best_known_height(&[]), None);
 
-    // Note the branch is `headers-only`, not `invalid`: a node that rejects a block
-    // stops downloading that chain, so gating on `"invalid"` would miss exactly the
-    // case this check exists for.
-    #[test]
-    fn a_stranded_node_needs_a_reconsider() {
-        assert!(needs_reconsider(&[
-            tip(100, "active"),
-            tip(120, "headers-only")
-        ]));
-        assert!(needs_reconsider(&[tip(100, "active"), tip(120, "invalid")]));
+        // Note the branch is `headers-only`, not `invalid`: a node that rejects a
+        // block stops downloading that chain, so counting only `invalid` branches
+        // would miss exactly the stranded case this exists for.
+        assert_eq!(
+            best_known_height(&[tip(100, "active"), tip(120, "headers-only")]),
+            Some(120)
+        );
+        assert_eq!(
+            best_known_height(&[tip(100, "active"), tip(120, "invalid")]),
+            Some(120)
+        );
     }
 
     #[test]

--- a/coincube-gui/src/node/revalidate.rs
+++ b/coincube-gui/src/node/revalidate.rs
@@ -438,24 +438,35 @@ impl ManagedNodeState {
         }
     }
 
-    /// Persist the fork point of a repair and tell this process's pollers about it.
+    /// Persist the floor of a repair's rollback and tell this process's pollers
+    /// about it.
     ///
-    /// Persisting first: the poller that has to adopt the rollback may belong to a
-    /// Vault that is not open yet, or to a later session entirely.
+    /// Returns whether it is now on disk. Callers must not begin the repair unless
+    /// it is: an in-memory-only authorisation dies with the process, and the Vault
+    /// that has to adopt the rollback may not open until a later session — at which
+    /// point the permanent refusal this exists to prevent is back, with the chain
+    /// already rewound.
+    ///
+    /// Published only once persisted, so what this process acts on and what the next
+    /// one will read cannot disagree.
     pub fn set_sanctioned_rollback(
         coincube_datadir: &CoincubeDirectory,
-        point: SanctionedRollback,
-    ) {
-        match Self::try_load(coincube_datadir) {
-            Ok(mut state) => {
-                state.sanctioned_rollback = Some(point.clone());
-                if let Err(e) = state.save(coincube_datadir) {
-                    warn!("could not record the repair's fork point: {e}");
-                }
+        floor: SanctionedRollback,
+    ) -> bool {
+        let mut state = match Self::try_load(coincube_datadir) {
+            Ok(state) => state,
+            Err(e) => {
+                warn!("could not read managed-node state to record the rollback floor: {e}");
+                return false;
             }
-            Err(e) => warn!("could not read managed-node state to record the fork point: {e}"),
+        };
+        state.sanctioned_rollback = Some(floor.clone());
+        if let Err(e) = state.save(coincube_datadir) {
+            warn!("could not record the repair's rollback floor: {e}");
+            return false;
         }
-        publish_sanctioned_rollback(Some(&point));
+        publish_sanctioned_rollback(Some(&floor));
+        true
     }
 }
 
@@ -563,9 +574,7 @@ pub fn reconcile_after_start(
     // a planner fed it draws exactly the wrong conclusion — a node parked at the
     // floor looks like "nothing left above the anchor", which records the current
     // flavour and retires the very swap the recovery is still working on.
-    if resume_pending_rewind(coincube_datadir, bitcoind, config, observed_flavor)
-        == RecoveryState::InFlight
-    {
+    if !resume_pending_rewind(coincube_datadir, bitcoind, config, observed_flavor).may_plan() {
         return;
     }
 
@@ -710,6 +719,19 @@ pub enum RecoveryState {
     /// A rewind is being finished, here or by another holder. The node's height is
     /// mid-operation and must not be planned from.
     InFlight,
+    /// We could not tell whether a rewind is pending. Treated exactly like one that
+    /// is: the node may be parked below an invalidated block, and planning from that
+    /// height is what turns an unfinished rewind into a permanent one.
+    Indeterminate,
+}
+
+impl RecoveryState {
+    /// Whether the caller may plan from the node's current height. Only a positive
+    /// "nothing is pending" earns that; both of the other answers mean the height on
+    /// offer may describe a half-rewound chain.
+    pub fn may_plan(self) -> bool {
+        self == Self::Idle
+    }
 }
 
 /// Finish a rewind that a previous run started but did not complete.
@@ -748,7 +770,11 @@ pub fn resume_pending_rewind(
                  its height against the network, and use \"Re-check chain\" in Node settings \
                  to release it."
             );
-            return RecoveryState::Idle;
+            // Not `Idle`. The comment above is only honoured if the caller also
+            // declines to plan: a node parked mid-rewind reports a height that reads
+            // as "nothing left above the anchor", and acting on it records the
+            // current flavour and retires the very swap that still needs replaying.
+            return RecoveryState::Indeterminate;
         }
     };
     let Some(rewind) = state.rewind else {
@@ -795,22 +821,35 @@ pub fn resume_pending_rewind(
                     return;
                 }
             };
-            if let Err(e) = bitcoind.reconsider_block_noreply(&anchor) {
-                warn!("could not finish the pending rewind: {e}");
-                return;
-            }
             // The rollback the interrupted rewind created is ours, so authorise the
-            // pollers to adopt it however deep it turns out to be.
-            ManagedNodeState::set_sanctioned_rollback(
+            // pollers to adopt it however deep it turns out to be. Before the
+            // reconsider and refusing to go on without it, for the same reason the
+            // replay does: an authorisation we cannot persist is one the Vault that
+            // needs it will never see. The rewind record stays, so a later start
+            // retries the whole recovery.
+            if !ManagedNodeState::set_sanctioned_rollback(
                 &coincube_datadir,
                 SanctionedRollback {
                     hash: anchor.to_string(),
                     height: rewind.floor_height,
                 },
-            );
-            match wait_for_tip(&bitcoind, RECONNECT_DEADLINE, |blocks| {
-                blocks >= rewind.target_height
-            }) {
+            ) {
+                warn!(
+                    "could not record the rollback floor; leaving the rewind for a later \
+                     start rather than reconnecting a chain no Vault would adopt"
+                );
+                return;
+            }
+            if let Err(e) = bitcoind.reconsider_block_noreply(&anchor) {
+                warn!("could not finish the pending rewind: {e}");
+                return;
+            }
+            match wait_for_tip(
+                &bitcoind,
+                RECONNECT_DEADLINE,
+                |blocks| blocks >= rewind.target_height,
+                |blocks| rejected_above(&bitcoind, blocks),
+            ) {
                 // A confirmed terminal state, either back where the rewind started or
                 // stopped short because Knots rejected a block. Either way the node is
                 // whole, so the record and the flavour may retire together.
@@ -917,25 +956,42 @@ pub fn execute_replay(
     );
 
     // The rollback about to happen is one we chose, so let every poller adopt it
-    // however deep it is. Published before the disconnect, not after: the poller
-    // that has to apply it may see the rewound chain before we get to observe it.
-    ManagedNodeState::set_sanctioned_rollback(
+    // however deep it is. Persisted before the disconnect and, like the rewind
+    // record above, a hard precondition for it: an authorisation that only ever
+    // lived in this process dies with it, and a Vault opened afterwards would refuse
+    // the repaired chain permanently — with the rewind already done and no way back.
+    if !ManagedNodeState::set_sanctioned_rollback(
         coincube_datadir,
         SanctionedRollback {
             hash: floor_hash.to_string(),
             height: floor_height,
         },
-    );
+    ) {
+        // Undo the intent we just recorded: nothing destructive has happened yet, so
+        // leaving a rewind record behind would send the next start looking for a
+        // rewind that never started.
+        ManagedNodeState::set_rewind(coincube_datadir, None);
+        return Err(
+            "could not record the rollback floor before starting the rewind; refusing to \
+             proceed"
+                .to_string(),
+        );
+    }
 
     bitcoind
         .invalidate_block_noreply(&invalidate_hash)
         .map_err(|e| format!("invalidateblock at height {first_divergent} failed: {e}"))?;
     // Only an observed disconnect may be built on. If we merely stopped watching,
     // the chain may still be anywhere, and the record we leave behind is what lets a
-    // later start pick the recovery up.
-    match wait_for_tip(bitcoind, DISCONNECT_DEADLINE, |blocks| {
-        blocks <= floor_height
-    })? {
+    // later start pick the recovery up. A disconnect has no "finished early" state
+    // worth honouring — it either reaches the floor or it has not happened — so
+    // nothing is treated as settled here.
+    match wait_for_tip(
+        bitcoind,
+        DISCONNECT_DEADLINE,
+        |blocks| blocks <= floor_height,
+        |_| false,
+    )? {
         TipWait::Reached(_) => {}
         TipWait::Settled(height) => {
             return Err(format!(
@@ -956,12 +1012,16 @@ pub fn execute_replay(
     bitcoind
         .reconsider_block_noreply(&floor_hash)
         .map_err(|e| format!("reconsiderblock at height {floor_height} failed: {e}"))?;
-    match wait_for_tip(bitcoind, RECONNECT_DEADLINE, |blocks| {
-        blocks >= target_height
-    })? {
+    match wait_for_tip(
+        bitcoind,
+        RECONNECT_DEADLINE,
+        |blocks| blocks >= target_height,
+        |blocks| rejected_above(bitcoind, blocks),
+    )? {
         TipWait::Reached(_) => Ok(()),
-        // The node stopped reconnecting below where it started. That is a real
-        // terminal state, not a failure: Knots rejected something Core had accepted.
+        // The node says it rejected the block above its tip, so it is done and will
+        // not climb further. A real terminal state, not a failure: this is Knots
+        // refusing something Core had accepted.
         TipWait::Settled(height) => {
             warn!(
                 "After re-checking, the node settled at height {height} rather than \
@@ -986,17 +1046,47 @@ pub fn execute_replay(
 enum TipWait {
     /// The predicate was satisfied — an observed, confirmed transition.
     Reached(i32),
-    /// The tip stopped moving without satisfying the predicate. The node is done;
-    /// it just did not end up where we expected. This is the shape a legitimate
-    /// RDTS rejection takes: Knots refuses a block Core accepted, so the reconnect
-    /// ends below the height it started from.
+    /// The node itself reported it is finished and will not advance further, short
+    /// of the predicate. This is the shape a legitimate RDTS rejection takes: Knots
+    /// refuses a block Core accepted, so the reconnect ends below the height it
+    /// started from.
     Settled(i32),
     /// Neither happened before the deadline. Nothing may be concluded.
     Deadline,
 }
 
-/// Poll the node's height until `done`, until it stops moving, until the deadline
-/// expires, or until the node stops answering.
+/// Whether the node says it has stopped advancing because it *rejected* what comes
+/// next: a branch above the active tip that it validated and marked invalid.
+///
+/// The authoritative end of a reconnect, and the reason a stationary height is not
+/// allowed to stand in for one. Validating a single block can outlast any stability
+/// window we would be willing to wait, so from the outside "still working" and
+/// "finished" look identical — and concluding the latter retires the only record
+/// that can retry, on a node that may still be mid-reconsideration.
+///
+/// `getchaintips` reports `invalid` only for a branch the node actually validated,
+/// which is exactly this case: the blocks were already on disk and were re-checked
+/// under the new rules. (Its other failure mode — a branch abandoned before
+/// download, reported `headers-only` — cannot arise here.)
+fn rejected_above(bitcoind: &coincubed::BitcoinD, blocks: i32) -> bool {
+    match bitcoind.chain_tips() {
+        Ok(tips) => tips
+            .iter()
+            .any(|tip| tip.status == "invalid" && tip.height > blocks),
+        Err(e) => {
+            warn!("could not read chain tips to tell whether the reconnect finished: {e}");
+            false
+        }
+    }
+}
+
+/// Poll the node's height until `done`, until `settled` confirms it has stopped for
+/// good, until the deadline expires, or until the node stops answering.
+///
+/// `settled` is consulted only once the height has held still for a while — it
+/// costs an RPC, and asking it of a tip that is still climbing is pointless. It is
+/// what turns "the number has not moved" into an actual terminal state; without it
+/// this function cannot tell a finished node from a slow one.
 ///
 /// A node that stops answering after `invalidateblock` is the fatal-abort case —
 /// disconnecting pruned data kills bitcoind rather than returning an error — so a
@@ -1005,10 +1095,12 @@ fn wait_for_tip(
     bitcoind: &coincubed::BitcoinD,
     deadline: Duration,
     done: impl Fn(i32) -> bool,
+    settled: impl Fn(i32) -> bool,
 ) -> Result<TipWait, String> {
     const MAX_CONSECUTIVE_FAILURES: u32 = 15;
-    /// Consecutive readings at one height before the node counts as finished.
-    /// Generous, because a reconnect legitimately pauses while it validates.
+    /// Consecutive readings at one height before we bother asking whether the node
+    /// has finished. Generous, because a reconnect legitimately pauses while it
+    /// validates, and re-checked every this many readings after that.
     const STABLE_POLLS: u32 = 150;
 
     let started = Instant::now();
@@ -1024,7 +1116,7 @@ fn wait_for_tip(
                 }
                 if last_seen == Some(status.blocks) {
                     stable += 1;
-                    if stable >= STABLE_POLLS {
+                    if stable.is_multiple_of(STABLE_POLLS) && settled(status.blocks) {
                         return Ok(TipWait::Settled(status.blocks));
                     }
                 } else {
@@ -1034,6 +1126,10 @@ fn wait_for_tip(
             }
             Err(e) => {
                 failures += 1;
+                // A gap in observation is not evidence the tip held still: the node
+                // may well have moved while we could not see it.
+                stable = 0;
+                last_seen = None;
                 if failures >= MAX_CONSECUTIVE_FAILURES {
                     return Err(format!(
                         "the managed node stopped responding during the rewind ({e}). It may have \
@@ -1063,17 +1159,25 @@ pub fn execute(
     let anchor = bitcoind
         .get_block_hash(anchor_height)
         .ok_or_else(|| format!("no block at the RDTS anchor height {anchor_height}"))?;
-    // Clearing the flags can reorg the node onto a branch that forks at the anchor,
-    // which is far deeper than the poller will follow on its own authority. It forks
-    // at a block we named, so name it: without this every Vault refuses the repaired
-    // chain from here on.
-    ManagedNodeState::set_sanctioned_rollback(
+    // Clearing the flags can reorg the node onto a branch that forks anywhere above
+    // the anchor, which is far deeper than the poller will follow on its own
+    // authority. The anchor bounds how far back that can reach, so publish it:
+    // without this every Vault refuses the repaired chain from here on. As in the
+    // replay, an authorisation we cannot persist is one a later session will not
+    // have, so it gates the repair rather than merely being logged.
+    if !ManagedNodeState::set_sanctioned_rollback(
         coincube_datadir,
         SanctionedRollback {
             hash: anchor.to_string(),
             height: anchor_height,
         },
-    );
+    ) {
+        return Err(
+            "could not record the rollback floor, so Vaults could not adopt the repaired \
+             chain; refusing to proceed"
+                .to_string(),
+        );
+    }
     info!(
         "Clearing inherited block-index rejections from the RDTS anchor \
          (height {anchor_height}, {anchor}) so this node can follow the most-work chain."
@@ -1441,7 +1545,7 @@ mod tests {
     // Vault that must adopt the rollback may not even be open yet, and without the
     // record its poller refuses the repaired chain as an implausible reorg forever.
     #[test]
-    fn a_repairs_fork_point_is_persisted_and_published() {
+    fn a_repairs_rollback_floor_is_persisted_and_published() {
         let dir = std::env::temp_dir().join(format!(
             "coincube-sanction-test-{}-{:?}",
             std::process::id(),
@@ -1450,21 +1554,24 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         let datadir = CoincubeDirectory::new(dir.clone());
 
-        let point = SanctionedRollback {
+        let floor = SanctionedRollback {
             hash: "00".repeat(31) + "2a",
             height: RDTS_ANCHOR_MAINNET,
         };
-        ManagedNodeState::set_sanctioned_rollback(&datadir, point.clone());
+        assert!(ManagedNodeState::set_sanctioned_rollback(
+            &datadir,
+            floor.clone()
+        ));
 
         // Durable...
         assert_eq!(
             ManagedNodeState::load(&datadir).sanctioned_rollback,
-            Some(point.clone())
+            Some(floor.clone())
         );
         // ...and live, so this session's pollers can already act on it.
         let published = coincubed::sanctioned_rollback().expect("published");
         assert_eq!(published.height, RDTS_ANCHOR_MAINNET);
-        assert_eq!(published.hash.to_string(), point.hash);
+        assert_eq!(published.hash.to_string(), floor.hash);
 
         // Republishing from a fresh load is what re-arms it on the next start.
         coincubed::set_sanctioned_rollback(None);
@@ -1483,7 +1590,28 @@ mod tests {
         }));
         assert!(coincubed::sanctioned_rollback().is_none());
 
+        // A floor that could not be written must report failure, and must not leave a
+        // live in-memory exception behind either: the caller aborts the repair on
+        // this, and an authorisation this process alone can see is exactly the state
+        // that strands the next one.
+        std::fs::write(ManagedNodeState::path(&datadir), b"{ not json").unwrap();
+        assert!(!ManagedNodeState::set_sanctioned_rollback(
+            &datadir,
+            floor.clone()
+        ));
+        assert!(coincubed::sanctioned_rollback().is_none());
+
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Only a positive "nothing is pending" lets planning run. Both other answers mean
+    // the height the node is offering may describe a half-rewound chain — and planning
+    // from that is what retires the swap the recovery has not finished yet.
+    #[test]
+    fn only_an_idle_recovery_permits_planning() {
+        assert!(RecoveryState::Idle.may_plan());
+        assert!(!RecoveryState::InFlight.may_plan());
+        assert!(!RecoveryState::Indeterminate.may_plan());
     }
 
     fn tip(height: i32, status: &str) -> coincubed::ChainTipEntry {

--- a/coincube-gui/src/node/revalidate.rs
+++ b/coincube-gui/src/node/revalidate.rs
@@ -31,6 +31,7 @@
 use std::{
     io,
     path::{Path, PathBuf},
+    str::FromStr,
     thread,
     time::{Duration, Instant},
 };
@@ -282,6 +283,24 @@ pub struct ManagedNodeState {
     /// the next start finish the job.
     #[serde(default)]
     pub rewind: Option<RewindInFlight>,
+    /// The block a repair rewound the chain to, so every Vault's poller can adopt
+    /// the result.
+    ///
+    /// Also load-bearing, and for a reason that only shows up after the repair
+    /// succeeds: a repair that moves the chain by more than the poller's
+    /// `MAX_REORG_DEPTH` is refused as implausible, forever, leaving Vaults pinned
+    /// to a chain the node no longer has. Publishing the fork point is what lets
+    /// them tell "we did this" from "the backend is lying". Durable because
+    /// adoption can outlive the session that performed the repair.
+    #[serde(default)]
+    pub sanctioned_rollback: Option<SanctionedRollback>,
+}
+
+/// The fork point of a rollback we performed deliberately.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SanctionedRollback {
+    pub hash: String,
+    pub height: i32,
 }
 
 /// A rewind we have started and not yet confirmed finished.
@@ -392,6 +411,71 @@ impl ManagedNodeState {
             }
         }
     }
+
+    /// Retire a completed rewind and advance the flavour ledger in a single write.
+    ///
+    /// Two writes would have a window between them, and a crash inside it is the
+    /// worst of both: `rewind` gone, so nothing knows a rewind ever happened, and
+    /// `last_run_flavor` still Core, so the next start plans the whole hours-long
+    /// replay again. One `save` makes the completion as atomic as the rename
+    /// underneath it.
+    pub fn finish_rewind(coincube_datadir: &CoincubeDirectory, flavor: NodeFlavor) -> bool {
+        let mut state = match Self::try_load(coincube_datadir) {
+            Ok(state) => state,
+            Err(e) => {
+                warn!("could not read managed-node state to retire the rewind: {e}");
+                return false;
+            }
+        };
+        state.rewind = None;
+        state.last_run_flavor = Some(flavor);
+        match state.save(coincube_datadir) {
+            Ok(()) => true,
+            Err(e) => {
+                warn!("could not retire the completed rewind: {e}");
+                false
+            }
+        }
+    }
+
+    /// Persist the fork point of a repair and tell this process's pollers about it.
+    ///
+    /// Persisting first: the poller that has to adopt the rollback may belong to a
+    /// Vault that is not open yet, or to a later session entirely.
+    pub fn set_sanctioned_rollback(
+        coincube_datadir: &CoincubeDirectory,
+        point: SanctionedRollback,
+    ) {
+        match Self::try_load(coincube_datadir) {
+            Ok(mut state) => {
+                state.sanctioned_rollback = Some(point.clone());
+                if let Err(e) = state.save(coincube_datadir) {
+                    warn!("could not record the repair's fork point: {e}");
+                }
+            }
+            Err(e) => warn!("could not read managed-node state to record the fork point: {e}"),
+        }
+        publish_sanctioned_rollback(Some(&point));
+    }
+}
+
+/// Hand the recorded fork point to coincubed, so every poller in this process can
+/// tell a rollback we caused from a backend misreporting one.
+fn publish_sanctioned_rollback(point: Option<&SanctionedRollback>) {
+    let tip =
+        point.and_then(|point| {
+            match coincube_core::miniscript::bitcoin::BlockHash::from_str(&point.hash) {
+                Ok(hash) => Some(coincubed::BlockChainTip {
+                    hash,
+                    height: point.height,
+                }),
+                Err(e) => {
+                    warn!("unreadable repair fork point {:?}: {e}", point.hash);
+                    None
+                }
+            }
+        });
+    coincubed::set_sanctioned_rollback(tip);
 }
 
 /// Write `contents` to `path` through a sibling temp file, flushing before the
@@ -464,9 +548,26 @@ pub fn reconcile_after_start(
     network: Network,
     observed_flavor: NodeFlavor,
 ) {
+    // Re-arm the poller exception first: a repair from an earlier session may still
+    // be waiting for some Vault to adopt its rollback, and that Vault's poller can
+    // start the moment we return.
+    publish_sanctioned_rollback(
+        ManagedNodeState::load(coincube_datadir)
+            .sanctioned_rollback
+            .as_ref(),
+    );
+
     // Before anything else: if a previous run died mid-rewind, the node is parked
-    // below an invalidated block and will not move until we release it.
-    resume_pending_rewind(coincube_datadir, bitcoind);
+    // below an invalidated block and will not move until we release it. Planning
+    // must not run alongside that. The node's height is meaningless mid-rewind, and
+    // a planner fed it draws exactly the wrong conclusion — a node parked at the
+    // floor looks like "nothing left above the anchor", which records the current
+    // flavour and retires the very swap the recovery is still working on.
+    if resume_pending_rewind(coincube_datadir, bitcoind, config, observed_flavor)
+        == RecoveryState::InFlight
+    {
+        return;
+    }
 
     let previous_flavor = ManagedNodeState::load(coincube_datadir).last_run_flavor;
 
@@ -517,7 +618,7 @@ pub fn reconcile_after_start(
             // Idempotent and cheap, so advancing the record is safe even if it fails:
             // a node still following less work than it knows about is caught again by
             // the height comparison on the next start, with no reliance on the ledger.
-            if let Err(e) = execute(bitcoind, plan) {
+            if let Err(e) = execute(coincube_datadir, bitcoind, plan) {
                 warn!("RDTS revalidation failed: {e}");
             }
             ManagedNodeState::record_run(coincube_datadir, observed_flavor);
@@ -586,7 +687,13 @@ fn spawn_replay(
                 // start retry, instead of seeing Knots → Knots and skipping forever —
                 // this direction has no stateless backstop, because a Knots node
                 // legitimately trailing the majority chain must never be "repaired".
-                Ok(()) => ManagedNodeState::record_run(&coincube_datadir, observed_flavor),
+                // Retiring the rewind and advancing the flavour is one write, not two.
+                // A crash between them would leave `rewind` gone and the flavour still
+                // Core, and the next start would plan the whole replay over again —
+                // hours of disconnect and reconnect, against a chain already re-checked.
+                Ok(()) => {
+                    ManagedNodeState::finish_rewind(&coincube_datadir, observed_flavor);
+                }
                 Err(e) => warn!("RDTS replay failed: {e}"),
             }
         });
@@ -595,21 +702,39 @@ fn spawn_replay(
     }
 }
 
+/// Whether a rewind is still being worked on, and so whether planning may proceed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryState {
+    /// Nothing was pending. The caller may plan from the node's current height.
+    Idle,
+    /// A rewind is being finished, here or by another holder. The node's height is
+    /// mid-operation and must not be planned from.
+    InFlight,
+}
+
 /// Finish a rewind that a previous run started but did not complete.
 ///
 /// Without this, dying between `invalidateblock` and `reconsiderblock` leaves the
 /// node parked below the invalidated block indefinitely: the failure flag is
 /// persistent and nothing in the node records that we were mid-operation.
 /// Idempotent, so running it when there is nothing to finish costs one RPC.
-pub fn resume_pending_rewind(coincube_datadir: &CoincubeDirectory, bitcoind: &coincubed::BitcoinD) {
-    // A replay running right now has a rewind recorded and a half-disconnected chain.
-    // Another Vault attaching at that moment must not mistake it for a crash: issuing
-    // `reconsiderblock` would cut the live replay off mid-disconnect and clear the
-    // record out from under it, leaving the chain half-rewound with nothing to
-    // finish it.
-    if coincubed::managed_node_maintenance() {
-        return;
-    }
+///
+/// The recovery is *not* complete when `reconsiderblock` returns. That call is
+/// fire-and-forget and the reconnect it starts can run for hours, so the record is
+/// only retired once the tip is observed back at the height the rewind started
+/// from — and retired together with the flavour, in one write. Clearing it on the
+/// RPC returning would throw away the only thing that can retry: a node that then
+/// crashes, or a reconnect that never lands, leaves neither a rewind to resume nor
+/// a Core → Knots transition to notice.
+///
+/// Returns promptly. The waiting happens on its own thread, for the same reason
+/// [`execute_replay`] does.
+pub fn resume_pending_rewind(
+    coincube_datadir: &CoincubeDirectory,
+    bitcoind: &coincubed::BitcoinD,
+    config: &coincubed::config::BitcoindConfig,
+    observed_flavor: NodeFlavor,
+) -> RecoveryState {
     // `try_load`, not `load`: an unreadable sidecar must not read as "nothing
     // pending". If a rewind really is in flight, defaulting here would leave the
     // node parked below the invalidated block with nothing left to release it, and
@@ -623,12 +748,24 @@ pub fn resume_pending_rewind(coincube_datadir: &CoincubeDirectory, bitcoind: &co
                  its height against the network, and use \"Re-check chain\" in Node settings \
                  to release it."
             );
-            return;
+            return RecoveryState::Idle;
         }
     };
     let Some(rewind) = state.rewind else {
-        return;
+        return RecoveryState::Idle;
     };
+
+    // A replay running right now has a rewind recorded and a half-disconnected chain.
+    // Another Vault attaching at that moment must not mistake it for a crash: issuing
+    // `reconsiderblock` would cut the live replay off mid-disconnect and clear the
+    // record out from under it, leaving the chain half-rewound with nothing to
+    // finish it. Claiming maintenance is both that check and this recovery's own
+    // exclusion, in one atomic step.
+    let Some(guard) = coincubed::MaintenanceGuard::try_acquire() else {
+        info!("A chain rewind is already being worked on; leaving it to its owner.");
+        return RecoveryState::InFlight;
+    };
+
     warn!(
         "A chain rewind from a previous run was left unfinished (floor {}, target {}). \
          Re-issuing reconsiderblock to release the node.",
@@ -640,21 +777,75 @@ pub fn resume_pending_rewind(coincube_datadir: &CoincubeDirectory, bitcoind: &co
              later start can retry.",
             rewind.floor_height
         );
-        return;
+        // Still in flight: the node is parked below an invalidated block, so its
+        // height describes a half-rewound chain and nothing may be planned from it.
+        return RecoveryState::InFlight;
     };
-    match bitcoind.reconsider_block_noreply(&anchor) {
-        Ok(()) => {
-            ManagedNodeState::set_rewind(coincube_datadir, None);
-        }
-        Err(e) => warn!("could not finish the pending rewind: {e}"),
+
+    let coincube_datadir = coincube_datadir.clone();
+    let config = config.clone();
+    let spawned = thread::Builder::new()
+        .name("rdts-rewind-recovery".to_string())
+        .spawn(move || {
+            let _guard = guard;
+            let bitcoind = match coincubed::BitcoinD::new(&config, "rdts_recovery".to_string()) {
+                Ok(bitcoind) => bitcoind,
+                Err(e) => {
+                    warn!("could not connect to the managed node to finish the rewind: {e}");
+                    return;
+                }
+            };
+            if let Err(e) = bitcoind.reconsider_block_noreply(&anchor) {
+                warn!("could not finish the pending rewind: {e}");
+                return;
+            }
+            // The rollback the interrupted rewind created is ours, so authorise the
+            // pollers to adopt it however deep it turns out to be.
+            ManagedNodeState::set_sanctioned_rollback(
+                &coincube_datadir,
+                SanctionedRollback {
+                    hash: anchor.to_string(),
+                    height: rewind.floor_height,
+                },
+            );
+            match wait_for_tip(&bitcoind, RECONNECT_DEADLINE, |blocks| {
+                blocks >= rewind.target_height
+            }) {
+                // A confirmed terminal state, either back where the rewind started or
+                // stopped short because Knots rejected a block. Either way the node is
+                // whole, so the record and the flavour may retire together.
+                Ok(TipWait::Reached(_)) => {
+                    ManagedNodeState::finish_rewind(&coincube_datadir, observed_flavor);
+                }
+                Ok(TipWait::Settled(height)) => {
+                    warn!(
+                        "The recovered node settled at height {height} rather than {}.",
+                        rewind.target_height
+                    );
+                    ManagedNodeState::finish_rewind(&coincube_datadir, observed_flavor);
+                }
+                // Still reconnecting when we stopped watching, or unresponsive. The
+                // record stays, so the next start picks the recovery up rather than
+                // losing both it and the swap that caused it.
+                Ok(TipWait::Deadline) => {
+                    warn!("the rewind recovery had not finished when we stopped watching")
+                }
+                Err(e) => warn!("the rewind recovery did not confirm: {e}"),
+            }
+        });
+    if let Err(e) = spawned {
+        warn!("could not spawn the rewind-recovery thread: {e}");
     }
+    RecoveryState::InFlight
 }
 
 /// How long to let each phase of a replay run before we stop watching it.
 ///
-/// Expiry is not an error: the node keeps working through the reconnect on its own,
-/// and the in-flight record means a later start can still finish the job. We simply
-/// stop holding every Vault's poller while we wait.
+/// Expiry is not a failure of the *node* — it keeps working through the reconnect
+/// on its own, and the in-flight record means a later start can still finish the
+/// job. It is reported as an error all the same, because the only thing we know at
+/// that point is that we stopped looking, and the record must survive to be
+/// confirmed later rather than be retired on an assumption.
 const DISCONNECT_DEADLINE: Duration = Duration::from_secs(30 * 60);
 const RECONNECT_DEADLINE: Duration = Duration::from_secs(6 * 60 * 60);
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
@@ -725,37 +916,87 @@ pub fn execute_replay(
          {first_divergent}..{target_height} under BIP-110."
     );
 
+    // The rollback about to happen is one we chose, so let every poller adopt it
+    // however deep it is. Published before the disconnect, not after: the poller
+    // that has to apply it may see the rewound chain before we get to observe it.
+    ManagedNodeState::set_sanctioned_rollback(
+        coincube_datadir,
+        SanctionedRollback {
+            hash: floor_hash.to_string(),
+            height: floor_height,
+        },
+    );
+
     bitcoind
         .invalidate_block_noreply(&invalidate_hash)
         .map_err(|e| format!("invalidateblock at height {first_divergent} failed: {e}"))?;
-    wait_for_tip(bitcoind, DISCONNECT_DEADLINE, |blocks| {
+    // Only an observed disconnect may be built on. If we merely stopped watching,
+    // the chain may still be anywhere, and the record we leave behind is what lets a
+    // later start pick the recovery up.
+    match wait_for_tip(bitcoind, DISCONNECT_DEADLINE, |blocks| {
         blocks <= floor_height
-    })?;
+    })? {
+        TipWait::Reached(_) => {}
+        TipWait::Settled(height) => {
+            return Err(format!(
+                "the rewind stalled at height {height} instead of reaching {floor_height}; \
+                 leaving the record so a later start can finish it"
+            ))
+        }
+        TipWait::Deadline => {
+            return Err(
+                "the rewind did not reach the floor before the deadline; leaving the record \
+                 so a later start can finish it"
+                    .to_string(),
+            )
+        }
+    }
 
     info!("Rewind complete; reconnecting under BIP-110 rules.");
     bitcoind
         .reconsider_block_noreply(&floor_hash)
         .map_err(|e| format!("reconsiderblock at height {floor_height} failed: {e}"))?;
-    let reached = wait_for_tip(bitcoind, RECONNECT_DEADLINE, |blocks| {
+    match wait_for_tip(bitcoind, RECONNECT_DEADLINE, |blocks| {
         blocks >= target_height
-    })?;
-
-    // Only now is the node whole again, so only now may the record go.
-    ManagedNodeState::set_rewind(coincube_datadir, None);
-    if reached < target_height {
-        // Knots rejected something Core had accepted, or the deadline expired. Either
-        // way the node is consistent; it just isn't where it started.
-        warn!(
-            "After re-checking, the node settled at height {reached} rather than {target_height}. \
-             If this is not simply a slow reconnect, blocks accepted under Core were rejected \
-             under BIP-110."
-        );
+    })? {
+        TipWait::Reached(_) => Ok(()),
+        // The node stopped reconnecting below where it started. That is a real
+        // terminal state, not a failure: Knots rejected something Core had accepted.
+        TipWait::Settled(height) => {
+            warn!(
+                "After re-checking, the node settled at height {height} rather than \
+                 {target_height}. Blocks accepted under Core were rejected under BIP-110."
+            );
+            Ok(())
+        }
+        // We stopped watching mid-reconnect. The node carries on by itself, and the
+        // record we leave behind lets a later start confirm and retire it.
+        TipWait::Deadline => Err(
+            "the reconnect had not finished when we stopped watching; leaving the record \
+             so a later start can confirm it"
+                .to_string(),
+        ),
     }
-    Ok(())
 }
 
-/// Poll the node's height until `done`, the deadline expires, or the node stops
-/// answering.
+/// How the wait ended. The distinction is the whole point: "we stopped watching"
+/// must never be mistaken for "the node got there", because the caller retires a
+/// durable recovery record on the strength of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TipWait {
+    /// The predicate was satisfied — an observed, confirmed transition.
+    Reached(i32),
+    /// The tip stopped moving without satisfying the predicate. The node is done;
+    /// it just did not end up where we expected. This is the shape a legitimate
+    /// RDTS rejection takes: Knots refuses a block Core accepted, so the reconnect
+    /// ends below the height it started from.
+    Settled(i32),
+    /// Neither happened before the deadline. Nothing may be concluded.
+    Deadline,
+}
+
+/// Poll the node's height until `done`, until it stops moving, until the deadline
+/// expires, or until the node stops answering.
 ///
 /// A node that stops answering after `invalidateblock` is the fatal-abort case —
 /// disconnecting pruned data kills bitcoind rather than returning an error — so a
@@ -764,19 +1005,31 @@ fn wait_for_tip(
     bitcoind: &coincubed::BitcoinD,
     deadline: Duration,
     done: impl Fn(i32) -> bool,
-) -> Result<i32, String> {
+) -> Result<TipWait, String> {
     const MAX_CONSECUTIVE_FAILURES: u32 = 15;
+    /// Consecutive readings at one height before the node counts as finished.
+    /// Generous, because a reconnect legitimately pauses while it validates.
+    const STABLE_POLLS: u32 = 150;
 
     let started = Instant::now();
-    let mut last_seen = None;
+    let mut last_seen: Option<i32> = None;
+    let mut stable = 0u32;
     let mut failures = 0u32;
     while started.elapsed() < deadline {
         match bitcoind.chain_status() {
             Ok(status) => {
                 failures = 0;
-                last_seen = Some(status.blocks);
                 if done(status.blocks) {
-                    return Ok(status.blocks);
+                    return Ok(TipWait::Reached(status.blocks));
+                }
+                if last_seen == Some(status.blocks) {
+                    stable += 1;
+                    if stable >= STABLE_POLLS {
+                        return Ok(TipWait::Settled(status.blocks));
+                    }
+                } else {
+                    stable = 0;
+                    last_seen = Some(status.blocks);
                 }
             }
             Err(e) => {
@@ -791,7 +1044,7 @@ fn wait_for_tip(
         }
         thread::sleep(POLL_INTERVAL);
     }
-    last_seen.ok_or_else(|| "the managed node never reported a height".to_string())
+    Ok(TipWait::Deadline)
 }
 
 /// Issue the `reconsiderblock` for `plan`, if it calls for one.
@@ -800,6 +1053,7 @@ fn wait_for_tip(
 /// exceed the RPC socket timeout. Progress is observed out of band, from the
 /// node's `getblockchaininfo` and its debug log.
 pub fn execute(
+    coincube_datadir: &CoincubeDirectory,
     bitcoind: &coincubed::BitcoinD,
     plan: RevalidationPlan,
 ) -> Result<Option<i32>, String> {
@@ -809,6 +1063,17 @@ pub fn execute(
     let anchor = bitcoind
         .get_block_hash(anchor_height)
         .ok_or_else(|| format!("no block at the RDTS anchor height {anchor_height}"))?;
+    // Clearing the flags can reorg the node onto a branch that forks at the anchor,
+    // which is far deeper than the poller will follow on its own authority. It forks
+    // at a block we named, so name it: without this every Vault refuses the repaired
+    // chain from here on.
+    ManagedNodeState::set_sanctioned_rollback(
+        coincube_datadir,
+        SanctionedRollback {
+            hash: anchor.to_string(),
+            height: anchor_height,
+        },
+    );
     info!(
         "Clearing inherited block-index rejections from the RDTS anchor \
          (height {anchor_height}, {anchor}) so this node can follow the most-work chain."
@@ -1128,6 +1393,95 @@ mod tests {
         let loaded = ManagedNodeState::load(&datadir);
         assert_eq!(loaded.rewind, None);
         assert_eq!(loaded.last_run_flavor, Some(NodeFlavor::Knots));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Completing a replay has to retire the rewind and advance the flavour together.
+    // Two writes leave a window whose crash outcome is the worst of both: no rewind
+    // record, so nothing knows one ever happened, and the flavour still Core, so the
+    // next start plans the entire hours-long replay again.
+    #[test]
+    fn a_completed_rewind_retires_with_the_flavour_in_one_write() {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-finish-rewind-test-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let datadir = CoincubeDirectory::new(dir.clone());
+
+        ManagedNodeState::record_run(&datadir, NodeFlavor::Core);
+        assert!(ManagedNodeState::set_rewind(
+            &datadir,
+            Some(RewindInFlight {
+                invalidated_hash: "00".repeat(32),
+                floor_height: RDTS_ANCHOR_MAINNET,
+                target_height: RDTS_ANCHOR_MAINNET + 100,
+            })
+        ));
+
+        assert!(ManagedNodeState::finish_rewind(&datadir, NodeFlavor::Knots));
+        let loaded = ManagedNodeState::load(&datadir);
+        assert_eq!(loaded.rewind, None);
+        assert_eq!(loaded.last_run_flavor, Some(NodeFlavor::Knots));
+
+        // Unreadable state must not be papered over with a default: writing back a
+        // fabricated one would erase a rewind that is still in flight.
+        std::fs::write(ManagedNodeState::path(&datadir), b"{ not json").unwrap();
+        assert!(!ManagedNodeState::finish_rewind(
+            &datadir,
+            NodeFlavor::Knots
+        ));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The fork point of a repair has to outlive the session that performed it: the
+    // Vault that must adopt the rollback may not even be open yet, and without the
+    // record its poller refuses the repaired chain as an implausible reorg forever.
+    #[test]
+    fn a_repairs_fork_point_is_persisted_and_published() {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-sanction-test-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let datadir = CoincubeDirectory::new(dir.clone());
+
+        let point = SanctionedRollback {
+            hash: "00".repeat(31) + "2a",
+            height: RDTS_ANCHOR_MAINNET,
+        };
+        ManagedNodeState::set_sanctioned_rollback(&datadir, point.clone());
+
+        // Durable...
+        assert_eq!(
+            ManagedNodeState::load(&datadir).sanctioned_rollback,
+            Some(point.clone())
+        );
+        // ...and live, so this session's pollers can already act on it.
+        let published = coincubed::sanctioned_rollback().expect("published");
+        assert_eq!(published.height, RDTS_ANCHOR_MAINNET);
+        assert_eq!(published.hash.to_string(), point.hash);
+
+        // Republishing from a fresh load is what re-arms it on the next start.
+        coincubed::set_sanctioned_rollback(None);
+        assert!(coincubed::sanctioned_rollback().is_none());
+        publish_sanctioned_rollback(
+            ManagedNodeState::load(&datadir)
+                .sanctioned_rollback
+                .as_ref(),
+        );
+        assert!(coincubed::sanctioned_rollback().is_some());
+
+        // An unreadable hash disarms rather than authorising something arbitrary.
+        publish_sanctioned_rollback(Some(&SanctionedRollback {
+            hash: "not a block hash".to_string(),
+            height: RDTS_ANCHOR_MAINNET,
+        }));
+        assert!(coincubed::sanctioned_rollback().is_none());
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/coincube-gui/src/node/revalidate.rs
+++ b/coincube-gui/src/node/revalidate.rs
@@ -110,9 +110,9 @@ pub struct ChainFacts {
     pub blocks: i32,
     /// Whether the RDTS deployment is locked in or active on this node.
     pub deployment_live: bool,
-    /// Oldest block the node still stores; `None` when it isn't pruned. Nothing at
-    /// or below this can be disconnected — the data needed to do so is gone.
-    pub prune_height: Option<i32>,
+    /// How much history the node still stores. Nothing at or below the prune height
+    /// can be disconnected — the data needed to do so is gone.
+    pub prune_state: coincubed::PruneState,
     /// Whether the node knows of a branch with more work than the one it follows
     /// (see [`needs_reconsider`]).
     ///
@@ -138,6 +138,10 @@ pub enum SkipReason {
     /// Core → Knots, but pruning has already discarded everything above the
     /// anchor, so there is nothing left we are able to re-check.
     NothingRetainedAboveAnchor,
+    /// Core → Knots, but the node reported a prune height we could not read, so we
+    /// cannot establish that any disconnect is safe. Declining is the only option:
+    /// disconnecting into pruned data aborts the node.
+    PruneHeightUnknown,
 }
 
 /// What to do about the observed flavour change.
@@ -215,9 +219,16 @@ pub fn plan(facts: ChainFacts) -> RevalidationPlan {
             // We can only disconnect blocks we still have. `pruneheight` climbs
             // forever while the anchor stays put, so past roughly the prune window
             // this floor — not the anchor — is what bounds the replay.
-            let floor_height = match facts.prune_height {
-                Some(prune_height) => anchor_height.max(prune_height + PRUNE_SAFETY_MARGIN),
-                None => anchor_height,
+            let floor_height = match facts.prune_state {
+                coincubed::PruneState::NotPruned => anchor_height,
+                coincubed::PruneState::Pruned(prune_height) => {
+                    anchor_height.max(prune_height + PRUNE_SAFETY_MARGIN)
+                }
+                // Unreadable height: we cannot prove any disconnect is safe, and the
+                // penalty for being wrong is an aborted node.
+                coincubed::PruneState::PrunedUnknown => {
+                    return RevalidationPlan::Skip(SkipReason::PruneHeightUnknown)
+                }
             };
             if floor_height >= facts.blocks {
                 return RevalidationPlan::Skip(SkipReason::NothingRetainedAboveAnchor);
@@ -283,19 +294,32 @@ impl ManagedNodeState {
         internal_bitcoind_directory(coincube_datadir).join("managed_node_state.json")
     }
 
-    /// Load the ledger, or the empty default when the sidecar is absent or
-    /// unreadable. Fail-safe: an unreadable ledger reads as "we've never seen this
-    /// node run", which makes the next start record the truth rather than act on a
-    /// guess.
-    pub fn load(coincube_datadir: &CoincubeDirectory) -> Self {
+    /// Load the ledger, distinguishing "there is no sidecar yet" from "there is one
+    /// and we could not read it".
+    ///
+    /// Only a missing file yields the default. A read error or a corrupt file is an
+    /// error, because anything that acts on [`Self::rewind`] must not mistake "we
+    /// couldn't tell" for "nothing is pending" — that would leave a node parked
+    /// below an invalidated block with nothing left to release it.
+    pub fn try_load(coincube_datadir: &CoincubeDirectory) -> io::Result<Self> {
         let path = Self::path(coincube_datadir);
-        match std::fs::read_to_string(&path) {
-            Ok(contents) => serde_json::from_str(&contents).unwrap_or_else(|e| {
-                warn!("unreadable managed-node state at {path:?} ({e}); treating as unknown");
-                Self::default()
-            }),
-            Err(_) => Self::default(),
-        }
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(contents) => contents,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Self::default()),
+            Err(e) => return Err(e),
+        };
+        serde_json::from_str(&contents).map_err(io::Error::other)
+    }
+
+    /// Fail-safe view of [`Self::try_load`] for the flavour ledger, where "unknown"
+    /// is a safe answer: the next start just records the truth rather than acting on
+    /// a guess. Callers that touch [`Self::rewind`] must use `try_load` instead.
+    pub fn load(coincube_datadir: &CoincubeDirectory) -> Self {
+        Self::try_load(coincube_datadir).unwrap_or_else(|e| {
+            let path = Self::path(coincube_datadir);
+            warn!("unreadable managed-node state at {path:?} ({e}); treating as unknown");
+            Self::default()
+        })
     }
 
     /// Persist the ledger via a temp file and a rename, so an interrupted write
@@ -313,8 +337,18 @@ impl ManagedNodeState {
 
     /// Record the flavour the node was just observed running as, preserving any
     /// in-flight rewind.
+    ///
+    /// Reads with `try_load` rather than `load`: defaulting on an unreadable sidecar
+    /// would write back a state with no `rewind`, silently erasing the only record
+    /// that can release a parked node. Skipping the update is the safe failure.
     pub fn record_run(coincube_datadir: &CoincubeDirectory, flavor: NodeFlavor) {
-        let mut state = Self::load(coincube_datadir);
+        let mut state = match Self::try_load(coincube_datadir) {
+            Ok(state) => state,
+            Err(e) => {
+                warn!("not recording the managed-node flavour: state unreadable ({e})");
+                return;
+            }
+        };
         state.last_run_flavor = Some(flavor);
         if let Err(e) = state.save(coincube_datadir) {
             warn!("could not record managed-node flavour: {e}");
@@ -323,13 +357,21 @@ impl ManagedNodeState {
 
     /// Record (or clear) an in-flight rewind, preserving the flavour ledger.
     ///
-    /// Returns whether the write succeeded: a rewind whose intent we could not
-    /// persist must not be started, because we would have no way to finish it.
+    /// Returns whether the state is now on disk as asked. A rewind whose intent we
+    /// could not persist must not be started, because we would have no way to
+    /// finish it — so a read failure is reported as failure too, not papered over
+    /// with a default.
     pub fn set_rewind(
         coincube_datadir: &CoincubeDirectory,
         rewind: Option<RewindInFlight>,
     ) -> bool {
-        let mut state = Self::load(coincube_datadir);
+        let mut state = match Self::try_load(coincube_datadir) {
+            Ok(state) => state,
+            Err(e) => {
+                warn!("could not read managed-node state to record the rewind: {e}");
+                return false;
+            }
+        };
         state.rewind = rewind;
         match state.save(coincube_datadir) {
             Ok(()) => true,
@@ -343,6 +385,11 @@ impl ManagedNodeState {
 
 /// Write `contents` to `path` through a sibling temp file, flushing before the
 /// rename so the visible file is either the old one or the complete new one.
+///
+/// The directory is fsynced after the rename as well. Without that, the file's
+/// contents are durable but the directory entry pointing at them may not be, so a
+/// crash can lose the rename and with it a rewind record — precisely the crash this
+/// record exists to survive.
 fn write_atomically(path: &Path, contents: &[u8]) -> io::Result<()> {
     use std::io::Write;
 
@@ -352,7 +399,16 @@ fn write_atomically(path: &Path, contents: &[u8]) -> io::Result<()> {
         file.write_all(contents)?;
         file.sync_all()?;
     }
-    std::fs::rename(&tmp, path)
+    std::fs::rename(&tmp, path)?;
+
+    // Unix only: Windows has no equivalent (a directory can't be opened as a file
+    // without backup semantics), and NTFS metadata journalling makes the rename
+    // durable there anyway.
+    #[cfg(unix)]
+    if let Some(parent) = path.parent() {
+        std::fs::File::open(parent)?.sync_all()?;
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -391,9 +447,15 @@ pub fn needs_reconsider(tips: &[coincubed::ChainTipEntry]) -> bool {
 ///
 /// Best-effort throughout: a node that just started is more important than this
 /// check, so every failure is logged and swallowed rather than blocking startup.
+///
+/// Returns promptly. The inline work is a handful of RPCs plus, at most, one
+/// fire-and-forget `reconsiderblock`. A Core → Knots replay is *not* inline —
+/// it can run for hours, and this sits on the startup path of every Vault — so it
+/// is handed to a background thread. See [`execute_replay`].
 pub fn reconcile_after_start(
     coincube_datadir: &CoincubeDirectory,
     bitcoind: &coincubed::BitcoinD,
+    config: &coincubed::config::BitcoindConfig,
     network: Network,
     observed_flavor: NodeFlavor,
 ) {
@@ -437,7 +499,7 @@ pub fn reconcile_after_start(
         current_flavor: observed_flavor,
         blocks: status.blocks,
         deployment_live,
-        prune_height: status.prune_height,
+        prune_state: status.prune_state,
         node_stranded,
     });
     match plan {
@@ -453,11 +515,59 @@ pub fn reconcile_after_start(
             floor_height,
             target_height,
         } => {
-            if let Err(e) = execute_replay(coincube_datadir, bitcoind, floor_height, target_height)
+            spawn_replay(
+                coincube_datadir.clone(),
+                config.clone(),
+                floor_height,
+                target_height,
+            );
+        }
+    }
+}
+
+/// Run a Core → Knots replay on its own thread.
+///
+/// The replay disconnects and reconnects blocks and can take hours. Every caller of
+/// [`reconcile_after_start`] is on a node-startup path — the loader at app launch,
+/// the installer, the settings flavour switch — so doing this inline would stall
+/// app startup, or leave the settings screen on "starting…" until it finished.
+///
+/// The thread opens its own RPC connection rather than borrowing the caller's, so
+/// nothing here is tied to the lifetime of the start that triggered it.
+fn spawn_replay(
+    coincube_datadir: CoincubeDirectory,
+    config: coincubed::config::BitcoindConfig,
+    floor_height: i32,
+    target_height: i32,
+) {
+    // The maintenance flag is held for the whole replay, so it doubles as a cheap
+    // "one at a time" check: several Vaults can start against the same shared node
+    // at once and must not each kick off their own rewind of it. Best-effort, not a
+    // lock — the flag is set by the thread we are about to spawn, so two calls
+    // landing in the same instant can still both get through. The durable rewind
+    // record is what keeps that recoverable, and the work is idempotent besides.
+    if coincubed::managed_node_maintenance() {
+        info!("A chain replay is already running; not starting another.");
+        return;
+    }
+    let spawned = thread::Builder::new()
+        .name("rdts-replay".to_string())
+        .spawn(move || {
+            let bitcoind = match coincubed::BitcoinD::new(&config, "rdts_replay".to_string()) {
+                Ok(bitcoind) => bitcoind,
+                Err(e) => {
+                    warn!("could not connect to the managed node to replay the chain: {e}");
+                    return;
+                }
+            };
+            if let Err(e) =
+                execute_replay(&coincube_datadir, &bitcoind, floor_height, target_height)
             {
                 warn!("RDTS replay failed: {e}");
             }
-        }
+        });
+    if let Err(e) = spawned {
+        warn!("could not spawn the chain-replay thread: {e}");
     }
 }
 
@@ -468,7 +578,23 @@ pub fn reconcile_after_start(
 /// persistent and nothing in the node records that we were mid-operation.
 /// Idempotent, so running it when there is nothing to finish costs one RPC.
 pub fn resume_pending_rewind(coincube_datadir: &CoincubeDirectory, bitcoind: &coincubed::BitcoinD) {
-    let Some(rewind) = ManagedNodeState::load(coincube_datadir).rewind else {
+    // `try_load`, not `load`: an unreadable sidecar must not read as "nothing
+    // pending". If a rewind really is in flight, defaulting here would leave the
+    // node parked below the invalidated block with nothing left to release it, and
+    // no sign of why.
+    let state = match ManagedNodeState::try_load(coincube_datadir) {
+        Ok(state) => state,
+        Err(e) => {
+            tracing::error!(
+                "Could not read the managed-node state ({e}). If a chain rewind was left \
+                 unfinished, this node may be stuck below the block it invalidated — check \
+                 its height against the network, and use \"Re-check chain\" in Node settings \
+                 to release it."
+            );
+            return;
+        }
+    };
+    let Some(rewind) = state.rewind else {
         return;
     };
     warn!(
@@ -522,11 +648,22 @@ pub fn execute_replay(
     let status = bitcoind
         .chain_status()
         .map_err(|e| format!("could not re-check the prune height before rewinding: {e}"))?;
-    if let Some(prune_height) = status.prune_height {
-        if floor_height <= prune_height + PRUNE_SAFETY_MARGIN {
-            return Err(format!(
-                "refusing to rewind to {floor_height}: pruning has reached {prune_height} and                  disconnecting pruned blocks would abort the node"
-            ));
+    match status.prune_state {
+        coincubed::PruneState::NotPruned => {}
+        coincubed::PruneState::Pruned(prune_height) => {
+            if floor_height <= prune_height + PRUNE_SAFETY_MARGIN {
+                return Err(format!(
+                    "refusing to rewind to {floor_height}: pruning has reached \
+                     {prune_height} and disconnecting pruned blocks would abort the node"
+                ));
+            }
+        }
+        coincubed::PruneState::PrunedUnknown => {
+            return Err(
+                "refusing to rewind: the node is pruned but did not report a readable \
+                 prune height, so we cannot tell which blocks are safe to disconnect"
+                    .to_string(),
+            );
         }
     }
 
@@ -665,7 +802,7 @@ mod tests {
             deployment_live: true,
             // Unpruned unless a test says otherwise, so the prune floor isn't a
             // hidden variable in the cases that aren't about it.
-            prune_height: None,
+            prune_state: coincubed::PruneState::NotPruned,
             node_stranded: false,
         }
     }
@@ -799,7 +936,7 @@ mod tests {
     fn pruning_raises_the_floor_and_makes_coverage_partial() {
         let mut f = facts(Network::Bitcoin, NodeFlavor::Core, NodeFlavor::Knots);
         let prune_height = RDTS_ANCHOR_MAINNET + 2_000;
-        f.prune_height = Some(prune_height);
+        f.prune_state = coincubed::PruneState::Pruned(prune_height);
         let p = plan(f);
         assert_eq!(
             p,
@@ -815,7 +952,7 @@ mod tests {
 
         // Pruning below the anchor cannot pull the floor down past it — there is
         // nothing to check below the anchor in the first place.
-        f.prune_height = Some(RDTS_ANCHOR_MAINNET - 50_000);
+        f.prune_state = coincubed::PruneState::Pruned(RDTS_ANCHOR_MAINNET - 50_000);
         assert_eq!(
             plan(f),
             RevalidationPlan::ReplayUnderRdts {
@@ -831,7 +968,7 @@ mod tests {
     #[test]
     fn a_fully_pruned_window_is_declined() {
         let mut f = facts(Network::Bitcoin, NodeFlavor::Core, NodeFlavor::Knots);
-        f.prune_height = Some(f.blocks);
+        f.prune_state = coincubed::PruneState::Pruned(f.blocks);
         assert_eq!(
             plan(f),
             RevalidationPlan::Skip(SkipReason::NothingRetainedAboveAnchor),
@@ -839,11 +976,29 @@ mod tests {
 
         // And the margin counts: a floor that lands exactly on the tip is refused,
         // not attempted with a zero-length replay.
-        f.prune_height = Some(f.blocks - PRUNE_SAFETY_MARGIN);
+        f.prune_state = coincubed::PruneState::Pruned(f.blocks - PRUNE_SAFETY_MARGIN);
         assert_eq!(
             plan(f),
             RevalidationPlan::Skip(SkipReason::NothingRetainedAboveAnchor),
         );
+    }
+
+    // An unreadable prune height must not read as "unpruned". Conflating the two
+    // would skip the prune floor entirely and let the rewind disconnect blocks whose
+    // data is gone, which aborts bitcoind rather than returning an error.
+    #[test]
+    fn an_unreadable_prune_height_declines_rather_than_assuming_unpruned() {
+        let mut f = facts(Network::Bitcoin, NodeFlavor::Core, NodeFlavor::Knots);
+        f.prune_state = coincubed::PruneState::PrunedUnknown;
+        assert_eq!(
+            plan(f),
+            RevalidationPlan::Skip(SkipReason::PruneHeightUnknown)
+        );
+
+        // Contrast: genuinely unpruned still replays from the anchor, so the new
+        // state hasn't just made everything decline.
+        f.prune_state = coincubed::PruneState::NotPruned;
+        assert!(matches!(plan(f), RevalidationPlan::ReplayUnderRdts { .. }));
     }
 
     // A rewind is only ever justified by an actual swap from Core. Restarting a
@@ -950,10 +1105,27 @@ mod tests {
             Some(NodeFlavor::Core),
         );
 
-        // A corrupt sidecar must fail safe to "unknown" rather than panic, so the
-        // next start records the truth instead of acting on garbage.
+        // A corrupt sidecar fails safe to "unknown" for the flavour ledger...
         std::fs::write(ManagedNodeState::path(&datadir), b"{ not json").unwrap();
         assert_eq!(ManagedNodeState::load(&datadir).last_run_flavor, None);
+
+        // ...but `try_load` must report it, because a caller acting on `rewind`
+        // cannot be allowed to read "unreadable" as "nothing pending" and leave a
+        // node parked below the block it invalidated.
+        assert!(ManagedNodeState::try_load(&datadir).is_err());
+
+        // A write must not clobber state it could not read: better to skip the
+        // update than to erase a pending rewind.
+        ManagedNodeState::record_run(&datadir, NodeFlavor::Core);
+        assert!(ManagedNodeState::try_load(&datadir).is_err());
+        assert!(!ManagedNodeState::set_rewind(&datadir, None));
+
+        // A *missing* sidecar is different: that genuinely means "nothing yet".
+        std::fs::remove_file(ManagedNodeState::path(&datadir)).unwrap();
+        assert_eq!(
+            ManagedNodeState::try_load(&datadir).unwrap(),
+            ManagedNodeState::default()
+        );
 
         // No stray temp file is left behind by the atomic write.
         assert!(!ManagedNodeState::path(&datadir)

--- a/coincube-gui/src/node/revalidate.rs
+++ b/coincube-gui/src/node/revalidate.rs
@@ -1,0 +1,965 @@
+//! Revalidating the managed node's chain state after a Core↔Knots flavour swap.
+//!
+//! Bitcoin Knots can enforce BIP-110 / RDTS (`consensusrules=rdts`); Bitcoin Core
+//! cannot. Both flavours of the managed node share one datadir, and swapping
+//! between them leaves stale rule-enforcement state behind in **both** directions:
+//!
+//! * **Core → Knots.** Knots adopts the inherited chainstate as-is — verified on
+//!   the shipped binaries, it emits zero `UpdateTip` lines on startup — so history
+//!   Core accepted is never checked against RDTS rules.
+//! * **Knots → Core.** `BLOCK_FAILED_VALID` marks are persisted in the block index
+//!   and survive a binary swap, so Core inherits Knots' rejections and stays on a
+//!   minority chain while the most-work branch remains flagged `invalid`. Core
+//!   never reconsiders those blocks on its own.
+//!
+//! The two are not equally cheap. Knots → Core is a single idempotent
+//! `reconsiderblock` that disconnects nothing and needs no block data. Core → Knots
+//! has to *rewind* the chain with `invalidateblock` so Knots can replay it, which
+//! manufactures a deep reorg under every Vault's poller and can only reach as far
+//! back as pruning has left block data. It therefore comes with a prune floor, a
+//! maintenance pause, and a durable record of the rewind — see [`execute_replay`].
+//!
+//! # Unverified premise
+//!
+//! The rewind assumes that blocks reconnected by `reconsiderblock` are re-checked
+//! against RDTS rather than fast-tracked on cached block-index validity. That has
+//! **not** been demonstrated: RDTS does not exist on regtest, testnet4 activation
+//! cannot be forced, and mainnet has not reached the window. Confirm it on a real
+//! chain before RDTS locks in — until then the deployment gate keeps all of this
+//! inert. See `plans/PLAN-rdts-flavor-swap-revalidation.md`, Task 0.
+
+use std::{
+    io,
+    path::{Path, PathBuf},
+    thread,
+    time::{Duration, Instant},
+};
+
+use coincube_core::miniscript::bitcoin::Network;
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+use crate::{
+    dir::CoincubeDirectory,
+    node::bitcoind::{internal_bitcoind_directory, NodeFlavor},
+};
+
+/// Name of the BIP-110 / RDTS deployment in `getdeploymentinfo`.
+///
+/// Note it is `reduced_data`, *not* `rdts` — the latter is only the value passed
+/// to `consensusrules`.
+pub const RDTS_DEPLOYMENT: &str = "reduced_data";
+
+/// Last mainnet block that cannot differ between a Core- and a Knots-built chain.
+///
+/// RDTS's mandatory-signalling window runs 961,632–963,647, so 961,632 is the
+/// earliest height at which an enforcing node can reject a block a non-enforcing
+/// node accepts, and its parent is the deepest point the two must agree on.
+///
+/// This is a constant because it cannot be derived at runtime: `getdeploymentinfo`
+/// exposes the deployment's `status`, `since`, `min_activation_height` and
+/// `max_activation_height`, but not the start of the mandatory-signalling window.
+/// It is corroborated by the parameters the Knots binary does report —
+/// `max_activation_height` is 965,664, and 961,632 / 963,648 / 965,664 are the
+/// 477th, 478th and 479th retarget boundaries, i.e. the window is exactly one
+/// retarget period. See [`RDTS_DEPLOYMENT`] for the runtime liveness gate that
+/// keeps this height from being acted on before the fork is real.
+pub const RDTS_ANCHOR_MAINNET: i32 = 961_631;
+
+/// Blocks of headroom we refuse to rewind into above `pruneheight`.
+///
+/// Load-bearing, not cosmetic. `pruneheight` advances whenever bitcoind flushes,
+/// so it can move between the moment we read it and the moment we call
+/// `invalidateblock` — and disconnecting a block whose data has been pruned aborts
+/// the node outright rather than returning an error. The margin buys us that race.
+pub const PRUNE_SAFETY_MARGIN: i32 = 1_000;
+
+/// The anchor for `network`, or `None` where we cannot place one.
+///
+/// Knots ships `reduced_data` on mainnet and testnet4 only; regtest and signet
+/// carry no such deployment, so the feature is inherently inert there.
+///
+/// Testnet4 is excluded for a different reason: it *has* the deployment, but its
+/// `getdeploymentinfo` output carries no `max_activation_height` and publishes no
+/// mandatory-signalling window we can anchor to, so we have no defensible height.
+/// Guessing one would risk clearing failure flags from the wrong depth. It should
+/// be added once the testnet4 spike reads the real window out of the binary —
+/// that is also what would make this code exercisable end to end before mainnet
+/// activation, so it is worth doing.
+pub fn rdts_anchor_height(network: Network) -> Option<i32> {
+    match network {
+        Network::Bitcoin => Some(RDTS_ANCHOR_MAINNET),
+        // TODO(testnet4): add once the spike pins down its signalling window.
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Planning
+// ---------------------------------------------------------------------------
+
+/// Everything the planner needs to decide whether a swap requires remediation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChainFacts {
+    pub network: Network,
+    /// The flavour the node ran as last time we observed it, if we ever did.
+    pub previous_flavor: Option<NodeFlavor>,
+    /// The flavour it is running as now.
+    pub current_flavor: NodeFlavor,
+    /// Blocks validated toward the best known tip.
+    pub blocks: i32,
+    /// Whether the RDTS deployment is locked in or active on this node.
+    pub deployment_live: bool,
+    /// Oldest block the node still stores; `None` when it isn't pruned. Nothing at
+    /// or below this can be disconnected — the data needed to do so is gone.
+    pub prune_height: Option<i32>,
+    /// Whether the node knows of a branch with more work than the one it follows
+    /// (see [`needs_reconsider`]).
+    ///
+    /// This is what keeps the ledger from being load-bearing: a swap we failed to
+    /// record still shows up here as an observable symptom.
+    pub node_stranded: bool,
+}
+
+/// Why no remediation is needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkipReason {
+    /// RDTS isn't deployed on this network (regtest, signet, …).
+    NoDeploymentOnNetwork,
+    /// The deployment has not locked in, so no rule is being enforced and the two
+    /// flavours cannot yet disagree.
+    DeploymentNotLive,
+    /// The chain has not reached the first height at which the flavours can
+    /// diverge. Until mainnet passes 961,632 this is the universal answer.
+    TipBelowAnchor,
+    /// The node follows the best chain it knows of and did not just come from
+    /// Knots. Nothing to clear.
+    NothingToClear,
+    /// Core → Knots, but pruning has already discarded everything above the
+    /// anchor, so there is nothing left we are able to re-check.
+    NothingRetainedAboveAnchor,
+}
+
+/// What to do about the observed flavour change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RevalidationPlan {
+    Skip(SkipReason),
+    /// Knots → Core. Clear the `BLOCK_FAILED_*` flags Knots left on the anchor's
+    /// descendants so Core can reorg to the most-work chain it would have
+    /// followed natively.
+    ClearFailureFlags {
+        anchor_height: i32,
+    },
+    /// Core → Knots. Disconnect back to `floor_height` and let Knots reconnect
+    /// everything above it, so blocks Core accepted are finally checked against
+    /// RDTS rules.
+    ///
+    /// `floor_height` is the deeper of the anchor and the prune floor: blocks below
+    /// `pruneheight` cannot be disconnected at all, so re-checking everything the
+    /// node still holds is the most that any mechanism could achieve here. When the
+    /// floor sits above the anchor the coverage is partial, and the UI must say so
+    /// rather than imply the whole chain was verified.
+    ReplayUnderRdts {
+        floor_height: i32,
+        target_height: i32,
+    },
+}
+
+impl RevalidationPlan {
+    /// Whether this plan re-checks every block that could possibly have diverged,
+    /// or only the tail that pruning left us.
+    pub fn is_full_coverage(&self) -> bool {
+        match self {
+            Self::ReplayUnderRdts { floor_height, .. } => *floor_height <= RDTS_ANCHOR_MAINNET,
+            _ => true,
+        }
+    }
+}
+
+/// Decide what the node's current state requires. Pure — all I/O happens in the
+/// caller, which is what makes every branch below directly testable.
+pub fn plan(facts: ChainFacts) -> RevalidationPlan {
+    let Some(anchor_height) = rdts_anchor_height(facts.network) else {
+        return RevalidationPlan::Skip(SkipReason::NoDeploymentOnNetwork);
+    };
+    if !facts.deployment_live {
+        return RevalidationPlan::Skip(SkipReason::DeploymentNotLive);
+    }
+    // Nothing above the anchor exists yet, so nothing can have diverged.
+    if facts.blocks <= anchor_height {
+        return RevalidationPlan::Skip(SkipReason::TipBelowAnchor);
+    }
+
+    match facts.current_flavor {
+        NodeFlavor::Core => {
+            // Two independent triggers. The ledger notices the swap immediately;
+            // the stranded check catches one we failed to record — a swap made
+            // through the installer, a lost or corrupt sidecar, a datadir moved
+            // between machines.
+            let came_from_knots = facts.previous_flavor == Some(NodeFlavor::Knots);
+            if came_from_knots || facts.node_stranded {
+                RevalidationPlan::ClearFailureFlags { anchor_height }
+            } else {
+                RevalidationPlan::Skip(SkipReason::NothingToClear)
+            }
+        }
+        NodeFlavor::Knots => {
+            // A Knots node trailing the most-work chain is not a bug — that is
+            // precisely what enforcing RDTS against a non-compliant majority looks
+            // like. Never "repair" it: clearing the flags would only re-validate
+            // and re-reject the same blocks, every startup, forever. So the only
+            // trigger here is an actual swap from Core, never `node_stranded`.
+            if facts.previous_flavor != Some(NodeFlavor::Core) {
+                return RevalidationPlan::Skip(SkipReason::NothingToClear);
+            }
+            // We can only disconnect blocks we still have. `pruneheight` climbs
+            // forever while the anchor stays put, so past roughly the prune window
+            // this floor — not the anchor — is what bounds the replay.
+            let floor_height = match facts.prune_height {
+                Some(prune_height) => anchor_height.max(prune_height + PRUNE_SAFETY_MARGIN),
+                None => anchor_height,
+            };
+            if floor_height >= facts.blocks {
+                return RevalidationPlan::Skip(SkipReason::NothingRetainedAboveAnchor);
+            }
+            RevalidationPlan::ReplayUnderRdts {
+                floor_height,
+                target_height: facts.blocks,
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The flavour ledger
+// ---------------------------------------------------------------------------
+
+/// Persistent record of how the managed node last ran.
+///
+/// Deliberately records the flavour **observed** from the started node's
+/// `getnetworkinfo.subversion`, not the flavour that was configured or requested.
+/// The configured value is not reliable: `select_managed_bitcoind_exe` falls back
+/// to the other flavour's binary when the preferred one isn't installed, and the
+/// installer and loader can start the node without going through the settings
+/// switch at all.
+///
+/// Correctness does not depend on this file. It is an optimisation that lets a
+/// swap be noticed immediately; if it is missing, stale, or corrupt, the stateless
+/// check in [`needs_reconsider`] still catches a node stranded off the most-work
+/// chain on the next start.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ManagedNodeState {
+    /// Flavour the node was observed running as, last time it started.
+    pub last_run_flavor: Option<NodeFlavor>,
+    /// Set while an `invalidateblock` has been issued and not yet undone.
+    ///
+    /// Unlike [`Self::last_run_flavor`] this one *is* load-bearing. The failure
+    /// flag `invalidateblock` writes is persistent and there is nothing in the node
+    /// itself saying we put it there, so if we die between the two calls the node
+    /// sits below the invalidated block forever. This is the only record that lets
+    /// the next start finish the job.
+    #[serde(default)]
+    pub rewind: Option<RewindInFlight>,
+}
+
+/// A rewind we have started and not yet confirmed finished.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RewindInFlight {
+    /// The block we invalidated; its parent is where the chain was rolled back to.
+    pub invalidated_hash: String,
+    /// Height of the block below the invalidated one — the reconnect anchor.
+    pub floor_height: i32,
+    /// Where the tip was before we started, so we know when we are whole again.
+    pub target_height: i32,
+}
+
+impl ManagedNodeState {
+    /// Sidecar path: `<datadir>/bitcoind/managed_node_state.json`.
+    ///
+    /// Alongside `inbound_tor.json` in the managed-node directory, not in a vault
+    /// datadir: the managed node is shared by every vault, and vault datadirs are
+    /// removed wholesale on delete.
+    pub fn path(coincube_datadir: &CoincubeDirectory) -> PathBuf {
+        internal_bitcoind_directory(coincube_datadir).join("managed_node_state.json")
+    }
+
+    /// Load the ledger, or the empty default when the sidecar is absent or
+    /// unreadable. Fail-safe: an unreadable ledger reads as "we've never seen this
+    /// node run", which makes the next start record the truth rather than act on a
+    /// guess.
+    pub fn load(coincube_datadir: &CoincubeDirectory) -> Self {
+        let path = Self::path(coincube_datadir);
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => serde_json::from_str(&contents).unwrap_or_else(|e| {
+                warn!("unreadable managed-node state at {path:?} ({e}); treating as unknown");
+                Self::default()
+            }),
+            Err(_) => Self::default(),
+        }
+    }
+
+    /// Persist the ledger via a temp file and a rename, so an interrupted write
+    /// cannot leave a half-written sidecar that would later parse as garbage.
+    /// (The `inbound_tor.json` precedent writes in place; this one is on the
+    /// startup path of every vault, so it is worth the extra care.)
+    pub fn save(&self, coincube_datadir: &CoincubeDirectory) -> io::Result<()> {
+        let path = Self::path(coincube_datadir);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(self).map_err(io::Error::other)?;
+        write_atomically(&path, json.as_bytes())
+    }
+
+    /// Record the flavour the node was just observed running as, preserving any
+    /// in-flight rewind.
+    pub fn record_run(coincube_datadir: &CoincubeDirectory, flavor: NodeFlavor) {
+        let mut state = Self::load(coincube_datadir);
+        state.last_run_flavor = Some(flavor);
+        if let Err(e) = state.save(coincube_datadir) {
+            warn!("could not record managed-node flavour: {e}");
+        }
+    }
+
+    /// Record (or clear) an in-flight rewind, preserving the flavour ledger.
+    ///
+    /// Returns whether the write succeeded: a rewind whose intent we could not
+    /// persist must not be started, because we would have no way to finish it.
+    pub fn set_rewind(
+        coincube_datadir: &CoincubeDirectory,
+        rewind: Option<RewindInFlight>,
+    ) -> bool {
+        let mut state = Self::load(coincube_datadir);
+        state.rewind = rewind;
+        match state.save(coincube_datadir) {
+            Ok(()) => true,
+            Err(e) => {
+                warn!("could not record the in-flight rewind: {e}");
+                false
+            }
+        }
+    }
+}
+
+/// Write `contents` to `path` through a sibling temp file, flushing before the
+/// rename so the visible file is either the old one or the complete new one.
+fn write_atomically(path: &Path, contents: &[u8]) -> io::Result<()> {
+    use std::io::Write;
+
+    let tmp = path.with_extension("tmp");
+    {
+        let mut file = std::fs::File::create(&tmp)?;
+        file.write_all(contents)?;
+        file.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)
+}
+
+// ---------------------------------------------------------------------------
+// The stateless check
+// ---------------------------------------------------------------------------
+
+/// Whether the node is stranded off the best chain it knows about, and so needs a
+/// `reconsiderblock`.
+///
+/// This is the backstop that makes the ledger non-load-bearing: it asks only "is
+/// our active tip the most-work chain the node has headers for?", which is true of
+/// a healthy node regardless of history.
+///
+/// Deliberately **not** keyed on a branch's status being `"invalid"`. A node that
+/// rejects a block stops downloading that branch, so the honest most-work chain
+/// commonly shows up as `headers-only` rather than `invalid` — gating on
+/// `"invalid"` would miss exactly the stranded case this exists to catch.
+pub fn needs_reconsider(tips: &[coincubed::ChainTipEntry]) -> bool {
+    let Some(active_height) = tips.iter().find(|t| t.is_active()).map(|t| t.height) else {
+        return false;
+    };
+    // Any other branch reaching higher than our active tip means the node knows of
+    // more work than it is following.
+    tips.iter()
+        .any(|t| !t.is_active() && t.height > active_height)
+}
+
+/// Observe how the managed node came up, record it, and remediate if the flavour
+/// it is running under has left it following the wrong chain.
+///
+/// Called from every managed-node start path, because `Bitcoind::maybe_start` is
+/// the one funnel the loader, the installer, and the settings switch all pass
+/// through. `observed_flavor` must come from the node's own
+/// `getnetworkinfo.subversion` — not from configuration, which can disagree with
+/// what actually launched.
+///
+/// Best-effort throughout: a node that just started is more important than this
+/// check, so every failure is logged and swallowed rather than blocking startup.
+pub fn reconcile_after_start(
+    coincube_datadir: &CoincubeDirectory,
+    bitcoind: &coincubed::BitcoinD,
+    network: Network,
+    observed_flavor: NodeFlavor,
+) {
+    // Before anything else: if a previous run died mid-rewind, the node is parked
+    // below an invalidated block and will not move until we release it.
+    resume_pending_rewind(coincube_datadir, bitcoind);
+
+    // Record what we saw first. If the remediation below fails we would otherwise
+    // never record it, and retry the same failing path on every single startup;
+    // the stranded check is what catches the case regardless.
+    let previous_flavor = ManagedNodeState::load(coincube_datadir).last_run_flavor;
+    ManagedNodeState::record_run(coincube_datadir, observed_flavor);
+
+    // Networks without the deployment cost us nothing: no RPCs at all.
+    if rdts_anchor_height(network).is_none() {
+        return;
+    }
+
+    let status = match bitcoind.chain_status() {
+        Ok(status) => status,
+        Err(e) => {
+            warn!("could not read chain status for the RDTS flavour check: {e}");
+            return;
+        }
+    };
+    let deployment_live = bitcoind
+        .deployment_status(RDTS_DEPLOYMENT)
+        .map(|d| d.is_live())
+        .unwrap_or(false);
+    let node_stranded = match bitcoind.chain_tips() {
+        Ok(tips) => needs_reconsider(&tips),
+        Err(e) => {
+            warn!("could not read chain tips for the RDTS flavour check: {e}");
+            false
+        }
+    };
+
+    let plan = plan(ChainFacts {
+        network,
+        previous_flavor,
+        current_flavor: observed_flavor,
+        blocks: status.blocks,
+        deployment_live,
+        prune_height: status.prune_height,
+        node_stranded,
+    });
+    match plan {
+        RevalidationPlan::Skip(reason) => {
+            tracing::debug!("No RDTS revalidation needed ({reason:?}).");
+        }
+        RevalidationPlan::ClearFailureFlags { .. } => {
+            if let Err(e) = execute(bitcoind, plan) {
+                warn!("RDTS revalidation failed: {e}");
+            }
+        }
+        RevalidationPlan::ReplayUnderRdts {
+            floor_height,
+            target_height,
+        } => {
+            if let Err(e) = execute_replay(coincube_datadir, bitcoind, floor_height, target_height)
+            {
+                warn!("RDTS replay failed: {e}");
+            }
+        }
+    }
+}
+
+/// Finish a rewind that a previous run started but did not complete.
+///
+/// Without this, dying between `invalidateblock` and `reconsiderblock` leaves the
+/// node parked below the invalidated block indefinitely: the failure flag is
+/// persistent and nothing in the node records that we were mid-operation.
+/// Idempotent, so running it when there is nothing to finish costs one RPC.
+pub fn resume_pending_rewind(coincube_datadir: &CoincubeDirectory, bitcoind: &coincubed::BitcoinD) {
+    let Some(rewind) = ManagedNodeState::load(coincube_datadir).rewind else {
+        return;
+    };
+    warn!(
+        "A chain rewind from a previous run was left unfinished (floor {}, target {}). \
+         Re-issuing reconsiderblock to release the node.",
+        rewind.floor_height, rewind.target_height
+    );
+    let Some(anchor) = bitcoind.get_block_hash(rewind.floor_height) else {
+        warn!(
+            "No block at height {} to reconsider from; leaving the record in place so a \
+             later start can retry.",
+            rewind.floor_height
+        );
+        return;
+    };
+    match bitcoind.reconsider_block_noreply(&anchor) {
+        Ok(()) => {
+            ManagedNodeState::set_rewind(coincube_datadir, None);
+        }
+        Err(e) => warn!("could not finish the pending rewind: {e}"),
+    }
+}
+
+/// How long to let each phase of a replay run before we stop watching it.
+///
+/// Expiry is not an error: the node keeps working through the reconnect on its own,
+/// and the in-flight record means a later start can still finish the job. We simply
+/// stop holding every Vault's poller while we wait.
+const DISCONNECT_DEADLINE: Duration = Duration::from_secs(30 * 60);
+const RECONNECT_DEADLINE: Duration = Duration::from_secs(6 * 60 * 60);
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Rewind the chain to `floor_height` and let the (now Knots) node reconnect it, so
+/// blocks accepted under Core are finally checked against RDTS.
+///
+/// Every Vault's poller is parked for the duration: mid-rewind the node's tip is
+/// meaningless, and recording it would clear the confirmation state of every coin
+/// above the floor. The parking is a courtesy — the poller's own depth guard is
+/// what actually prevents that — but it keeps Vaults from flapping into a warning
+/// state during an operation the user deliberately asked for.
+pub fn execute_replay(
+    coincube_datadir: &CoincubeDirectory,
+    bitcoind: &coincubed::BitcoinD,
+    floor_height: i32,
+    target_height: i32,
+) -> Result<(), String> {
+    // Re-read the prune height immediately before committing. It advances on every
+    // flush, and disconnecting into pruned data aborts the node outright rather
+    // than failing the RPC — a fire-and-forget call would not even show us the
+    // corpse.
+    let status = bitcoind
+        .chain_status()
+        .map_err(|e| format!("could not re-check the prune height before rewinding: {e}"))?;
+    if let Some(prune_height) = status.prune_height {
+        if floor_height <= prune_height + PRUNE_SAFETY_MARGIN {
+            return Err(format!(
+                "refusing to rewind to {floor_height}: pruning has reached {prune_height} and                  disconnecting pruned blocks would abort the node"
+            ));
+        }
+    }
+
+    let first_divergent = floor_height + 1;
+    let invalidate_hash = bitcoind
+        .get_block_hash(first_divergent)
+        .ok_or_else(|| format!("no block at height {first_divergent} to rewind from"))?;
+    let floor_hash = bitcoind
+        .get_block_hash(floor_height)
+        .ok_or_else(|| format!("no block at the rewind floor {floor_height}"))?;
+
+    // Persist the intent BEFORE the destructive call. If this write fails we must
+    // not proceed: the failure flag would outlive us with nothing to undo it.
+    let rewind = RewindInFlight {
+        invalidated_hash: invalidate_hash.to_string(),
+        floor_height,
+        target_height,
+    };
+    if !ManagedNodeState::set_rewind(coincube_datadir, Some(rewind)) {
+        return Err(
+            "could not record the rewind before starting it; refusing to proceed".to_string(),
+        );
+    }
+
+    let _maintenance = coincubed::MaintenanceGuard::new();
+    info!(
+        "Rewinding the managed node to height {floor_height} so Knots can re-check blocks \
+         {first_divergent}..{target_height} under BIP-110."
+    );
+
+    bitcoind
+        .invalidate_block_noreply(&invalidate_hash)
+        .map_err(|e| format!("invalidateblock at height {first_divergent} failed: {e}"))?;
+    wait_for_tip(bitcoind, DISCONNECT_DEADLINE, |blocks| {
+        blocks <= floor_height
+    })?;
+
+    info!("Rewind complete; reconnecting under BIP-110 rules.");
+    bitcoind
+        .reconsider_block_noreply(&floor_hash)
+        .map_err(|e| format!("reconsiderblock at height {floor_height} failed: {e}"))?;
+    let reached = wait_for_tip(bitcoind, RECONNECT_DEADLINE, |blocks| {
+        blocks >= target_height
+    })?;
+
+    // Only now is the node whole again, so only now may the record go.
+    ManagedNodeState::set_rewind(coincube_datadir, None);
+    if reached < target_height {
+        // Knots rejected something Core had accepted, or the deadline expired. Either
+        // way the node is consistent; it just isn't where it started.
+        warn!(
+            "After re-checking, the node settled at height {reached} rather than {target_height}. \
+             If this is not simply a slow reconnect, blocks accepted under Core were rejected \
+             under BIP-110."
+        );
+    }
+    Ok(())
+}
+
+/// Poll the node's height until `done`, the deadline expires, or the node stops
+/// answering.
+///
+/// A node that stops answering after `invalidateblock` is the fatal-abort case —
+/// disconnecting pruned data kills bitcoind rather than returning an error — so a
+/// run of consecutive failures is treated as a hard error, never as success.
+fn wait_for_tip(
+    bitcoind: &coincubed::BitcoinD,
+    deadline: Duration,
+    done: impl Fn(i32) -> bool,
+) -> Result<i32, String> {
+    const MAX_CONSECUTIVE_FAILURES: u32 = 15;
+
+    let started = Instant::now();
+    let mut last_seen = None;
+    let mut failures = 0u32;
+    while started.elapsed() < deadline {
+        match bitcoind.chain_status() {
+            Ok(status) => {
+                failures = 0;
+                last_seen = Some(status.blocks);
+                if done(status.blocks) {
+                    return Ok(status.blocks);
+                }
+            }
+            Err(e) => {
+                failures += 1;
+                if failures >= MAX_CONSECUTIVE_FAILURES {
+                    return Err(format!(
+                        "the managed node stopped responding during the rewind ({e}). It may have \
+                         shut down; check its debug.log before restarting."
+                    ));
+                }
+            }
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+    last_seen.ok_or_else(|| "the managed node never reported a height".to_string())
+}
+
+/// Issue the `reconsiderblock` for `plan`, if it calls for one.
+///
+/// Fire-and-forget: re-activating the chain can reconnect many blocks and far
+/// exceed the RPC socket timeout. Progress is observed out of band, from the
+/// node's `getblockchaininfo` and its debug log.
+pub fn execute(
+    bitcoind: &coincubed::BitcoinD,
+    plan: RevalidationPlan,
+) -> Result<Option<i32>, String> {
+    let RevalidationPlan::ClearFailureFlags { anchor_height } = plan else {
+        return Ok(None);
+    };
+    let anchor = bitcoind
+        .get_block_hash(anchor_height)
+        .ok_or_else(|| format!("no block at the RDTS anchor height {anchor_height}"))?;
+    info!(
+        "Clearing inherited block-index rejections from the RDTS anchor \
+         (height {anchor_height}, {anchor}) so this node can follow the most-work chain."
+    );
+    bitcoind
+        .reconsider_block_noreply(&anchor)
+        .map_err(|e| format!("reconsiderblock at height {anchor_height} failed: {e}"))?;
+    Ok(Some(anchor_height))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn facts(network: Network, from: NodeFlavor, to: NodeFlavor) -> ChainFacts {
+        ChainFacts {
+            network,
+            previous_flavor: Some(from),
+            current_flavor: to,
+            // Comfortably past the anchor, so the height gate isn't what's under test.
+            blocks: RDTS_ANCHOR_MAINNET + 5_000,
+            deployment_live: true,
+            // Unpruned unless a test says otherwise, so the prune floor isn't a
+            // hidden variable in the cases that aren't about it.
+            prune_height: None,
+            node_stranded: false,
+        }
+    }
+
+    #[test]
+    fn rdts_is_only_anchored_on_mainnet() {
+        assert_eq!(rdts_anchor_height(Network::Bitcoin), Some(961_631));
+        assert_eq!(rdts_anchor_height(Network::Regtest), None);
+        assert_eq!(rdts_anchor_height(Network::Signet), None);
+        assert_eq!(rdts_anchor_height(Network::Testnet4), None);
+    }
+
+    #[test]
+    fn networks_without_an_anchor_are_skipped() {
+        for network in [Network::Regtest, Network::Signet, Network::Testnet4] {
+            let mut f = facts(network, NodeFlavor::Knots, NodeFlavor::Core);
+            // Even a stranded node: we have no defensible height to act from.
+            f.node_stranded = true;
+            assert_eq!(
+                plan(f),
+                RevalidationPlan::Skip(SkipReason::NoDeploymentOnNetwork),
+            );
+        }
+    }
+
+    // The runtime gate. Until RDTS locks in, both flavours enforce the same rules,
+    // so no swap can strand the node and this must stay entirely inert.
+    #[test]
+    fn a_dormant_deployment_is_skipped() {
+        let mut f = facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Core);
+        f.deployment_live = false;
+        f.node_stranded = true;
+        assert_eq!(
+            plan(f),
+            RevalidationPlan::Skip(SkipReason::DeploymentNotLive)
+        );
+    }
+
+    // As of writing mainnet has not reached 961,632, so this is what every real
+    // node answers today. Shipping before activation is what lets the ledger be
+    // seeded correctly on every install before divergence is possible at all.
+    #[test]
+    fn a_tip_below_the_anchor_is_skipped() {
+        let mut f = facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Core);
+        f.blocks = RDTS_ANCHOR_MAINNET;
+        assert_eq!(plan(f), RevalidationPlan::Skip(SkipReason::TipBelowAnchor));
+
+        // One block into the mandatory-signalling window, divergence is possible.
+        f.blocks = RDTS_ANCHOR_MAINNET + 1;
+        assert_eq!(
+            plan(f),
+            RevalidationPlan::ClearFailureFlags {
+                anchor_height: RDTS_ANCHOR_MAINNET
+            },
+        );
+    }
+
+    #[test]
+    fn knots_to_core_clears_inherited_rejections() {
+        assert_eq!(
+            plan(facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Core)),
+            RevalidationPlan::ClearFailureFlags {
+                anchor_height: RDTS_ANCHOR_MAINNET
+            },
+        );
+    }
+
+    #[test]
+    fn a_healthy_core_node_is_left_alone() {
+        assert_eq!(
+            plan(facts(Network::Bitcoin, NodeFlavor::Core, NodeFlavor::Core)),
+            RevalidationPlan::Skip(SkipReason::NothingToClear),
+        );
+    }
+
+    // The ledger is not load-bearing: a Core node observably trailing a heavier
+    // branch gets repaired even when we have no record of a swap at all (installer
+    // switch, lost sidecar, datadir moved between machines).
+    #[test]
+    fn a_stranded_core_node_is_repaired_without_any_ledger() {
+        let mut f = facts(Network::Bitcoin, NodeFlavor::Core, NodeFlavor::Core);
+        f.previous_flavor = None;
+        f.node_stranded = true;
+        assert_eq!(
+            plan(f),
+            RevalidationPlan::ClearFailureFlags {
+                anchor_height: RDTS_ANCHOR_MAINNET
+            },
+        );
+    }
+
+    // The most important negative case. A Knots node trailing the most-work chain
+    // is doing its job — enforcing RDTS against a non-compliant majority. Clearing
+    // its flags would re-validate and re-reject the same blocks on every startup.
+    #[test]
+    fn a_stranded_knots_node_is_never_repaired() {
+        let mut f = facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Knots);
+        f.node_stranded = true;
+        assert_eq!(plan(f), RevalidationPlan::Skip(SkipReason::NothingToClear));
+
+        // Not even right after a Core -> Knots swap. That swap does trigger work,
+        // but it must be a replay under RDTS — never a "repair" that clears the
+        // rejections and drags the node back onto the chain the user just opted out
+        // of following.
+        let mut f = facts(Network::Bitcoin, NodeFlavor::Core, NodeFlavor::Knots);
+        f.node_stranded = true;
+        assert!(matches!(plan(f), RevalidationPlan::ReplayUnderRdts { .. }));
+    }
+
+    // Core -> Knots on an unpruned node: rewind all the way to the anchor, which is
+    // the deepest point the two flavours must agree on.
+    #[test]
+    fn core_to_knots_replays_from_the_anchor() {
+        let f = facts(Network::Bitcoin, NodeFlavor::Core, NodeFlavor::Knots);
+        let p = plan(f);
+        assert_eq!(
+            p,
+            RevalidationPlan::ReplayUnderRdts {
+                floor_height: RDTS_ANCHOR_MAINNET,
+                target_height: RDTS_ANCHOR_MAINNET + 5_000,
+            },
+        );
+        assert!(p.is_full_coverage());
+    }
+
+    // Pruning, not the anchor, is what really bounds the replay: we cannot
+    // disconnect blocks whose data is gone. The floor must clear `pruneheight` by
+    // the safety margin, because pruning advances between our read and the call and
+    // disconnecting into pruned data aborts the node outright.
+    #[test]
+    fn pruning_raises_the_floor_and_makes_coverage_partial() {
+        let mut f = facts(Network::Bitcoin, NodeFlavor::Core, NodeFlavor::Knots);
+        let prune_height = RDTS_ANCHOR_MAINNET + 2_000;
+        f.prune_height = Some(prune_height);
+        let p = plan(f);
+        assert_eq!(
+            p,
+            RevalidationPlan::ReplayUnderRdts {
+                floor_height: prune_height + PRUNE_SAFETY_MARGIN,
+                target_height: RDTS_ANCHOR_MAINNET + 5_000,
+            },
+        );
+        assert!(
+            !p.is_full_coverage(),
+            "a floor above the anchor means blocks were pruned and cannot be re-checked"
+        );
+
+        // Pruning below the anchor cannot pull the floor down past it — there is
+        // nothing to check below the anchor in the first place.
+        f.prune_height = Some(RDTS_ANCHOR_MAINNET - 50_000);
+        assert_eq!(
+            plan(f),
+            RevalidationPlan::ReplayUnderRdts {
+                floor_height: RDTS_ANCHOR_MAINNET,
+                target_height: RDTS_ANCHOR_MAINNET + 5_000,
+            },
+        );
+    }
+
+    // Once pruning has eaten everything above the anchor there is no mechanism —
+    // short of re-downloading the chain — that could re-check anything, so we must
+    // decline rather than rewind into data we don't have.
+    #[test]
+    fn a_fully_pruned_window_is_declined() {
+        let mut f = facts(Network::Bitcoin, NodeFlavor::Core, NodeFlavor::Knots);
+        f.prune_height = Some(f.blocks);
+        assert_eq!(
+            plan(f),
+            RevalidationPlan::Skip(SkipReason::NothingRetainedAboveAnchor),
+        );
+
+        // And the margin counts: a floor that lands exactly on the tip is refused,
+        // not attempted with a zero-length replay.
+        f.prune_height = Some(f.blocks - PRUNE_SAFETY_MARGIN);
+        assert_eq!(
+            plan(f),
+            RevalidationPlan::Skip(SkipReason::NothingRetainedAboveAnchor),
+        );
+    }
+
+    // A rewind is only ever justified by an actual swap from Core. Restarting a
+    // Knots node must not re-run it every time.
+    #[test]
+    fn a_restarting_knots_node_does_not_replay() {
+        let mut f = facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Knots);
+        f.node_stranded = true;
+        assert_eq!(plan(f), RevalidationPlan::Skip(SkipReason::NothingToClear));
+
+        let mut f = facts(Network::Bitcoin, NodeFlavor::Knots, NodeFlavor::Knots);
+        f.previous_flavor = None;
+        assert_eq!(plan(f), RevalidationPlan::Skip(SkipReason::NothingToClear));
+    }
+
+    #[test]
+    fn the_rewind_record_survives_a_flavour_write_and_vice_versa() {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-rewind-test-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let datadir = CoincubeDirectory::new(dir.clone());
+
+        let rewind = RewindInFlight {
+            invalidated_hash: "00".repeat(32),
+            floor_height: RDTS_ANCHOR_MAINNET,
+            target_height: RDTS_ANCHOR_MAINNET + 100,
+        };
+        assert!(ManagedNodeState::set_rewind(&datadir, Some(rewind.clone())));
+        ManagedNodeState::record_run(&datadir, NodeFlavor::Knots);
+
+        // Recording the flavour must not drop the rewind: losing it would strand the
+        // node below the invalidated block with nothing left to undo it.
+        let loaded = ManagedNodeState::load(&datadir);
+        assert_eq!(loaded.rewind, Some(rewind));
+        assert_eq!(loaded.last_run_flavor, Some(NodeFlavor::Knots));
+
+        // And clearing the rewind must not drop the flavour.
+        assert!(ManagedNodeState::set_rewind(&datadir, None));
+        let loaded = ManagedNodeState::load(&datadir);
+        assert_eq!(loaded.rewind, None);
+        assert_eq!(loaded.last_run_flavor, Some(NodeFlavor::Knots));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn tip(height: i32, status: &str) -> coincubed::ChainTipEntry {
+        use coincube_core::miniscript::bitcoin::{self, hashes::Hash};
+        coincubed::ChainTipEntry {
+            height,
+            hash: bitcoin::BlockHash::from_byte_array([height as u8; 32]),
+            branch_len: 0,
+            status: status.to_string(),
+        }
+    }
+
+    #[test]
+    fn a_healthy_node_needs_no_reconsider() {
+        assert!(!needs_reconsider(&[
+            tip(100, "active"),
+            tip(98, "valid-fork")
+        ]));
+        // No active tip at all (shouldn't happen) must not read as stranded.
+        assert!(!needs_reconsider(&[]));
+    }
+
+    // Note the branch is `headers-only`, not `invalid`: a node that rejects a block
+    // stops downloading that chain, so gating on `"invalid"` would miss exactly the
+    // case this check exists for.
+    #[test]
+    fn a_stranded_node_needs_a_reconsider() {
+        assert!(needs_reconsider(&[
+            tip(100, "active"),
+            tip(120, "headers-only")
+        ]));
+        assert!(needs_reconsider(&[tip(100, "active"), tip(120, "invalid")]));
+    }
+
+    #[test]
+    fn the_ledger_round_trips_and_fails_safe() {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-revalidate-test-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let datadir = CoincubeDirectory::new(dir.clone());
+
+        // Absent sidecar reads as "never observed", not as an error.
+        assert_eq!(ManagedNodeState::load(&datadir).last_run_flavor, None);
+
+        ManagedNodeState::record_run(&datadir, NodeFlavor::Knots);
+        assert_eq!(
+            ManagedNodeState::load(&datadir).last_run_flavor,
+            Some(NodeFlavor::Knots),
+        );
+
+        // Overwriting must replace, not append or corrupt.
+        ManagedNodeState::record_run(&datadir, NodeFlavor::Core);
+        assert_eq!(
+            ManagedNodeState::load(&datadir).last_run_flavor,
+            Some(NodeFlavor::Core),
+        );
+
+        // A corrupt sidecar must fail safe to "unknown" rather than panic, so the
+        // next start records the truth instead of acting on garbage.
+        std::fs::write(ManagedNodeState::path(&datadir), b"{ not json").unwrap();
+        assert_eq!(ManagedNodeState::load(&datadir).last_run_flavor, None);
+
+        // No stray temp file is left behind by the atomic write.
+        assert!(!ManagedNodeState::path(&datadir)
+            .with_extension("tmp")
+            .exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/coincube-gui/src/services/connect/client/backend/mod.rs
+++ b/coincube-gui/src/services/connect/client/backend/mod.rs
@@ -590,6 +590,9 @@ impl Daemon for BackendWalletClient {
             },
             sync: 1.0,
             rescan_progress: None,
+            // Only the local poller can refuse a reorg; the remote backend owns its own
+            // chain view and never reports this.
+            refused_reorg_depth: None,
             timestamp: wallet.created_at as u32,
             // We can ignore this field for remote backend as the wallet should remain synced.
             last_poll_timestamp: None,

--- a/coincubed/src/bitcoin/d/mod.rs
+++ b/coincubed/src/bitcoin/d/mod.rs
@@ -78,6 +78,9 @@ pub enum BitcoindError {
     NetworkMismatch(String /*config*/, String /*bitcoind*/),
     StartRescan,
     RescanPastPruneHeight,
+    /// A field we rely on was missing, of the wrong type, or out of range in an
+    /// otherwise successful RPC response.
+    MalformedResponse(String /* what was wrong */),
 }
 
 impl BitcoindError {
@@ -170,6 +173,9 @@ impl std::fmt::Display for BitcoindError {
                     f,
                     "Trying to rescan the block chain past the prune block height."
                 )
+            }
+            BitcoindError::MalformedResponse(what) => {
+                write!(f, "Malformed response from bitcoind: {}.", what)
             }
         }
     }
@@ -1281,9 +1287,21 @@ impl BitcoinD {
                 None => PruneState::PrunedUnknown,
             },
         };
+        // `blocks` and `headers` are not optional the way `pruneheight` is, and a
+        // missing or unreadable one must not read as height 0: callers wait for the
+        // tip to fall to a floor, and a fabricated 0 satisfies that immediately —
+        // declaring a rewind complete while the node is still at its original tip.
+        let required = |key: &str| -> Result<i32, BitcoindError> {
+            int(key).ok_or_else(|| {
+                BitcoindError::MalformedResponse(format!(
+                    "missing or out-of-range '{}' in 'getblockchaininfo' result",
+                    key
+                ))
+            })
+        };
         Ok(ChainStatus {
-            blocks: int("blocks").unwrap_or(0),
-            headers: int("headers").unwrap_or(0),
+            blocks: required("blocks")?,
+            headers: required("headers")?,
             best_block_hash: info
                 .get("bestblockhash")
                 .and_then(Json::as_str)

--- a/coincubed/src/bitcoin/d/mod.rs
+++ b/coincubed/src/bitcoin/d/mod.rs
@@ -1270,6 +1270,17 @@ impl BitcoinD {
                 .and_then(Json::as_i64)
                 .and_then(|v| v.try_into().ok())
         };
+        // `pruneheight` is absent exactly when the node is unpruned. Present but
+        // unreadable is a third case and must not collapse into the first: callers
+        // use this to decide whether disconnecting a block is safe, and getting that
+        // wrong aborts the node outright.
+        let prune_state = match info.get("pruneheight") {
+            None => PruneState::NotPruned,
+            Some(_) => match int("pruneheight") {
+                Some(height) => PruneState::Pruned(height),
+                None => PruneState::PrunedUnknown,
+            },
+        };
         Ok(ChainStatus {
             blocks: int("blocks").unwrap_or(0),
             headers: int("headers").unwrap_or(0),
@@ -1277,8 +1288,7 @@ impl BitcoinD {
                 .get("bestblockhash")
                 .and_then(Json::as_str)
                 .and_then(|s| bitcoin::BlockHash::from_str(s).ok()),
-            // Absent when the node isn't pruned.
-            prune_height: int("pruneheight"),
+            prune_state,
         })
     }
 
@@ -1585,11 +1595,24 @@ pub struct ChainStatus {
     pub headers: i32,
     /// The active chain's tip, when the node reported a parseable one.
     pub best_block_hash: Option<bitcoin::BlockHash>,
-    /// Oldest block the node still stores. `None` when the node isn't pruned.
-    ///
-    /// Nothing at or below this height can be disconnected — the block and undo
-    /// data needed to do so are gone.
-    pub prune_height: Option<i32>,
+    /// How much history the node still stores.
+    pub prune_state: PruneState,
+}
+
+/// What `getblockchaininfo` says about pruning.
+///
+/// Three states, not two: a node that reports a `pruneheight` we cannot read is
+/// pruned, and treating that as unpruned would let a caller disconnect blocks whose
+/// data is gone — which aborts bitcoind rather than returning an error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PruneState {
+    /// No `pruneheight` reported: the node stores the whole chain.
+    NotPruned,
+    /// Oldest block still stored. Nothing at or below this can be disconnected.
+    Pruned(i32),
+    /// Pruned, but the height was unreadable. Callers must treat this as "we cannot
+    /// establish that any disconnect is safe" and decline, not as unpruned.
+    PrunedUnknown,
 }
 
 /// One entry of `getchaintips`.

--- a/coincubed/src/bitcoin/d/mod.rs
+++ b/coincubed/src/bitcoin/d/mod.rs
@@ -1644,14 +1644,16 @@ pub struct DeploymentStatus {
 }
 
 impl DeploymentStatus {
-    /// Whether the deployment has reached a point where the enforcing and
-    /// non-enforcing chains can diverge — i.e. it is locked in or already active.
+    /// Whether the deployment is dead: it timed out without locking in, so its rules
+    /// will never be enforced and nothing can diverge over them.
     ///
-    /// `defined` and `started` mean no rule is being enforced yet, and `failed`
-    /// means none ever will be, so in all three cases there is nothing to
-    /// revalidate.
-    pub fn is_live(&self) -> bool {
-        self.active || matches!(self.status.as_str(), "locked_in" | "active")
+    /// Deliberately NOT the inverse of "locked in or active". BIP-110 rejects
+    /// non-signalling blocks throughout the mandatory-signalling window while the
+    /// deployment is still `started`, and only reaches `locked_in` afterwards — so
+    /// treating `started` as "not yet live" would skip precisely the window in which
+    /// an enforcing and a non-enforcing node first disagree.
+    pub fn has_failed(&self) -> bool {
+        !self.active && self.status == "failed"
     }
 }
 
@@ -2008,23 +2010,24 @@ impl From<&&Json> for MempoolEntryFees {
 mod tests {
     use super::*;
 
-    // Only a locked-in or active deployment can make an enforcing and a
-    // non-enforcing node disagree. Before that there is no rule to enforce, and
-    // `failed` means there never will be — in both cases there is nothing to
-    // revalidate, so the whole flavour-swap remediation must stay a no-op.
+    // The liveness gate exists only to rule out a deployment that will never
+    // activate. Anything else must fall through to the height check, which is the
+    // real divergence condition.
     #[test]
-    fn only_locked_in_or_active_deployments_are_live() {
+    fn only_an_abandoned_deployment_is_ruled_out() {
         let status = |s: &str, active: bool| DeploymentStatus {
             active,
             status: s.to_string(),
         };
-        assert!(!status("defined", false).is_live());
-        assert!(!status("started", false).is_live());
-        assert!(!status("failed", false).is_live());
-        assert!(status("locked_in", false).is_live());
-        assert!(status("active", true).is_live());
-        // `active` alone is authoritative even if the textual state is missing.
-        assert!(status("", true).is_live());
+        // Only an abandoned deployment can be ruled out. `started` in particular
+        // must NOT be: BIP-110's mandatory-signalling window rejects non-signalling
+        // blocks while still in that state, which is exactly when the enforcing and
+        // non-enforcing chains first diverge.
+        assert!(!status("defined", false).has_failed());
+        assert!(!status("started", false).has_failed());
+        assert!(!status("locked_in", false).has_failed());
+        assert!(!status("active", true).has_failed());
+        assert!(status("failed", false).has_failed());
     }
 
     // Bitcoin Knots 29.x shares Core's numeric `getnetworkinfo.version` scheme:

--- a/coincubed/src/bitcoin/d/mod.rs
+++ b/coincubed/src/bitcoin/d/mod.rs
@@ -235,7 +235,13 @@ enum ClientKind {
     /// Wallet calls ([`BitcoinD::watchonly_client`]).
     Watchonly,
     /// Fire-and-forget calls with a low timeout ([`BitcoinD::sendonly_client`]).
+    ///
+    /// NOTE: built against the *watchonly* URL, because its only user is
+    /// `importdescriptors`. Non-wallet calls must use [`Self::SendonlyNode`].
     Sendonly,
+    /// Fire-and-forget calls with a low timeout, against the node URL
+    /// ([`BitcoinD::sendonly_node_client`]).
+    SendonlyNode,
 }
 
 pub struct BitcoinD {
@@ -248,6 +254,9 @@ pub struct BitcoinD {
     node_client: RwLock<Client>,
     /// A client that will disregard responses to the queries it makes.
     sendonly_client: RwLock<Client>,
+    /// Same, but for non-wallet calls: [`Self::sendonly_client`] points at the
+    /// `/wallet/<path>` URL.
+    sendonly_node_client: RwLock<Client>,
     /// A client for calls related to the wallet.
     watchonly_client: RwLock<Client>,
     watchonly_wallet_path: String,
@@ -316,9 +325,18 @@ impl BitcoinD {
                 .timeout(Duration::from_secs(3))
                 .build(),
         );
+        let sendonly_node_client = Client::with_transport(
+            builder
+                .clone()
+                .url(&node_url)
+                .map_err(BitcoindError::from)?
+                .timeout(Duration::from_secs(1))
+                .build(),
+        );
         let dummy_bitcoind = BitcoinD {
             node_client: RwLock::new(dummy_node_client),
             sendonly_client: RwLock::new(sendonly_client),
+            sendonly_node_client: RwLock::new(sendonly_node_client),
             watchonly_client: RwLock::new(dummy_wo_client),
             watchonly_wallet_path: watchonly_wallet_path.clone(),
             config: config.clone(),
@@ -339,6 +357,11 @@ impl BitcoinD {
                 config,
                 &watchonly_wallet_path,
                 ClientKind::Sendonly,
+            )?),
+            sendonly_node_client: RwLock::new(Self::build_client(
+                config,
+                &watchonly_wallet_path,
+                ClientKind::SendonlyNode,
             )?),
             watchonly_client: RwLock::new(Self::build_client(
                 config,
@@ -377,6 +400,7 @@ impl BitcoinD {
             ClientKind::Watchonly => (watchonly_url, RPC_SOCKET_TIMEOUT),
             // Fire-and-forget: a very low timeout so we ignore the response.
             ClientKind::Sendonly => (watchonly_url, 1),
+            ClientKind::SendonlyNode => (node_url, 1),
         };
         Ok(Client::with_transport(
             builder
@@ -393,6 +417,7 @@ impl BitcoinD {
             ClientKind::Node => &self.node_client,
             ClientKind::Watchonly => &self.watchonly_client,
             ClientKind::Sendonly => &self.sendonly_client,
+            ClientKind::SendonlyNode => &self.sendonly_node_client,
         }
     }
 
@@ -553,6 +578,25 @@ impl BitcoinD {
             Ok(_) => Ok(()),
             Err(e) => {
                 // A timeout error is expected, as that's our workaround to avoid blocking
+                if e.is_timeout() {
+                    Ok(())
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    }
+
+    // Same as `make_noreply_request` but for non-wallet calls.
+    fn make_noreply_node_request(
+        &self,
+        method: &str,
+        params: Option<&serde_json::value::RawValue>,
+    ) -> Result<(), BitcoindError> {
+        match self.make_request_inner(ClientKind::SendonlyNode, method, params, false) {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                // A timeout error is expected, as that's our workaround to avoid blocking.
                 if e.is_timeout() {
                     Ok(())
                 } else {
@@ -1214,6 +1258,140 @@ impl BitcoinD {
         true
     }
 
+    /// A snapshot of the node's view of the chain: how far it has validated, how
+    /// far it has headers for, and the oldest block it still stores.
+    ///
+    /// Fallible, unlike [`Self::chain_tip`], because its callers are maintenance
+    /// paths that must tolerate a busy or restarting node rather than panic.
+    pub fn chain_status(&self) -> Result<ChainStatus, BitcoindError> {
+        let info = self.make_fallible_node_request("getblockchaininfo", None)?;
+        let int = |key: &str| -> Option<i32> {
+            info.get(key)
+                .and_then(Json::as_i64)
+                .and_then(|v| v.try_into().ok())
+        };
+        Ok(ChainStatus {
+            blocks: int("blocks").unwrap_or(0),
+            headers: int("headers").unwrap_or(0),
+            best_block_hash: info
+                .get("bestblockhash")
+                .and_then(Json::as_str)
+                .and_then(|s| bitcoin::BlockHash::from_str(s).ok()),
+            // Absent when the node isn't pruned.
+            prune_height: int("pruneheight"),
+        })
+    }
+
+    /// The tip of every branch in the node's block index (`getchaintips`).
+    ///
+    /// Note the `status` of a branch a node rejected is only `"invalid"` if it
+    /// actually validated the branch. A node that stopped downloading a chain it
+    /// knows it would reject reports `"headers-only"` instead, so this must not be
+    /// used as a correctness gate — see [`Self::reconsider_block_noreply`].
+    pub fn chain_tips(&self) -> Result<Vec<ChainTipEntry>, BitcoindError> {
+        let tips = self.make_fallible_node_request("getchaintips", None)?;
+        Ok(tips
+            .as_array()
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(|entry| {
+                        Some(ChainTipEntry {
+                            height: entry
+                                .get("height")
+                                .and_then(Json::as_i64)?
+                                .try_into()
+                                .ok()?,
+                            hash: bitcoin::BlockHash::from_str(
+                                entry.get("hash").and_then(Json::as_str)?,
+                            )
+                            .ok()?,
+                            branch_len: entry
+                                .get("branchlen")
+                                .and_then(Json::as_i64)?
+                                .try_into()
+                                .ok()?,
+                            status: entry.get("status").and_then(Json::as_str)?.to_string(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
+
+    /// Status of the softfork deployment named `name` per `getdeploymentinfo`
+    /// (e.g. `"reduced_data"` for BIP-110 / RDTS).
+    ///
+    /// `None` when the RPC is unavailable or the deployment does not exist on this
+    /// network — Knots only ships `reduced_data` on mainnet and testnet4, so on
+    /// regtest and signet this is always `None`.
+    pub fn deployment_status(&self, name: &str) -> Option<DeploymentStatus> {
+        let info = self
+            .make_fallible_node_request("getdeploymentinfo", None)
+            .ok()?;
+        let deployment = info.get("deployments")?.get(name)?;
+        Some(DeploymentStatus {
+            active: deployment
+                .get("active")
+                .and_then(Json::as_bool)
+                .unwrap_or(false),
+            status: deployment
+                .get("bip9")
+                .and_then(|bip9| bip9.get("status"))
+                .and_then(Json::as_str)
+                .unwrap_or_default()
+                .to_string(),
+        })
+    }
+
+    /// Mark `hash` invalid and disconnect it and everything built on it, rolling
+    /// the active chain back to its parent.
+    ///
+    /// # Danger
+    ///
+    /// Two ways this bites, both of which the caller must have handled:
+    ///
+    /// 1. **It is not self-undoing.** The `BLOCK_FAILED_VALID` flag is persisted in
+    ///    the block index and survives restarts *and* a swap to a different client.
+    ///    A caller that dies between this and [`Self::reconsider_block_noreply`]
+    ///    leaves the node parked below the invalidated block forever, with nothing
+    ///    in the node itself to indicate why. Record your intent durably *before*
+    ///    calling this.
+    /// 2. **Disconnecting a pruned block is fatal.** `DisconnectTip` must read each
+    ///    block and its undo data back off disk, and pruning deletes both. If the
+    ///    range crosses `pruneheight` the node aborts with an internal error rather
+    ///    than returning an RPC error — and because this call is fire-and-forget,
+    ///    you will not see it. Check `pruneheight` immediately before calling, keep
+    ///    a margin (it advances on every flush), and treat "the node stopped
+    ///    answering" afterwards as a failure, never as success.
+    ///
+    /// Fire-and-forget for the same reason as
+    /// [`Self::reconsider_block_noreply`]: disconnecting many blocks far exceeds
+    /// [`RPC_SOCKET_TIMEOUT`]. Poll [`Self::chain_status`] to follow it.
+    pub fn invalidate_block_noreply(&self, hash: &bitcoin::BlockHash) -> Result<(), BitcoindError> {
+        self.make_noreply_node_request("invalidateblock", params!(Json::String(hash.to_string())))
+    }
+
+    /// Clear the `BLOCK_FAILED_*` flags on `hash` **and all its descendants**,
+    /// including those on sibling branches, then re-activate the most-work chain.
+    ///
+    /// This is how a node recovers from having inherited another client's
+    /// rejections: those flags are persisted in the block index and survive both a
+    /// restart and a binary swap, so a Core node opening a datadir a Knots node
+    /// rejected blocks in will otherwise stay on the minority chain forever.
+    ///
+    /// Idempotent, and safe on a pruned node: pruning clears `BLOCK_HAVE_DATA`, so
+    /// blocks whose data is gone are never activation candidates. It also needs no
+    /// block data of its own, unlike `invalidateblock`.
+    ///
+    /// Fire-and-forget: re-activating the chain can reconnect a large number of
+    /// blocks and far exceed [`RPC_SOCKET_TIMEOUT`], so we don't wait for the
+    /// reply. Poll [`Self::chain_status`] to observe the effect. Mirrors
+    /// [`Self::start_rescan`].
+    pub fn reconsider_block_noreply(&self, hash: &bitcoin::BlockHash) -> Result<(), BitcoindError> {
+        self.make_noreply_node_request("reconsiderblock", params!(Json::String(hash.to_string())))
+    }
+
     // Make sure the bitcoind has enough blocks to rescan up to this timestamp.
     fn check_prune_height(&self, timestamp: u32) -> Result<(), BitcoindError> {
         let chain_info = self.block_chain_info();
@@ -1395,6 +1573,62 @@ impl BitcoinD {
                     .and_then(Json::as_str)
                     .map(String::from)
             })
+    }
+}
+
+/// A snapshot of the node's chain state, from `getblockchaininfo`.
+#[derive(Debug, Clone)]
+pub struct ChainStatus {
+    /// Blocks validated toward the best known tip.
+    pub blocks: i32,
+    /// Headers count for the best known tip.
+    pub headers: i32,
+    /// The active chain's tip, when the node reported a parseable one.
+    pub best_block_hash: Option<bitcoin::BlockHash>,
+    /// Oldest block the node still stores. `None` when the node isn't pruned.
+    ///
+    /// Nothing at or below this height can be disconnected — the block and undo
+    /// data needed to do so are gone.
+    pub prune_height: Option<i32>,
+}
+
+/// One entry of `getchaintips`.
+#[derive(Debug, Clone)]
+pub struct ChainTipEntry {
+    pub height: i32,
+    pub hash: bitcoin::BlockHash,
+    /// Blocks on this branch that are not on the active chain. `0` for the active tip.
+    pub branch_len: i32,
+    /// bitcoind's own label: `active`, `valid-fork`, `valid-headers`,
+    /// `headers-only`, or `invalid`.
+    pub status: String,
+}
+
+impl ChainTipEntry {
+    /// Whether this entry is the active chain's tip.
+    pub fn is_active(&self) -> bool {
+        self.status == "active"
+    }
+}
+
+/// Status of a softfork deployment, from `getdeploymentinfo`.
+#[derive(Debug, Clone)]
+pub struct DeploymentStatus {
+    /// Whether the deployment's rules are being enforced right now.
+    pub active: bool,
+    /// The BIP-9 state: `defined`, `started`, `locked_in`, `active`, or `failed`.
+    pub status: String,
+}
+
+impl DeploymentStatus {
+    /// Whether the deployment has reached a point where the enforcing and
+    /// non-enforcing chains can diverge — i.e. it is locked in or already active.
+    ///
+    /// `defined` and `started` mean no rule is being enforced yet, and `failed`
+    /// means none ever will be, so in all three cases there is nothing to
+    /// revalidate.
+    pub fn is_live(&self) -> bool {
+        self.active || matches!(self.status.as_str(), "locked_in" | "active")
     }
 }
 
@@ -1750,6 +1984,25 @@ impl From<&&Json> for MempoolEntryFees {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Only a locked-in or active deployment can make an enforcing and a
+    // non-enforcing node disagree. Before that there is no rule to enforce, and
+    // `failed` means there never will be — in both cases there is nothing to
+    // revalidate, so the whole flavour-swap remediation must stay a no-op.
+    #[test]
+    fn only_locked_in_or_active_deployments_are_live() {
+        let status = |s: &str, active: bool| DeploymentStatus {
+            active,
+            status: s.to_string(),
+        };
+        assert!(!status("defined", false).is_live());
+        assert!(!status("started", false).is_live());
+        assert!(!status("failed", false).is_live());
+        assert!(status("locked_in", false).is_live());
+        assert!(status("active", true).is_live());
+        // `active` alone is authoritative even if the textual state is missing.
+        assert!(status("", true).is_live());
+    }
 
     // Bitcoin Knots 29.x shares Core's numeric `getnetworkinfo.version` scheme:
     // the 29.x base reports 290000. Compatibility is gated on that number, not

--- a/coincubed/src/bitcoin/mod.rs
+++ b/coincubed/src/bitcoin/mod.rs
@@ -164,20 +164,30 @@ pub fn managed_node_maintenance() -> bool {
     MANAGED_NODE_MAINTENANCE.load(sync::atomic::Ordering::SeqCst)
 }
 
-/// RAII wrapper around [`set_managed_node_maintenance`], so an early return or a
-/// panic cannot leave every Vault's poller parked forever.
+/// RAII wrapper around the maintenance flag, so an early return or a panic cannot
+/// leave every Vault's poller parked forever.
+///
+/// Acquired atomically, so it doubles as a mutual exclusion for the operation it
+/// guards: several Vaults can attach to the shared node at the same instant, and
+/// only one may rewind it.
 pub struct MaintenanceGuard;
 
 impl MaintenanceGuard {
-    pub fn new() -> Self {
-        set_managed_node_maintenance(true);
-        MaintenanceGuard
-    }
-}
-
-impl Default for MaintenanceGuard {
-    fn default() -> Self {
-        Self::new()
+    /// Claim maintenance, or `None` if another holder already has it.
+    ///
+    /// A compare-and-swap rather than a check followed by a set: the two Vaults this
+    /// exists to separate can arrive in the same instant, which is exactly when a
+    /// read-then-write loses.
+    pub fn try_acquire() -> Option<Self> {
+        MANAGED_NODE_MAINTENANCE
+            .compare_exchange(
+                false,
+                true,
+                sync::atomic::Ordering::SeqCst,
+                sync::atomic::Ordering::SeqCst,
+            )
+            .is_ok()
+            .then_some(MaintenanceGuard)
     }
 }
 

--- a/coincubed/src/bitcoin/mod.rs
+++ b/coincubed/src/bitcoin/mod.rs
@@ -84,8 +84,108 @@ impl SyncProgressCache {
     }
 }
 
+/// Lock-free flag published by the poller when it refuses to apply a block chain
+/// reorganisation because it is implausibly deep, and read by `get_info` without
+/// taking the `BitcoinInterface` mutex (same rationale as [`SyncProgressCache`]).
+///
+/// A reorg deeper than `MAX_REORG_DEPTH` blocks almost certainly means the backend
+/// is misreporting rather than that Bitcoin genuinely undid that much history: a
+/// node rewound with `invalidateblock`, a datadir swapped underneath us, or a
+/// chainstate mid-rebuild. Applying it would clear the confirmation state of every
+/// coin above the ancestor and hard-delete any deposit no longer in the mempool, so
+/// the poller declines and publishes the observed depth here instead.
+///
+/// Stored as the depth in blocks; `0` means "no alert".
+#[derive(Debug, Default)]
+pub struct ReorgAlertCache {
+    depth: sync::atomic::AtomicI64,
+}
+
+impl ReorgAlertCache {
+    /// Record that a reorg of `depth` blocks was refused.
+    pub fn store(&self, depth: i32) {
+        self.depth
+            .store(depth.into(), sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Clear the alert. Called on every poll that completes normally, so a
+    /// transient misreport resolves itself once the backend behaves again.
+    pub fn clear(&self) {
+        self.depth.store(0, sync::atomic::Ordering::Relaxed);
+    }
+
+    /// The depth of the most recently refused reorg, if one is outstanding.
+    pub fn load(&self) -> Option<i32> {
+        match self.depth.load(sync::atomic::Ordering::Relaxed) {
+            0 => None,
+            depth => Some(depth as i32),
+        }
+    }
+}
+
+/// Set while the shared managed node is being deliberately rewound, so pollers
+/// know to stand down instead of reacting to a chain they are being shown
+/// mid-surgery.
+///
+/// Process-wide because the managed node is process-wide: every Vault runs its own
+/// poller against the one node, so a rewind driven by one Vault's settings screen
+/// has to quiesce all of them. A per-daemon channel would only reach the Vault that
+/// started it. (Same reasoning as the process-wide managed-Tor registry.)
+///
+/// This is a courtesy, not a safety mechanism. It stops pollers from *starting*
+/// work; it cannot stop one already in flight. What actually protects wallet state
+/// is the depth guard in the poller, which refuses an implausible rollback whether
+/// or not this flag is set.
+static MANAGED_NODE_MAINTENANCE: sync::atomic::AtomicBool = sync::atomic::AtomicBool::new(false);
+
+/// Mark the shared managed node as under (or no longer under) maintenance.
+///
+/// Callers MUST clear this on every exit path, including failures — a flag left
+/// set silently stops every Vault from updating. Prefer [`MaintenanceGuard`].
+pub fn set_managed_node_maintenance(active: bool) {
+    MANAGED_NODE_MAINTENANCE.store(active, sync::atomic::Ordering::SeqCst);
+}
+
+/// Whether the shared managed node is currently under maintenance.
+pub fn managed_node_maintenance() -> bool {
+    MANAGED_NODE_MAINTENANCE.load(sync::atomic::Ordering::SeqCst)
+}
+
+/// RAII wrapper around [`set_managed_node_maintenance`], so an early return or a
+/// panic cannot leave every Vault's poller parked forever.
+pub struct MaintenanceGuard;
+
+impl MaintenanceGuard {
+    pub fn new() -> Self {
+        set_managed_node_maintenance(true);
+        MaintenanceGuard
+    }
+}
+
+impl Default for MaintenanceGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for MaintenanceGuard {
+    fn drop(&mut self) {
+        set_managed_node_maintenance(false);
+    }
+}
+
 /// Our Bitcoin backend.
 pub trait BitcoinInterface: Send {
+    /// Whether this backend talks to a `bitcoind`.
+    ///
+    /// Used to scope the managed-node maintenance pause: an Esplora or Electrum
+    /// Vault is unaffected by a rewind of the managed node and must keep polling.
+    /// An external `bitcoind` we cannot distinguish from the managed one, so it
+    /// pauses too — conservative, and bounded by the rewind's duration.
+    fn is_bitcoind(&self) -> bool {
+        false
+    }
+
     fn genesis_block_timestamp(&self) -> u32;
 
     fn genesis_block(&self) -> BlockChainTip;
@@ -195,6 +295,10 @@ pub trait BitcoinInterface: Send {
 }
 
 impl BitcoinInterface for d::BitcoinD {
+    fn is_bitcoind(&self) -> bool {
+        true
+    }
+
     fn genesis_block_timestamp(&self) -> u32 {
         self.get_block_stats(
             self.get_block_hash(0)
@@ -802,6 +906,10 @@ impl BitcoinInterface for esplora::Esplora {
 
 // FIXME: do we need to repeat the entire trait implementation? Isn't there a nicer way?
 impl BitcoinInterface for sync::Arc<sync::Mutex<dyn BitcoinInterface + 'static>> {
+    fn is_bitcoind(&self) -> bool {
+        self.lock().unwrap().is_bitcoind()
+    }
+
     fn genesis_block_timestamp(&self) -> u32 {
         self.lock().unwrap().genesis_block_timestamp()
     }

--- a/coincubed/src/bitcoin/mod.rs
+++ b/coincubed/src/bitcoin/mod.rs
@@ -197,31 +197,37 @@ impl Drop for MaintenanceGuard {
     }
 }
 
-/// A rollback we deliberately caused and may therefore apply, even though it is
-/// deeper than the poller's limit.
+/// The floor of a rollback we deliberately caused, which the poller may therefore
+/// apply even though it is deeper than its limit.
 ///
 /// The depth guard exists to distrust the *backend*: past a few hundred blocks, a
 /// node claiming that much history was undone is far likelier to be misreporting
 /// than right. A managed-node repair breaks that assumption — we asked for the
-/// rewind and we chose the fork point — and without an exception the guard is
+/// rewind and we chose how deep it went — and without an exception the guard is
 /// permanent: maintenance ends, every later poll sees the same over-deep reorg,
 /// refuses it, and the Vault stays pinned to a chain the node no longer has.
 ///
-/// Deliberately an exact `(height, hash)` and not a floor. A floor would weaken the
-/// guard for every rollback below it; naming the block means a misreporting backend
-/// has to land on the very one we picked. Set by the repair that creates it,
-/// republished from the durable record on each start, and overwritten by the next
-/// repair.
+/// A floor rather than a single block, because the fork point is not knowable in
+/// advance. A repair rewinds to this block and lets the node reconnect from there;
+/// where the two chains part company is wherever the node first refuses a block,
+/// which can be anywhere above the floor. Rewinding to 961,631 and rejecting
+/// 966,000 leaves the chains sharing everything up to 965,999, and it is *that*
+/// block the poller will find — so pinning the exception to the floor would refuse
+/// every realistic outcome and authorise only the one where nothing replayed.
+///
+/// The hash is still carried, and still checked: the poller confirms the backend's
+/// chain actually contains this block before honouring the floor, so a sanction
+/// left over from a different chain or a different datadir authorises nothing.
 static SANCTIONED_ROLLBACK: sync::Mutex<Option<BlockChainTip>> = sync::Mutex::new(None);
 
-/// Authorise (or withdraw) an over-deep rollback landing exactly on `point`.
-pub fn set_sanctioned_rollback(point: Option<BlockChainTip>) {
+/// Authorise (or withdraw) over-deep rollbacks reaching no deeper than `floor`.
+pub fn set_sanctioned_rollback(floor: Option<BlockChainTip>) {
     *SANCTIONED_ROLLBACK
         .lock()
-        .expect("sanctioned rollback lock poisoned") = point;
+        .expect("sanctioned rollback lock poisoned") = floor;
 }
 
-/// The rollback the poller is currently allowed to apply past its depth limit.
+/// The floor the poller is currently allowed to roll back to past its depth limit.
 pub fn sanctioned_rollback() -> Option<BlockChainTip> {
     *SANCTIONED_ROLLBACK
         .lock()

--- a/coincubed/src/bitcoin/mod.rs
+++ b/coincubed/src/bitcoin/mod.rs
@@ -197,6 +197,37 @@ impl Drop for MaintenanceGuard {
     }
 }
 
+/// A rollback we deliberately caused and may therefore apply, even though it is
+/// deeper than the poller's limit.
+///
+/// The depth guard exists to distrust the *backend*: past a few hundred blocks, a
+/// node claiming that much history was undone is far likelier to be misreporting
+/// than right. A managed-node repair breaks that assumption — we asked for the
+/// rewind and we chose the fork point — and without an exception the guard is
+/// permanent: maintenance ends, every later poll sees the same over-deep reorg,
+/// refuses it, and the Vault stays pinned to a chain the node no longer has.
+///
+/// Deliberately an exact `(height, hash)` and not a floor. A floor would weaken the
+/// guard for every rollback below it; naming the block means a misreporting backend
+/// has to land on the very one we picked. Set by the repair that creates it,
+/// republished from the durable record on each start, and overwritten by the next
+/// repair.
+static SANCTIONED_ROLLBACK: sync::Mutex<Option<BlockChainTip>> = sync::Mutex::new(None);
+
+/// Authorise (or withdraw) an over-deep rollback landing exactly on `point`.
+pub fn set_sanctioned_rollback(point: Option<BlockChainTip>) {
+    *SANCTIONED_ROLLBACK
+        .lock()
+        .expect("sanctioned rollback lock poisoned") = point;
+}
+
+/// The rollback the poller is currently allowed to apply past its depth limit.
+pub fn sanctioned_rollback() -> Option<BlockChainTip> {
+    *SANCTIONED_ROLLBACK
+        .lock()
+        .expect("sanctioned rollback lock poisoned")
+}
+
 /// Our Bitcoin backend.
 pub trait BitcoinInterface: Send {
     /// Whether this backend talks to a `bitcoind`.

--- a/coincubed/src/bitcoin/mod.rs
+++ b/coincubed/src/bitcoin/mod.rs
@@ -41,6 +41,19 @@ impl fmt::Display for BlockChainTip {
     }
 }
 
+/// Outcome of walking back from our tip to where it rejoins the backend's chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AncestorSearch {
+    /// The fork point, found within the allowed depth.
+    Found(BlockChainTip),
+    /// The walk hit its bound without rejoining, so the fork is at least that deep.
+    /// Distinct from [`Self::Failed`] because it is an answer, not an absence of
+    /// one: the caller should reject the reorg rather than retry the lookup.
+    TooDeep,
+    /// The backend could not answer.
+    Failed,
+}
+
 /// Lock-free cache of the latest [`SyncProgress`], published by the poller and
 /// read by `get_info` WITHOUT taking the `BitcoinInterface` mutex.
 ///
@@ -244,7 +257,14 @@ pub trait BitcoinInterface: Send {
     ) -> (Vec<SpentCoin>, Vec<bitcoin::OutPoint>);
 
     /// Get the common ancestor between the Bitcoin backend's tip and the given tip.
-    fn common_ancestor(&self, tip: &BlockChainTip) -> Option<BlockChainTip>;
+    /// Walk back from `tip` until it rejoins our chain, giving up after `max_depth`
+    /// steps.
+    ///
+    /// The bound matters: this costs one backend round-trip per block, so an
+    /// unbounded walk lets a misreporting backend extract tens of thousands of
+    /// sequential requests from us before the caller gets a chance to reject the
+    /// result. `TooDeep` lets the caller refuse without paying for the rest.
+    fn common_ancestor(&self, tip: &BlockChainTip, max_depth: i32) -> AncestorSearch;
 
     /// Broadcast this transaction to the Bitcoin P2P network
     fn broadcast_tx(&self, tx: &bitcoin::Transaction) -> Result<(), String>;
@@ -498,19 +518,32 @@ impl BitcoinInterface for d::BitcoinD {
         (spent, expired)
     }
 
-    fn common_ancestor(&self, tip: &BlockChainTip) -> Option<BlockChainTip> {
-        let mut stats = self.get_block_stats(tip.hash)?;
+    fn common_ancestor(&self, tip: &BlockChainTip, max_depth: i32) -> AncestorSearch {
+        let Some(mut stats) = self.get_block_stats(tip.hash) else {
+            return AncestorSearch::Failed;
+        };
         let mut ancestor = *tip;
 
+        let mut steps = 0;
         while stats.confirmations == -1 {
-            stats = self.get_block_stats(stats.previous_blockhash?)?;
+            if steps >= max_depth {
+                return AncestorSearch::TooDeep;
+            }
+            steps += 1;
+            let Some(previous) = stats.previous_blockhash else {
+                return AncestorSearch::Failed;
+            };
+            let Some(next) = self.get_block_stats(previous) else {
+                return AncestorSearch::Failed;
+            };
+            stats = next;
             ancestor = BlockChainTip {
                 hash: stats.blockhash,
                 height: stats.height,
             };
         }
 
-        Some(ancestor)
+        AncestorSearch::Found(ancestor)
     }
 
     fn broadcast_tx(&self, tx: &bitcoin::Transaction) -> Result<(), String> {
@@ -727,7 +760,7 @@ impl BitcoinInterface for electrum::Electrum {
 
     /// FIXME: make the Bitcoin backend interface higher level. See the comment in the poller next
     /// to the `sync_wallet()` call.
-    fn common_ancestor(&self, _tip: &BlockChainTip) -> Option<BlockChainTip> {
+    fn common_ancestor(&self, _tip: &BlockChainTip, _max_depth: i32) -> AncestorSearch {
         unreachable!("The common ancestor is returned in `sync_wallet()`. If no reorg was detected then, this method will never be called on an Electrum backend.")
     }
 
@@ -852,7 +885,7 @@ impl BitcoinInterface for esplora::Esplora {
 
     /// FIXME: make the Bitcoin backend interface higher level. See the comment in the poller next
     /// to the `sync_wallet()` call.
-    fn common_ancestor(&self, _tip: &BlockChainTip) -> Option<BlockChainTip> {
+    fn common_ancestor(&self, _tip: &BlockChainTip, _max_depth: i32) -> AncestorSearch {
         unreachable!("The common ancestor is returned in `sync_wallet()`. If no reorg was detected then, this method will never be called on an Esplora backend.")
     }
 
@@ -969,8 +1002,8 @@ impl BitcoinInterface for sync::Arc<sync::Mutex<dyn BitcoinInterface + 'static>>
         self.lock().unwrap().spent_coins(outpoints)
     }
 
-    fn common_ancestor(&self, tip: &BlockChainTip) -> Option<BlockChainTip> {
-        self.lock().unwrap().common_ancestor(tip)
+    fn common_ancestor(&self, tip: &BlockChainTip, max_depth: i32) -> AncestorSearch {
+        self.lock().unwrap().common_ancestor(tip, max_depth)
     }
 
     fn broadcast_tx(&self, tx: &bitcoin::Transaction) -> Result<(), String> {

--- a/coincubed/src/bitcoin/poller/looper.rs
+++ b/coincubed/src/bitcoin/poller/looper.rs
@@ -703,11 +703,21 @@ mod tests {
         assert!(!DummyBitcoind::new().is_bitcoind());
 
         {
-            let _guard = MaintenanceGuard::new();
+            let guard = MaintenanceGuard::try_acquire().expect("uncontended acquire");
             assert!(managed_node_maintenance());
+            // Mutual exclusion: several Vaults attach to the one shared node, and only
+            // one may rewind it. A check-then-set would let two through here.
+            assert!(
+                MaintenanceGuard::try_acquire().is_none(),
+                "a second holder must not be able to claim maintenance"
+            );
+            drop(guard);
         }
         // The guard must clear on drop — a flag left set silently stops every Vault
         // from ever updating again.
+        assert!(!managed_node_maintenance());
+        // And release must make it claimable again.
+        assert!(MaintenanceGuard::try_acquire().is_some());
         assert!(!managed_node_maintenance());
 
         set_managed_node_maintenance(true);

--- a/coincubed/src/bitcoin/poller/looper.rs
+++ b/coincubed/src/bitcoin/poller/looper.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bitcoin::{BitcoinInterface, BlockChainTip, UTxO, UTxOAddress},
+    bitcoin::{BitcoinInterface, BlockChainTip, ReorgAlertCache, UTxO, UTxOAddress},
     database::{Coin, DatabaseConnection, DatabaseInterface},
 };
 
@@ -7,6 +7,35 @@ use std::{collections::HashSet, convert::TryInto, sync, thread, time};
 
 use coincube_core::descriptors;
 use miniscript::bitcoin::{self, secp256k1};
+
+/// Deepest block chain reorganisation we will apply to our state.
+///
+/// Beyond this the far likelier explanation is a misreporting backend — a node
+/// rewound with `invalidateblock`, a datadir swapped underneath us, a chainstate
+/// mid-rebuild — than that Bitcoin genuinely undid this much history. Acting on it
+/// is destructive and not fully reversible: `rollback_tip` clears the confirmation
+/// state of every coin above the ancestor (which alone disables coin selection and
+/// the recovery sweep, both of which require `block_info`), and the following
+/// `update_coins` pass hard-deletes any deposit that is neither confirmed on the
+/// new chain nor still in the local mempool. So we decline and keep our state,
+/// rather than corrupting it on a backend we have reason to distrust.
+///
+/// 500 blocks is ~3.5 days of chain. The deepest reorg ever observed on mainnet is
+/// 53 blocks (March 2013, the v0.7/v0.8 split), so this is a generous margin.
+pub const MAX_REORG_DEPTH: i32 = 500;
+
+/// How many times to retry a failed common-ancestor lookup within a single poll
+/// before giving up and leaving our state untouched until the next one.
+const ANCESTOR_LOOKUP_ATTEMPTS: u32 = 3;
+
+fn ancestor_lookup_retry_interval() -> time::Duration {
+    #[cfg(not(test))]
+    {
+        time::Duration::from_secs(2)
+    }
+    #[cfg(test)]
+    time::Duration::ZERO
+}
 
 #[derive(Debug, Clone)]
 struct UpdatedCoins {
@@ -199,43 +228,71 @@ enum TipUpdate {
     Progress(BlockChainTip),
     // There is a new best block that extends a chain which does not contain our former tip.
     Reorged(BlockChainTip),
+    // The backend reports a reorg deeper than `MAX_REORG_DEPTH`. We decline to apply it and
+    // leave our state alone; see that constant for why.
+    ImplausibleReorg { depth: i32 },
+    // We could not establish how the backend's chain relates to ours. Skip this poll rather
+    // than update state from a backend we could not read.
+    Unavailable,
 }
 
 // Returns the new block chain tip, if it changed.
 fn new_tip(bit: &impl BitcoinInterface, current_tip: &BlockChainTip) -> TipUpdate {
-    let bitcoin_tip = bit.chain_tip();
+    // A failed common-ancestor lookup used to re-enter this function immediately and without
+    // bound. On a backend that keeps failing that is an unthrottled RPC spin loop which also
+    // grows the stack on every turn, since the call is not guaranteed to be optimised into a
+    // jump. Retry a few times with a pause, then give up until the next poll.
+    for attempt in 1..=ANCESTOR_LOOKUP_ATTEMPTS {
+        let bitcoin_tip = bit.chain_tip();
 
-    // If the tip didn't change, there is nothing to update.
-    if current_tip == &bitcoin_tip {
-        return TipUpdate::Same;
-    }
+        // If the tip didn't change, there is nothing to update.
+        if current_tip == &bitcoin_tip {
+            return TipUpdate::Same;
+        }
 
-    if bitcoin_tip.height > current_tip.height {
-        // Make sure we are on the same chain.
-        if bit.is_in_chain(current_tip) {
-            // All good, we just moved forward.
-            return TipUpdate::Progress(bitcoin_tip);
+        if bitcoin_tip.height > current_tip.height {
+            // Make sure we are on the same chain.
+            if bit.is_in_chain(current_tip) {
+                // All good, we just moved forward.
+                return TipUpdate::Progress(bitcoin_tip);
+            }
+        }
+
+        // Either the new height is lower or the same but the block hash differs. There was a
+        // block chain re-organisation. Find the common ancestor between our current chain and
+        // the new chain and return that. The caller will take care of rewinding our state.
+        log::info!("Block chain reorganization detected. Looking for common ancestor.");
+        if let Some(common_ancestor) = bit.common_ancestor(current_tip) {
+            let depth = current_tip.height.saturating_sub(common_ancestor.height);
+            if depth > MAX_REORG_DEPTH {
+                return TipUpdate::ImplausibleReorg { depth };
+            }
+            log::info!(
+                "Common ancestor found: '{}'. Starting rescan from there. Old tip was '{}'.",
+                common_ancestor,
+                current_tip
+            );
+            return TipUpdate::Reorged(common_ancestor);
+        }
+
+        log::error!(
+            "Failed to get common ancestor for tip '{}' (attempt {}/{}).",
+            current_tip,
+            attempt,
+            ANCESTOR_LOOKUP_ATTEMPTS
+        );
+        if attempt < ANCESTOR_LOOKUP_ATTEMPTS {
+            thread::sleep(ancestor_lookup_retry_interval());
         }
     }
 
-    // Either the new height is lower or the same but the block hash differs. There was a
-    // block chain re-organisation. Find the common ancestor between our current chain and
-    // the new chain and return that. The caller will take care of rewinding our state.
-    log::info!("Block chain reorganization detected. Looking for common ancestor.");
-    if let Some(common_ancestor) = bit.common_ancestor(current_tip) {
-        log::info!(
-            "Common ancestor found: '{}'. Starting rescan from there. Old tip was '{}'.",
-            common_ancestor,
-            current_tip
-        );
-        TipUpdate::Reorged(common_ancestor)
-    } else {
-        log::error!(
-            "Failed to get common ancestor for tip '{}'. Starting over.",
-            current_tip
-        );
-        new_tip(bit, current_tip)
-    }
+    log::error!(
+        "Giving up on the common ancestor lookup for tip '{}' after {} attempts. Leaving our \
+         state untouched; will retry on the next poll.",
+        current_tip,
+        ANCESTOR_LOOKUP_ATTEMPTS
+    );
+    TipUpdate::Unavailable
 }
 
 fn updates(
@@ -243,6 +300,7 @@ fn updates(
     bit: &mut impl BitcoinInterface,
     descs: &[descriptors::SinglePathCoincubeDesc],
     secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
+    reorg_alert: &ReorgAlertCache,
 ) {
     // Check if there was a new block before we update our state.
     //
@@ -264,8 +322,22 @@ fn updates(
                     // between our former chain and the new one, then restart fresh.
                     db_conn.rollback_tip(&new_tip);
                     log::info!("Tip was rolled back to '{}'.", new_tip);
-                    return updates(db_conn, bit, descs, secp);
+                    return updates(db_conn, bit, descs, secp, reorg_alert);
                 }
+                TipUpdate::ImplausibleReorg { depth } => {
+                    log::error!(
+                        "Backend reports a {}-block reorganization from our tip '{}', deeper than \
+                         the {}-block limit. Refusing to roll back our state: this is far more \
+                         likely a misreporting backend than real chain history being undone. \
+                         Wallet state is left untouched and no coins are removed.",
+                        depth,
+                        current_tip,
+                        MAX_REORG_DEPTH
+                    );
+                    reorg_alert.store(depth);
+                    return;
+                }
+                TipUpdate::Unavailable => return,
             }
         }
         Ok(Some(reorg_common_ancestor)) => {
@@ -277,6 +349,25 @@ fn updates(
                 // check hash in case height is the same
                 && reorg_common_ancestor.hash != current_tip.hash
             {
+                // Same depth guard as the `new_tip` path above: backends that hand us the
+                // common ancestor directly (Electrum) can misreport just as badly as those we
+                // walk back ourselves, and the rollback is equally destructive either way.
+                let depth = current_tip
+                    .height
+                    .saturating_sub(reorg_common_ancestor.height);
+                if depth > MAX_REORG_DEPTH {
+                    log::error!(
+                        "Backend reports a {}-block reorganization from our tip '{}', deeper than \
+                         the {}-block limit. Refusing to roll back our state: this is far more \
+                         likely a misreporting backend than real chain history being undone. \
+                         Wallet state is left untouched and no coins are removed.",
+                        depth,
+                        current_tip,
+                        MAX_REORG_DEPTH
+                    );
+                    reorg_alert.store(depth);
+                    return;
+                }
                 db_conn.rollback_tip(&reorg_common_ancestor);
                 log::info!("Tip was rolled back to '{}'.", &reorg_common_ancestor);
             } else {
@@ -285,7 +376,7 @@ fn updates(
                     &reorg_common_ancestor
                 );
             }
-            return updates(db_conn, bit, descs, secp);
+            return updates(db_conn, bit, descs, secp, reorg_alert);
         }
         Err(e) => {
             // The Esplora "every provider cooling" case isn't a real
@@ -318,9 +409,13 @@ fn updates(
                 log::error!("Error syncing wallet: '{}'.", e);
                 thread::sleep(time::Duration::from_secs(2));
             }
-            return updates(db_conn, bit, descs, secp);
+            return updates(db_conn, bit, descs, secp, reorg_alert);
         }
     };
+
+    // We got a coherent answer out of the backend, so any outstanding "implausible reorg"
+    // alert no longer reflects reality. Clear it before touching coins.
+    reorg_alert.clear();
 
     // Then check the state of our coins. Do it even if the tip did not change since last poll, as
     // we may have unconfirmed transactions.
@@ -329,7 +424,7 @@ fn updates(
     // If the tip changed while we were polling our Bitcoin interface, start over.
     if bit.chain_tip() != latest_tip {
         log::info!("Chain tip changed while we were updating our state. Starting over.");
-        return updates(db_conn, bit, descs, secp);
+        return updates(db_conn, bit, descs, secp, reorg_alert);
     }
 
     // Transactions must be added to the DB before coins due to foreign key constraints.
@@ -360,6 +455,7 @@ fn rescan_check(
     bit: &mut impl BitcoinInterface,
     descs: &[descriptors::SinglePathCoincubeDesc],
     secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
+    reorg_alert: &ReorgAlertCache,
 ) {
     log::debug!("Checking the state of an ongoing rescan if there is any");
 
@@ -396,7 +492,7 @@ fn rescan_check(
             "Rolling back our internal tip to '{}' to update our internal state with past transactions.",
             rescan_tip
         );
-        updates(db_conn, bit, descs, secp)
+        updates(db_conn, bit, descs, secp, reorg_alert)
     } else {
         log::debug!("No ongoing rescan.");
     }
@@ -428,10 +524,11 @@ pub fn poll(
     db: &sync::Arc<sync::Mutex<dyn DatabaseInterface>>,
     secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
     descs: &[descriptors::SinglePathCoincubeDesc],
+    reorg_alert: &ReorgAlertCache,
 ) {
     let mut db_conn = db.connection();
-    updates(&mut db_conn, bit, descs, secp);
-    rescan_check(&mut db_conn, bit, descs, secp);
+    updates(&mut db_conn, bit, descs, secp, reorg_alert);
+    rescan_check(&mut db_conn, bit, descs, secp, reorg_alert);
     let now: u32 = time::SystemTime::now()
         .duration_since(time::UNIX_EPOCH)
         .expect("current system time must be later than epoch")
@@ -439,4 +536,201 @@ pub fn poll(
         .try_into()
         .expect("system clock year is earlier than 2106");
     db_conn.set_last_poll(now);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        database::{Coin, DatabaseInterface},
+        testutils::{DummyBitcoind, DummyDatabase},
+    };
+    use std::str::FromStr;
+
+    use miniscript::{
+        bitcoin::{bip32, hashes::Hash},
+        descriptor,
+    };
+
+    fn tip(height: i32, seed: u8) -> BlockChainTip {
+        BlockChainTip {
+            hash: bitcoin::BlockHash::from_byte_array([seed; 32]),
+            height,
+        }
+    }
+
+    /// A backend whose chain forks `depth` blocks below our tip.
+    fn forked_backend(our_tip: &BlockChainTip, depth: i32) -> DummyBitcoind {
+        let mut bit = DummyBitcoind::new();
+        // A different block at the same height: a reorg, not forward progress.
+        bit.tip = tip(our_tip.height, 0xbb);
+        bit.in_chain = false;
+        bit.ancestor = Some(tip(our_tip.height - depth, 0xcc));
+        bit
+    }
+
+    #[test]
+    fn shallow_reorg_is_applied() {
+        let our_tip = tip(20_000, 0xaa);
+        let bit = forked_backend(&our_tip, MAX_REORG_DEPTH);
+        match new_tip(&bit, &our_tip) {
+            TipUpdate::Reorged(ancestor) => {
+                assert_eq!(ancestor.height, 20_000 - MAX_REORG_DEPTH);
+            }
+            other => panic!("expected a reorg at the depth limit, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn deep_reorg_is_refused() {
+        let our_tip = tip(20_000, 0xaa);
+        // One block past the limit is already refused.
+        let bit = forked_backend(&our_tip, MAX_REORG_DEPTH + 1);
+        match new_tip(&bit, &our_tip) {
+            TipUpdate::ImplausibleReorg { depth } => assert_eq!(depth, MAX_REORG_DEPTH + 1),
+            other => panic!("expected the reorg to be refused, got {:?}", other),
+        }
+
+        // And so is the 10k-block rewind an `invalidateblock` at the RDTS anchor would produce.
+        let bit = forked_backend(&our_tip, 10_000);
+        match new_tip(&bit, &our_tip) {
+            TipUpdate::ImplausibleReorg { depth } => assert_eq!(depth, 10_000),
+            other => panic!("expected the deep reorg to be refused, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn failed_ancestor_lookup_gives_up_instead_of_spinning() {
+        let our_tip = tip(20_000, 0xaa);
+        let mut bit = forked_backend(&our_tip, 10);
+        // The lookup never succeeds. Before the retry bound this re-entered `new_tip`
+        // forever, hammering the backend and growing the stack.
+        bit.ancestor = None;
+        assert!(matches!(new_tip(&bit, &our_tip), TipUpdate::Unavailable));
+    }
+
+    #[test]
+    fn unchanged_tip_is_still_reported_as_same() {
+        let our_tip = tip(100, 0xaa);
+        let mut bit = DummyBitcoind::new();
+        bit.tip = our_tip;
+        assert!(matches!(new_tip(&bit, &our_tip), TipUpdate::Same));
+    }
+
+    // The maintenance flag exists so a deliberate rewind doesn't make every Vault
+    // flap into a warning state. It must scope to bitcoind-backed Vaults only: an
+    // Esplora or Electrum Vault has its own view of the chain and is unaffected by
+    // whatever we do to the managed node, so pausing it would be a plain bug.
+    #[test]
+    fn maintenance_pauses_only_bitcoind_backends() {
+        use crate::bitcoin::{
+            managed_node_maintenance, set_managed_node_maintenance, BitcoinInterface,
+            MaintenanceGuard,
+        };
+
+        assert!(!managed_node_maintenance());
+        // `DummyBitcoind` stands in for a non-bitcoind backend: it takes the trait's
+        // default `is_bitcoind() == false`.
+        assert!(!DummyBitcoind::new().is_bitcoind());
+
+        {
+            let _guard = MaintenanceGuard::new();
+            assert!(managed_node_maintenance());
+        }
+        // The guard must clear on drop — a flag left set silently stops every Vault
+        // from ever updating again.
+        assert!(!managed_node_maintenance());
+
+        set_managed_node_maintenance(true);
+        set_managed_node_maintenance(false);
+        assert!(!managed_node_maintenance());
+    }
+
+    fn test_descs() -> [descriptors::SinglePathCoincubeDesc; 2] {
+        let owner_key = descriptors::PathInfo::Single(descriptor::DescriptorPublicKey::from_str("[aabbccdd]xpub68JJTXc1MWK8KLW4HGLXZBJknja7kDUJuFHnM424LbziEXsfkh1WQCiEjjHw4zLqSUm4rvhgyGkkuRowE9tCJSgt3TQB5J3SKAbZ2SdcKST/<0;1>/*").unwrap());
+        let heir_key = descriptors::PathInfo::Single(descriptor::DescriptorPublicKey::from_str("[aabbccdd]xpub68JJTXc1MWK8PEQozKsRatrUHXKFNkD1Cb1BuQU9Xr5moCv87anqGyXLyUd4KpnDyZgo3gz4aN1r3NiaoweFW8UutBsBbgKHzaD5HkTkifK/<0;1>/*").unwrap());
+        let policy = descriptors::CoincubePolicy::new_legacy(
+            owner_key,
+            [(10u16, heir_key)].iter().cloned().collect(),
+        )
+        .unwrap();
+        let desc = descriptors::CoincubeDescriptor::new(policy);
+        [
+            desc.receive_descriptor().clone(),
+            desc.change_descriptor().clone(),
+        ]
+    }
+
+    /// The acceptance test for this guard: a 10k-block rewind — what an `invalidateblock`
+    /// at the RDTS anchor looks like to the poller — must not roll our tip back and must
+    /// not delete a single coin row.
+    #[test]
+    fn deep_reorg_leaves_coins_and_tip_untouched() {
+        let our_tip = tip(20_000, 0xaa);
+
+        let mut db = DummyDatabase::new();
+        db.connection().update_tip(&our_tip);
+        let outpoint = bitcoin::OutPoint::from_str(
+            "3d8ea3e05e4c1e2f4b2e9dbd4a2b4e0dd7f6b0f7c9e8d5a4b3c2d1e0f9a8b7c6:0",
+        )
+        .unwrap();
+        db.insert_coins(vec![Coin {
+            outpoint,
+            is_immature: false,
+            amount: bitcoin::Amount::from_sat(100_000),
+            derivation_index: bip32::ChildNumber::from_normal_idx(0).unwrap(),
+            is_change: false,
+            block_info: None,
+            spend_txid: None,
+            spend_block: None,
+            is_from_self: false,
+        }]);
+
+        let mut bit = forked_backend(&our_tip, 10_000);
+        let descs = test_descs();
+        let secp = secp256k1::Secp256k1::verification_only();
+        let alert = ReorgAlertCache::default();
+        let mut db_conn = db.connection();
+
+        updates(&mut db_conn, &mut bit, &descs, &secp, &alert);
+
+        assert!(
+            db.rollbacks().is_empty(),
+            "a {}-block reorg must not roll our tip back",
+            10_000
+        );
+        assert_eq!(
+            db.coin_outpoints(),
+            vec![outpoint],
+            "no coin may be removed on a refused reorg"
+        );
+        assert_eq!(db_conn.chain_tip(), Some(our_tip), "our tip must not move");
+        assert_eq!(
+            alert.load(),
+            Some(10_000),
+            "the refusal must be published for get_info"
+        );
+    }
+
+    #[test]
+    fn shallow_reorg_still_rolls_back() {
+        // The guard must not block ordinary reorgs.
+        let our_tip = tip(20_000, 0xaa);
+        let db = DummyDatabase::new();
+        db.connection().update_tip(&our_tip);
+
+        let mut bit = forked_backend(&our_tip, 3);
+        // Once we've rolled back, stop reporting a fork so `updates` can finish.
+        let descs = test_descs();
+        let secp = secp256k1::Secp256k1::verification_only();
+        let alert = ReorgAlertCache::default();
+        let mut db_conn = db.connection();
+
+        // After the rollback the recursive call sees a tip equal to the rolled-back one.
+        bit.tip = tip(20_000 - 3, 0xcc);
+        updates(&mut db_conn, &mut bit, &descs, &secp, &alert);
+
+        assert_eq!(db.rollbacks(), vec![tip(20_000 - 3, 0xcc)]);
+        assert_eq!(alert.load(), None, "an applied reorg raises no alert");
+    }
 }

--- a/coincubed/src/bitcoin/poller/looper.rs
+++ b/coincubed/src/bitcoin/poller/looper.rs
@@ -666,6 +666,17 @@ mod tests {
             shallow.common_ancestor(&our_tip, MAX_REORG_DEPTH + 1),
             AncestorSearch::Found(tip(19_990, 0xcc))
         );
+
+        // A walk starts at the tip and only moves down, so no real backend can hand
+        // back an ancestor *above* it. The double refuses to model one: left to fall
+        // through, the depth would compute as zero, read as a shallow reorg, and roll
+        // our tip forward — a scenario production can never actually be shown.
+        let mut inverted = forked_backend(&our_tip, 10);
+        inverted.ancestor = Some(tip(our_tip.height + 1, 0xdd));
+        assert_eq!(
+            inverted.common_ancestor(&our_tip, MAX_REORG_DEPTH + 1),
+            AncestorSearch::Failed
+        );
     }
 
     #[test]

--- a/coincubed/src/bitcoin/poller/looper.rs
+++ b/coincubed/src/bitcoin/poller/looper.rs
@@ -269,21 +269,22 @@ fn new_tip(bit: &impl BitcoinInterface, current_tip: &BlockChainTip) -> TipUpdat
         // block chain re-organisation. Find the common ancestor between our current chain and
         // the new chain and return that. The caller will take care of rewinding our state.
         log::info!("Block chain reorganization detected. Looking for common ancestor.");
-        // A repair we performed on the managed node publishes the exact block it rewound
-        // to. That rollback is ours, not a backend misreporting, so it is both walked for
-        // and applied past the limit — otherwise the repaired node and our state stay
-        // permanently divorced. See `crate::bitcoin::sanctioned_rollback`.
+        // A repair we performed on the managed node publishes the block it rewound to.
+        // Rollbacks reaching no deeper than that one are ours, not a backend
+        // misreporting, so they are both walked for and applied past the limit —
+        // otherwise the repaired node and our state stay permanently divorced. See
+        // `crate::bitcoin::sanctioned_rollback`.
         let sanctioned =
-            crate::bitcoin::sanctioned_rollback().filter(|point| point.height < current_tip.height);
+            crate::bitcoin::sanctioned_rollback().filter(|floor| floor.height < current_tip.height);
         // Bounded at one past the limit: any fork we would accept is found inside it, and
         // anything deeper is refused without walking the rest of the way. Unbounded, a
         // backend claiming a 10k-block reorg would cost us 10k sequential round-trips before
         // we rejected the answer. A sanctioned rollback raises the bound just far enough to
-        // reach the one block it names.
+        // reach its floor, and no further.
         let max_depth = match sanctioned {
-            Some(point) => current_tip
+            Some(floor) => current_tip
                 .height
-                .saturating_sub(point.height)
+                .saturating_sub(floor.height)
                 .max(MAX_REORG_DEPTH),
             None => MAX_REORG_DEPTH,
         };
@@ -291,12 +292,22 @@ fn new_tip(bit: &impl BitcoinInterface, current_tip: &BlockChainTip) -> TipUpdat
             AncestorSearch::Found(common_ancestor) => {
                 let depth = current_tip.height.saturating_sub(common_ancestor.height);
                 if depth > MAX_REORG_DEPTH {
-                    if sanctioned != Some(common_ancestor) {
+                    // Two conditions, and the second is what keeps this from being a
+                    // blanket depth increase: the fork must be at or above the floor we
+                    // rewound to, *and* the backend's chain must actually contain that
+                    // floor block. A sanction left over from another chain, another
+                    // datadir, or a node that never underwent the repair authorises
+                    // nothing.
+                    let authorised = sanctioned.is_some_and(|floor| {
+                        common_ancestor.height >= floor.height && bit.is_in_chain(&floor)
+                    });
+                    if !authorised {
                         return TipUpdate::ImplausibleReorg { min_depth: depth };
                     }
                     log::warn!(
                         "Applying a {}-block rollback to '{}', past the {}-block limit: it lands \
-                         exactly on '{}', the block a managed-node repair rewound to.",
+                         on '{}', at or above the block a managed-node repair rewound this chain \
+                         to.",
                         depth,
                         current_tip,
                         MAX_REORG_DEPTH,
@@ -677,20 +688,33 @@ mod tests {
         }
     }
 
+    /// A backend that forks `depth` below our tip and whose chain still contains
+    /// `floor` — the shape a repaired managed node has: rewound to the floor, then
+    /// reconnected back up to wherever it stopped accepting blocks.
+    fn repaired_backend(
+        our_tip: &BlockChainTip,
+        depth: i32,
+        floor: BlockChainTip,
+    ) -> DummyBitcoind {
+        let mut bit = forked_backend(our_tip, depth);
+        bit.also_in_chain = vec![floor];
+        bit
+    }
+
     // A repair we performed ourselves rewinds the managed node far past the depth
     // limit. Refusing it is what left every Vault pinned to a chain the node no
     // longer had: maintenance ends, and every later poll re-refuses the same reorg.
     #[test]
     fn a_sanctioned_rollback_is_applied_past_the_limit() {
         let our_tip = tip(20_000, 0xaa);
-        // Far deeper than the walk's usual bound, so this also covers the case where
-        // the fork point could not even be reached before.
-        let fork = tip(20_000 - 10_000, 0xcc);
-        let bit = forked_backend(&our_tip, 10_000);
+        // Rewound to 10,000 below our tip. Far deeper than the walk's usual bound, so
+        // this also covers the case where the fork point could not even be reached.
+        let floor = tip(10_000, 0xcc);
+        let bit = repaired_backend(&our_tip, 10_000, floor);
 
-        let _armed = Sanction::arm(fork);
+        let _armed = Sanction::arm(floor);
         match new_tip(&bit, &our_tip) {
-            TipUpdate::Reorged(ancestor) => assert_eq!(ancestor, fork),
+            TipUpdate::Reorged(ancestor) => assert_eq!(ancestor, floor),
             other => panic!(
                 "expected the sanctioned rollback to be applied, got {:?}",
                 other
@@ -698,30 +722,57 @@ mod tests {
         }
     }
 
-    // The exception authorises one block, not a depth. A backend forking anywhere
-    // else — including deeper than the block we named — is refused exactly as before.
+    // The realistic outcome, and the one an exact-block exception got wrong: the node
+    // replays most of what it rewound and only refuses a block near the top, so the
+    // chains part company thousands of blocks *above* the floor. That fork point is
+    // not knowable when the repair starts, which is why the sanction is a floor.
     #[test]
-    fn a_sanction_does_not_authorise_a_different_fork() {
+    fn a_rollback_above_the_sanctioned_floor_is_applied() {
         let our_tip = tip(20_000, 0xaa);
-        let bit = forked_backend(&our_tip, 10_000);
+        let floor = tip(10_000, 0xcc);
+        // Rewound to 10,000; everything up to 19,000 was re-accepted, 19,001 was not.
+        let bit = repaired_backend(&our_tip, 1_000, floor);
 
-        // Right height, wrong block.
-        let _armed = Sanction::arm(tip(10_000, 0xee));
+        let _armed = Sanction::arm(floor);
+        match new_tip(&bit, &our_tip) {
+            TipUpdate::Reorged(ancestor) => assert_eq!(ancestor.height, 19_000),
+            other => panic!(
+                "expected a fork above the sanctioned floor to be applied, got {:?}",
+                other
+            ),
+        }
+    }
+
+    // The floor is a limit, not a licence. Anything deeper than it, and any backend
+    // whose chain does not contain the floor block at all, is refused as before.
+    #[test]
+    fn a_sanction_authorises_nothing_below_its_floor_or_off_its_chain() {
+        let our_tip = tip(20_000, 0xaa);
+        let floor = tip(10_000, 0xcc);
+
+        // A fork 1,000 blocks below the floor: outside what the repair could produce.
+        let bit = repaired_backend(&our_tip, 11_000, floor);
+        let _armed = Sanction::arm(floor);
         match new_tip(&bit, &our_tip) {
             TipUpdate::ImplausibleReorg { .. } => {}
             other => panic!(
-                "expected a fork at another block to be refused, got {:?}",
+                "expected a fork below the floor to be refused, got {:?}",
                 other
             ),
         }
         drop(_armed);
 
-        // Sanctioned at a depth the backend's fork sits below: the walk stops at the
-        // sanctioned height without finding it, so nothing is concluded from it.
-        let _armed = Sanction::arm(tip(15_000, 0xcc));
+        // Right depth, but this backend's chain never contained the block we rewound
+        // to — a sanction left over from another chain or another datadir.
+        let mut bit = forked_backend(&our_tip, 10_000);
+        bit.also_in_chain = vec![tip(10_000, 0xee)];
+        let _armed = Sanction::arm(floor);
         match new_tip(&bit, &our_tip) {
-            TipUpdate::ImplausibleReorg { min_depth } => assert_eq!(min_depth, 5_001),
-            other => panic!("expected a deeper fork to stay refused, got {:?}", other),
+            TipUpdate::ImplausibleReorg { .. } => {}
+            other => panic!(
+                "expected a sanction from another chain to authorise nothing, got {:?}",
+                other
+            ),
         }
     }
 

--- a/coincubed/src/bitcoin/poller/looper.rs
+++ b/coincubed/src/bitcoin/poller/looper.rs
@@ -1,5 +1,7 @@
 use crate::{
-    bitcoin::{BitcoinInterface, BlockChainTip, ReorgAlertCache, UTxO, UTxOAddress},
+    bitcoin::{
+        AncestorSearch, BitcoinInterface, BlockChainTip, ReorgAlertCache, UTxO, UTxOAddress,
+    },
     database::{Coin, DatabaseConnection, DatabaseInterface},
 };
 
@@ -21,7 +23,10 @@ use miniscript::bitcoin::{self, secp256k1};
 /// rather than corrupting it on a backend we have reason to distrust.
 ///
 /// 500 blocks is ~3.5 days of chain. The deepest reorg ever observed on mainnet is
-/// 53 blocks (March 2013, the v0.7/v0.8 split), so this is a generous margin.
+/// 53 blocks (August 2010, the value overflow incident: the corrected chain
+/// overtook the bad one at height 74691, 53 above the offending block 74638). The
+/// deepest since is 24 blocks (March 2013, the v0.7/v0.8 split). So this is a
+/// generous margin over both.
 pub const MAX_REORG_DEPTH: i32 = 500;
 
 /// How many times to retry a failed common-ancestor lookup within a single poll
@@ -229,8 +234,10 @@ enum TipUpdate {
     // There is a new best block that extends a chain which does not contain our former tip.
     Reorged(BlockChainTip),
     // The backend reports a reorg deeper than `MAX_REORG_DEPTH`. We decline to apply it and
-    // leave our state alone; see that constant for why.
-    ImplausibleReorg { depth: i32 },
+    // leave our state alone; see that constant for why. `min_depth` is a lower bound: once
+    // the ancestor walk hits its limit we stop paying for round-trips, so past that point we
+    // know only that the fork is at least this deep.
+    ImplausibleReorg { min_depth: i32 },
     // We could not establish how the backend's chain relates to ours. Skip this poll rather
     // than update state from a backend we could not read.
     Unavailable,
@@ -262,17 +269,31 @@ fn new_tip(bit: &impl BitcoinInterface, current_tip: &BlockChainTip) -> TipUpdat
         // block chain re-organisation. Find the common ancestor between our current chain and
         // the new chain and return that. The caller will take care of rewinding our state.
         log::info!("Block chain reorganization detected. Looking for common ancestor.");
-        if let Some(common_ancestor) = bit.common_ancestor(current_tip) {
-            let depth = current_tip.height.saturating_sub(common_ancestor.height);
-            if depth > MAX_REORG_DEPTH {
-                return TipUpdate::ImplausibleReorg { depth };
+        // Bounded at one past the limit: any fork we would accept is found inside it, and
+        // anything deeper is refused without walking the rest of the way. Unbounded, a
+        // backend claiming a 10k-block reorg would cost us 10k sequential round-trips before
+        // we rejected the answer.
+        match bit.common_ancestor(current_tip, MAX_REORG_DEPTH + 1) {
+            AncestorSearch::Found(common_ancestor) => {
+                let depth = current_tip.height.saturating_sub(common_ancestor.height);
+                if depth > MAX_REORG_DEPTH {
+                    return TipUpdate::ImplausibleReorg { min_depth: depth };
+                }
+                log::info!(
+                    "Common ancestor found: '{}'. Starting rescan from there. Old tip was '{}'.",
+                    common_ancestor,
+                    current_tip
+                );
+                return TipUpdate::Reorged(common_ancestor);
             }
-            log::info!(
-                "Common ancestor found: '{}'. Starting rescan from there. Old tip was '{}'.",
-                common_ancestor,
-                current_tip
-            );
-            return TipUpdate::Reorged(common_ancestor);
+            // An answer, not a failure: retrying would just spend the same round-trips again
+            // to reach the same conclusion.
+            AncestorSearch::TooDeep => {
+                return TipUpdate::ImplausibleReorg {
+                    min_depth: MAX_REORG_DEPTH + 1,
+                }
+            }
+            AncestorSearch::Failed => {}
         }
 
         log::error!(
@@ -293,6 +314,44 @@ fn new_tip(bit: &impl BitcoinInterface, current_tip: &BlockChainTip) -> TipUpdat
         ANCESTOR_LOOKUP_ATTEMPTS
     );
     TipUpdate::Unavailable
+}
+
+/// Whether a refused reorg's depth was measured or merely bounded.
+#[derive(Debug, Clone, Copy)]
+enum RefusedDepth {
+    /// We reached the fork point, so this is the true depth.
+    Exact(i32),
+    /// The ancestor walk stopped at its limit, so the fork is at least this deep.
+    AtLeast(i32),
+}
+
+/// Decline a reorganization deeper than [`MAX_REORG_DEPTH`]: say so loudly, publish it
+/// for `get_info`, and leave wallet state alone.
+///
+/// Shared by both paths that can encounter one — the ancestor walk in [`new_tip`], and
+/// the ancestor an Electrum-style backend hands us directly from `sync_wallet`. The
+/// refusal has to be identical either way; keeping two copies is how their messages
+/// drifted apart once already.
+fn refuse_deep_reorg(
+    reorg_alert: &ReorgAlertCache,
+    current_tip: &BlockChainTip,
+    depth: RefusedDepth,
+) {
+    let (depth, bound) = match depth {
+        RefusedDepth::Exact(depth) => (depth, ""),
+        RefusedDepth::AtLeast(depth) => (depth, " or more"),
+    };
+    log::error!(
+        "Backend reports a reorganization of {} blocks{} from our tip '{}', deeper than the \
+         {}-block limit. Refusing to roll back our state: this is far more likely a misreporting \
+         backend than real chain history being undone. Wallet state is left untouched and no \
+         coins are removed.",
+        depth,
+        bound,
+        current_tip,
+        MAX_REORG_DEPTH
+    );
+    reorg_alert.store(depth);
 }
 
 fn updates(
@@ -324,17 +383,8 @@ fn updates(
                     log::info!("Tip was rolled back to '{}'.", new_tip);
                     return updates(db_conn, bit, descs, secp, reorg_alert);
                 }
-                TipUpdate::ImplausibleReorg { depth } => {
-                    log::error!(
-                        "Backend reports a {}-block reorganization from our tip '{}', deeper than \
-                         the {}-block limit. Refusing to roll back our state: this is far more \
-                         likely a misreporting backend than real chain history being undone. \
-                         Wallet state is left untouched and no coins are removed.",
-                        depth,
-                        current_tip,
-                        MAX_REORG_DEPTH
-                    );
-                    reorg_alert.store(depth);
+                TipUpdate::ImplausibleReorg { min_depth } => {
+                    refuse_deep_reorg(reorg_alert, &current_tip, RefusedDepth::AtLeast(min_depth));
                     return;
                 }
                 TipUpdate::Unavailable => return,
@@ -356,16 +406,7 @@ fn updates(
                     .height
                     .saturating_sub(reorg_common_ancestor.height);
                 if depth > MAX_REORG_DEPTH {
-                    log::error!(
-                        "Backend reports a {}-block reorganization from our tip '{}', deeper than \
-                         the {}-block limit. Refusing to roll back our state: this is far more \
-                         likely a misreporting backend than real chain history being undone. \
-                         Wallet state is left untouched and no coins are removed.",
-                        depth,
-                        current_tip,
-                        MAX_REORG_DEPTH
-                    );
-                    reorg_alert.store(depth);
+                    refuse_deep_reorg(reorg_alert, &current_tip, RefusedDepth::Exact(depth));
                     return;
                 }
                 db_conn.rollback_tip(&reorg_common_ancestor);
@@ -584,19 +625,47 @@ mod tests {
     #[test]
     fn deep_reorg_is_refused() {
         let our_tip = tip(20_000, 0xaa);
-        // One block past the limit is already refused.
+        // One block past the limit is already refused, and is still inside the
+        // ancestor walk's bound, so the depth is known exactly.
         let bit = forked_backend(&our_tip, MAX_REORG_DEPTH + 1);
         match new_tip(&bit, &our_tip) {
-            TipUpdate::ImplausibleReorg { depth } => assert_eq!(depth, MAX_REORG_DEPTH + 1),
+            TipUpdate::ImplausibleReorg { min_depth } => {
+                assert_eq!(min_depth, MAX_REORG_DEPTH + 1)
+            }
             other => panic!("expected the reorg to be refused, got {:?}", other),
         }
 
-        // And so is the 10k-block rewind an `invalidateblock` at the RDTS anchor would produce.
+        // And so is the 10k-block rewind an `invalidateblock` at the RDTS anchor
+        // would produce. Here the walk stops at its bound rather than paying for
+        // 10k round-trips, so we know only that the fork is at least that deep —
+        // and crucially this must NOT come back as a failed lookup to be retried.
         let bit = forked_backend(&our_tip, 10_000);
         match new_tip(&bit, &our_tip) {
-            TipUpdate::ImplausibleReorg { depth } => assert_eq!(depth, 10_000),
+            TipUpdate::ImplausibleReorg { min_depth } => {
+                assert_eq!(min_depth, MAX_REORG_DEPTH + 1)
+            }
             other => panic!("expected the deep reorg to be refused, got {:?}", other),
         }
+    }
+
+    // The bound is what stops a misreporting backend from extracting one round-trip
+    // per claimed block from us before we reject its answer.
+    #[test]
+    fn the_ancestor_walk_is_bounded() {
+        use crate::bitcoin::AncestorSearch;
+
+        let our_tip = tip(20_000, 0xaa);
+        let bit = forked_backend(&our_tip, 10_000);
+        assert_eq!(
+            bit.common_ancestor(&our_tip, MAX_REORG_DEPTH + 1),
+            AncestorSearch::TooDeep
+        );
+        // Within the bound the ancestor is still found normally.
+        let shallow = forked_backend(&our_tip, 10);
+        assert_eq!(
+            shallow.common_ancestor(&our_tip, MAX_REORG_DEPTH + 1),
+            AncestorSearch::Found(tip(19_990, 0xcc))
+        );
     }
 
     #[test]
@@ -705,9 +774,11 @@ mod tests {
             "no coin may be removed on a refused reorg"
         );
         assert_eq!(db_conn.chain_tip(), Some(our_tip), "our tip must not move");
+        // A lower bound, not the true 10,000: the ancestor walk stops at its limit
+        // rather than paying for a round-trip per block just to report a number.
         assert_eq!(
             alert.load(),
-            Some(10_000),
+            Some(MAX_REORG_DEPTH + 1),
             "the refusal must be published for get_info"
         );
     }

--- a/coincubed/src/bitcoin/poller/looper.rs
+++ b/coincubed/src/bitcoin/poller/looper.rs
@@ -269,15 +269,39 @@ fn new_tip(bit: &impl BitcoinInterface, current_tip: &BlockChainTip) -> TipUpdat
         // block chain re-organisation. Find the common ancestor between our current chain and
         // the new chain and return that. The caller will take care of rewinding our state.
         log::info!("Block chain reorganization detected. Looking for common ancestor.");
+        // A repair we performed on the managed node publishes the exact block it rewound
+        // to. That rollback is ours, not a backend misreporting, so it is both walked for
+        // and applied past the limit — otherwise the repaired node and our state stay
+        // permanently divorced. See `crate::bitcoin::sanctioned_rollback`.
+        let sanctioned =
+            crate::bitcoin::sanctioned_rollback().filter(|point| point.height < current_tip.height);
         // Bounded at one past the limit: any fork we would accept is found inside it, and
         // anything deeper is refused without walking the rest of the way. Unbounded, a
         // backend claiming a 10k-block reorg would cost us 10k sequential round-trips before
-        // we rejected the answer.
-        match bit.common_ancestor(current_tip, MAX_REORG_DEPTH + 1) {
+        // we rejected the answer. A sanctioned rollback raises the bound just far enough to
+        // reach the one block it names.
+        let max_depth = match sanctioned {
+            Some(point) => current_tip
+                .height
+                .saturating_sub(point.height)
+                .max(MAX_REORG_DEPTH),
+            None => MAX_REORG_DEPTH,
+        };
+        match bit.common_ancestor(current_tip, max_depth + 1) {
             AncestorSearch::Found(common_ancestor) => {
                 let depth = current_tip.height.saturating_sub(common_ancestor.height);
                 if depth > MAX_REORG_DEPTH {
-                    return TipUpdate::ImplausibleReorg { min_depth: depth };
+                    if sanctioned != Some(common_ancestor) {
+                        return TipUpdate::ImplausibleReorg { min_depth: depth };
+                    }
+                    log::warn!(
+                        "Applying a {}-block rollback to '{}', past the {}-block limit: it lands \
+                         exactly on '{}', the block a managed-node repair rewound to.",
+                        depth,
+                        current_tip,
+                        MAX_REORG_DEPTH,
+                        common_ancestor
+                    );
                 }
                 log::info!(
                     "Common ancestor found: '{}'. Starting rescan from there. Old tip was '{}'.",
@@ -288,9 +312,11 @@ fn new_tip(bit: &impl BitcoinInterface, current_tip: &BlockChainTip) -> TipUpdat
             }
             // An answer, not a failure: retrying would just spend the same round-trips again
             // to reach the same conclusion.
+            // Deeper than we were willing to walk — including past a sanctioned rollback,
+            // which means the fork is not the one we authorised.
             AncestorSearch::TooDeep => {
                 return TipUpdate::ImplausibleReorg {
-                    min_depth: MAX_REORG_DEPTH + 1,
+                    min_depth: max_depth + 1,
                 }
             }
             AncestorSearch::Failed => {}
@@ -622,8 +648,86 @@ mod tests {
         }
     }
 
+    /// Serialises the tests that read or write the process-wide sanctioned-rollback
+    /// slot. Without it a test that arms the slot can change what a concurrently
+    /// running depth-guard test observes.
+    static SANCTION_LOCK: sync::Mutex<()> = sync::Mutex::new(());
+
+    /// Arms the sanctioned-rollback slot and disarms it again on drop, so a failing
+    /// assertion cannot leak the exception into the rest of the suite.
+    struct Sanction(#[allow(dead_code)] sync::MutexGuard<'static, ()>);
+
+    impl Sanction {
+        fn arm(point: BlockChainTip) -> Self {
+            let guard = SANCTION_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            crate::bitcoin::set_sanctioned_rollback(Some(point));
+            Self(guard)
+        }
+
+        fn none() -> Self {
+            let guard = SANCTION_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            crate::bitcoin::set_sanctioned_rollback(None);
+            Self(guard)
+        }
+    }
+
+    impl Drop for Sanction {
+        fn drop(&mut self) {
+            crate::bitcoin::set_sanctioned_rollback(None);
+        }
+    }
+
+    // A repair we performed ourselves rewinds the managed node far past the depth
+    // limit. Refusing it is what left every Vault pinned to a chain the node no
+    // longer had: maintenance ends, and every later poll re-refuses the same reorg.
+    #[test]
+    fn a_sanctioned_rollback_is_applied_past_the_limit() {
+        let our_tip = tip(20_000, 0xaa);
+        // Far deeper than the walk's usual bound, so this also covers the case where
+        // the fork point could not even be reached before.
+        let fork = tip(20_000 - 10_000, 0xcc);
+        let bit = forked_backend(&our_tip, 10_000);
+
+        let _armed = Sanction::arm(fork);
+        match new_tip(&bit, &our_tip) {
+            TipUpdate::Reorged(ancestor) => assert_eq!(ancestor, fork),
+            other => panic!(
+                "expected the sanctioned rollback to be applied, got {:?}",
+                other
+            ),
+        }
+    }
+
+    // The exception authorises one block, not a depth. A backend forking anywhere
+    // else — including deeper than the block we named — is refused exactly as before.
+    #[test]
+    fn a_sanction_does_not_authorise_a_different_fork() {
+        let our_tip = tip(20_000, 0xaa);
+        let bit = forked_backend(&our_tip, 10_000);
+
+        // Right height, wrong block.
+        let _armed = Sanction::arm(tip(10_000, 0xee));
+        match new_tip(&bit, &our_tip) {
+            TipUpdate::ImplausibleReorg { .. } => {}
+            other => panic!(
+                "expected a fork at another block to be refused, got {:?}",
+                other
+            ),
+        }
+        drop(_armed);
+
+        // Sanctioned at a depth the backend's fork sits below: the walk stops at the
+        // sanctioned height without finding it, so nothing is concluded from it.
+        let _armed = Sanction::arm(tip(15_000, 0xcc));
+        match new_tip(&bit, &our_tip) {
+            TipUpdate::ImplausibleReorg { min_depth } => assert_eq!(min_depth, 5_001),
+            other => panic!("expected a deeper fork to stay refused, got {:?}", other),
+        }
+    }
+
     #[test]
     fn deep_reorg_is_refused() {
+        let _disarmed = Sanction::none();
         let our_tip = tip(20_000, 0xaa);
         // One block past the limit is already refused, and is still inside the
         // ancestor walk's bound, so the depth is known exactly.

--- a/coincubed/src/bitcoin/poller/mod.rs
+++ b/coincubed/src/bitcoin/poller/mod.rs
@@ -37,6 +37,9 @@ pub struct Poller {
     // without contending for the `BitcoinInterface` mutex this poller holds
     // across a full wallet scan.
     sync_cache: sync::Arc<crate::bitcoin::SyncProgressCache>,
+    // Published when a poll declines an implausibly deep reorg, so `get_info` can
+    // report it without taking the `BitcoinInterface` mutex.
+    reorg_alert: sync::Arc<crate::bitcoin::ReorgAlertCache>,
 }
 
 impl Poller {
@@ -45,6 +48,7 @@ impl Poller {
         db: sync::Arc<sync::Mutex<dyn DatabaseInterface>>,
         desc: descriptors::CoincubeDescriptor,
         sync_cache: sync::Arc<crate::bitcoin::SyncProgressCache>,
+        reorg_alert: sync::Arc<crate::bitcoin::ReorgAlertCache>,
     ) -> Poller {
         let secp = secp256k1::Secp256k1::verification_only();
         let descs = [
@@ -68,6 +72,7 @@ impl Poller {
             secp,
             descs,
             sync_cache,
+            reorg_alert,
         }
     }
 
@@ -78,6 +83,13 @@ impl Poller {
     /// repeat that bookkeeping or decide independently when the
     /// next scheduled tick should fire.
     fn run_immediate_poll(&mut self, synced: &mut bool, last_poll: &mut Option<time::Instant>) {
+        // An explicit "poll now" is still refused during a rewind — the caller wants
+        // fresh state, and mid-rewind the node has none to give.
+        if self.paused_for_node_maintenance() {
+            log::debug!("Skipped immediate poll: the managed node is under maintenance.");
+            *last_poll = Some(time::Instant::now());
+            return;
+        }
         // Polling while the block chain is syncing could lead to
         // poller restarts if the height increases before
         // completion, and in any case this is consistent with
@@ -98,7 +110,13 @@ impl Poller {
         // don't attempt another poll too soon.
         *last_poll = Some(time::Instant::now());
         if *synced {
-            looper::poll(&mut self.bit, &self.db, &self.secp, &self.descs);
+            looper::poll(
+                &mut self.bit,
+                &self.db,
+                &self.secp,
+                &self.descs,
+                &self.reorg_alert,
+            );
         } else {
             log::warn!("Skipped poll as block chain is still synchronizing.");
         }
@@ -166,6 +184,13 @@ impl Poller {
             }
             last_poll = Some(time::Instant::now());
 
+            // Stand down while the managed node is being deliberately rewound: the
+            // chain it would show us mid-operation is not one to record.
+            if self.paused_for_node_maintenance() {
+                log::debug!("Skipped poll: the managed node is under maintenance.");
+                continue;
+            }
+
             // Don't poll until the Bitcoin backend is fully synced.
             if !synced {
                 let progress = self.bit.sync_progress();
@@ -182,7 +207,21 @@ impl Poller {
                 }
             }
 
-            looper::poll(&mut self.bit, &self.db, &self.secp, &self.descs);
+            looper::poll(
+                &mut self.bit,
+                &self.db,
+                &self.secp,
+                &self.descs,
+                &self.reorg_alert,
+            );
         }
+    }
+
+    /// Whether to skip this tick because the shared managed node is being rewound.
+    ///
+    /// Only bitcoind-backed Vaults stand down: an Esplora or Electrum Vault has its
+    /// own view of the chain and is unaffected by whatever we do to the managed node.
+    fn paused_for_node_maintenance(&self) -> bool {
+        crate::bitcoin::managed_node_maintenance() && self.bit.is_bitcoind()
     }
 }

--- a/coincubed/src/commands/mod.rs
+++ b/coincubed/src/commands/mod.rs
@@ -395,6 +395,7 @@ impl DaemonControl {
                 main: self.config.main_descriptor.clone(),
             },
             rescan_progress,
+            refused_reorg_depth: self.reorg_alert_cache.load(),
             timestamp: wallet.timestamp,
             last_poll_timestamp: wallet.last_poll_timestamp,
             receive_index,
@@ -1417,6 +1418,12 @@ pub struct GetInfoResult {
     pub descriptors: GetInfoDescriptors,
     /// The progress as a percentage (between 0 and 1) of an ongoing rescan if there is any
     pub rescan_progress: Option<f64>,
+    /// Depth, in blocks, of a block chain reorganization the poller refused to apply because
+    /// it exceeded `MAX_REORG_DEPTH`. `Some` means our view of the chain is deliberately not
+    /// being updated from the backend, because the backend looks untrustworthy — see
+    /// [`crate::bitcoin::ReorgAlertCache`]. Absent from older daemons, hence `serde(default)`.
+    #[serde(default)]
+    pub refused_reorg_depth: Option<i32>,
     /// Timestamp at wallet creation date
     pub timestamp: u32,
     /// Timestamp of last poll, if any.

--- a/coincubed/src/lib.rs
+++ b/coincubed/src/lib.rs
@@ -21,7 +21,8 @@ pub use crate::bitcoin::{
     },
     electrum::{Electrum, ElectrumError},
     esplora::{Esplora, EsploraError},
-    managed_node_maintenance, set_managed_node_maintenance, MaintenanceGuard,
+    managed_node_maintenance, sanctioned_rollback, set_managed_node_maintenance,
+    set_sanctioned_rollback, BlockChainTip, MaintenanceGuard,
 };
 
 use crate::jsonrpc::server;

--- a/coincubed/src/lib.rs
+++ b/coincubed/src/lib.rs
@@ -15,9 +15,10 @@ use datadir::DataDirectory;
 pub use miniscript;
 
 pub use crate::bitcoin::{
-    d::{BitcoinD, BitcoindError, WalletError},
+    d::{BitcoinD, BitcoindError, ChainStatus, ChainTipEntry, DeploymentStatus, WalletError},
     electrum::{Electrum, ElectrumError},
     esplora::{Esplora, EsploraError},
+    managed_node_maintenance, set_managed_node_maintenance, MaintenanceGuard,
 };
 
 use crate::jsonrpc::server;
@@ -401,6 +402,9 @@ pub struct DaemonControl {
     // this instead of locking `bitcoin`, so it never blocks behind the poller's
     // full wallet scan (the "Starting daemon…" stall).
     sync_progress_cache: sync::Arc<crate::bitcoin::SyncProgressCache>,
+    // Lock-free mirror of the poller's "refused an implausibly deep reorg" alert,
+    // read by `get_info` for the same reason as `sync_progress_cache`.
+    reorg_alert_cache: sync::Arc<crate::bitcoin::ReorgAlertCache>,
 }
 
 impl DaemonControl {
@@ -411,6 +415,7 @@ impl DaemonControl {
         db: sync::Arc<sync::Mutex<dyn DatabaseInterface>>,
         secp: secp256k1::Secp256k1<secp256k1::VerifyOnly>,
         sync_progress_cache: sync::Arc<crate::bitcoin::SyncProgressCache>,
+        reorg_alert_cache: sync::Arc<crate::bitcoin::ReorgAlertCache>,
     ) -> DaemonControl {
         DaemonControl {
             config,
@@ -419,6 +424,7 @@ impl DaemonControl {
             db,
             secp,
             sync_progress_cache,
+            reorg_alert_cache,
         }
     }
 
@@ -535,6 +541,7 @@ impl DaemonHandle {
         // `get_info` reads from it — so `get_info` (and the GUI's startup gate
         // that awaits it) never blocks behind the poller's full wallet scan.
         let sync_progress_cache = sync::Arc::new(crate::bitcoin::SyncProgressCache::default());
+        let reorg_alert_cache = sync::Arc::new(crate::bitcoin::ReorgAlertCache::default());
 
         // Start the poller thread. Keep the thread handle to be able to check if it crashed. Store
         // an atomic to be able to stop it.
@@ -543,6 +550,7 @@ impl DaemonHandle {
             db.clone(),
             config.main_descriptor.clone(),
             sync_progress_cache.clone(),
+            reorg_alert_cache.clone(),
         );
         let (poller_sender, poller_receiver) = mpsc::sync_channel(1);
         let poller_handle = thread::Builder::new()
@@ -566,6 +574,7 @@ impl DaemonHandle {
             db,
             secp,
             sync_progress_cache,
+            reorg_alert_cache,
         );
 
         if with_rpc_server {

--- a/coincubed/src/lib.rs
+++ b/coincubed/src/lib.rs
@@ -15,7 +15,10 @@ use datadir::DataDirectory;
 pub use miniscript;
 
 pub use crate::bitcoin::{
-    d::{BitcoinD, BitcoindError, ChainStatus, ChainTipEntry, DeploymentStatus, WalletError},
+    d::{
+        BitcoinD, BitcoindError, ChainStatus, ChainTipEntry, DeploymentStatus, PruneState,
+        WalletError,
+    },
     electrum::{Electrum, ElectrumError},
     esplora::{Esplora, EsploraError},
     managed_node_maintenance, set_managed_node_maintenance, MaintenanceGuard,

--- a/coincubed/src/testutils.rs
+++ b/coincubed/src/testutils.rs
@@ -1,5 +1,7 @@
 use crate::{
-    bitcoin::{BitcoinInterface, Block, BlockChainTip, MempoolEntry, SyncProgress, UTxO},
+    bitcoin::{
+        AncestorSearch, BitcoinInterface, Block, BlockChainTip, MempoolEntry, SyncProgress, UTxO,
+    },
     config::{BitcoinConfig, Config},
     database::{
         BlockInfo, Coin, CoinStatus, DatabaseConnection, DatabaseInterface, LabelItem, Wallet,
@@ -110,8 +112,16 @@ impl BitcoinInterface for DummyBitcoind {
         (Vec::new(), Vec::new())
     }
 
-    fn common_ancestor(&self, _: &BlockChainTip) -> Option<BlockChainTip> {
-        self.ancestor
+    fn common_ancestor(&self, tip: &BlockChainTip, max_depth: i32) -> AncestorSearch {
+        match self.ancestor {
+            // Honour the bound like a real backend would, so callers are exercised
+            // against the truncated case and not just the found one.
+            Some(ancestor) if tip.height.saturating_sub(ancestor.height) > max_depth => {
+                AncestorSearch::TooDeep
+            }
+            Some(ancestor) => AncestorSearch::Found(ancestor),
+            None => AncestorSearch::Failed,
+        }
     }
 
     fn broadcast_tx(&self, _: &bitcoin::Transaction) -> Result<(), String> {

--- a/coincubed/src/testutils.rs
+++ b/coincubed/src/testutils.rs
@@ -114,6 +114,9 @@ impl BitcoinInterface for DummyBitcoind {
 
     fn common_ancestor(&self, tip: &BlockChainTip, max_depth: i32) -> AncestorSearch {
         match self.ancestor {
+            // An ancestor above our tip is a nonsensical fixture; a real backend
+            // could never return one, so reject it before considering the bound.
+            Some(ancestor) if ancestor.height > tip.height => AncestorSearch::Failed,
             // Honour the bound like a real backend would, so callers are exercised
             // against the truncated case and not just the found one.
             Some(ancestor) if tip.height.saturating_sub(ancestor.height) > max_depth => {

--- a/coincubed/src/testutils.rs
+++ b/coincubed/src/testutils.rs
@@ -25,14 +25,25 @@ use miniscript::{
 
 pub struct DummyBitcoind {
     pub txs: HashMap<Txid, (Transaction, Option<Block>)>,
+    /// What `chain_tip` reports. Defaults to the historical fixed value (height 100).
+    pub tip: BlockChainTip,
+    /// What `is_in_chain` reports. Defaults to `true`, i.e. no reorg.
+    pub in_chain: bool,
+    /// What `common_ancestor` reports. `None` models a lookup that keeps failing.
+    pub ancestor: Option<BlockChainTip>,
 }
-
-impl DummyBitcoind {}
 
 impl DummyBitcoind {
     pub fn new() -> Self {
+        let hash = bitcoin::BlockHash::from_str(
+            "000000007bc154e0fa7ea32218a72fe2c1bb9f86cf8c9ebf9a715ed27fdb229a",
+        )
+        .unwrap();
         Self {
             txs: HashMap::new(),
+            tip: BlockChainTip { hash, height: 100 },
+            in_chain: true,
+            ancestor: None,
         }
     }
 }
@@ -55,17 +66,11 @@ impl BitcoinInterface for DummyBitcoind {
     }
 
     fn chain_tip(&self) -> BlockChainTip {
-        let hash = bitcoin::BlockHash::from_str(
-            "000000007bc154e0fa7ea32218a72fe2c1bb9f86cf8c9ebf9a715ed27fdb229a",
-        )
-        .unwrap();
-        let height = 100;
-        BlockChainTip { hash, height }
+        self.tip
     }
 
     fn is_in_chain(&self, _: &BlockChainTip) -> bool {
-        // No reorg
-        true
+        self.in_chain
     }
 
     fn sync_wallet(
@@ -106,7 +111,7 @@ impl BitcoinInterface for DummyBitcoind {
     }
 
     fn common_ancestor(&self, _: &BlockChainTip) -> Option<BlockChainTip> {
-        todo!()
+        self.ancestor
     }
 
     fn broadcast_tx(&self, _: &bitcoin::Transaction) -> Result<(), String> {
@@ -156,6 +161,7 @@ struct DummyDbState {
     timestamp: u32,
     rescan_timestamp: Option<u32>,
     last_poll_timestamp: Option<u32>,
+    rollbacks: Vec<BlockChainTip>,
 }
 
 pub struct DummyDatabase {
@@ -191,8 +197,20 @@ impl DummyDatabase {
                 timestamp: now,
                 rescan_timestamp: None,
                 last_poll_timestamp: None,
+                rollbacks: Vec::new(),
             })),
         }
+    }
+
+    /// Every tip this database was asked to roll back to, in order.
+    pub fn rollbacks(&self) -> Vec<BlockChainTip> {
+        self.db.read().unwrap().rollbacks.clone()
+    }
+
+    /// The outpoints currently stored, for asserting that a poll did or did not
+    /// remove coins.
+    pub fn coin_outpoints(&self) -> Vec<bitcoin::OutPoint> {
+        self.db.read().unwrap().coins.keys().copied().collect()
     }
 
     pub fn insert_coins(&mut self, coins: Vec<Coin>) {
@@ -416,8 +434,10 @@ impl DatabaseConnection for DummyDatabase {
         self.db.write().unwrap().spend_txs.remove(txid);
     }
 
-    fn rollback_tip(&mut self, _: &BlockChainTip) {
-        todo!()
+    fn rollback_tip(&mut self, new_tip: &BlockChainTip) {
+        let mut db = self.db.write().unwrap();
+        db.rollbacks.push(*new_tip);
+        db.curr_tip = Some(*new_tip);
     }
 
     fn rescan_timestamp(&mut self) -> Option<u32> {

--- a/coincubed/src/testutils.rs
+++ b/coincubed/src/testutils.rs
@@ -33,6 +33,9 @@ pub struct DummyBitcoind {
     pub in_chain: bool,
     /// What `common_ancestor` reports. `None` models a lookup that keeps failing.
     pub ancestor: Option<BlockChainTip>,
+    /// Blocks this backend's chain contains regardless of [`Self::in_chain`], so a
+    /// forked backend can still be asked about a block deeper than the fork point.
+    pub also_in_chain: Vec<BlockChainTip>,
 }
 
 impl DummyBitcoind {
@@ -46,6 +49,7 @@ impl DummyBitcoind {
             tip: BlockChainTip { hash, height: 100 },
             in_chain: true,
             ancestor: None,
+            also_in_chain: Vec::new(),
         }
     }
 }
@@ -71,8 +75,8 @@ impl BitcoinInterface for DummyBitcoind {
         self.tip
     }
 
-    fn is_in_chain(&self, _: &BlockChainTip) -> bool {
-        self.in_chain
+    fn is_in_chain(&self, tip: &BlockChainTip) -> bool {
+        self.in_chain || self.also_in_chain.contains(tip)
     }
 
     fn sync_wallet(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes chain selection via `invalidateblock`/`reconsiderblock`, can pause Vault polling for hours, and alters when wallet state accepts rollbacks—mistakes could strand nodes or desync vaults from the backend.
> 
> **Overview**
> Adds **managed-node chain reconciliation** after Bitcoin Core ↔ Knots swaps on shared datadirs, keyed to the mainnet BIP-110 / RDTS anchor. **Knots → Core** clears persisted `BLOCK_FAILED_*` flags via `reconsiderblock`; **Core → Knots** can trigger a background `invalidateblock` replay (prune-bounded, durable `managed_node_state.json` ledger, maintenance guard).
> 
> **Automatic path:** `reconcile_after_start` runs on every internal bitcoind start (including attach-to-already-running), with crash recovery for half-finished rewinds.
> 
> **Manual path:** mainnet managed-bitcoind settings get a **Chain repair** card (`RepairNodeChain`) for the same idempotent `reconsiderblock` when sidecar state is lost.
> 
> **Wallet safety:** the poller now **refuses reorgs deeper than 500 blocks** unless a **sanctioned rollback** floor was published by a repair; `get_info` exposes `refused_reorg_depth`. Bitcoind pollers **pause during maintenance**; `common_ancestor` is depth-bounded with retries instead of unbounded recursion.
> 
> **UX / ops:** flavour-switch confirmation copy is direction-specific; internal `debug.log` tailing falls back to the active managed bitcoind (not only `pending_bitcoind`). **coincubed** gains chain-status/tips/deployment RPC helpers and fire-and-forget `invalidateblock` / `reconsiderblock` on a dedicated node client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40dc51911ed413754d04c43b251d7cb597a5be6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Chain repair** for managed Bitcoin nodes, with a **“Re-check chain”** action.
  * Managed nodes now perform RDTS-aware chain revalidation after startup and flavour changes.
  * Daemon info now reports the **depth of rejected deep reorganizations**.
* **Bug Fixes**
  * Improved block/sync progress visibility during certain node transitions.
  * Prevented unsafe handling of **implausibly deep reorgs** (to avoid unintended rollbacks).
* **UI Improvements**
  * Managed-node flavour switch confirmation copy is now **direction-specific** (Core vs Knots).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->