### PR TITLE
cleanup

### DIFF
--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -735,6 +735,12 @@ pub struct App {
     /// Global "payment received" celebration overlay — shown for incoming
     /// Liquid payments (e.g. LNURL) regardless of which panel is active.
     show_received_celebration: bool,
+    /// One-time "turn on recovery alerts?" consent prompt overlay
+    /// (PLAN-recovery-alerts-cleanup PR 3). Set once per session when a Vault
+    /// with keyholders has no monitoring and the prompt hasn't been answered for
+    /// this Cube; cleared on accept/decline. The durable "answered" record lives
+    /// in `CubeSettings::recovery_alerts_prompt_answered`.
+    show_recovery_alerts_prompt: bool,
     received_celebration_amount: String,
     received_celebration_context: String,
     received_celebration_quote: coincube_ui::component::quote_display::Quote,
@@ -1610,6 +1616,7 @@ impl App {
                 daemon_switch_in_progress: false,
                 auto_switch_suppressed: false,
                 show_received_celebration: false,
+                show_recovery_alerts_prompt: false,
                 received_celebration_amount: String::new(),
                 received_celebration_context: "transaction-received".to_string(),
                 received_celebration_quote: coincube_ui::component::quote_display::random_quote(
@@ -1728,6 +1735,7 @@ impl App {
                 daemon_switch_in_progress: false,
                 auto_switch_suppressed: false,
                 show_received_celebration: false,
+                show_recovery_alerts_prompt: false,
                 received_celebration_amount: String::new(),
                 received_celebration_context: "transaction-received".to_string(),
                 received_celebration_quote: coincube_ui::component::quote_display::random_quote(
@@ -1890,6 +1898,51 @@ impl App {
                     .map_err(|e| e.to_string())
             },
             Message::RecoveryHeartbeatSent,
+        )
+    }
+
+    /// Show the one-time recovery-alerts consent prompt (PR 3) when this Cube's
+    /// Vault has keyholders, a Connect session, and no monitoring yet — and the
+    /// prompt hasn't already been answered for this Cube. Idempotent within a
+    /// session (the overlay flag guards re-entry); the durable answer lives in
+    /// `CubeSettings::recovery_alerts_prompt_answered`. Called both at Vault
+    /// setup completion and after each monitoring-status load (the post-sync
+    /// hydration path), whichever reaches an eligible state first.
+    fn maybe_show_recovery_alerts_prompt(&mut self) {
+        if should_show_recovery_alerts_prompt(
+            self.show_recovery_alerts_prompt,
+            self.cube_settings.recovery_alerts_prompt_answered,
+            self.panels.connect.account.is_authenticated(),
+            self.panels.connect.cube.server_cube_id.is_some(),
+            self.panels.connect.account.is_recovery_alerts_entitled(),
+            !self.panels.connect.cube.members.members.is_empty(),
+            self.panels.global_settings.recovery_alerts.alerts_on(),
+        ) {
+            self.show_recovery_alerts_prompt = true;
+        }
+    }
+
+    /// Persist this Cube's "answered the consent prompt" flag to the settings
+    /// file (PR 3). The in-memory `cube_settings` copy is set by the caller; this
+    /// just makes it durable so the prompt never re-fires across restarts.
+    fn persist_recovery_alerts_answered(&self) -> Task<Message> {
+        let network_dir = self.cache.datadir_path.network_directory(self.cache.network);
+        let cube_id = self.cube_settings.id.clone();
+        Task::perform(
+            async move {
+                settings::update_settings_file(&network_dir, |mut s| {
+                    if let Some(cube) = s.cubes.iter_mut().find(|c| c.id == cube_id) {
+                        cube.recovery_alerts_prompt_answered = true;
+                    }
+                    Some(s)
+                })
+                .await
+                .map_err(|e| format!("Failed to save recovery-alerts answer: {}", e))
+            },
+            |res: Result<(), String>| match res {
+                Ok(()) => Message::SettingsSaved,
+                Err(e) => Message::View(view::Message::ShowError(e)),
+            },
         )
     }
 
@@ -3501,6 +3554,44 @@ impl App {
                 // terminal message just closes the task. Nothing to do.
                 return Task::none();
             }
+            Message::View(view::Message::RecoveryAlertsConsent(accept)) => {
+                // Answer the one-time consent prompt (PR 3). Persist the answer
+                // (durably, so it never re-fires) and dismiss the overlay.
+                self.show_recovery_alerts_prompt = false;
+                self.cube_settings.recovery_alerts_prompt_answered = true;
+                let persist = self.persist_recovery_alerts_answered();
+                // On accept, turn alerts on now (cube-scoped POST). Route the
+                // result through the settings card's `ChangeResult` so the card
+                // reflects alerts-on and any failure surfaces there; the next
+                // post-sync hydration resolves the vault id for heartbeats.
+                // `enable_alerts` is idempotent, so a redundant accept is safe.
+                let enable = if accept {
+                    let gen = self.panels.connect.account.session_generation();
+                    match (
+                        self.authenticated_coincube_client(),
+                        self.panels.connect.cube.server_cube_id,
+                    ) {
+                        (Some(client), Some(cube_id)) => Task::perform(
+                            async move {
+                                crate::services::inheritance::enable_alerts(&client, cube_id)
+                                    .await
+                                    .map_err(|e| e.to_string())
+                            },
+                            move |res| {
+                                Message::View(view::Message::Settings(
+                                    view::SettingsMessage::RecoveryAlerts(
+                                        view::RecoveryAlertsMessage::ChangeResult(res, gen, None),
+                                    ),
+                                ))
+                            },
+                        ),
+                        _ => Task::none(),
+                    }
+                } else {
+                    Task::none()
+                };
+                return Task::batch([persist, enable]);
+            }
             Message::CacheUpdated => {
                 // Cube (Home) Settings lives on every cube, vault or not,
                 // so its cache update must fire independently of the
@@ -3749,6 +3840,11 @@ impl App {
                         Some(nudge) => Task::batch([report_task, nudge]),
                         None => report_task,
                     };
+
+                    // Vault-setup-completion trigger (PR 3): the new Vault has a
+                    // keyholder set and a Connect session — offer the one-time
+                    // recovery-alerts consent prompt (alerts pre-selected on).
+                    self.maybe_show_recovery_alerts_prompt();
                     // Forward to the current panel; batch the nudge and the
                     // has_vault re-report in when present.
                     if let (Some(daemon), Some(panel)) =
@@ -4528,21 +4624,52 @@ impl App {
                 let server_cube_id = self.panels.connect.cube.server_cube_id;
                 let wallet = self.wallet.clone();
                 let entitled = self.panels.connect.account.is_recovery_alerts_entitled();
+                let escrow_entitled = self.panels.connect.account.is_inheritance_escrow_entitled();
                 let members = self.panels.connect.cube.members.members.clone();
                 let session_generation = self.panels.connect.account.session_generation();
                 let local_cube_id = self.cube_settings.id.clone();
-                return crate::app::state::settings::recovery_alerts::update(
+                // A status load is the only message that reveals an eligible
+                // Vault for the one-time prompt; a *successful user change* means
+                // the owner has engaged with the alerts decision, so the prompt
+                // must never re-fire for this Cube (else turning alerts off would
+                // immediately re-nudge — the residual nudge is the banner, not
+                // the modal). Classify before `msg` is moved into `update`.
+                let is_status_load =
+                    matches!(msg, view::RecoveryAlertsMessage::StatusLoaded(..));
+                let is_ok_change = matches!(
+                    msg,
+                    view::RecoveryAlertsMessage::ChangeResult(Ok(_), _, _)
+                );
+                let task = crate::app::state::settings::recovery_alerts::update(
                     &mut self.panels.global_settings.recovery_alerts,
                     msg,
                     client,
                     server_cube_id,
                     wallet,
                     entitled,
+                    escrow_entitled,
                     &members,
                     session_generation,
                     &self.cache,
                     &local_cube_id,
                 );
+                // The owner engaged with the alerts decision via the card → mark
+                // the prompt answered (durably) so the modal never fires for this
+                // Cube again.
+                let engaged = if is_ok_change && !self.cube_settings.recovery_alerts_prompt_answered
+                {
+                    self.cube_settings.recovery_alerts_prompt_answered = true;
+                    self.persist_recovery_alerts_answered()
+                } else {
+                    Task::none()
+                };
+                // Existing-Vault trigger (PR 3): a just-resolved `StatusLoaded`
+                // may have revealed an eligible (keyholders, monitoring off,
+                // unanswered) Vault. Offer the one-time consent prompt now.
+                if is_status_load {
+                    self.maybe_show_recovery_alerts_prompt();
+                }
+                return Task::batch([task, engaged]);
             }
 
             // Route refundables updates directly to LiquidTransactions so that
@@ -4771,7 +4898,7 @@ impl App {
         };
 
         // Overlay toast at bottom if present
-        match self.errors.is_empty() {
+        let content: Element<'_, Message> = match self.errors.is_empty() {
             true => content,
             false => {
                 // Errors are already in chronological order (Vec is append-only)
@@ -4791,12 +4918,108 @@ impl App {
                     )
                     .into()
             }
+        };
+
+        // One-time recovery-alerts consent prompt overlays everything (PR 3).
+        if self.show_recovery_alerts_prompt {
+            iced::widget::Stack::new()
+                .push(content)
+                .push(recovery_alerts_consent_overlay().map(Message::View))
+                .into()
+        } else {
+            content
         }
     }
 
     pub fn datadir_path(&self) -> &CoincubeDirectory {
         &self.cache.datadir_path
     }
+}
+
+/// Pure gating rules for the one-time recovery-alerts consent prompt (PR 3),
+/// separated from `App::maybe_show_recovery_alerts_prompt` so they're unit-
+/// testable without a full `App`. The prompt shows exactly when: it isn't
+/// already up, it hasn't been answered for this Cube, there's an authenticated
+/// Connect session with a resolved cube, alerts are available on the plan
+/// (defense-in-depth; universal after API PR 3), the Cube has ≥1 keyholder
+/// (someone to alert), and this Vault isn't already monitored.
+#[allow(clippy::too_many_arguments)]
+fn should_show_recovery_alerts_prompt(
+    already_showing: bool,
+    answered: bool,
+    authenticated: bool,
+    has_server_cube: bool,
+    entitled: bool,
+    has_keyholders: bool,
+    alerts_on: bool,
+) -> bool {
+    !already_showing
+        && !answered
+        && authenticated
+        && has_server_cube
+        && entitled
+        && has_keyholders
+        && !alerts_on
+}
+
+/// The one-time recovery-alerts consent prompt (PR 3): a centered modal card
+/// over a dimmed backdrop, offering to turn on recovery alerts (pre-selected)
+/// or decline. Both buttons resolve `view::Message::RecoveryAlertsConsent`,
+/// which persists the answer so the prompt never re-fires. Copy is the C4
+/// disclosure plus one line of *why*; no escrow mention (that stays a
+/// settings-page choice). Returns a `view::Message` element so its buttons are
+/// `Clone` (the top-level `Message` isn't); the caller maps it to `Message::View`.
+fn recovery_alerts_consent_overlay<'a>() -> Element<'a, view::Message> {
+    use coincube_ui::component::text::*;
+    use coincube_ui::component::{button, card};
+    use coincube_ui::theme;
+    use iced::widget::{Column, Container, Row, Space};
+    use iced::Length;
+
+    let body = Column::new()
+        .spacing(14)
+        .max_width(460)
+        .push(text("Alert your keyholders?").size(20).bold())
+        .push(
+            text(
+                "Turn on recovery alerts so COINCUBE can email your keyholders when this Vault's \
+                 recovery window opens. Without this, your keyholders are never told when your \
+                 recovery window opens.",
+            )
+            .size(14),
+        )
+        .push(
+            text(
+                "COINCUBE learns only the block height at which the window opens and that this \
+                 desktop checked in — never your addresses or balances.",
+            )
+            .size(13)
+            .style(theme::text::secondary),
+        )
+        .push(Space::new().height(Length::Fixed(6.0)))
+        .push(
+            Row::new()
+                .spacing(10)
+                .push(
+                    button::primary(None, "Turn on recovery alerts")
+                        .on_press(view::Message::RecoveryAlertsConsent(true)),
+                )
+                .push(
+                    button::secondary(None, "Not now")
+                        .on_press(view::Message::RecoveryAlertsConsent(false)),
+                ),
+        );
+
+    Container::new(card::simple(body).max_width(520))
+        .center_x(Length::Fill)
+        .center_y(Length::Fill)
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .padding(24)
+        .style(theme::container::custom(iced::Color::from_rgba(
+            0.0, 0.0, 0.0, 0.6,
+        )))
+        .into()
 }
 
 fn new_recovery_panel(
@@ -4944,6 +5167,72 @@ mod tests {
         app::settings::{CubeSettings, Settings, SETTINGS_FILE_NAME},
         services::duress::DuressLocalState,
     };
+
+    // Baseline: every gating precondition satisfied → prompt shows.
+    fn prompt_args_all_go() -> (bool, bool, bool, bool, bool, bool, bool) {
+        // (already_showing, answered, authenticated, has_server_cube, entitled,
+        //  has_keyholders, alerts_on)
+        (false, false, true, true, true, true, false)
+    }
+
+    #[test]
+    fn recovery_alerts_prompt_shows_when_all_conditions_met() {
+        let (a, b, c, d, e, f, g) = prompt_args_all_go();
+        assert!(should_show_recovery_alerts_prompt(a, b, c, d, e, f, g));
+    }
+
+    #[test]
+    fn recovery_alerts_prompt_suppressed_by_each_gate() {
+        // Already showing → don't stack a second prompt.
+        assert!(!should_show_recovery_alerts_prompt(
+            true, false, true, true, true, true, false
+        ));
+        // Already answered → durable, never re-prompt.
+        assert!(!should_show_recovery_alerts_prompt(
+            false, true, true, true, true, true, false
+        ));
+        // No Connect session.
+        assert!(!should_show_recovery_alerts_prompt(
+            false, false, false, true, true, true, false
+        ));
+        // No resolved Connect cube.
+        assert!(!should_show_recovery_alerts_prompt(
+            false, false, true, false, true, true, false
+        ));
+        // Not entitled (alerts unavailable on plan).
+        assert!(!should_show_recovery_alerts_prompt(
+            false, false, true, true, false, true, false
+        ));
+        // No keyholders → nobody to alert.
+        assert!(!should_show_recovery_alerts_prompt(
+            false, false, true, true, true, false, false
+        ));
+        // Already monitored → nothing to prompt for.
+        assert!(!should_show_recovery_alerts_prompt(
+            false, false, true, true, true, true, true
+        ));
+    }
+
+    #[test]
+    fn recovery_alerts_prompt_answered_flag_defaults_false_and_round_trips() {
+        // Old settings.json without the field parses as "not answered".
+        let cube: CubeSettings = serde_json::from_value(serde_json::json!({
+            "id": "cube-1",
+            "name": "Vault",
+            "network": "bitcoin",
+            "created_at": 0
+        }))
+        .unwrap();
+        assert!(!cube.recovery_alerts_prompt_answered);
+
+        // Once answered it survives a serialize/deserialize round-trip, so a
+        // decline persists across restarts (never re-prompt).
+        let mut answered = cube;
+        answered.recovery_alerts_prompt_answered = true;
+        let json = serde_json::to_string(&answered).unwrap();
+        let back: CubeSettings = serde_json::from_str(&json).unwrap();
+        assert!(back.recovery_alerts_prompt_answered);
+    }
 
     struct TempRoot(PathBuf);
 

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -3567,26 +3567,25 @@ impl App {
                     return self.persist_recovery_alerts_answered();
                 }
                 // Accept: turn alerts on now (cube-scoped POST). Route the result
-                // through the settings card's `ChangeResult` so the card reflects
-                // alerts-on and any post-dispatch failure surfaces there; the next
-                // post-sync hydration resolves the vault id for heartbeats.
-                // `enable_alerts` is idempotent, so a redundant accept is safe.
+                // through the settings card's `ChangeResult`, which reflects
+                // alerts-on on the card AND — on `Ok` — marks + persists the prompt
+                // answered (the shared `is_ok_change` handler below). So the answer
+                // is recorded only after the enable actually succeeds: a
+                // post-dispatch API failure surfaces there and leaves the prompt
+                // un-answered, so it re-fires later. `enable_alerts` is idempotent,
+                // so a redundant accept is safe.
                 //
-                // Only mark the prompt answered once we can actually dispatch the
-                // enable. If the Connect session dropped while the overlay was up
-                // (token expiry / account switch), persisting "answered" here would
-                // suppress the prompt forever while having enabled nothing — a
-                // silent permanent failure. Instead, leave it un-answered (so it
-                // re-fires once Connect is back) and surface a visible error.
+                // If the Connect session dropped while the overlay was up (token
+                // expiry / account switch) there's nothing to dispatch: leave the
+                // prompt un-answered (it re-fires once Connect is back) and surface
+                // a visible error rather than failing silently.
                 let gen = self.panels.connect.account.session_generation();
                 match (
                     self.authenticated_coincube_client(),
                     self.panels.connect.cube.server_cube_id,
                 ) {
                     (Some(client), Some(cube_id)) => {
-                        self.cube_settings.recovery_alerts_prompt_answered = true;
-                        let persist = self.persist_recovery_alerts_answered();
-                        let enable = Task::perform(
+                        return Task::perform(
                             async move {
                                 crate::services::inheritance::enable_alerts(&client, cube_id)
                                     .await
@@ -3600,7 +3599,6 @@ impl App {
                                 ))
                             },
                         );
-                        return Task::batch([persist, enable]);
                     }
                     _ => {
                         return Task::done(Message::View(view::Message::ShowError(

--- a/coincube-gui/src/app/mod.rs
+++ b/coincube-gui/src/app/mod.rs
@@ -1926,7 +1926,10 @@ impl App {
     /// file (PR 3). The in-memory `cube_settings` copy is set by the caller; this
     /// just makes it durable so the prompt never re-fires across restarts.
     fn persist_recovery_alerts_answered(&self) -> Task<Message> {
-        let network_dir = self.cache.datadir_path.network_directory(self.cache.network);
+        let network_dir = self
+            .cache
+            .datadir_path
+            .network_directory(self.cache.network);
         let cube_id = self.cube_settings.id.clone();
         Task::perform(
             async move {
@@ -3555,23 +3558,35 @@ impl App {
                 return Task::none();
             }
             Message::View(view::Message::RecoveryAlertsConsent(accept)) => {
-                // Answer the one-time consent prompt (PR 3). Persist the answer
-                // (durably, so it never re-fires) and dismiss the overlay.
+                // Answer the one-time consent prompt (PR 3). Dismiss the overlay
+                // either way.
                 self.show_recovery_alerts_prompt = false;
-                self.cube_settings.recovery_alerts_prompt_answered = true;
-                let persist = self.persist_recovery_alerts_answered();
-                // On accept, turn alerts on now (cube-scoped POST). Route the
-                // result through the settings card's `ChangeResult` so the card
-                // reflects alerts-on and any failure surfaces there; the next
+                if !accept {
+                    // Decline: record durably and move on — never re-prompt.
+                    self.cube_settings.recovery_alerts_prompt_answered = true;
+                    return self.persist_recovery_alerts_answered();
+                }
+                // Accept: turn alerts on now (cube-scoped POST). Route the result
+                // through the settings card's `ChangeResult` so the card reflects
+                // alerts-on and any post-dispatch failure surfaces there; the next
                 // post-sync hydration resolves the vault id for heartbeats.
                 // `enable_alerts` is idempotent, so a redundant accept is safe.
-                let enable = if accept {
-                    let gen = self.panels.connect.account.session_generation();
-                    match (
-                        self.authenticated_coincube_client(),
-                        self.panels.connect.cube.server_cube_id,
-                    ) {
-                        (Some(client), Some(cube_id)) => Task::perform(
+                //
+                // Only mark the prompt answered once we can actually dispatch the
+                // enable. If the Connect session dropped while the overlay was up
+                // (token expiry / account switch), persisting "answered" here would
+                // suppress the prompt forever while having enabled nothing — a
+                // silent permanent failure. Instead, leave it un-answered (so it
+                // re-fires once Connect is back) and surface a visible error.
+                let gen = self.panels.connect.account.session_generation();
+                match (
+                    self.authenticated_coincube_client(),
+                    self.panels.connect.cube.server_cube_id,
+                ) {
+                    (Some(client), Some(cube_id)) => {
+                        self.cube_settings.recovery_alerts_prompt_answered = true;
+                        let persist = self.persist_recovery_alerts_answered();
+                        let enable = Task::perform(
                             async move {
                                 crate::services::inheritance::enable_alerts(&client, cube_id)
                                     .await
@@ -3584,13 +3599,17 @@ impl App {
                                     ),
                                 ))
                             },
-                        ),
-                        _ => Task::none(),
+                        );
+                        return Task::batch([persist, enable]);
                     }
-                } else {
-                    Task::none()
-                };
-                return Task::batch([persist, enable]);
+                    _ => {
+                        return Task::done(Message::View(view::Message::ShowError(
+                            "Couldn't reach your Connect account — recovery alerts weren't turned \
+                             on. We'll ask again."
+                                .to_string(),
+                        )));
+                    }
+                }
             }
             Message::CacheUpdated => {
                 // Cube (Home) Settings lives on every cube, vault or not,
@@ -4634,12 +4653,9 @@ impl App {
                 // must never re-fire for this Cube (else turning alerts off would
                 // immediately re-nudge — the residual nudge is the banner, not
                 // the modal). Classify before `msg` is moved into `update`.
-                let is_status_load =
-                    matches!(msg, view::RecoveryAlertsMessage::StatusLoaded(..));
-                let is_ok_change = matches!(
-                    msg,
-                    view::RecoveryAlertsMessage::ChangeResult(Ok(_), _, _)
-                );
+                let is_status_load = matches!(msg, view::RecoveryAlertsMessage::StatusLoaded(..));
+                let is_ok_change =
+                    matches!(msg, view::RecoveryAlertsMessage::ChangeResult(Ok(_), _, _));
                 let task = crate::app::state::settings::recovery_alerts::update(
                     &mut self.panels.global_settings.recovery_alerts,
                     msg,
@@ -4921,10 +4937,15 @@ impl App {
         };
 
         // One-time recovery-alerts consent prompt overlays everything (PR 3).
+        // `opaque` makes the full-screen overlay capture mouse presses so a
+        // backdrop click can't fall through to (and actuate) the content layer
+        // beneath it in the Stack — a proper modal focus trap.
         if self.show_recovery_alerts_prompt {
             iced::widget::Stack::new()
                 .push(content)
-                .push(recovery_alerts_consent_overlay().map(Message::View))
+                .push(iced::widget::opaque(
+                    recovery_alerts_consent_overlay().map(Message::View),
+                ))
                 .into()
         } else {
             content

--- a/coincube-gui/src/app/settings/mod.rs
+++ b/coincube-gui/src/app/settings/mod.rs
@@ -450,6 +450,14 @@ pub struct CubeSettings {
     /// Remove-all. Back-compat is free — only the phone-seal path ever writes it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recovery_kit_last_backed_up_keychain_descriptor_fingerprint: Option<String>,
+    /// Whether the one-time "turn on recovery alerts?" consent prompt has been
+    /// answered for this Cube's Vault (PLAN-recovery-alerts-cleanup PR 3). Once
+    /// `true` — whether the user accepted or declined — the prompt never fires
+    /// again: a decline is durable, not nagging. `false`/absent = not yet asked.
+    /// The residual nudge (a banner on the Recovery settings card when keyholders
+    /// exist and alerts are off) is derived from live state, independent of this.
+    #[serde(default)]
+    pub recovery_alerts_prompt_answered: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -491,6 +499,7 @@ impl CubeSettings {
             balance_masked: false,
             recovery_kit_last_backed_up_descriptor_fingerprint: None,
             recovery_kit_last_backed_up_keychain_descriptor_fingerprint: None,
+            recovery_alerts_prompt_answered: false,
         }
     }
 

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -860,13 +860,28 @@ impl ConnectAccountPanel {
             .unwrap_or(false)
     }
 
-    /// True when the account carries the Estate-only `recovery_alerts`
-    /// entitlement. Gates the Vault Recovery Alerts settings card (Estate
-    /// Notifications — PR 2).
+    /// True when the account carries the `recovery_alerts` entitlement. Gates
+    /// the Vault Recovery Alerts card's **alerts toggle** and the heartbeat
+    /// reporting. After the recovery-alerts cleanup (API PR 3) the server
+    /// returns this on all plans, so it becomes universally true; the desktop
+    /// keeps the check as defense-in-depth. See `PLAN-recovery-alerts-cleanup.md`.
     pub fn is_recovery_alerts_entitled(&self) -> bool {
         self.plan
             .as_ref()
             .map(|p| p.entitlements.recovery_alerts)
+            .unwrap_or(false)
+    }
+
+    /// True when the account carries the Estate-only `inheritanceEscrow`
+    /// entitlement — the server-blind ECIES recovery kit sealed to keyholders.
+    /// Gates the "What keyholders can recover" tier selector on the Recovery
+    /// Alerts card, separately from the (universal) alerts toggle. Fails closed
+    /// against an older API that omits the field. See
+    /// `PLAN-recovery-alerts-cleanup.md` PR 2 + ADDENDUM.
+    pub fn is_inheritance_escrow_entitled(&self) -> bool {
+        self.plan
+            .as_ref()
+            .map(|p| p.entitlements.inheritance_escrow)
             .unwrap_or(false)
     }
 

--- a/coincube-gui/src/app/state/settings/recovery_alerts.rs
+++ b/coincube-gui/src/app/state/settings/recovery_alerts.rs
@@ -1,18 +1,27 @@
-//! Vault Recovery Alerts settings card (Estate Notifications — PR 2).
+//! Vault Recovery Alerts settings card (Estate Notifications — PR 2, cleaned up
+//! per `PLAN-recovery-alerts-cleanup.md`).
 //!
-//! Estate-only, per-vault opt-in for recovery-path monitoring. Modeled on
-//! the Cube Recovery Kit card (`recovery_kit.rs`): the state container lives
-//! on the outer `SettingsState` so `App::update` can inject the
-//! authenticated `CoincubeClient`, the Connect cube id, the live wallet
-//! descriptor, the keyholder list, and the entitlement — none of which are
-//! plumbed through `State::update`.
+//! Per-vault opt-in for recovery-path monitoring. Modeled on the Cube Recovery
+//! Kit card (`recovery_kit.rs`): the state container lives on the outer
+//! `SettingsState` so `App::update` can inject the authenticated
+//! `CoincubeClient`, the Connect cube id, the live wallet descriptor, the
+//! keyholder list, and the entitlements — none of which are plumbed through
+//! `State::update`.
 //!
-//! Three tiers (`VaultMonitoringLevel`): **Off** (true-delete any escrowed
-//! descriptor), **Alerts only / Heartbeat** (timelock heartbeat only — the
-//! server never sees addresses/balances), **Full** (a service-encrypted
-//! copy of the descriptor is escrowed so keyholders can recover without the
-//! owner's password). A separate keyholder download policy governs when
-//! keyholders may pull the encrypted recovery kit.
+//! The card exposes **two independent controls** backed by two server records:
+//!
+//! - **Recovery alerts** (the monitoring record) — a timelock heartbeat so
+//!   COINCUBE emails keyholders when the recovery window opens. The server only
+//!   ever learns one block height and that this desktop checked in — never
+//!   addresses or balances. Not Estate-gated.
+//! - **What keyholders can recover** (the ECIES escrow set) — **Nothing —
+//!   alerts only** / **Vault only** (descriptor sealed to each keyholder's key)
+//!   / **Full Cube** (seed + descriptor). Estate-gated (`inheritanceEscrow`).
+//!
+//! The escrow **tier is derived from the server**, not tracked per-session:
+//! `VaultMonitoringStatus::escrowed_artifacts` reports exactly which kinds are
+//! escrowed, so a reload or a restart shows the true selection. See
+//! [`RecoveryAlerts::escrow_tier`]. Invariant: escrow present ⟹ alerts on.
 
 use std::sync::Arc;
 
@@ -22,7 +31,7 @@ use zeroize::Zeroizing;
 use crate::{
     app::{cache::Cache, message::Message, settings, view, wallet::Wallet},
     services::coincube::{CoincubeClient, CubeMember, VaultMonitoringLevel, VaultMonitoringStatus},
-    services::inheritance::{disable_escrow, enroll_escrow, EscrowTier},
+    services::inheritance::{disable_alerts, disable_escrow, enable_alerts, enroll_escrow, EscrowTier},
     services::recovery::{SeedBlob, SeedBlobCube, SeedBlobMnemonic, BLOB_VERSION},
 };
 
@@ -32,9 +41,11 @@ use view::{EscrowPin, RecoveryAlertsMessage, SettingsMessage};
 #[derive(Debug)]
 pub struct RecoveryAlerts {
     /// Connect vault id, resolved from the cube on first load and cached so
-    /// level/policy changes don't re-resolve it.
+    /// alerts/escrow changes don't re-resolve it.
     pub vault_id: Option<u64>,
     /// Last-known monitoring status from Connect. `None` until first load.
+    /// Both the alerts state ([`Self::alerts_on`]) and the escrow tier
+    /// ([`Self::escrow_tier`]) are derived from this — no session-tracked guess.
     pub status: Option<VaultMonitoringStatus>,
     pub loading: bool,
     pub submitting: bool,
@@ -42,21 +53,23 @@ pub struct RecoveryAlerts {
     /// Keyholder emails (the cube members who'd be notified), snapshotted on
     /// each load so the card can show exactly who would receive alerts.
     pub keyholders: Vec<String>,
-    /// Whether the account carries the Estate `recovery_alerts` entitlement.
+    /// Whether the account carries the `recovery_alerts` entitlement (gates the
+    /// alerts toggle / unlocks the card). Universal after API PR 3; kept as a
+    /// defense-in-depth check.
     pub entitled: bool,
+    /// Whether the account carries the Estate `inheritanceEscrow` entitlement
+    /// (gates the escrow tier selector, separately from the alerts toggle).
+    pub escrow_entitled: bool,
     /// True once a load resolved that there's no Connect vault to monitor
     /// (no cube registered / no vault created yet).
     pub no_vault: bool,
     /// True once at least one load has been attempted — lets the card pick
     /// the right loading vs. empty copy.
     pub loaded_once: bool,
-    /// The escrow tier this session tracked from an enrol/disable we performed.
-    /// The owner monitoring status reports on/off, not which tier, so this is
-    /// the only tier signal we have — and it resets to `Off` on restart. `Off`
-    /// therefore means *either* escrow is off *or* it's on but untracked on this
-    /// device; use [`Self::tier`] (the method), which combines this with
-    /// [`Self::level`], to disambiguate (it returns `None` for the latter).
-    pub tier: EscrowTier,
+    /// True while the alerts-off confirm dialog is open. Turning alerts off is
+    /// never silent: when a recovery kit is escrowed the dialog discloses that
+    /// it will also be deleted (escrow can't outlive alerts).
+    pub confirming_alerts_off: bool,
     /// True while the card is collecting the owner's PIN to unlock the seed for
     /// a Full-Cube enrolment (the only tier that escrows the seed).
     pub awaiting_pin: bool,
@@ -83,30 +96,53 @@ impl RecoveryAlerts {
             error: None,
             keyholders: Vec::new(),
             entitled: false,
+            escrow_entitled: false,
             no_vault: false,
             loaded_once: false,
-            tier: EscrowTier::Off,
+            confirming_alerts_off: false,
             awaiting_pin: false,
             pin: EscrowPin::default(),
         }
     }
 
-    /// Current tier for the view and the no-op guards:
-    /// - `Some(Off)` when monitoring is off;
-    /// - `Some(tier)` when this session tracked the enrolled tier;
-    /// - `None` when escrow is on but this device doesn't know which tier —
-    ///   e.g. after a restart, since the owner monitoring status doesn't report
-    ///   it. We surface "on, tier unknown" rather than guess: guessing
-    ///   Vault-only for a Full-Cube vault would print a false claim (its copy
-    ///   says "the seed is never escrowed") for a seed that *is* escrowed.
-    pub fn tier(&self) -> Option<EscrowTier> {
-        if matches!(self.level(), VaultMonitoringLevel::Off) {
-            Some(EscrowTier::Off)
-        } else if self.tier == EscrowTier::Off {
-            None
-        } else {
-            Some(self.tier)
+    /// Whether recovery **alerts** (the monitoring record) are on — any non-Off
+    /// monitoring level. The alerts toggle and the heartbeat both key off this.
+    pub fn alerts_on(&self) -> bool {
+        !matches!(self.level(), VaultMonitoringLevel::Off)
+    }
+
+    /// The escrow tier keyholders can recover, **derived from the server's
+    /// reported escrowed-artifact kinds** rather than a session guess:
+    /// - `["…","seed"]` → `Some(FullCube)`;
+    /// - `["descriptor"]` → `Some(VaultOnly)`;
+    /// - `[]` (present, empty) → `Some(Off)` — nothing escrowed (alerts-only);
+    /// - field **absent** (older API that predates the report): `Some(Off)` when
+    ///   monitoring is off (nothing can be escrowed then — confident), else
+    ///   `None` ("on, tier unknown"). Returning `None` avoids asserting — and
+    ///   mis-stating — a tier the server didn't confirm (C2).
+    pub fn escrow_tier(&self) -> Option<EscrowTier> {
+        match self.status.as_ref().and_then(|s| s.escrowed_artifacts.as_ref()) {
+            Some(kinds) if kinds.iter().any(|k| k == "seed") => Some(EscrowTier::FullCube),
+            Some(kinds) if kinds.iter().any(|k| k == "descriptor") => Some(EscrowTier::VaultOnly),
+            Some(_) => Some(EscrowTier::Off),
+            None => {
+                if matches!(self.level(), VaultMonitoringLevel::Off) {
+                    Some(EscrowTier::Off)
+                } else {
+                    None
+                }
+            }
         }
+    }
+
+    /// Whether an escrow set is currently stored (Vault-only or Full-Cube). Used
+    /// to decide whether an alerts-off must also delete the kit, and whether the
+    /// confirm dialog discloses that deletion.
+    pub fn has_escrow(&self) -> bool {
+        matches!(
+            self.escrow_tier(),
+            Some(EscrowTier::VaultOnly | EscrowTier::FullCube)
+        )
     }
 
     /// Current monitoring level (Off when unloaded).
@@ -119,14 +155,18 @@ impl RecoveryAlerts {
 
     /// Fold a change result into state.
     ///
-    /// **Ok:** apply the confirmed `tier_change` (if any) and cache `status`.
+    /// **Ok:** cache the returned `status`. Each owner operation stamps the
+    /// resulting `escrowed_artifacts` onto that status, so caching it *is*
+    /// applying the confirmed tier immediately — the card reflects the change
+    /// without flicker while the next `LoadStatus` reconciles against the
+    /// server. Also closes the alerts-off dialog.
     ///
     /// **Err:** surface the (display-safe) error. A failed **Full-Cube** enrol
     /// also restores `awaiting_pin`: `ConfirmFullCube` clears it before the
     /// blocking verify, so a wrong PIN would otherwise hide the PIN entry and
     /// force the owner to re-pick Full Cube. Restoring it re-shows the (now
     /// empty — the buffer was taken) PIN field alongside the error for an inline
-    /// retry.
+    /// retry. `tier_change` is carried only to identify that Full-Cube case.
     fn apply_change(
         &mut self,
         res: Result<VaultMonitoringStatus, String>,
@@ -134,11 +174,9 @@ impl RecoveryAlerts {
     ) {
         match res {
             Ok(status) => {
-                if let Some(t) = tier_change {
-                    self.tier = t;
-                }
                 self.status = Some(status);
                 self.error = None;
+                self.confirming_alerts_off = false;
             }
             Err(e) => {
                 self.error = Some(e);
@@ -149,21 +187,15 @@ impl RecoveryAlerts {
         }
     }
 
-    /// Fold a successful `LoadStatus` into state.
-    ///
-    /// The monitoring status reports on/off (`level`) — **not** which escrow
-    /// tier. So we reset our session-tracked tier on every (re)load: the status
-    /// can't confirm it, and another device may have changed it (e.g. upgraded
-    /// Vault-only → Full-Cube) while monitoring stayed on. [`Self::tier`] then
-    /// reports an on vault as `None` ("on, tier unknown") until *this* device
-    /// performs an enrol/disable, so the card never re-asserts a stale tier (and
-    /// its false seed-escrow copy) it can't actually confirm.
+    /// Fold a successful `LoadStatus` into state. The status carries the
+    /// server-reported `escrowed_artifacts`, so caching it is enough — both the
+    /// alerts state and the escrow tier are derived from it. No session tier to
+    /// reset.
     fn apply_status_loaded(&mut self, vault_id: u64, status: VaultMonitoringStatus) {
         self.vault_id = Some(vault_id);
         self.status = Some(status);
         self.no_vault = false;
         self.error = None;
-        self.tier = EscrowTier::Off;
     }
 }
 
@@ -173,13 +205,13 @@ fn ra_msg(m: RecoveryAlertsMessage) -> Message {
 }
 
 /// App-level dispatcher. `client` / `server_cube_id` / `wallet` / `members`
-/// are injected by `App::update`; `entitled` is the account's
-/// `recovery_alerts` entitlement. `session_generation` is the connect
-/// account's current session counter (bumped on login / logout / reset):
-/// it's stamped into spawned async results so a load / change that lands
-/// after the session changed is dropped instead of writing a prior account's
-/// vault id + status into the reset state — the same guard the duress-contacts
-/// handlers use.
+/// are injected by `App::update`; `entitled` is the account's `recovery_alerts`
+/// entitlement (alerts toggle) and `escrow_entitled` the `inheritanceEscrow` one
+/// (escrow tier selector). `session_generation` is the connect account's current
+/// session counter (bumped on login / logout / reset): it's stamped into spawned
+/// async results so a load / change that lands after the session changed is
+/// dropped instead of writing a prior account's vault id + status into the reset
+/// state — the same guard the duress-contacts handlers use.
 #[allow(clippy::too_many_arguments)]
 pub fn update(
     ra: &mut RecoveryAlerts,
@@ -188,12 +220,14 @@ pub fn update(
     server_cube_id: Option<u64>,
     wallet: Option<Arc<Wallet>>,
     entitled: bool,
+    escrow_entitled: bool,
     members: &[CubeMember],
     session_generation: u64,
     cache: &Cache,
     local_cube_id: &str,
 ) -> Task<Message> {
     ra.entitled = entitled;
+    ra.escrow_entitled = escrow_entitled;
     match msg {
         RecoveryAlertsMessage::LoadStatus => {
             // Refresh the keyholder snapshot every load so the card reflects
@@ -260,9 +294,10 @@ pub fn update(
             ra.loaded_once = true;
             match res {
                 Ok((vid, status)) => {
-                    // Cache the freshly-loaded status and reset our tracked tier
-                    // (the status confirms on/off only, not the tier — so we
-                    // never re-assert a tier we can't confirm). See the method.
+                    // Cache the freshly-loaded status. Both the alerts state and
+                    // the escrow tier derive from its `escrowed_artifacts`, so
+                    // the reload reflects the true server selection (including
+                    // changes made on another device). See `escrow_tier`.
                     ra.apply_status_loaded(vid, status);
                 }
                 Err(e) => {
@@ -286,21 +321,111 @@ pub fn update(
             }
             Task::none()
         }
-        RecoveryAlertsMessage::SelectTier(tier) => {
-            ra.awaiting_pin = false;
-            ra.pin.clear();
+        RecoveryAlertsMessage::ToggleAlerts(on) => {
+            // The alerts toggle keys off the (universal after API PR 3)
+            // `recovery_alerts` entitlement — kept as defense-in-depth. The card
+            // only renders the toggle when entitled, so this guard is belt-and-braces.
             if !entitled {
-                ra.error = Some("Recovery alerts require an Estate plan.".to_string());
+                ra.error = Some("Recovery alerts aren't available on this plan.".to_string());
                 return Task::none();
             }
-            // Skip a no-op re-select of the *known* current tier. When the tier
-            // is unknown on this device (`None`), any selection proceeds so the
-            // owner can confirm/change it.
-            if ra.tier() == Some(tier) {
+            ra.error = None;
+            if on {
+                // Turning alerts ON alone: no escrow involved. No-op if already on.
+                if ra.alerts_on() {
+                    return Task::none();
+                }
+                let (Some(client), Some(_vault_id), Some(server_cube_id)) =
+                    (client, ra.vault_id, server_cube_id)
+                else {
+                    ra.error = Some(
+                        "Couldn't find this Vault on Connect yet — try again in a moment."
+                            .to_string(),
+                    );
+                    return Task::none();
+                };
+                ra.submitting = true;
+                Task::perform(
+                    async move {
+                        enable_alerts(&client, server_cube_id)
+                            .await
+                            .map_err(|e| e.to_string())
+                    },
+                    move |res| {
+                        // No escrow change → `None` (no PIN re-show on failure).
+                        ra_msg(RecoveryAlertsMessage::ChangeResult(res, session_generation, None))
+                    },
+                )
+            } else {
+                // Turning alerts OFF is destructive when a kit is escrowed, so
+                // open the confirm dialog rather than acting silently. No-op if
+                // already off.
+                if !ra.alerts_on() {
+                    return Task::none();
+                }
+                ra.confirming_alerts_off = true;
+                Task::none()
+            }
+        }
+        RecoveryAlertsMessage::CancelAlertsOff => {
+            ra.confirming_alerts_off = false;
+            Task::none()
+        }
+        RecoveryAlertsMessage::ConfirmAlertsOff => {
+            if !entitled || !ra.confirming_alerts_off {
+                return Task::none();
+            }
+            // Escrow can't outlive alerts (invariant: escrow present ⟹ alerts
+            // on), so turning alerts off deletes any kit too. Delete unless we're
+            // *certain* nothing is escrowed (`Some(Off)`): when the tier is
+            // unknown (older API that doesn't report it), delete anyway — the
+            // escrow DELETE is idempotent (404 = success), so this is free
+            // insurance against ever stranding escrow with monitoring off.
+            let also_delete_escrow = !matches!(ra.escrow_tier(), Some(EscrowTier::Off));
+            let (Some(client), Some(_vault_id), Some(server_cube_id)) =
+                (client, ra.vault_id, server_cube_id)
+            else {
+                ra.error = Some(
+                    "Couldn't find this Vault on Connect yet — try again in a moment.".to_string(),
+                );
+                return Task::none();
+            };
+            ra.submitting = true;
+            ra.confirming_alerts_off = false;
+            ra.error = None;
+            Task::perform(
+                async move {
+                    disable_alerts(&client, server_cube_id, also_delete_escrow)
+                        .await
+                        .map_err(|e| e.to_string())
+                },
+                move |res| {
+                    // Resulting escrow tier is Off; `Some(Off)` (not FullCube) so
+                    // a failure never spuriously re-shows the PIN entry.
+                    ra_msg(RecoveryAlertsMessage::ChangeResult(
+                        res,
+                        session_generation,
+                        Some(EscrowTier::Off),
+                    ))
+                },
+            )
+        }
+        RecoveryAlertsMessage::SelectEscrow(tier) => {
+            ra.awaiting_pin = false;
+            ra.pin.clear();
+            if !escrow_entitled {
+                ra.error =
+                    Some("An encrypted recovery kit is part of the Estate plan.".to_string());
+                return Task::none();
+            }
+            // Skip a no-op re-select of the *known* current tier. When it's
+            // unknown on this device (`None`, older API), any selection proceeds
+            // so the owner can confirm/change it.
+            if ra.escrow_tier() == Some(tier) {
                 return Task::none();
             }
             // `ra.vault_id` is checked (not used further) as the "does Connect
-            // know about a Vault for this cube yet" gate — monitoring/escrow
+            // know about a Vault for this cube yet" gate — escrow/monitoring
             // calls below are cube-scoped and never need the vault id itself.
             let (Some(client), Some(_vault_id), Some(server_cube_id)) =
                 (client, ra.vault_id, server_cube_id)
@@ -312,6 +437,7 @@ pub fn update(
             };
             match tier {
                 EscrowTier::Off => {
+                    // "Nothing — alerts only": delete the escrow set, keep alerts.
                     ra.submitting = true;
                     ra.error = None;
                     Task::perform(
@@ -331,7 +457,8 @@ pub fn update(
                 }
                 EscrowTier::VaultOnly => {
                     // Descriptor-only escrow needs no seed (no PIN). Build the
-                    // descriptor blob from the live wallet and enrol.
+                    // descriptor blob from the live wallet and enrol. `enroll_escrow`
+                    // turns alerts on too, so this auto-enables alerts when off.
                     let Some(descriptor_json) =
                         descriptor_blob_json(wallet.as_deref(), local_cube_id, cache.network)
                     else {
@@ -388,7 +515,8 @@ pub fn update(
             Task::none()
         }
         RecoveryAlertsMessage::ConfirmFullCube => {
-            if !entitled || !ra.awaiting_pin {
+            // Full-Cube is an escrow tier, so it's gated on `inheritanceEscrow`.
+            if !escrow_entitled || !ra.awaiting_pin {
                 return Task::none();
             }
             // We still require a resolved vault as a fast precondition, but
@@ -557,37 +685,62 @@ fn build_seed_blob_json(
 mod tests {
     use super::*;
 
-    fn monitoring_on() -> VaultMonitoringStatus {
+    /// Monitoring on with the given escrowed-artifact kinds reported (new API).
+    fn monitoring_on_with(artifacts: Option<Vec<&str>>) -> VaultMonitoringStatus {
         VaultMonitoringStatus {
             level: VaultMonitoringLevel::Heartbeat,
+            escrowed_artifacts: artifacts.map(|v| v.into_iter().map(String::from).collect()),
             ..VaultMonitoringStatus::default()
         }
     }
 
+    fn with_status(status: VaultMonitoringStatus) -> RecoveryAlerts {
+        let mut ra = RecoveryAlerts::new();
+        ra.status = Some(status);
+        ra
+    }
+
+    // ── Server-derived escrow tier: the PR-1 derivation matrix ──────────────
+
     #[test]
-    fn tier_is_off_when_monitoring_off() {
-        // No status loaded yet → level Off → tier is a confirmed Off.
-        assert_eq!(RecoveryAlerts::new().tier(), Some(EscrowTier::Off));
+    fn escrow_tier_off_when_monitoring_off() {
+        // No status loaded / monitoring off → Nothing escrowed, confident Off.
+        assert_eq!(RecoveryAlerts::new().escrow_tier(), Some(EscrowTier::Off));
+        assert!(!RecoveryAlerts::new().alerts_on());
     }
 
     #[test]
-    fn tier_is_unknown_when_on_but_untracked() {
-        // Monitoring on but `tier` still at its default (e.g. fresh after a
-        // restart): we must report `None` ("on, tier unknown"), NOT guess
-        // Vault-only — guessing would render the false "the seed is never
-        // escrowed" copy for a vault that may be Full-Cube.
-        let mut ra = RecoveryAlerts::new();
-        ra.status = Some(monitoring_on());
-        assert_eq!(ra.tier(), None);
+    fn escrow_tier_vault_only_from_descriptor_kind() {
+        let ra = with_status(monitoring_on_with(Some(vec!["descriptor"])));
+        assert_eq!(ra.escrow_tier(), Some(EscrowTier::VaultOnly));
+        assert!(ra.alerts_on());
+        assert!(ra.has_escrow());
     }
 
     #[test]
-    fn tier_is_reported_when_on_and_tracked() {
-        // A tier we applied this session is reported as-is while monitoring is on.
-        let mut ra = RecoveryAlerts::new();
-        ra.status = Some(monitoring_on());
-        ra.tier = EscrowTier::FullCube;
-        assert_eq!(ra.tier(), Some(EscrowTier::FullCube));
+    fn escrow_tier_full_cube_from_seed_kind() {
+        let ra = with_status(monitoring_on_with(Some(vec!["descriptor", "seed"])));
+        assert_eq!(ra.escrow_tier(), Some(EscrowTier::FullCube));
+        assert!(ra.has_escrow());
+    }
+
+    #[test]
+    fn escrow_tier_nothing_when_alerts_only() {
+        // Monitoring on, artifacts present but empty → alerts-only (Off/Nothing).
+        let ra = with_status(monitoring_on_with(Some(vec![])));
+        assert_eq!(ra.escrow_tier(), Some(EscrowTier::Off));
+        assert!(ra.alerts_on());
+        assert!(!ra.has_escrow());
+    }
+
+    #[test]
+    fn escrow_tier_unknown_when_field_absent_and_on() {
+        // Old API (no `escrowedArtifacts`) with monitoring on: we must report
+        // `None` ("on, tier unknown"), NOT guess — guessing Vault-only would
+        // render the false "seed is never escrowed" copy for a maybe-Full vault.
+        let ra = with_status(monitoring_on_with(None));
+        assert_eq!(ra.escrow_tier(), None);
+        assert!(ra.alerts_on());
     }
 
     #[test]
@@ -613,21 +766,32 @@ mod tests {
     }
 
     #[test]
-    fn enroll_caches_returned_status_verbatim() {
-        // A (re-)enrol returns the real monitoring status; it is cached as-is
-        // and the confirmed tier is tracked.
-        let mut ra = RecoveryAlerts::new();
-        ra.status = Some(VaultMonitoringStatus {
-            level: VaultMonitoringLevel::Heartbeat,
-            ..VaultMonitoringStatus::default()
-        });
-        let returned = VaultMonitoringStatus {
-            level: VaultMonitoringLevel::Heartbeat,
-            ..VaultMonitoringStatus::default()
-        };
+    fn enroll_caches_returned_status_and_derives_tier() {
+        // A (re-)enrol returns a status whose `escrowed_artifacts` the owner op
+        // stamped; caching it derives the confirmed tier immediately, no session
+        // state. Here a Full-Cube enrol returns descriptor+seed.
+        let mut ra = with_status(monitoring_on_with(Some(vec![])));
+        let returned = monitoring_on_with(Some(vec!["descriptor", "seed"]));
         ra.apply_change(Ok(returned), Some(EscrowTier::FullCube));
-        assert_eq!(ra.tier, EscrowTier::FullCube);
-        assert_eq!(ra.level(), VaultMonitoringLevel::Heartbeat);
+        assert_eq!(ra.escrow_tier(), Some(EscrowTier::FullCube));
+        assert!(ra.alerts_on());
+    }
+
+    #[test]
+    fn confirm_change_closes_alerts_off_dialog() {
+        // An Ok change result must also dismiss the alerts-off confirm dialog.
+        let mut ra = RecoveryAlerts::new();
+        ra.confirming_alerts_off = true;
+        ra.apply_change(
+            Ok(VaultMonitoringStatus {
+                level: VaultMonitoringLevel::Off,
+                escrowed_artifacts: Some(Vec::new()),
+                ..VaultMonitoringStatus::default()
+            }),
+            Some(EscrowTier::Off),
+        );
+        assert!(!ra.confirming_alerts_off);
+        assert!(!ra.alerts_on());
     }
 
     #[test]
@@ -663,30 +827,31 @@ mod tests {
     }
 
     #[test]
-    fn reload_clears_stale_session_tier_for_on_vault() {
-        // This device thinks it's Full-Cube from an earlier enrol...
-        let mut ra = RecoveryAlerts::new();
-        ra.tier = EscrowTier::FullCube;
-        // ...but a reload only confirms monitoring is *on* (level), not the tier
-        // — another device may have changed it. The card must NOT keep asserting
-        // Full-Cube ("seed is escrowed"); it must report "on, tier unknown".
-        ra.apply_status_loaded(
-            7,
-            VaultMonitoringStatus {
-                level: VaultMonitoringLevel::Heartbeat,
-                ..VaultMonitoringStatus::default()
-            },
-        );
-        assert_eq!(ra.tier(), None);
+    fn reload_reflects_server_reported_tier() {
+        // A device that just enrolled Full-Cube... then another device downgrades
+        // to Vault-only. A reload reports `["descriptor"]`, and the card derives
+        // Vault-only straight from the server — no stale Full-Cube assertion.
+        let mut ra = with_status(monitoring_on_with(Some(vec!["descriptor", "seed"])));
+        assert_eq!(ra.escrow_tier(), Some(EscrowTier::FullCube));
+        ra.apply_status_loaded(7, monitoring_on_with(Some(vec!["descriptor"])));
+        assert_eq!(ra.escrow_tier(), Some(EscrowTier::VaultOnly));
         assert_eq!(ra.vault_id, Some(7));
         assert!(!ra.no_vault);
     }
 
     #[test]
+    fn reload_against_old_api_reports_unknown_not_a_wrong_tier() {
+        // An older API omits `escrowedArtifacts`. A reload of an *on* vault must
+        // report `None` ("on, tier unknown") — the fallback banner — rather than
+        // asserting whatever this device last enrolled.
+        let mut ra = with_status(monitoring_on_with(Some(vec!["descriptor", "seed"])));
+        ra.apply_status_loaded(7, monitoring_on_with(None));
+        assert_eq!(ra.escrow_tier(), None);
+    }
+
+    #[test]
     fn reload_reports_off_when_monitoring_off() {
-        // A stale tracked tier must collapse to Off when the load says off.
-        let mut ra = RecoveryAlerts::new();
-        ra.tier = EscrowTier::FullCube;
+        let mut ra = with_status(monitoring_on_with(Some(vec!["descriptor", "seed"])));
         ra.apply_status_loaded(
             7,
             VaultMonitoringStatus {
@@ -694,6 +859,7 @@ mod tests {
                 ..VaultMonitoringStatus::default()
             },
         );
-        assert_eq!(ra.tier(), Some(EscrowTier::Off));
+        assert_eq!(ra.escrow_tier(), Some(EscrowTier::Off));
+        assert!(!ra.alerts_on());
     }
 }

--- a/coincube-gui/src/app/state/settings/recovery_alerts.rs
+++ b/coincube-gui/src/app/state/settings/recovery_alerts.rs
@@ -31,7 +31,9 @@ use zeroize::Zeroizing;
 use crate::{
     app::{cache::Cache, message::Message, settings, view, wallet::Wallet},
     services::coincube::{CoincubeClient, CubeMember, VaultMonitoringLevel, VaultMonitoringStatus},
-    services::inheritance::{disable_alerts, disable_escrow, enable_alerts, enroll_escrow, EscrowTier},
+    services::inheritance::{
+        disable_alerts, disable_escrow, enable_alerts, enroll_escrow, EscrowTier,
+    },
     services::recovery::{SeedBlob, SeedBlobCube, SeedBlobMnemonic, BLOB_VERSION},
 };
 
@@ -121,7 +123,11 @@ impl RecoveryAlerts {
     ///   `None` ("on, tier unknown"). Returning `None` avoids asserting — and
     ///   mis-stating — a tier the server didn't confirm (C2).
     pub fn escrow_tier(&self) -> Option<EscrowTier> {
-        match self.status.as_ref().and_then(|s| s.escrowed_artifacts.as_ref()) {
+        match self
+            .status
+            .as_ref()
+            .and_then(|s| s.escrowed_artifacts.as_ref())
+        {
             Some(kinds) if kinds.iter().any(|k| k == "seed") => Some(EscrowTier::FullCube),
             Some(kinds) if kinds.iter().any(|k| k == "descriptor") => Some(EscrowTier::VaultOnly),
             Some(_) => Some(EscrowTier::Off),
@@ -353,7 +359,11 @@ pub fn update(
                     },
                     move |res| {
                         // No escrow change → `None` (no PIN re-show on failure).
-                        ra_msg(RecoveryAlertsMessage::ChangeResult(res, session_generation, None))
+                        ra_msg(RecoveryAlertsMessage::ChangeResult(
+                            res,
+                            session_generation,
+                            None,
+                        ))
                     },
                 )
             } else {

--- a/coincube-gui/src/app/view/message.rs
+++ b/coincube-gui/src/app/view/message.rs
@@ -233,6 +233,11 @@ pub enum Message {
     DuressLockRemote,
     ToggleTheme,
     DismissReceivedCelebration,
+    /// Answer to the one-time recovery-alerts consent prompt overlay
+    /// (PLAN-recovery-alerts-cleanup PR 3). `true` = accept (enable monitoring),
+    /// `false` = decline. Handled at the App level; the answer is persisted
+    /// per-cube so the prompt never re-fires.
+    RecoveryAlertsConsent(bool),
     DismissBackupWarning,
     /// Flip the global fiat-native ↔ bitcoin-native display preference
     /// and persist it. Emitted by the click-to-swap mouse_area on any
@@ -440,10 +445,22 @@ pub enum RecoveryAlertsMessage {
         Result<(u64, crate::services::coincube::VaultMonitoringStatus), String>,
         u64,
     ),
-    /// User picked an inheritance escrow tier (Off / Vault-only / Full-Cube).
-    /// Vault-only and Off apply immediately; Full-Cube first collects the PIN
-    /// (to unlock the seed) and applies on `ConfirmFullCube`.
-    SelectTier(crate::services::inheritance::EscrowTier),
+    /// Flip the standalone **Recovery alerts** toggle (monitoring on/off),
+    /// independent of escrow. `true` posts the monitoring opt-in immediately;
+    /// `false` opens the alerts-off confirm dialog (which discloses that it will
+    /// also delete any stored keyholder recovery kit) rather than acting silently.
+    ToggleAlerts(bool),
+    /// Confirm turning alerts off from the dialog. Deletes the monitoring record,
+    /// and — when a recovery kit is currently escrowed — deletes the envelope set
+    /// too (escrow can't outlive alerts). See the state handler for the ordering.
+    ConfirmAlertsOff,
+    /// Dismiss the alerts-off confirm dialog without changing anything.
+    CancelAlertsOff,
+    /// User picked what keyholders can recover (Nothing / Vault-only / Full-Cube).
+    /// Nothing deletes the escrow set only (alerts stay on); Vault-only enrols the
+    /// descriptor (auto-enabling alerts); Full-Cube first collects the PIN (to
+    /// unlock the seed) and enrols on `ConfirmFullCube`.
+    SelectEscrow(crate::services::inheritance::EscrowTier),
     /// PIN digit input while enrolling the Full-Cube tier (escrows the seed).
     /// Carried in a redacting, zeroizing [`EscrowPin`] so the PIN never lands
     /// in a `{:?}` dump or lingers un-wiped in a dropped message.

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -273,19 +273,18 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
                 .push(
                     button::primary(None, "Turn off")
                         .padding([8, 14])
-                        .on_press_maybe((!busy).then_some(
-                            SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::ConfirmAlertsOff)
+                        .on_press_maybe(
+                            (!busy).then_some(
+                                SettingsMessage::RecoveryAlerts(
+                                    RecoveryAlertsMessage::ConfirmAlertsOff,
+                                )
                                 .into(),
-                        )),
-                )
-                .push(
-                    button::secondary(None, "Cancel")
-                        .padding([8, 14])
-                        .on_press(
-                            SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::CancelAlertsOff)
-                                .into(),
+                            ),
                         ),
-                ),
+                )
+                .push(button::secondary(None, "Cancel").padding([8, 14]).on_press(
+                    SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::CancelAlertsOff).into(),
+                )),
         );
     }
 
@@ -323,7 +322,11 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
 /// The "What keyholders can recover" escrow selector — Estate-gated (locked
 /// affordance when the account lacks the `inheritanceEscrow` entitlement). The
 /// tier is server-derived; picking Vault only / Full Cube auto-enables alerts.
-fn escrow_selector<'a>(ra: &'a RecoveryAlerts, alerts_on: bool, busy: bool) -> Element<'a, Message> {
+fn escrow_selector<'a>(
+    ra: &'a RecoveryAlerts,
+    alerts_on: bool,
+    busy: bool,
+) -> Element<'a, Message> {
     // Locked affordance when the account can't escrow a recovery kit.
     if !ra.escrow_entitled {
         return Column::new()
@@ -415,19 +418,18 @@ fn escrow_selector<'a>(ra: &'a RecoveryAlerts, alerts_on: bool, busy: bool) -> E
                 .push(
                     button::primary(None, "Confirm")
                         .padding([8, 14])
-                        .on_press_maybe((!busy).then_some(
-                            SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::ConfirmFullCube)
+                        .on_press_maybe(
+                            (!busy).then_some(
+                                SettingsMessage::RecoveryAlerts(
+                                    RecoveryAlertsMessage::ConfirmFullCube,
+                                )
                                 .into(),
-                        )),
-                )
-                .push(
-                    button::secondary(None, "Cancel")
-                        .padding([8, 14])
-                        .on_press(
-                            SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::CancelFullCube)
-                                .into(),
+                            ),
                         ),
-                ),
+                )
+                .push(button::secondary(None, "Cancel").padding([8, 14]).on_press(
+                    SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::CancelFullCube).into(),
+                )),
         );
     }
 

--- a/coincube-gui/src/app/view/settings/general.rs
+++ b/coincube-gui/src/app/view/settings/general.rs
@@ -160,9 +160,11 @@ fn recovery_section<'a>(
     dashboard(menu, cache, col)
 }
 
-/// Vault Recovery Alerts card: three-tier monitoring selector + keyholder
-/// download policy + the keyholder list, with honest opt-in copy. Estate-
-/// gated; shows the locked affordance for non-Estate accounts.
+/// Vault Recovery Alerts card. Two independent controls backed by two server
+/// records: the **Recovery alerts** toggle (monitoring; not Estate-gated) and
+/// the **What keyholders can recover** escrow selector (Estate-gated). The
+/// keyholder list lives under the alerts toggle (it's who alerts notify). See
+/// `PLAN-recovery-alerts-cleanup.md` PR 2.
 fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
     let mut body = Column::new()
         .spacing(10)
@@ -175,13 +177,13 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
             .size(13),
         );
 
-    // Locked affordance for non-Estate accounts.
+    // Locked affordance when the account can't use recovery alerts at all.
     if !ra.entitled {
         body = body
             .push(
                 text(
-                    "Recovery alerts are part of the Estate plan. Upgrade your Connect plan to \
-                     enable chain monitoring and keyholder alerts.",
+                    "Recovery alerts aren't available on your current plan. Upgrade your Connect \
+                     plan to alert your keyholders when this Vault's recovery window opens.",
                 )
                 .size(13),
             )
@@ -207,102 +209,89 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
         return card::simple(body).width(Length::Fill).into();
     }
 
-    // `None` = escrow is on but this device doesn't know which tier (e.g. after
-    // a restart). Escrow is "on" for anything that isn't a confirmed Off.
-    let tier = ra.tier();
-    let is_on = !matches!(tier, Some(EscrowTier::Off));
+    let alerts_on = ra.alerts_on();
     let busy = ra.submitting;
 
-    // Inheritance escrow tier selector (ECIES pivot). Picking a tier turns the
-    // server-blind heartbeat gate on and uploads the per-keyholder ciphertext;
-    // Off tears the escrow down. The old plaintext-descriptor "Full" tier is
-    // gone — COINCUBE never sees the descriptor or seed.
-    let tier_row = Row::new()
-        .spacing(8)
-        .push(tier_button(
-            "Off",
-            EscrowTier::Off,
-            tier,
-            busy,
-            ra.awaiting_pin,
-        ))
-        .push(tier_button(
-            "Vault only",
-            EscrowTier::VaultOnly,
-            tier,
-            busy,
-            ra.awaiting_pin,
-        ))
-        .push(tier_button(
-            "Full Cube",
-            EscrowTier::FullCube,
-            tier,
-            busy,
-            ra.awaiting_pin,
-        ));
-    body = body.push(tier_row);
+    // ── Control 1: the Recovery alerts toggle (monitoring on/off) ──────────
+    body = body.push(Space::new().height(Length::Fixed(4.0)));
+    body = body.push(
+        Row::new()
+            .spacing(20)
+            .align_y(Alignment::Center)
+            .push(text("Recovery alerts").bold())
+            .push(Space::new().width(Length::Fill))
+            .push(
+                Toggler::new(alerts_on)
+                    .on_toggle(|on| {
+                        SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::ToggleAlerts(on))
+                            .into()
+                    })
+                    .width(50)
+                    .style(theme::toggler::orange),
+            ),
+    );
+    // The C4 disclosure — stated plainly, no euphemisms.
+    body = body.push(
+        text(
+            "When on, COINCUBE learns only the block height at which this Vault's recovery window \
+             opens and that this desktop checked in — never your addresses or balances.",
+        )
+        .size(13),
+    );
 
-    // The honest trade-off copy for the selected tier. While the PIN is being
-    // collected for a Full-Cube enrolment, `ra.tier()` still reports the prior
-    // tier (it only advances on a confirmed change) but the Full Cube button is
-    // already highlighted — show its copy to match (same condition the button
-    // uses for its highlight).
-    let display_tier = if ra.awaiting_pin {
-        Some(EscrowTier::FullCube)
-    } else {
-        tier
-    };
-    body = body.push(text(tier_copy(display_tier)).size(13));
+    // Residual nudge (PR 3): with keyholders present but alerts off, they'd
+    // never be told when the recovery window opens. Not a re-prompt — the
+    // one-time consent card is durable — just a standing warning on the card.
+    if !alerts_on && !ra.keyholders.is_empty() {
+        body = body.push(
+            text(
+                "Your keyholders will NOT be alerted when this Vault's recovery window opens. \
+                 Turn on Recovery alerts to fix this.",
+            )
+            .size(13)
+            .style(theme::text::error),
+        );
+    }
 
-    // Full-Cube re-confirms the PIN before exporting the seed into escrow.
-    if ra.awaiting_pin {
+    // Inline confirm for turning alerts off. Never silent: when a recovery kit
+    // is escrowed, the confirm discloses that it will be deleted too (escrow
+    // can't outlive alerts).
+    if ra.confirming_alerts_off {
         body = body.push(Space::new().height(Length::Fixed(6.0)));
-        body = body.push(
-            text("Enter your PIN to include this Cube's seed in the encrypted escrow.").size(13),
-        );
-        body = body.push(
-            iced::widget::text_input("PIN", ra.pin.as_str())
-                .secure(true)
-                .padding(8)
-                .on_input(|s| {
-                    SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::EscrowPinChanged(
-                        s.into(),
-                    ))
-                    .into()
-                })
-                .on_submit(
-                    SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::ConfirmFullCube).into(),
-                ),
-        );
+        let warning = if ra.has_escrow() {
+            "Turn off recovery alerts? COINCUBE will stop watching for this Vault's recovery \
+             window. This also deletes the encrypted recovery kit currently stored for your \
+             keyholders — they'll no longer be able to recover this Vault."
+        } else {
+            "Turn off recovery alerts? COINCUBE will stop watching for this Vault's recovery \
+             window, so your keyholders won't be alerted when it opens."
+        };
+        body = body.push(text(warning).size(13));
         body = body.push(
             Row::new()
                 .spacing(8)
                 .push(
-                    button::primary(None, "Confirm")
+                    button::primary(None, "Turn off")
                         .padding([8, 14])
-                        .on_press_maybe(
-                            (!busy).then_some(
-                                SettingsMessage::RecoveryAlerts(
-                                    RecoveryAlertsMessage::ConfirmFullCube,
-                                )
+                        .on_press_maybe((!busy).then_some(
+                            SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::ConfirmAlertsOff)
                                 .into(),
-                            ),
-                        ),
+                        )),
                 )
                 .push(
                     button::secondary(None, "Cancel")
                         .padding([8, 14])
-                        .on_press_maybe(Some(
-                            SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::CancelFullCube)
+                        .on_press(
+                            SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::CancelAlertsOff)
                                 .into(),
-                        )),
+                        ),
                 ),
         );
     }
 
-    // The keyholder list only makes sense when escrow is on.
-    if is_on {
-        // Who would be notified.
+    // The keyholder list belongs to alerts (who'd be notified), so it shows
+    // whenever alerts are on.
+    if alerts_on {
         body = body.push(Space::new().height(Length::Fixed(4.0)));
         body = body.push(text("Keyholders who'd be notified").bold().size(14));
         if ra.keyholders.is_empty() {
@@ -319,6 +308,11 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
         }
     }
 
+    // ── Control 2: the escrow selector (what keyholders can recover) ───────
+    body = body.push(Space::new().height(Length::Fixed(10.0)));
+    body = body.push(text("What keyholders can recover").bold().size(14));
+    body = body.push(escrow_selector(ra, alerts_on, busy));
+
     if let Some(err) = ra.error.as_deref() {
         body = body.push(text(err).size(13).style(theme::text::error));
     }
@@ -326,21 +320,135 @@ fn recovery_alerts_card<'a>(ra: &'a RecoveryAlerts) -> Element<'a, Message> {
     card::simple(body).width(Length::Fill).into()
 }
 
+/// The "What keyholders can recover" escrow selector — Estate-gated (locked
+/// affordance when the account lacks the `inheritanceEscrow` entitlement). The
+/// tier is server-derived; picking Vault only / Full Cube auto-enables alerts.
+fn escrow_selector<'a>(ra: &'a RecoveryAlerts, alerts_on: bool, busy: bool) -> Element<'a, Message> {
+    // Locked affordance when the account can't escrow a recovery kit.
+    if !ra.escrow_entitled {
+        return Column::new()
+            .spacing(10)
+            .push(
+                text(
+                    "An encrypted recovery kit for your keyholders is part of the Estate plan. \
+                     Recovery alerts above still work on your current plan.",
+                )
+                .size(13),
+            )
+            .push(
+                button::primary(None, "View plans")
+                    .width(Length::Fixed(160.0))
+                    .on_press(Message::OpenPlanBilling),
+            )
+            .into();
+    }
+
+    // `None` = escrow is on but this device can't tell which tier (older API
+    // that doesn't report `escrowedArtifacts`). While collecting the PIN for a
+    // Full-Cube enrolment, highlight Full Cube to match the copy below.
+    let escrow_tier = ra.escrow_tier();
+    let display_tier = if ra.awaiting_pin {
+        Some(EscrowTier::FullCube)
+    } else {
+        escrow_tier
+    };
+
+    let selector = Row::new()
+        .spacing(8)
+        .push(escrow_button(
+            "Nothing",
+            EscrowTier::Off,
+            display_tier,
+            busy,
+        ))
+        .push(escrow_button(
+            "Vault only",
+            EscrowTier::VaultOnly,
+            display_tier,
+            busy,
+        ))
+        .push(escrow_button(
+            "Full Cube",
+            EscrowTier::FullCube,
+            display_tier,
+            busy,
+        ));
+
+    let mut col = Column::new()
+        .spacing(10)
+        .push(selector)
+        .push(text(escrow_copy(display_tier)).size(13));
+
+    // Auto-enable disclosure: picking a kit while alerts are off turns them on.
+    if !alerts_on {
+        col = col.push(
+            text("Choosing Vault only or Full Cube also turns Recovery alerts on.")
+                .size(13)
+                .style(theme::text::secondary),
+        );
+    }
+
+    // Full-Cube re-confirms the PIN before exporting the seed into escrow.
+    if ra.awaiting_pin {
+        col = col.push(Space::new().height(Length::Fixed(6.0)));
+        col = col.push(
+            text("Enter your PIN to include this Cube's seed in the encrypted recovery kit.")
+                .size(13),
+        );
+        col = col.push(
+            iced::widget::text_input("PIN", ra.pin.as_str())
+                .secure(true)
+                .padding(8)
+                .on_input(|s| {
+                    SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::EscrowPinChanged(
+                        s.into(),
+                    ))
+                    .into()
+                })
+                .on_submit(
+                    SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::ConfirmFullCube).into(),
+                ),
+        );
+        col = col.push(
+            Row::new()
+                .spacing(8)
+                .push(
+                    button::primary(None, "Confirm")
+                        .padding([8, 14])
+                        .on_press_maybe((!busy).then_some(
+                            SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::ConfirmFullCube)
+                                .into(),
+                        )),
+                )
+                .push(
+                    button::secondary(None, "Cancel")
+                        .padding([8, 14])
+                        .on_press(
+                            SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::CancelFullCube)
+                                .into(),
+                        ),
+                ),
+        );
+    }
+
+    col.into()
+}
+
 /// An escrow-tier option button. Highlighted (primary) when it's the active
 /// tier (or while collecting the PIN for a Full-Cube enrolment); disabled while
 /// a change is in flight.
-fn tier_button<'a>(
+fn escrow_button<'a>(
     label: &'static str,
     this: EscrowTier,
     active: Option<EscrowTier>,
     busy: bool,
-    awaiting_pin: bool,
 ) -> Element<'a, Message> {
     // `active == None` (tier on but unknown on this device) highlights nothing,
     // leaving every tier pressable so the owner can confirm/change it.
-    let is_active = active == Some(this) || (awaiting_pin && this == EscrowTier::FullCube);
-    let on_press = (!busy && !is_active)
-        .then_some(SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::SelectTier(this)).into());
+    let is_active = active == Some(this);
+    let on_press = (!busy && !is_active).then_some(
+        SettingsMessage::RecoveryAlerts(RecoveryAlertsMessage::SelectEscrow(this)).into(),
+    );
     if is_active {
         button::primary(None, label)
             .padding([8, 14])
@@ -358,20 +466,19 @@ fn tier_button<'a>(
 /// self-custody trust model demands it; see the ECIES decision record).
 /// Everything is encrypted to the keyholders' own keys: COINCUBE can read
 /// neither the descriptor nor the seed.
-fn tier_copy(tier: Option<EscrowTier>) -> &'static str {
+fn escrow_copy(tier: Option<EscrowTier>) -> &'static str {
     match tier {
-        // Escrow is on, but this device didn't enrol it this session and the
-        // owner monitoring status doesn't report the tier — so we state that
+        // Escrow is on, but an older API doesn't report which tier — state that
         // honestly rather than assert (and possibly mis-state) descriptor-only
         // vs seed escrow.
         None => {
-            "Recovery escrow is on, but this device can't tell which tier is active (it isn't \
-             reported after a restart). Reselect Vault only or Full Cube to confirm or change it, \
-             or Off to turn recovery off."
+            "A recovery kit is stored, but this device can't tell which kind (this server doesn't \
+             report it). Reselect Vault only or Full Cube to confirm or change it, or Nothing to \
+             remove it."
         }
         Some(EscrowTier::Off) => {
-            "Off: heirs can't recover this Vault. No encrypted copy is kept and COINCUBE watches \
-             nothing."
+            "Nothing — alerts only: your keyholders are told when the recovery window opens, but \
+             no encrypted recovery kit is stored, so they can't recover this Vault themselves."
         }
         Some(EscrowTier::VaultOnly) => {
             "Vault only: an encrypted copy of this Vault's descriptor is sealed to each \

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -2707,7 +2707,10 @@ mod vault_monitoring_tests {
             "escrowedArtifacts": ["descriptor"]
         }))
         .unwrap();
-        assert_eq!(vault_only.escrowed_artifacts.as_deref(), Some(&["descriptor".to_string()][..]));
+        assert_eq!(
+            vault_only.escrowed_artifacts.as_deref(),
+            Some(&["descriptor".to_string()][..])
+        );
 
         let full_cube: VaultMonitoringStatus = serde_json::from_value(serde_json::json!({
             "monitoringLevel": "heartbeat",

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -319,11 +319,24 @@ pub struct PlanEntitlements {
     /// fan-out when duress fires). See `PLAN-estate-notifications.md` PR 1.
     #[serde(default)]
     pub duress_alerts: bool,
-    /// Estate-only: vault recovery-path monitoring (descriptor escrow or
-    /// timelock heartbeat → keyholder emails). See
-    /// `PLAN-estate-notifications.md` PR 2.
+    /// Vault recovery-path monitoring (timelock heartbeat → keyholder emails).
+    /// After the recovery-alerts cleanup (API PR 3) the server returns this
+    /// `true` on **all** plans, so the alerts toggle is available to everyone;
+    /// the desktop keeps reading it as a defense-in-depth gate. See
+    /// `PLAN-estate-notifications.md` PR 2 and `PLAN-recovery-alerts-cleanup.md`.
     #[serde(default)]
     pub recovery_alerts: bool,
+    /// Estate-only: the server-blind ECIES **inheritance escrow** — the
+    /// encrypted recovery kit (descriptor, optionally seed) sealed to each
+    /// keyholder's key. Gates the "What keyholders can recover" tier selector on
+    /// the Recovery Alerts card, separately from the (universal) alerts toggle
+    /// above. `#[serde(default)]` means an older API that omits it fails
+    /// **closed** (the selector shows its locked affordance) — the safe
+    /// direction for a paid feature. Wire key `inheritanceEscrow` (the API's
+    /// canonical name in `entitlements.go`; via the struct-level camelCase). See
+    /// `PLAN-recovery-alerts-cleanup.md` PR 2 + ADDENDUM.
+    #[serde(default)]
+    pub inheritance_escrow: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -2165,6 +2178,21 @@ pub struct VaultMonitoringStatus {
     pub last_notified_state: Option<String>,
     #[serde(default)]
     pub updated_at: Option<String>,
+    /// Which ECIES artifact kinds the owner currently has escrowed for this
+    /// Vault's keyholders. Drives the desktop's server-derived escrow tier
+    /// (no session-tracked guess):
+    /// - `["descriptor"]` → Vault-only,
+    /// - `["descriptor","seed"]` → Full-Cube,
+    /// - `[]` (present but empty) → alerts-only (nothing escrowed).
+    ///
+    /// `None` when the field is **absent** — an older API that predates the
+    /// escrowed-artifacts report. The desktop then can't tell which tier is
+    /// enrolled and falls back to the "on, tier unknown" copy rather than
+    /// asserting a tier the server didn't confirm (C2). Wire key
+    /// `escrowedArtifacts` (struct-level camelCase); `#[serde(default)]` keeps
+    /// older payloads parsing.
+    #[serde(default)]
+    pub escrowed_artifacts: Option<Vec<String>>,
 }
 
 impl Default for VaultMonitoringStatus {
@@ -2173,6 +2201,7 @@ impl Default for VaultMonitoringStatus {
             level: VaultMonitoringLevel::Off,
             last_notified_state: None,
             updated_at: None,
+            escrowed_artifacts: None,
         }
     }
 }
@@ -2543,6 +2572,38 @@ pub struct PutRecoveryKitEnvelopeRequest {
 }
 
 #[cfg(test)]
+mod plan_entitlements_tests {
+    use super::*;
+
+    #[test]
+    fn escrow_entitlement_reads_canonical_inheritance_escrow_key() {
+        // Regression lock (PLAN-recovery-alerts-cleanup ADDENDUM): the escrow
+        // selector gates on the API's canonical `inheritanceEscrow` key — NOT
+        // the `recoveryEscrow` name the desktop first coined. A drift here silently
+        // fails the selector closed even for Estate, so pin the exact wire key.
+        let estate: PlanEntitlements = serde_json::from_value(serde_json::json!({
+            "recoveryAlerts": true,
+            "inheritanceEscrow": true
+        }))
+        .unwrap();
+        assert!(estate.inheritance_escrow);
+        assert!(estate.recovery_alerts);
+
+        // The old (wrong) key must NOT satisfy the gate — proves the rename stuck.
+        let wrong_key: PlanEntitlements =
+            serde_json::from_value(serde_json::json!({ "recoveryEscrow": true })).unwrap();
+        assert!(!wrong_key.inheritance_escrow);
+    }
+
+    #[test]
+    fn escrow_entitlement_fails_closed_when_absent() {
+        // Older API that omits the field → the selector fails closed (locked).
+        let entitlements = PlanEntitlements::default();
+        assert!(!entitlements.inheritance_escrow);
+    }
+}
+
+#[cfg(test)]
 mod vault_monitoring_tests {
     use super::*;
 
@@ -2635,6 +2696,45 @@ mod vault_monitoring_tests {
         let s: VaultMonitoringStatus = serde_json::from_value(v).unwrap();
         assert_eq!(s.level, VaultMonitoringLevel::Off);
         assert!(s.last_notified_state.is_none());
+    }
+
+    #[test]
+    fn monitoring_status_reads_escrowed_artifacts() {
+        // New API (API PR 1) reports the escrowed artifact kinds so the desktop
+        // derives the tier from the server instead of a session-tracked guess.
+        let vault_only: VaultMonitoringStatus = serde_json::from_value(serde_json::json!({
+            "monitoringLevel": "heartbeat",
+            "escrowedArtifacts": ["descriptor"]
+        }))
+        .unwrap();
+        assert_eq!(vault_only.escrowed_artifacts.as_deref(), Some(&["descriptor".to_string()][..]));
+
+        let full_cube: VaultMonitoringStatus = serde_json::from_value(serde_json::json!({
+            "monitoringLevel": "heartbeat",
+            "escrowedArtifacts": ["descriptor", "seed"]
+        }))
+        .unwrap();
+        assert_eq!(
+            full_cube.escrowed_artifacts.as_deref(),
+            Some(&["descriptor".to_string(), "seed".to_string()][..])
+        );
+
+        // Present but empty → alerts-only (nothing escrowed) — distinct from absent.
+        let alerts_only: VaultMonitoringStatus = serde_json::from_value(serde_json::json!({
+            "monitoringLevel": "heartbeat",
+            "escrowedArtifacts": []
+        }))
+        .unwrap();
+        assert_eq!(alerts_only.escrowed_artifacts.as_deref(), Some(&[][..]));
+    }
+
+    #[test]
+    fn monitoring_status_tolerates_absent_escrowed_artifacts() {
+        // Old API (pre-PR-1) omits the field entirely → None, so the desktop
+        // can distinguish "on, tier unknown" from "on, nothing escrowed".
+        let s: VaultMonitoringStatus =
+            serde_json::from_value(serde_json::json!({ "monitoringLevel": "heartbeat" })).unwrap();
+        assert!(s.escrowed_artifacts.is_none());
     }
 
     #[test]

--- a/coincube-gui/src/services/inheritance/mod.rs
+++ b/coincube-gui/src/services/inheritance/mod.rs
@@ -27,7 +27,7 @@ pub use ecies::{
 pub use error::EciesError;
 pub use escrow::{build_escrow_set, keyholders_from_vault, EscrowError, EscrowTier, KeyholderXpub};
 pub use heir::{decrypt_envelopes, HeirDecryptError};
-pub use owner::{disable_escrow, enroll_escrow, OwnerEscrowError};
+pub use owner::{disable_alerts, disable_escrow, enable_alerts, enroll_escrow, OwnerEscrowError};
 pub use owner_self::{
     build_owner_self_envelope_set, find_owner_self_recipient, seal_and_upload_owner_self,
     OwnerSelfError,

--- a/coincube-gui/src/services/inheritance/owner.rs
+++ b/coincube-gui/src/services/inheritance/owner.rs
@@ -337,7 +337,8 @@ mod tests {
         let escrow_put = server.mock(|when, then| {
             when.method(Method::PUT)
                 .path("/api/v1/connect/cubes/42/vault/escrow");
-            then.status(200).json_body(json!({ "success": true, "data": {} }));
+            then.status(200)
+                .json_body(json!({ "success": true, "data": {} }));
         });
 
         let client = CoincubeClient::for_test(server.base_url());

--- a/coincube-gui/src/services/inheritance/owner.rs
+++ b/coincube-gui/src/services/inheritance/owner.rs
@@ -97,7 +97,7 @@ pub async fn enroll_escrow(
     // 3. Switch the server-blind heartbeat gate on. Monitoring is keyed on
     //    the same cube id as the escrow upload above — no vault id involved.
     //    No descriptor — under ECIES the server stores none.
-    let status = client
+    let mut status = client
         .set_vault_monitoring(
             server_cube_id,
             SetVaultMonitoringRequest {
@@ -107,31 +107,100 @@ pub async fn enroll_escrow(
             },
         )
         .await?;
+    // The desktop knows exactly which artifact kinds it just sealed, so stamp
+    // them onto the returned status. The settings card derives the escrow tier
+    // straight from `escrowed_artifacts` (server-derived model, no session-tracked
+    // guess), so this makes the card reflect the enrolment immediately and stays
+    // correct even against an API that doesn't yet echo the field on this
+    // response. The next `LoadStatus` reconciles against the server's own report.
+    status.escrowed_artifacts = Some(if seed_json.is_some() {
+        vec!["descriptor".to_string(), "seed".to_string()]
+    } else {
+        vec!["descriptor".to_string()]
+    });
     Ok(status)
 }
 
-/// Turns inheritance escrow off: true-delete the monitoring record and the
-/// stored envelope set. Idempotent (both deletes treat 404 as success).
+/// Turns **alerts** (monitoring) on without escrowing anything — the standalone
+/// "Recovery alerts" opt-in (PR 2). Posts the monitoring record so the server
+/// watches the timelock heartbeat and emails keyholders when the recovery window
+/// opens; no descriptor or seed is uploaded. Returns the new (alerts-on,
+/// nothing-escrowed) status.
 ///
-/// Order mirrors `enroll_escrow` in reverse to preserve its invariant — escrow
-/// is uploaded before monitoring is switched on, so "monitoring on" always
-/// implies "ciphertext present." Tearing down, we therefore switch monitoring
-/// **off first**, then delete the escrow set. If the second call fails the Vault
-/// is left un-monitored with a harmless leftover (opaque, server-blind)
-/// envelope set that a retry removes — never the inverse, a monitored Vault with
-/// no ciphertext, where a recovery window could open with nothing for heirs.
+/// Only ever called when alerts were off — and by the split-model invariant
+/// (*escrow present ⟹ monitoring on*) escrow was therefore off too — so nothing
+/// is escrowed on return. We stamp `escrowed_artifacts = []` to say so.
+pub async fn enable_alerts(
+    client: &CoincubeClient,
+    server_cube_id: u64,
+) -> Result<VaultMonitoringStatus, OwnerEscrowError> {
+    let mut status = client
+        .set_vault_monitoring(
+            server_cube_id,
+            SetVaultMonitoringRequest {
+                level: VaultMonitoringLevel::Heartbeat,
+                descriptor: None,
+                gap_limit: None,
+            },
+        )
+        .await?;
+    status.escrowed_artifacts = Some(Vec::new());
+    Ok(status)
+}
+
+/// Turns **alerts** (monitoring) off — the only path that deletes the monitoring
+/// record. When `also_delete_escrow` is set (an escrow set is currently stored),
+/// the envelope set is deleted **first**, then monitoring, so a partial failure
+/// can never strand the forbidden state *escrow present + monitoring off* — a
+/// recovery window that could open with a stored kit no keyholder is being
+/// watched for. This reverses the old fused order deliberately: under the split
+/// model the safe-to-linger leftover is a *monitored* Vault (alerts-only), not a
+/// stored-kit-without-monitoring one. Both deletes are idempotent (404 =
+/// success). Returns the fully-off status.
+pub async fn disable_alerts(
+    client: &CoincubeClient,
+    server_cube_id: u64,
+    also_delete_escrow: bool,
+) -> Result<VaultMonitoringStatus, OwnerEscrowError> {
+    if also_delete_escrow {
+        // Escrow first: once it's gone we're in the valid alerts-only state, so
+        // if the monitoring delete then fails a retry finishes the job and we
+        // were never in the forbidden escrow-without-monitoring state.
+        client.delete_vault_escrow(server_cube_id).await?;
+    }
+    client.delete_vault_monitoring(server_cube_id).await?;
+    Ok(VaultMonitoringStatus {
+        level: VaultMonitoringLevel::Off,
+        escrowed_artifacts: Some(Vec::new()),
+        ..VaultMonitoringStatus::default()
+    })
+}
+
+/// Turns inheritance **escrow** off while leaving alerts (the monitoring record)
+/// in place — the "Nothing — alerts only" escrow selection (PR 2). True-deletes
+/// the stored envelope set; monitoring keeps running so keyholders are still
+/// alerted when the recovery window opens (they simply have no escrowed kit to
+/// recover with). Idempotent (a 404 on the escrow delete is success).
 ///
-/// Monitoring and escrow are both **cube-scoped**, so unlike a vault-keyed
-/// design there is no separate id to keep in sync here — a rebuilt Vault
-/// (new vault id, same cube) doesn't strand either delete.
+/// This is the escrow half of the old fused teardown, split out so the card's
+/// two controls map to two operations. It preserves the split-model invariant
+/// *escrow present ⟹ monitoring on*: after this returns escrow is gone and
+/// monitoring survives — a valid state. The monitoring record is deleted **only**
+/// by [`disable_alerts`].
+///
+/// Escrow is **cube-scoped**, so a rebuilt Vault (new vault id, same cube)
+/// doesn't strand the delete.
 pub async fn disable_escrow(
     client: &CoincubeClient,
     server_cube_id: u64,
 ) -> Result<VaultMonitoringStatus, OwnerEscrowError> {
-    client.delete_vault_monitoring(server_cube_id).await?;
     client.delete_vault_escrow(server_cube_id).await?;
+    // Monitoring stays on; report alerts-on with nothing escrowed. The exact
+    // on-level (heartbeat vs full) is immaterial to the desktop — any non-Off
+    // level reads as "alerts on" — and the next LoadStatus reconciles it.
     Ok(VaultMonitoringStatus {
-        level: VaultMonitoringLevel::Off,
+        level: VaultMonitoringLevel::Heartbeat,
+        escrowed_artifacts: Some(Vec::new()),
         ..VaultMonitoringStatus::default()
     })
 }
@@ -224,7 +293,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn disable_deletes_escrow_and_monitoring() {
+    async fn disable_escrow_deletes_escrow_only_keeping_alerts() {
+        // The "Nothing — alerts only" selection deletes the envelope set but
+        // NOT the monitoring record: keyholders still get the recovery-window
+        // alert. The monitoring DELETE mock is registered and must NOT be hit.
         let server = MockServer::start();
         let escrow_del = server.mock(|when, then| {
             when.method(Method::DELETE)
@@ -242,22 +314,48 @@ mod tests {
         let client = CoincubeClient::for_test(server.base_url());
         let status = disable_escrow(&client, 42).await.expect("disable ok");
         escrow_del.assert();
-        monitoring_del.assert();
-        assert_eq!(status.level, VaultMonitoringLevel::Off);
+        monitoring_del.assert_hits(0);
+        // Alerts stay on, nothing escrowed.
+        assert_ne!(status.level, VaultMonitoringLevel::Off);
+        assert_eq!(status.escrowed_artifacts.as_deref(), Some(&[][..]));
     }
 
     #[tokio::test]
-    async fn disable_removes_monitoring_before_escrow() {
-        // Safety ordering: monitoring is switched off first. If that fails we
-        // must bail *before* deleting the escrow set, so a partial failure never
-        // leaves a monitored Vault with no ciphertext (a recovery window could
-        // open with nothing for heirs). The escrow DELETE mock is registered but
-        // must NOT be hit.
+    async fn enable_alerts_posts_monitoring_without_escrow() {
+        // The standalone "Recovery alerts" opt-in posts the monitoring record
+        // and uploads nothing — no PUT escrow, no descriptor in the body.
+        let server = MockServer::start();
+        let monitoring_mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/api/v1/connect/cubes/42/vault/monitoring");
+            then.status(200).json_body(json!({
+                "success": true,
+                "data": { "monitoringLevel": "heartbeat" }
+            }));
+        });
+        // Escrow PUT must NOT be called.
+        let escrow_put = server.mock(|when, then| {
+            when.method(Method::PUT)
+                .path("/api/v1/connect/cubes/42/vault/escrow");
+            then.status(200).json_body(json!({ "success": true, "data": {} }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let status = enable_alerts(&client, 42).await.expect("enable ok");
+        monitoring_mock.assert();
+        escrow_put.assert_hits(0);
+        assert_ne!(status.level, VaultMonitoringLevel::Off);
+        assert_eq!(status.escrowed_artifacts.as_deref(), Some(&[][..]));
+    }
+
+    #[tokio::test]
+    async fn disable_alerts_without_escrow_deletes_monitoring_only() {
         let server = MockServer::start();
         let monitoring_del = server.mock(|when, then| {
             when.method(Method::DELETE)
                 .path("/api/v1/connect/cubes/42/vault/monitoring");
-            then.status(500).json_body(json!({ "success": false }));
+            then.status(200)
+                .json_body(json!({ "success": true, "data": {} }));
         });
         let escrow_del = server.mock(|when, then| {
             when.method(Method::DELETE)
@@ -267,13 +365,43 @@ mod tests {
         });
 
         let client = CoincubeClient::for_test(server.base_url());
-        let err = disable_escrow(&client, 42)
+        let status = disable_alerts(&client, 42, false)
             .await
-            .expect_err("monitoring delete failure should propagate");
-        assert!(matches!(err, OwnerEscrowError::Connect(_)));
+            .expect("disable ok");
         monitoring_del.assert();
-        // Escrow set is left intact (opaque, server-blind) for a retry to clear.
         escrow_del.assert_hits(0);
+        assert_eq!(status.level, VaultMonitoringLevel::Off);
+    }
+
+    #[tokio::test]
+    async fn disable_alerts_removes_escrow_before_monitoring() {
+        // Safety ordering under the split model: when both go, escrow is
+        // deleted FIRST. If that fails we must bail *before* deleting the
+        // monitoring record, so a partial failure never leaves the forbidden
+        // state escrow-present + monitoring-off (a recovery window could open
+        // with a stored kit no keyholder is being watched for). The monitoring
+        // DELETE mock is registered but must NOT be hit.
+        let server = MockServer::start();
+        let escrow_del = server.mock(|when, then| {
+            when.method(Method::DELETE)
+                .path("/api/v1/connect/cubes/42/vault/escrow");
+            then.status(500).json_body(json!({ "success": false }));
+        });
+        let monitoring_del = server.mock(|when, then| {
+            when.method(Method::DELETE)
+                .path("/api/v1/connect/cubes/42/vault/monitoring");
+            then.status(200)
+                .json_body(json!({ "success": true, "data": {} }));
+        });
+
+        let client = CoincubeClient::for_test(server.base_url());
+        let err = disable_alerts(&client, 42, true)
+            .await
+            .expect_err("escrow delete failure should propagate");
+        assert!(matches!(err, OwnerEscrowError::Connect(_)));
+        escrow_del.assert();
+        // Monitoring record is left intact (alerts stay on) for a retry to clear.
+        monitoring_del.assert_hits(0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Connect-backed monitoring and escrow teardown ordering and user consent persistence; mistakes could strand wrong monitoring/escrow state or suppress re-prompts incorrectly, but behavior is heavily gated, idempotent deletes, and covered by new unit tests.
> 
> **Overview**
> Implements the **recovery-alerts cleanup**: vault **recovery alerts** (timelock heartbeat / keyholder email) are separated from **inheritance escrow** (what keyholders can recover), with Estate gating only on the escrow tier selector via `inheritanceEscrow`.
> 
> The **Vault Recovery Alerts** settings card now has a **Recovery alerts** toggler (with confirm when turning off and optional escrow deletion), a **What keyholders can recover** selector (Nothing / Vault only / Full Cube), and a residual banner when keyholders exist but alerts are off. Escrow tier is **derived from server `escrowedArtifacts`** instead of a session-local guess; owner ops stamp artifacts on returned status for immediate UI consistency.
> 
> A **one-time full-screen consent modal** can appear when a Vault has keyholders, Connect is ready, alerts are off, and the user hasn’t answered yet; accept calls `enable_alerts`, decline or successful engagement persists `recovery_alerts_prompt_answered` per cube in settings. Triggers after vault setup and on recovery-alerts status load.
> 
> Connect client adds `inheritance_escrow` on plan entitlements and `escrowed_artifacts` on monitoring status; inheritance owner layer adds **`enable_alerts`** / **`disable_alerts`** (escrow-before-monitoring when both removed) and narrows **`disable_escrow`** to kit-only teardown while keeping monitoring on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cc08628d4d9019df036a47d7e39681b46d12322. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a one-time recovery-alerts consent prompt for eligible Vaults, with the choice remembered per Vault.
  - Reworked the Vault Recovery Alerts card into separate on/off monitoring controls and an Estate-gated escrow selector.
  - Added an alerts-off confirmation flow, including messaging when escrowed recovery data exists.
- **Bug Fixes**
  - Recovery/escrow state now derives from server-reported escrow artifacts, correctly handling older server responses where this data is missing.
  - If enabling recovery alerts fails due to missing prerequisites, the prompt remains available instead of being suppressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->