### PR TITLE
Feature Flags

### DIFF
--- a/coincube-gui/src/app/features.rs
+++ b/coincube-gui/src/app/features.rs
@@ -153,6 +153,62 @@ fn liquid_sunset() -> Availability {
     }
 }
 
+/// Whether the Duress Mode surface is shown at all — the third server-flag
+/// dimension, structurally the [`LiquidGate`] shape (two inputs OR'd) but with
+/// the Marketplace *hidden-not-greyed* kill-switch semantics.
+///
+/// Two independent inputs, OR'd:
+///
+/// - `server_enabled` — the per-user `duressEnabled` flag from
+///   `GET /connect/features`. Only meaningful on an *authenticated* call;
+///   pre-login the API silently reports `false`, so this stays `false` until
+///   features load for a signed-in user. Fails **closed** (absent / unloaded /
+///   unreachable = `false`): the launch build ships duress dark, and a stale or
+///   missing API response must never surface the untested setup wizard.
+/// - `enrolled` — this account has completed duress enrollment. The client
+///   mirror of the server's grandfather rule (master I4): an account enrolled
+///   during beta keeps every duress surface — manage, trigger, clear — even
+///   when prod later serves `duressEnabled: false` or Connect is unreachable.
+///
+/// Unlike [`LiquidGate`], the gated inputs both live in server / account state,
+/// not on disk: enrollment is the durable half and the enrolled client learns
+/// it (via account state) long before it could ever need the surface. So this
+/// gate is recomputed live from the account panel and is **not** mirrored into
+/// [`crate::app::cache::Cache`] or persisted to per-cube settings. An
+/// un-enrolled user is fail-closed, exactly like Marketplace: hiding a setup
+/// wizard costs them nothing.
+///
+/// This is only the launch/visibility half of the show-rule; the paid
+/// `duress` entitlement (`ConnectAccountPanel::is_duress_entitled`) is a
+/// separate, unchanged authority AND'd on top (see
+/// `ConnectAccountPanel::show_duress`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct DuressGate {
+    /// `duressEnabled` from `/connect/features` (authenticated). Defaults
+    /// `false`: fails closed until the server grants it for a signed-in user.
+    pub server_enabled: bool,
+    /// This account has completed duress enrollment. Never cleared by a
+    /// missing/`false` server flag — an enrolled account keeps duress forever.
+    pub enrolled: bool,
+}
+
+impl DuressGate {
+    /// Nothing granted, not enrolled — a fresh account before features load.
+    /// The starting value everywhere.
+    pub const OFF: Self = Self {
+        server_enabled: false,
+        enrolled: false,
+    };
+
+    /// The single source of truth for "should the duress surface exist" — the
+    /// launch flag OR'd with enrollment. Consulted by the nav row, the route
+    /// backstop, the duress view, and the enrollment-wizard backstop (each
+    /// after AND'ing the `duress` entitlement).
+    pub fn on(&self) -> bool {
+        self.server_enabled || self.enrolled
+    }
+}
+
 /// Display name for a network, used in popover text.
 fn net_label(n: Network) -> &'static str {
     match n {
@@ -525,6 +581,40 @@ mod tests {
             gate,
         )
         .is_available()
+    }
+
+    // ── Duress gate ─────────────────────────────────────────────────────
+    //
+    // The launch/visibility half of the duress show-rule (PLAN-feature-flags).
+    // The load-bearing rows are the grandfather ones: an enrolled account keeps
+    // the surface even when the server flag is off (master I4).
+
+    #[test]
+    fn duress_gate_off_is_fail_closed_and_matches_default() {
+        assert!(!DuressGate::OFF.on());
+        assert_eq!(DuressGate::default(), DuressGate::OFF);
+    }
+
+    #[test]
+    fn duress_gate_on_truth_table() {
+        // on() == server_enabled OR enrolled — the full 2×2.
+        let cases = [
+            (false, false, false), // fresh, un-enrolled, flag off → hidden
+            (true, false, true),   // server granted the flag → shown
+            (false, true, true),   // grandfathered: enrolled beats a flag-off
+            (true, true, true),    // both → shown
+        ];
+        for (server_enabled, enrolled, expected) in cases {
+            let gate = DuressGate {
+                server_enabled,
+                enrolled,
+            };
+            assert_eq!(
+                gate.on(),
+                expected,
+                "server_enabled={server_enabled} enrolled={enrolled}"
+            );
+        }
     }
 
     #[test]

--- a/coincube-gui/src/app/state/connect/account.rs
+++ b/coincube-gui/src/app/state/connect/account.rs
@@ -919,6 +919,13 @@ impl ConnectAccountPanel {
     /// intro screen, so it can show the enabled state instead of the setup
     /// flow. No-op for accounts without the duress entitlement. Best-effort:
     /// a failed fetch leaves the state `None` and the setup flow is shown.
+    ///
+    /// Gated on the entitlement only — deliberately **not** on the full
+    /// [`Self::show_duress`] gate. This fetch is what *discovers* `enrolled`
+    /// for an account enrolled on another device, and `show_duress()` depends
+    /// on `enrolled`; gating it on the gate would be circular and would strand
+    /// a grandfathered account (flag off, enrolled elsewhere) with the surface
+    /// hidden forever. The surface itself is gated elsewhere.
     pub fn reload_duress_state(&mut self) -> iced::Task<Message> {
         if !self.is_duress_entitled() {
             return iced::Task::none();
@@ -2642,10 +2649,13 @@ impl ConnectAccountPanel {
 
             // ── Enrollment wizard (Phases 2 & 8) ──
             DuressMessage::StartEnrollment => {
-                // Duress is a paid (Pro/Estate) feature. The view hides the CTA
-                // for un-entitled accounts; re-check here as a defensive backstop
-                // so a stale view can never open the wizard without entitlement.
-                if !self.is_duress_entitled() {
+                // Duress is a paid (Pro/Estate) feature behind a launch
+                // kill-switch. The nav hides the surface and the CTA for anyone
+                // who fails the show-rule (entitlement AND the launch gate);
+                // re-check the full gate here as a defensive backstop so a stale
+                // view can never open the wizard while duress is dark. Fails
+                // closed for an un-enrolled account with the flag off.
+                if !self.show_duress() {
                     return iced::Task::none();
                 }
                 // The hard vault gate (PLAN-duress-vault-gate). The CTA is
@@ -3858,6 +3868,54 @@ impl ConnectAccountPanel {
             .as_ref()
             .and_then(|f| f.liquid_enabled)
             .unwrap_or(false)
+    }
+
+    /// The per-user duress launch flag from `GET /connect/features`
+    /// (`duressEnabled`) — the server half of [`Self::duress_gate`].
+    ///
+    /// Defaults `false` while features are unloaded (in flight after sign-in,
+    /// fetch failed, or never signed in) and when the flag is absent — fails
+    /// closed like [`Self::marketplace_server_flags`]: a launch build ships
+    /// duress dark and must not surface the untested setup on a stale, silent,
+    /// or unreachable API. Unlike Marketplace, a `false` here is **not** the
+    /// whole story — it cannot hide duress from an already-enrolled account
+    /// (see [`Self::duress_gate`]).
+    ///
+    /// Deliberately **not** mirrored into [`crate::app::cache::Cache`] or
+    /// persisted to per-cube settings: the durable half of the gate is
+    /// enrollment, which lives in server/account state, so the gate is
+    /// recomputed live rather than cached (contrast the Liquid grant, which is
+    /// persisted because *funds* must survive offline).
+    pub fn duress_server_enabled(&self) -> bool {
+        self.features
+            .as_ref()
+            .and_then(|f| f.duress_enabled)
+            .unwrap_or(false)
+    }
+
+    /// The launch/visibility gate for the duress surface: the server flag OR'd
+    /// with this account's enrollment. The `OR enrolled` half is the client
+    /// mirror of the server's grandfather rule (master I4) — an enrolled
+    /// account keeps duress even when prod later serves `duressEnabled: false`
+    /// or Connect is unreachable. See [`crate::app::features::DuressGate`].
+    pub fn duress_gate(&self) -> crate::app::features::DuressGate {
+        crate::app::features::DuressGate {
+            server_enabled: self.duress_server_enabled(),
+            enrolled: self.is_duress_enrolled(),
+        }
+    }
+
+    /// Whether any duress surface should be shown: the paid `duress`
+    /// entitlement AND the launch gate. The single source of truth consulted
+    /// by the nav row, the route backstop, the duress view, and the
+    /// enrollment-wizard backstop.
+    ///
+    /// A launch kill-switch like Marketplace — when this is `false` the surface
+    /// is *hidden*, not greyed. (The duress *unlock* path — a duress PIN at
+    /// unlock — is not a UI surface and is deliberately untouched by this gate;
+    /// it must keep working for enrolled accounts regardless. Master I4/I8.)
+    pub fn show_duress(&self) -> bool {
+        self.is_duress_entitled() && self.duress_gate().on()
     }
 
     /// Whether the pre-expiry renewal banner should render: the plan is
@@ -6059,6 +6117,7 @@ mod plan_lifecycle_tests {
             liquid_enabled: None,
             buy_sell_enabled: None,
             p2p_enabled: None,
+            duress_enabled: None,
         }
     }
 
@@ -6408,6 +6467,127 @@ mod plan_lifecycle_tests {
         assert!(flags.marketplace_enabled);
         assert!(flags.buy_sell_on());
         assert!(!flags.p2p_on());
+    }
+
+    // ── Duress launch gate (PLAN-feature-flags) ───────────────────────────
+    fn features_with_duress(duress: Option<bool>) -> FeaturesResponse {
+        let mut f = features_with_purchasing(None, None);
+        f.duress_enabled = duress;
+        f
+    }
+
+    /// A Pro plan carrying the paid `duress` entitlement.
+    fn duress_entitled_plan() -> ConnectPlan {
+        let mut p = plan(PlanTier::Pro, PlanStatus::Active, None, None);
+        p.entitlements.duress = true;
+        p
+    }
+
+    #[test]
+    fn duress_flag_fail_closed_until_features_load() {
+        let panel = ConnectAccountPanel::new();
+        // Unloaded (fetch in flight / failed / unreachable / never signed in)
+        // → the flag and the whole gate read off.
+        assert!(!panel.duress_server_enabled());
+        assert_eq!(panel.duress_gate(), crate::app::features::DuressGate::OFF);
+        assert!(!panel.show_duress());
+    }
+
+    #[test]
+    fn duress_flag_absent_reads_as_off() {
+        let mut panel = ConnectAccountPanel::new();
+        // Loaded but the flag is absent (older backend) → off, fail-closed.
+        panel.features = Some(features_with_duress(None));
+        assert!(!panel.duress_server_enabled());
+    }
+
+    #[test]
+    fn duress_flag_mirrors_the_response() {
+        let mut panel = ConnectAccountPanel::new();
+        panel.features = Some(features_with_duress(Some(true)));
+        assert!(panel.duress_server_enabled());
+        panel.features = Some(features_with_duress(Some(false)));
+        assert!(!panel.duress_server_enabled());
+    }
+
+    #[test]
+    fn show_duress_full_matrix() {
+        // show_duress() == entitled AND (server_flag OR enrolled): all 8 cells
+        // of (entitled × flag × enrolled). Enrollment is supplied via the local
+        // arm signal here; the cross-device server-`enrolled` path is covered
+        // separately below.
+        let cases = [
+            // entitled, flag, enrolled, expected
+            (false, false, false, false),
+            (false, false, true, false),
+            (false, true, false, false),
+            (false, true, true, false),
+            (true, false, false, false), // fresh Pro on prod (flag off) → hidden
+            (true, false, true, true),   // grandfathered: enrolled beats flag-off
+            (true, true, false, true),   // server granted the flag → shown
+            (true, true, true, true),
+        ];
+        for (entitled, flag, enrolled, expected) in cases {
+            let mut panel = ConnectAccountPanel::new();
+            panel.plan = Some(if entitled {
+                duress_entitled_plan()
+            } else {
+                plan(PlanTier::Free, PlanStatus::Active, None, None)
+            });
+            panel.features = Some(features_with_duress(Some(flag)));
+            panel.duress_locally_armed = enrolled;
+            assert_eq!(
+                panel.show_duress(),
+                expected,
+                "entitled={entitled} flag={flag} enrolled={enrolled}"
+            );
+            // The gate half is entitlement-independent: it's the OR of inputs.
+            assert_eq!(panel.duress_gate().on(), flag || enrolled);
+        }
+    }
+
+    #[test]
+    fn show_duress_fail_closed_before_features_load_for_unenrolled() {
+        // Entitled Pro, features not yet loaded, never enrolled → hidden. This
+        // is the launch-critical row: a signed-in Pro must see nothing until a
+        // features fetch explicitly turns duress on.
+        let mut panel = ConnectAccountPanel::new();
+        panel.plan = Some(duress_entitled_plan());
+        assert!(!panel.show_duress());
+    }
+
+    #[test]
+    fn server_enrolled_state_grandfathers_with_flag_off() {
+        // The cross-device grandfather: `duressEnabled` is off and this device
+        // never armed, but the server reports the account enrolled (armed on
+        // another device). The surface must stay shown. `reload_duress_state`
+        // is what discovers this, which is why it is NOT gated on the gate.
+        let mut panel = ConnectAccountPanel::new();
+        panel.plan = Some(duress_entitled_plan());
+        panel.features = Some(features_with_duress(Some(false)));
+        assert!(!panel.duress_locally_armed);
+        panel.duress_state = Some(crate::services::coincube::DuressState {
+            active: false,
+            unlock_at: None,
+            enrolled: true,
+            this_device_registered: false,
+        });
+        assert!(panel.is_duress_enrolled());
+        assert!(panel.show_duress());
+    }
+
+    #[test]
+    fn duress_gate_reverts_to_off_when_features_cleared() {
+        // A flag granted mid-session must not survive logout: `features` is
+        // dropped on `clear_session`, so the accessor reverts to off (unless the
+        // account is still locally enrolled, which is the durable half).
+        let mut panel = ConnectAccountPanel::new();
+        panel.plan = Some(duress_entitled_plan());
+        panel.features = Some(features_with_duress(Some(true)));
+        assert!(panel.show_duress());
+        panel.features = None;
+        assert!(!panel.duress_server_enabled());
+        assert!(!panel.show_duress());
     }
 
     #[test]

--- a/coincube-gui/src/app/view/connect/mod.rs
+++ b/coincube-gui/src/app/view/connect/mod.rs
@@ -1648,6 +1648,17 @@ fn duress_ux<'a>(state: &'a ConnectAccountPanel) -> Element<'a, ConnectAccountMe
             .into();
     }
 
+    // Entitled but the launch gate is off (server flag off and this account
+    // hasn't enrolled): duress is a *hidden* kill-switch, not a greyed one. The
+    // nav hides the entry and both the navigation guard and the features-poll
+    // backstop redirect away, so this branch only guards a stale route for the
+    // instant before the redirect lands — render nothing rather than the
+    // upgrade CTA above, which would read wrong to an already-paid account. See
+    // `ConnectAccountPanel::show_duress`.
+    if !state.duress_gate().on() {
+        return Column::new().width(Length::Fill).into();
+    }
+
     // What duress activation does — stated plainly, no fine print. Shown in
     // both the enrolled and not-yet-enrolled states.
     col = col.push(
@@ -2685,6 +2696,7 @@ mod renewal_banner_tests {
             liquid_enabled: None,
             buy_sell_enabled: None,
             p2p_enabled: None,
+            duress_enabled: None,
         }
     }
 
@@ -2733,6 +2745,7 @@ mod renewal_banner_tests {
             liquid_enabled: Some(true),
             buy_sell_enabled: Some(true),
             p2p_enabled: Some(false),
+            duress_enabled: Some(true),
         }
     }
 
@@ -3066,6 +3079,19 @@ mod renewal_banner_tests {
             is_passkey: Some(false),
             local: true,
         }]);
+
+        // Entitled but the launch gate is off (features cleared → flag off, not
+        // enrolled): the hidden-placeholder branch. Normally unreachable (nav
+        // hides it + route backstop redirects); exercised here belt-and-suspenders.
+        account.features = None;
+        assert!(!account.show_duress());
+        let _ = duress_ux(&account);
+
+        // Launch flag on → gate opens, so the not-yet-enrolled setup flow (not
+        // the hidden placeholder) renders. `priced_features` carries
+        // `duressEnabled: true`.
+        account.features = Some(priced_features(None, None));
+        assert!(account.show_duress());
         let _ = duress_ux(&account);
 
         account.duress_locally_armed = true;

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1414,6 +1414,21 @@ impl Home {
             }
 
             Message::View(ViewMessage::GoToSection(section)) => {
+                // Duress launch kill-switch backstop: a deep-linked or otherwise
+                // programmatic navigation to the Duress section while it's gated
+                // off (the nav hides the entry, so a click can't produce this)
+                // redirects to Overview — fail-closed, hidden not greyed, the
+                // same shape as the Marketplace route guard. See
+                // `ConnectAccountPanel::show_duress`.
+                let section = if matches!(
+                    section,
+                    HomeSection::Connect(app::menu::ConnectSubMenu::Duress)
+                ) && !self.connect_account.show_duress()
+                {
+                    HomeSection::Connect(app::menu::ConnectSubMenu::Overview)
+                } else {
+                    section
+                };
                 // Update the account panel's active_sub when navigating to a Connect submenu
                 if let HomeSection::Connect(ref sub) = section {
                     self.connect_account.active_sub = sub.clone();
@@ -1714,6 +1729,22 @@ impl Home {
                 if !was_authenticated && now_authenticated {
                     self.connect_expanded = true;
                     self.active_section = HomeSection::Cubes;
+                }
+                // Duress launch kill-switch backstop for a mid-session flip: if
+                // the features refetch (or a duress-state change) that just flowed
+                // through `update_message` turned the gate off while the user is
+                // sitting on the Duress section, redirect to Overview. The surface
+                // is hidden, not greyed, so a stale route must not keep rendering
+                // it — a server flag flip propagates on the next `/connect/
+                // features` poll without a restart. See `show_duress`.
+                if matches!(
+                    self.active_section,
+                    HomeSection::Connect(app::menu::ConnectSubMenu::Duress)
+                ) && !self.connect_account.show_duress()
+                {
+                    self.active_section =
+                        HomeSection::Connect(app::menu::ConnectSubMenu::Overview);
+                    self.connect_account.active_sub = app::menu::ConnectSubMenu::Overview;
                 }
                 // Sync account tier from the Connect plan data
                 let old_tier = self.account_tier;
@@ -2436,17 +2467,21 @@ fn home_sidebar<'a>(home: &'a Home) -> Element<'a, Message> {
 
     if home.connect_expanded && is_authenticated {
         use app::menu::ConnectSubMenu;
-        let items: &[(&str, ConnectSubMenu)] = &[
+        let mut items: Vec<(&str, ConnectSubMenu)> = vec![
             ("Overview", ConnectSubMenu::Overview),
             ("Contacts", ConnectSubMenu::Contacts),
             ("Plan & Billing", ConnectSubMenu::PlanBilling),
             ("Security", ConnectSubMenu::Security),
-            // Duress (Phase 9). The duress_ux() panel gates on the `duress`
-            // entitlement and shows an upgrade prompt for Free, so the entry is
-            // safe to show for any authenticated user.
-            ("Duress", ConnectSubMenu::Duress),
         ];
-        for (label, sub) in items {
+        // Duress (Phase 9) is a launch kill-switch: shown only when the account
+        // is entitled AND the launch gate is on (server `duressEnabled`, or this
+        // account is already enrolled — the grandfather case). Hidden, not
+        // greyed, when off — like Marketplace. See
+        // `ConnectAccountPanel::show_duress`.
+        if home.connect_account.show_duress() {
+            items.push(("Duress", ConnectSubMenu::Duress));
+        }
+        for (label, sub) in &items {
             let is_active = matches!(
                 &home.active_section,
                 HomeSection::Connect(s) if *s == *sub
@@ -4205,6 +4240,81 @@ mod tests {
 
         signed_in.active_section = HomeSection::RecoverVault;
         signed_in.view();
+    }
+
+    // ── Duress launch kill-switch route backstop (PLAN-feature-flags PR 2) ──
+
+    /// A Pro plan carrying the paid `duress` entitlement.
+    fn duress_entitled_plan() -> crate::services::coincube::ConnectPlan {
+        use crate::services::coincube::{ConnectPlan, PlanEntitlements, PlanStatus, PlanTier};
+        let mut entitlements = PlanEntitlements::default();
+        entitlements.duress = true;
+        ConnectPlan {
+            plan: PlanTier::Pro,
+            status: PlanStatus::Active,
+            renewal_at: None,
+            entitlements,
+            billing_cycle: None,
+            plan_provenance: None,
+        }
+    }
+
+    /// A features payload with the duress launch flag explicitly off.
+    fn features_duress_off() -> crate::services::coincube::FeaturesResponse {
+        crate::services::coincube::FeaturesResponse {
+            plans: Vec::new(),
+            pricing_schema_version: None,
+            purchasing_enabled: None,
+            marketplace_enabled: None,
+            liquid_enabled: None,
+            buy_sell_enabled: None,
+            p2p_enabled: None,
+            duress_enabled: Some(false),
+        }
+    }
+
+    #[test]
+    fn duress_route_redirects_to_overview_when_gated_off() {
+        // Entitled Pro, launch flag off, not enrolled → the surface is hidden.
+        // A programmatic or restored navigation to it fails closed onto
+        // Overview rather than rendering the gated-off panel.
+        let mut home = signed_in_home();
+        home.connect_account.plan = Some(duress_entitled_plan());
+        home.connect_account.features = Some(features_duress_off());
+        assert!(!home.connect_account.show_duress());
+
+        let _ = home.update(Message::View(ViewMessage::GoToSection(HomeSection::Connect(
+            app::menu::ConnectSubMenu::Duress,
+        ))));
+
+        assert_eq!(
+            home.active_section,
+            HomeSection::Connect(app::menu::ConnectSubMenu::Overview)
+        );
+        assert_eq!(
+            home.connect_account.active_sub,
+            app::menu::ConnectSubMenu::Overview
+        );
+    }
+
+    #[test]
+    fn duress_route_reachable_when_enrolled_with_flag_off() {
+        // Grandfathered: enrolled on this device, launch flag off → the surface
+        // stays fully reachable. Navigation to it sticks rather than redirecting.
+        let mut home = signed_in_home();
+        home.connect_account.plan = Some(duress_entitled_plan());
+        home.connect_account.features = Some(features_duress_off());
+        home.connect_account.duress_locally_armed = true;
+        assert!(home.connect_account.show_duress());
+
+        let _ = home.update(Message::View(ViewMessage::GoToSection(HomeSection::Connect(
+            app::menu::ConnectSubMenu::Duress,
+        ))));
+
+        assert_eq!(
+            home.active_section,
+            HomeSection::Connect(app::menu::ConnectSubMenu::Duress)
+        );
     }
 
     #[test]

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -1742,8 +1742,7 @@ impl Home {
                     HomeSection::Connect(app::menu::ConnectSubMenu::Duress)
                 ) && !self.connect_account.show_duress()
                 {
-                    self.active_section =
-                        HomeSection::Connect(app::menu::ConnectSubMenu::Overview);
+                    self.active_section = HomeSection::Connect(app::menu::ConnectSubMenu::Overview);
                     self.connect_account.active_sub = app::menu::ConnectSubMenu::Overview;
                 }
                 // Sync account tier from the Connect plan data
@@ -4283,9 +4282,9 @@ mod tests {
         home.connect_account.features = Some(features_duress_off());
         assert!(!home.connect_account.show_duress());
 
-        let _ = home.update(Message::View(ViewMessage::GoToSection(HomeSection::Connect(
-            app::menu::ConnectSubMenu::Duress,
-        ))));
+        let _ = home.update(Message::View(ViewMessage::GoToSection(
+            HomeSection::Connect(app::menu::ConnectSubMenu::Duress),
+        )));
 
         assert_eq!(
             home.active_section,
@@ -4307,9 +4306,9 @@ mod tests {
         home.connect_account.duress_locally_armed = true;
         assert!(home.connect_account.show_duress());
 
-        let _ = home.update(Message::View(ViewMessage::GoToSection(HomeSection::Connect(
-            app::menu::ConnectSubMenu::Duress,
-        ))));
+        let _ = home.update(Message::View(ViewMessage::GoToSection(
+            HomeSection::Connect(app::menu::ConnectSubMenu::Duress),
+        )));
 
         assert_eq!(
             home.active_section,

--- a/coincube-gui/src/home.rs
+++ b/coincube-gui/src/home.rs
@@ -4246,13 +4246,14 @@ mod tests {
     /// A Pro plan carrying the paid `duress` entitlement.
     fn duress_entitled_plan() -> crate::services::coincube::ConnectPlan {
         use crate::services::coincube::{ConnectPlan, PlanEntitlements, PlanStatus, PlanTier};
-        let mut entitlements = PlanEntitlements::default();
-        entitlements.duress = true;
         ConnectPlan {
             plan: PlanTier::Pro,
             status: PlanStatus::Active,
             renewal_at: None,
-            entitlements,
+            entitlements: PlanEntitlements {
+                duress: true,
+                ..PlanEntitlements::default()
+            },
             billing_cycle: None,
             plan_provenance: None,
         }

--- a/coincube-gui/src/services/coincube/mod.rs
+++ b/coincube-gui/src/services/coincube/mod.rs
@@ -430,6 +430,25 @@ pub struct FeaturesResponse {
     /// [`crate::app::features::LiquidGate`], which OR's this with local state.
     #[serde(default, alias = "liquidEnabled", alias = "liquid_enabled")]
     pub liquid_enabled: Option<bool>,
+    /// Per-user launch flag for the Duress Mode surface (`duressEnabled`).
+    /// `Some(true)` means the server permits this account to see the duress
+    /// enrollment/management UI; absent/`Some(false)` means it doesn't.
+    ///
+    /// Fails **closed** like the Marketplace flags: absent, unloaded, or an
+    /// unreachable API all read as *off*, so the public launch build ships
+    /// duress dark and never surfaces the untested setup on a stale response.
+    ///
+    /// The same authenticated-only caveat as `liquid_enabled` applies — the
+    /// desktop only fetches features after `set_token` (see
+    /// `ConnectAccountPanel::post_login_tasks`), so this is only meaningful on
+    /// a signed-in call.
+    ///
+    /// A `false` here never hides duress from an *already-enrolled* account —
+    /// see [`crate::app::features::DuressGate`], which OR's this with the
+    /// account's enrollment state (the client mirror of the server's
+    /// grandfather rule).
+    #[serde(default, alias = "duressEnabled", alias = "duress_enabled")]
+    pub duress_enabled: Option<bool>,
 }
 
 // ── Checkout / Billing ──────────────────────────────────────────────────────
@@ -2862,6 +2881,51 @@ mod cube_has_vault_tests {
         });
         let resp: CubeResponse = serde_json::from_value(v).unwrap();
         assert_eq!(resp.has_vault, Some(true));
+    }
+}
+
+#[cfg(test)]
+mod features_response_duress_tests {
+    //! `duressEnabled` transport (PLAN-feature-flags PR 1). Mirrors the
+    //! `liquidEnabled`/`marketplaceEnabled` shape: absent → `None` (treated
+    //! false, fail-closed), and both the camelCase wire key and the snake_case
+    //! alias parse to the same field.
+    use super::FeaturesResponse;
+    use serde_json::json;
+
+    fn features_json(extra: serde_json::Value) -> serde_json::Value {
+        let mut base = json!({ "plans": [] });
+        if let (Some(obj), Some(add)) = (base.as_object_mut(), extra.as_object()) {
+            for (k, v) in add {
+                obj.insert(k.clone(), v.clone());
+            }
+        }
+        base
+    }
+
+    #[test]
+    fn duress_enabled_absent_is_none() {
+        // Older backend / field omitted → None, which the gate reads as off.
+        let resp: FeaturesResponse = serde_json::from_value(features_json(json!({}))).unwrap();
+        assert_eq!(resp.duress_enabled, None);
+    }
+
+    #[test]
+    fn duress_enabled_true_and_false_parse() {
+        let on: FeaturesResponse =
+            serde_json::from_value(features_json(json!({ "duressEnabled": true }))).unwrap();
+        assert_eq!(on.duress_enabled, Some(true));
+
+        let off: FeaturesResponse =
+            serde_json::from_value(features_json(json!({ "duressEnabled": false }))).unwrap();
+        assert_eq!(off.duress_enabled, Some(false));
+    }
+
+    #[test]
+    fn duress_enabled_snake_case_alias_parses() {
+        let resp: FeaturesResponse =
+            serde_json::from_value(features_json(json!({ "duress_enabled": true }))).unwrap();
+        assert_eq!(resp.duress_enabled, Some(true));
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches security-adjacent UX gating and enrollment flows, but changes are defensive (fail-closed, grandfathering) with broad test coverage; unlock behavior is unchanged.
> 
> **Overview**
> Adds a **server launch kill-switch** for Duress Mode UI via `duressEnabled` on `GET /connect/features`, wired through a new `DuressGate` (`server_enabled OR enrolled`) and `ConnectAccountPanel::show_duress()` (paid entitlement **and** that gate).
> 
> **Visibility** follows Marketplace-style semantics: when off, the Connect nav **hides** Duress (no greyed row). **Enrolled accounts keep access** even if the flag is later `false` or features are unloaded—mirroring the Liquid/Marketplace grandfather patterns.
> 
> **Fail-closed** behavior until features load for unenrolled users; route guards in `home.rs` redirect deep links and mid-session flag flips to Overview; the duress view renders empty when the gate is off (avoids a misleading upgrade CTA for entitled users). Enrollment start is gated on `show_duress()` instead of entitlement alone; `reload_duress_state` stays entitlement-only so cross-device enrollment can be discovered without a circular gate.
> 
> The duress **unlock PIN path** is explicitly out of scope for this gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ce1f98dc67513dbe3641203157eca76d92dc913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a server-controlled launch flag for Duress Mode, combined with account enrollment to determine visibility.
* **Bug Fixes**
  * Duress Mode now stays hidden from navigation and replaces the Duress view with a placeholder when the launch gate is off, even if the account is entitled.
  * Added safeguards to redirect users away from Duress when it becomes unavailable mid-session.
* **New Features / API**
  * The features payload now supports an optional Duress flag (including fallback when omitted).
* **Tests**
  * Expanded coverage for the duress visibility gate matrix and redirect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->