### PR TITLE
cleanup

### DIFF
--- a/coincube-gui/src/app/state/vault/settings/bitcoind.rs
+++ b/coincube-gui/src/app/state/vault/settings/bitcoind.rs
@@ -754,7 +754,10 @@ impl State for BitcoindSettingsState {
                         // `Bitcoind::maybe_start`. Idempotent and non-destructive:
                         // `reconsiderblock` only clears rejection flags and lets the
                         // node re-activate the most-work chain, so the worst case is
-                        // that it does nothing.
+                        // that it does nothing — with one exception, which
+                        // `clear_failure_flags` handles by claiming the node first: a
+                        // replay in progress is holding the chain down with an
+                        // `invalidateblock` mark that this would clear.
                         let Some(settings) = self.bitcoind_settings.as_ref() else {
                             return Task::none();
                         };
@@ -1220,6 +1223,16 @@ fn write_internal_bitcoind_config(
     conf.to_file(&config_path).map_err(|e| e.to_string())?;
 
     let cookie_path = internal_bitcoind_cookie_path(&bitcoind_datadir, &network);
+    // Stamp the datadir with an identity, if it does not already carry one. This is
+    // what lets a chain repair be scoped to the node it was performed on: the RPC port
+    // and the cookie path both survive the datadir being wiped and rebuilt underneath
+    // them, and a repair authorisation left over from the old one would then apply to
+    // the new. The marker lives inside the datadir, so it goes when the datadir goes.
+    if let Err(e) = crate::node::bitcoind::ensure_node_instance_marker(&cookie_path) {
+        // Not fatal: without it, identity falls back to the endpoint and cookie path,
+        // which is where it stood before the marker existed.
+        tracing::warn!("could not stamp the managed node's datadir with an identity: {e}");
+    }
     Ok(BitcoindConfig {
         rpc_auth: BitcoindRpcAuth::CookieFile(cookie_path),
         addr: internal_bitcoind_address(rpc_port),
@@ -1247,11 +1260,21 @@ fn repair_managed_node_chain(
     let anchor_height = crate::node::revalidate::rdts_anchor_height(network).ok_or_else(|| {
         "BIP-110 isn't deployed on this network, so there is nothing to repair.".to_string()
     })?;
-    let bitcoind = coincubed::BitcoinD::new(cfg, "repair_node_chain".to_string())
-        .map_err(|e| format!("Could not reach the managed node: {e}"))?;
-    crate::node::revalidate::execute(
+    // An unreadable state sidecar is set aside by `clear_failure_flags` itself, once it
+    // owns the node and knows the repair is going ahead — not here. Doing it before the
+    // identity is settled would discard the one record telling the next start that
+    // something may still be pending, in exactly the case where the repair is then
+    // refused.
+    //
+    // Re-attempt the identity here too, so a start that could not settle it does not
+    // leave the user with a button that can never work — this is the "explicit repair"
+    // retry. It still refuses rather than repairing under a provisional identity, and
+    // `clear_failure_flags` turns that into a message the user can act on.
+    let identity = crate::node::bitcoind::establish_node_identity(cfg);
+    crate::node::revalidate::clear_failure_flags(
         coincube_datadir,
-        &bitcoind,
+        cfg,
+        &identity,
         crate::node::revalidate::RevalidationPlan::ClearFailureFlags { anchor_height },
     )?;
     Ok("Asked the node to re-check its chain. This may take a few minutes.".to_string())

--- a/coincube-gui/src/app/view/vault/settings/mod.rs
+++ b/coincube-gui/src/app/view/vault/settings/mod.rs
@@ -635,8 +635,15 @@ pub fn flavor_switch_confirm<'a>(target: NodeFlavor) -> Element<'a, NodeSettings
 /// otherwise keep following the chain Knots chose rather than the one with the
 /// most work. The app repairs that automatically whenever the node starts, so this
 /// button only matters when the state driving that check has been lost (a datadir
-/// carried between machines, a wiped sidecar). Safe to press at any time: the call
-/// is idempotent and clears flags rather than discarding anything.
+/// carried between machines, a wiped sidecar). The call is idempotent and clears
+/// flags rather than discarding anything.
+///
+/// Not, however, safe to fire *concurrently with a chain replay*: `reconsiderblock`
+/// at the anchor clears the `BLOCK_FAILED_*` marks on its descendants, and the
+/// replay's own `invalidateblock` mark is one of them, so it would release the chain
+/// the replay is holding down. The handler claims the node before issuing anything
+/// and reports a busy node back to the user instead — see
+/// `node::revalidate::clear_failure_flags`.
 pub fn chain_repair_section<'a>() -> Element<'a, NodeSettingsMessage> {
     card::simple(Container::new(
         Column::new()

--- a/coincube-gui/src/node/bitcoind.rs
+++ b/coincube-gui/src/node/bitcoind.rs
@@ -393,6 +393,247 @@ pub fn internal_bitcoind_cookie_path(bitcoind_datadir: &Path, network: &Network)
     cookie_path
 }
 
+/// Give the managed node's datadir an identity, unless it already has one.
+///
+/// Written beside the cookie file, i.e. inside the node's own network datadir, and
+/// read back by `coincubed` as part of [`coincubed::BackendId`]. That placement is the
+/// whole point: a chain repair authorises a deep rollback on one specific node, and
+/// the things that would otherwise identify it — the RPC port, the cookie path — both
+/// outlive the datadir being deleted and recreated beneath them. An authorisation from
+/// the old datadir would then be honoured against the new one. This marker goes with
+/// the datadir, so the replacement gets a fresh identity and the stale authorisation
+/// stops matching.
+///
+/// Generated once and never rewritten, so it is stable across restarts, node upgrades
+/// and flavour switches — all of which leave the datadir in place.
+///
+/// Installed atomically, and that matters more than it looks. Creating the final name
+/// and *then* writing into it leaves a window in which the marker exists but is empty:
+/// a second caller sees it, reports success, and connects — so a repair can be
+/// recorded against an identity derived from an empty marker while every later reader
+/// derives a different one from the finished file, and the authorisation stops
+/// matching for good. So the contents are staged under a private name, flushed, and
+/// linked into place in one step. A reader sees either no marker or a complete one.
+///
+/// Returns the identity now in force, which may be another caller's if it got there
+/// first. An incomplete marker — an empty file from a crash, or one left by an earlier
+/// version of this function — is discarded and replaced rather than trusted forever.
+/// How long to keep trying for the marker lock, as (attempts, delay between them).
+///
+/// Short in tests so the timeout path is exercisable without a two-second wait; the
+/// behaviour either side of it is what the tests are about, not the duration.
+fn lock_acquisition_bound() -> (u32, std::time::Duration) {
+    #[cfg(not(test))]
+    {
+        (40, std::time::Duration::from_millis(50))
+    }
+    #[cfg(test)]
+    (30, std::time::Duration::from_millis(10))
+}
+
+/// Whether the managed node's durable identity can be relied on yet.
+///
+/// A `BitcoinD` reads the datadir's instance marker once, at construction, and caches
+/// the identity it derives. That is fine when the marker is there, and fine when none is
+/// expected — but not when one is expected and merely *late*: everything built in the
+/// meantime reports the endpoint-and-cookie-path identity, and everything built after the
+/// marker lands reports a different one. A repair recorded in that window names an
+/// identity that no later client agrees with, and the authorisation it depends on stops
+/// matching — which is the failure the marker was introduced to prevent, reached by
+/// another route.
+///
+/// So the answer to a failed marker install is not "carry on with the weaker identity".
+/// It is to let the node start and sync, and to refuse anything that would write a repair
+/// down until the identity is settled.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NodeIdentity {
+    /// Settled: either the marker is installed and validated, or none is expected here,
+    /// so what a `BitcoinD` reports now is what it will keep reporting.
+    Stable,
+    /// A marker is expected and is not there. Any identity derived right now is
+    /// provisional, so no chain repair may be started or recorded against it.
+    Unstable,
+}
+
+impl NodeIdentity {
+    /// Whether a chain repair may be started or recorded.
+    pub fn permits_chain_repair(&self) -> bool {
+        matches!(self, Self::Stable)
+    }
+}
+
+/// Settle the managed node's identity, installing its marker if that has not happened
+/// yet.
+///
+/// Called before the first `BitcoinD` of a managed-node start, and again on an explicit
+/// repair — so a start that could not establish it does not poison later attempts, it
+/// just declines to repair until one of them succeeds.
+pub fn establish_node_identity(config: &BitcoindConfig) -> NodeIdentity {
+    match &config.rpc_auth {
+        coincubed::config::BitcoindRpcAuth::CookieFile(cookie_path) => {
+            match ensure_node_instance_marker(cookie_path) {
+                Ok(instance) => {
+                    tracing::debug!("managed node identity: {instance}");
+                    NodeIdentity::Stable
+                }
+                Err(e) => {
+                    warn!(
+                        "could not establish the managed node's identity ({e}); it will start \
+                         and sync as usual, but chain repairs are declined until this succeeds"
+                    );
+                    NodeIdentity::Unstable
+                }
+            }
+        }
+        // No cookie file for a marker to sit beside, so none is expected and none will
+        // ever appear. The endpoint-and-username identity such a node reports is already
+        // settled — weaker than a marker, but it does not change under us, which is what
+        // matters here. Repairs may proceed.
+        coincubed::config::BitcoindRpcAuth::UserPass(..) => NodeIdentity::Stable,
+    }
+}
+
+/// Installed under an advisory lock on a sibling file, because the whole
+/// read-validate-replace-install sequence has to be one transaction and not just its
+/// last step.
+///
+/// The atomic install alone is not enough once a *malformed* marker is in the way.
+/// Two callers both read it, both decide to replace it, and the second one's
+/// `remove_file` — decided on a read that is now stale — deletes the valid marker the
+/// first has just installed, after which they disagree about the identity forever.
+/// Holding the lock across the read means the file cannot change under a caller
+/// between validating it and replacing it.
+///
+/// An OS advisory lock rather than a lock *file*, deliberately: the kernel drops it
+/// when the holder's descriptor closes, including on a crash, so there is no stale lock
+/// to break and no timeout to guess. The lock file itself is left in place — it carries
+/// no state, and its existence is not what locks anything.
+pub fn ensure_node_instance_marker(cookie_path: &Path) -> std::io::Result<String> {
+    use fs4::fs_std::FileExt;
+
+    let dir = cookie_path.parent().ok_or_else(|| {
+        std::io::Error::other("the managed node's cookie path has no parent directory")
+    })?;
+    std::fs::create_dir_all(dir)?;
+
+    let lock_path = dir.join(format!("{}.lock", coincubed::NODE_INSTANCE_FILE));
+    let lock = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&lock_path)?;
+    // Bounded rather than blocking. Real contention here is a handful of Vaults starting
+    // in the same instant, all of which finish in microseconds — but this sits on the
+    // startup path of every Vault, and a holder that is wedged rather than crashed would
+    // otherwise wedge startup with it.
+    //
+    // Giving up is *not* the same as "no marker is expected here": the identity a
+    // `BitcoinD` caches while a marker is still on its way will change once it lands. See
+    // [`establish_node_identity`], which is what turns that distinction into a refusal to
+    // repair rather than a repair recorded against an identity about to move.
+    let (lock_attempts, lock_retry) = lock_acquisition_bound();
+    let mut acquired = false;
+    for attempt in 0..lock_attempts {
+        if lock.try_lock_exclusive()? {
+            acquired = true;
+            break;
+        }
+        if attempt + 1 < lock_attempts {
+            std::thread::sleep(lock_retry);
+        }
+    }
+    if !acquired {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::WouldBlock,
+            "another process is still establishing the managed node's identity",
+        ));
+    }
+    let established = establish_node_instance(dir);
+    // Explicit, so the unlock is not left to the order fields happen to drop in.
+    let _ = FileExt::unlock(&lock);
+    established
+}
+
+/// The locked part of [`ensure_node_instance_marker`]. Assumes exclusive access to
+/// `dir`'s marker.
+fn establish_node_instance(dir: &Path) -> std::io::Result<String> {
+    use rand::Rng;
+
+    /// Distinguishes concurrent stagers; only reachable by callers in different
+    /// processes holding the lock in turn, but the name still has to be unique.
+    static STAGING_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    let marker = dir.join(coincubed::NODE_INSTANCE_FILE);
+    match std::fs::read_to_string(&marker) {
+        Ok(existing) => {
+            let existing = existing.trim().to_string();
+            if coincubed::valid_node_instance(&existing) {
+                return Ok(existing);
+            }
+            // Empty or truncated — a crash between creating the file and filling it, or
+            // a marker from an older version of this code. Trusting it would hand out an
+            // identity that differs from whatever a complete marker later says, which is
+            // exactly the mismatch this function exists to prevent. Safe to replace only
+            // because the lock means no one has installed a valid marker since the read.
+            warn!("discarding a malformed managed-node identity at {marker:?}");
+            match std::fs::remove_file(&marker) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
+
+    let instance: String = rand::thread_rng()
+        .sample_iter(rand::distributions::Alphanumeric)
+        .take(coincubed::NODE_INSTANCE_LEN)
+        .map(char::from)
+        .collect();
+    let staged = dir.join(format!(
+        "{}.{}.{}.tmp",
+        coincubed::NODE_INSTANCE_FILE,
+        std::process::id(),
+        STAGING_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    let install = (|| -> std::io::Result<()> {
+        {
+            use std::io::Write;
+            let mut file = std::fs::File::create(&staged)?;
+            file.write_all(instance.as_bytes())?;
+            file.sync_all()?;
+        }
+        // Rename rather than link: under the lock there is nothing to lose a race
+        // against, and it leaves no second name to clean up. The final name therefore
+        // goes from absent to complete in one step — a concurrent *reader*, which takes
+        // no lock, never sees a half-written marker.
+        std::fs::rename(&staged, &marker)?;
+        // The contents are durable but the directory entry naming them may not be, and
+        // a lost entry is a marker that silently changes identity after a crash.
+        sync_directory(dir)
+    })();
+    // Nothing to remove on the success path — the rename consumed it — but a failure
+    // part-way must not leave staging files behind.
+    if install.is_err() {
+        let _ = std::fs::remove_file(&staged);
+    }
+    install.map(|()| instance)
+}
+
+/// Flush a directory entry, so a rename or link into it survives a crash.
+///
+/// Unix only: Windows cannot open a directory as a file without backup semantics, and
+/// NTFS metadata journalling makes the operation durable there anyway. Mirrors the
+/// managed-node state sidecar's own writes.
+fn sync_directory(dir: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    std::fs::File::open(dir)?.sync_all()?;
+    #[cfg(not(unix))]
+    let _ = dir;
+    Ok(())
+}
+
 /// Path of the cookie file used by internal bitcoind on a given network.
 pub fn internal_bitcoind_debug_log_path(
     coincubed_datadir: &CoincubeDirectory,
@@ -1150,6 +1391,18 @@ impl Bitcoind {
         coincube_datadir: &CoincubeDirectory,
     ) -> Result<Self, StartInternalBitcoindError> {
         let bitcoind_datadir = internal_bitcoind_datadir(coincube_datadir);
+        // Settle the datadir's identity before the first connection to it, not after.
+        // Every managed-node start comes through here — the loader with a config it read
+        // off disk, the installer with one it just wrote, the settings switch — and each
+        // goes on to build a `BitcoinD`, which reads the marker once at construction and
+        // caches what it derives. Establishing it later means a repair can be recorded
+        // against the endpoint-and-cookie-path identity and then stop matching the moment
+        // the marker appears.
+        //
+        // Not fatal if it fails: the node still starts and syncs, which is what the user
+        // is waiting for. What it does cost is chain reconciliation — every repair path
+        // declines while the answer is provisional, and the next start tries again.
+        let identity = establish_node_identity(&config);
         // Launch a binary consistent with the on-disk `bitcoin.conf`. A conf
         // carrying `consensusrules=rdts` *requires* a Knots binary — starting
         // Core against it makes Core reject the unknown option and exit — so we
@@ -1184,6 +1437,7 @@ impl Bitcoind {
                     coincube_datadir,
                     &running,
                     &config,
+                    &identity,
                     network,
                     running_flavor,
                 );
@@ -1292,6 +1546,7 @@ impl Bitcoind {
                         coincube_datadir,
                         &started,
                         &config,
+                        &identity,
                         network,
                         observed_flavor,
                     );
@@ -1493,6 +1748,374 @@ mod tests {
     use super::*;
     use coincube_core::miniscript::bitcoin::Network;
     use ini::Ini;
+
+    fn a_marker_datadir(name: &str) -> (std::path::PathBuf, PathBuf) {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-node-instance-{name}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let cookie_path = dir.join("signet").join(".cookie");
+        (dir, cookie_path)
+    }
+
+    // The marker is what turns "this endpoint with this cookie path" into "this node".
+    // It has to be stable while the datadir lives — restarts, upgrades and flavour
+    // switches all keep it — and gone once the datadir is, so a repair authorisation
+    // from the old datadir stops matching its replacement.
+    #[test]
+    fn the_node_instance_marker_is_stable_but_dies_with_its_datadir() {
+        let (dir, cookie_path) = a_marker_datadir("stable");
+        let marker = cookie_path
+            .parent()
+            .unwrap()
+            .join(coincubed::NODE_INSTANCE_FILE);
+
+        // The installer's shape: the network directory does not exist yet, and the
+        // marker has to be installable before anything connects.
+        assert!(!cookie_path.parent().unwrap().exists());
+        let first = ensure_node_instance_marker(&cookie_path).expect("stamped");
+        assert!(coincubed::valid_node_instance(&first));
+        assert_eq!(std::fs::read_to_string(&marker).unwrap(), first);
+
+        // Stable: stamping again is a no-op, so every later start of the same datadir
+        // sees the same identity.
+        assert_eq!(
+            ensure_node_instance_marker(&cookie_path).expect("idempotent"),
+            first
+        );
+
+        // Nothing but the marker and its (stateless) lock file.
+        assert_eq!(
+            marker_artifacts(&cookie_path),
+            vec![format!("{}.lock", coincubed::NODE_INSTANCE_FILE)],
+            "staging files were not cleaned up"
+        );
+
+        // Gone with the datadir, and the replacement is a different node.
+        let _ = std::fs::remove_dir_all(&dir);
+        let second = ensure_node_instance_marker(&cookie_path).expect("re-stamped");
+        assert_ne!(second, first);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // An empty or truncated marker is what the pre-atomic version of this function
+    // could leave behind, and what a crash between creating the file and filling it
+    // would leave. Trusting it hands out an identity that differs from the one the
+    // finished file would give, so a repair recorded against it stops matching for
+    // good. It has to be replaced, not adopted.
+    #[test]
+    fn an_incomplete_marker_is_replaced_rather_than_trusted() {
+        let (dir, cookie_path) = a_marker_datadir("incomplete");
+        let network_dir = cookie_path.parent().unwrap().to_path_buf();
+        let marker = network_dir.join(coincubed::NODE_INSTANCE_FILE);
+
+        for malformed in ["", "   ", "short", &"x".repeat(64), "not-alnum!!!"] {
+            std::fs::create_dir_all(&network_dir).unwrap();
+            std::fs::write(&marker, malformed).unwrap();
+            assert!(!coincubed::valid_node_instance(malformed.trim()));
+
+            let recovered = ensure_node_instance_marker(&cookie_path).expect("recovered");
+            assert!(
+                coincubed::valid_node_instance(&recovered),
+                "an incomplete marker ({:?}) must be replaced with a complete one",
+                malformed
+            );
+            assert_eq!(std::fs::read_to_string(&marker).unwrap(), recovered);
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Every marker-directory entry that is not the marker itself: staging files, lock
+    /// files, anything left behind.
+    fn marker_artifacts(cookie_path: &Path) -> Vec<String> {
+        std::fs::read_dir(cookie_path.parent().unwrap())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|name| name != coincubed::NODE_INSTANCE_FILE)
+            .collect()
+    }
+
+    // The hard case, and the one the fresh-datadir test below cannot reach: a *malformed*
+    // marker is already there when several callers arrive. Each of them decides to replace
+    // it, and without the whole read-validate-replace-install sequence being one
+    // transaction, the second one's delete — decided on a read that is now stale — removes
+    // the valid marker the first has just installed, leaving them permanently disagreeing.
+    #[test]
+    fn concurrent_recovery_from_a_malformed_marker_agrees_on_one_identity() {
+        let (dir, cookie_path) = a_marker_datadir("concurrent-malformed");
+        let network_dir = cookie_path.parent().unwrap().to_path_buf();
+        let marker = network_dir.join(coincubed::NODE_INSTANCE_FILE);
+
+        // The state a crash between creating the marker and filling it leaves behind.
+        std::fs::create_dir_all(&network_dir).unwrap();
+        std::fs::write(&marker, "").unwrap();
+
+        const CALLERS: usize = 8;
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(CALLERS));
+        let observed: Vec<String> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..CALLERS)
+                .map(|_| {
+                    let barrier = barrier.clone();
+                    let cookie_path = cookie_path.clone();
+                    scope.spawn(move || {
+                        // Every caller reads the malformed marker at as near the same
+                        // instant as we can arrange, which is what makes the stale-read
+                        // delete reachable.
+                        barrier.wait();
+                        ensure_node_instance_marker(&cookie_path).expect("recovered")
+                    })
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let winner = &observed[0];
+        assert!(
+            coincubed::valid_node_instance(winner),
+            "recovery produced a malformed identity"
+        );
+        for instance in &observed {
+            assert_eq!(
+                instance, winner,
+                "concurrent recovery from a malformed marker disagreed about the identity"
+            );
+        }
+        // Exactly one identity won, and it is the one on disk — not a later caller's that
+        // deleted it.
+        assert_eq!(&std::fs::read_to_string(&marker).unwrap(), winner);
+
+        // The lock is expected to remain (it holds no state); nothing else may.
+        let artifacts = marker_artifacts(&cookie_path);
+        let expected_lock = format!("{}.lock", coincubed::NODE_INSTANCE_FILE);
+        assert_eq!(
+            artifacts,
+            vec![expected_lock],
+            "recovery left staging artifacts behind"
+        );
+
+        // And the settled marker is now stable: a further caller adopts it rather than
+        // replacing it.
+        assert_eq!(
+            &ensure_node_instance_marker(&cookie_path).expect("stable"),
+            winner
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The timeout path, which is the one the bounded lock introduced. A holder that is
+    // slow but not wedged makes a second caller give up — and a caller that then carried
+    // on would build a `BitcoinD` caching the endpoint-and-cookie-path identity, record a
+    // repair against it, and watch that authorisation stop matching the moment the marker
+    // finally landed. So giving up has to mean "no repair", not "repair under whatever
+    // identity we have".
+    #[test]
+    fn a_timed_out_caller_gets_an_unstable_identity_and_recovers_on_retry() {
+        use fs4::fs_std::FileExt;
+
+        let (dir, cookie_path) = a_marker_datadir("timeout");
+        let network_dir = cookie_path.parent().unwrap().to_path_buf();
+        let marker = network_dir.join(coincubed::NODE_INSTANCE_FILE);
+        std::fs::create_dir_all(&network_dir).unwrap();
+
+        let config = coincubed::config::BitcoindConfig {
+            rpc_auth: coincubed::config::BitcoindRpcAuth::CookieFile(cookie_path.clone()),
+            addr: "127.0.0.1:8332".parse().unwrap(),
+        };
+
+        // A holder takes the lock and keeps it for longer than the acquisition bound.
+        let lock_path = network_dir.join(format!("{}.lock", coincubed::NODE_INSTANCE_FILE));
+        let held = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&lock_path)
+            .unwrap();
+        held.lock_exclusive().unwrap();
+
+        // The second caller exhausts its attempts and gives up. Joining takes exactly as
+        // long as the bound, so nothing here depends on a guessed sleep.
+        let timed_out = {
+            let config = config.clone();
+            std::thread::spawn(move || establish_node_identity(&config))
+                .join()
+                .unwrap()
+        };
+        assert_eq!(
+            timed_out,
+            NodeIdentity::Unstable,
+            "a timed-out caller must not report a settled identity"
+        );
+        assert!(!timed_out.permits_chain_repair());
+
+        // ...and with that, no chain operation can be claimed, so nothing can issue
+        // `invalidateblock` or `reconsiderblock`, record a rollback floor, or reconcile.
+        // The identity is checked before the maintenance guard is even reached, so this
+        // says nothing about whether some other test happens to hold it.
+        let (state_dir, datadir) = {
+            let d = dir.join("coincube");
+            (d.clone(), crate::dir::CoincubeDirectory::new(d))
+        };
+        assert!(matches!(
+            crate::node::revalidate::probe_chain_operation(&datadir, &timed_out),
+            Err(crate::node::revalidate::ClaimRefused::UnstableIdentity)
+        ));
+        // Nor can the manual "Re-check chain" repair, which surfaces it to the user.
+        let refusal = crate::node::revalidate::clear_failure_flags(
+            &datadir,
+            &config,
+            &timed_out,
+            crate::node::revalidate::RevalidationPlan::ClearFailureFlags {
+                anchor_height: crate::node::revalidate::RDTS_ANCHOR_MAINNET,
+            },
+        )
+        .expect_err("must refuse");
+        assert!(
+            refusal.contains("identity"),
+            "the refusal should say why: {}",
+            refusal
+        );
+        // Refused before anything was written down, so there is no half-recorded repair
+        // for a later start to trip over.
+        assert_eq!(
+            crate::node::revalidate::ManagedNodeState::load(&datadir).sanctioned_rollback,
+            None
+        );
+        let _ = std::fs::remove_dir_all(&state_dir);
+
+        // The original holder now finishes and releases, which is the "late successful
+        // installation" the timed-out caller has to pick up.
+        let installed = establish_node_instance(&network_dir).expect("installed");
+        let _ = FileExt::unlock(&held);
+
+        // A later start — or an explicit repair — settles on the marker that landed, and
+        // repairs are permitted again.
+        let retried = establish_node_identity(&config);
+        assert_eq!(retried, NodeIdentity::Stable);
+        assert!(retried.permits_chain_repair());
+        assert_eq!(std::fs::read_to_string(&marker).unwrap(), installed);
+        // Deliberately not asserting that a claim now succeeds: that also depends on the
+        // process-wide maintenance guard other tests take, and taking it here to look
+        // would make *their* assertions flaky in return. `permits_chain_repair` above is
+        // the identity-level property this test owns; that the gate then opens is
+        // asserted under the serialising lock in
+        // `revalidate::tests::an_unsettled_identity_permits_no_chain_operation`.
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The same property as the test above, established deterministically rather than by
+    // running threads at each other and hoping the bad interleaving shows up: hold the
+    // lock, prove a caller cannot proceed while it is held, install an identity underneath
+    // it, and require the caller to adopt that one once released. A caller that could
+    // delete a marker installed after its own validation read would return a different
+    // identity here, every time.
+    #[test]
+    fn a_caller_cannot_replace_a_marker_installed_while_it_waited() {
+        use fs4::fs_std::FileExt;
+
+        let (dir, cookie_path) = a_marker_datadir("locked-out");
+        let network_dir = cookie_path.parent().unwrap().to_path_buf();
+        let marker = network_dir.join(coincubed::NODE_INSTANCE_FILE);
+        std::fs::create_dir_all(&network_dir).unwrap();
+        // Malformed, so the waiting caller's plan is to replace it.
+        std::fs::write(&marker, "partial").unwrap();
+
+        let lock_path = network_dir.join(format!("{}.lock", coincubed::NODE_INSTANCE_FILE));
+        let held = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&lock_path)
+            .unwrap();
+        held.lock_exclusive().unwrap();
+
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let waiter = {
+            let cookie_path = cookie_path.clone();
+            std::thread::spawn(move || {
+                let instance = ensure_node_instance_marker(&cookie_path).expect("stamped");
+                let _ = done_tx.send(());
+                instance
+            })
+        };
+
+        // It must not get past the lock. If it did, it would be reading the malformed
+        // marker right now and preparing to delete whatever replaces it. Comfortably
+        // inside the acquisition bound, so it is still waiting rather than giving up.
+        assert!(
+            done_rx
+                .recv_timeout(std::time::Duration::from_millis(40))
+                .is_err(),
+            "a caller proceeded while the marker lock was held"
+        );
+
+        // Install the winning identity under the lock we are holding.
+        let winner = establish_node_instance(&network_dir).expect("installed");
+        assert!(coincubed::valid_node_instance(&winner));
+        let _ = FileExt::unlock(&held);
+
+        assert_eq!(
+            waiter.join().unwrap(),
+            winner,
+            "a caller replaced a marker that was installed while it waited"
+        );
+        assert_eq!(std::fs::read_to_string(&marker).unwrap(), winner);
+        assert_eq!(
+            marker_artifacts(&cookie_path),
+            vec![format!("{}.lock", coincubed::NODE_INSTANCE_FILE)]
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Several Vaults can attach to one fresh managed datadir in the same instant. Every
+    // one of them must come away with the *same* complete identity: if one of them
+    // records a repair against an identity another never sees, the authorisation stops
+    // matching and the repaired chain is refused indefinitely.
+    #[test]
+    fn concurrent_stamping_agrees_on_one_complete_identity() {
+        let (dir, cookie_path) = a_marker_datadir("concurrent");
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(8));
+        let observed: Vec<String> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..8)
+                .map(|_| {
+                    let barrier = barrier.clone();
+                    let cookie_path = cookie_path.clone();
+                    scope.spawn(move || {
+                        barrier.wait();
+                        ensure_node_instance_marker(&cookie_path).expect("stamped")
+                    })
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let first = &observed[0];
+        assert!(coincubed::valid_node_instance(first));
+        for instance in &observed {
+            assert_eq!(
+                instance, first,
+                "racing callers disagreed about the node's identity"
+            );
+        }
+        // And what is on disk is what they all reported — never an empty or partial
+        // file that a reader could have picked up in between.
+        let marker = cookie_path
+            .parent()
+            .unwrap()
+            .join(coincubed::NODE_INSTANCE_FILE);
+        assert_eq!(&std::fs::read_to_string(&marker).unwrap(), first);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     // Test the format of the internal bitcoind configuration file.
     #[test]

--- a/coincube-gui/src/node/revalidate.rs
+++ b/coincube-gui/src/node/revalidate.rs
@@ -42,7 +42,7 @@ use tracing::{info, warn};
 
 use crate::{
     dir::CoincubeDirectory,
-    node::bitcoind::{internal_bitcoind_directory, NodeFlavor},
+    node::bitcoind::{internal_bitcoind_directory, NodeFlavor, NodeIdentity},
 };
 
 /// Name of the BIP-110 / RDTS deployment in `getdeploymentinfo`.
@@ -289,18 +289,88 @@ pub struct ManagedNodeState {
     /// Also load-bearing, and for a reason that only shows up after the repair
     /// succeeds: a repair that moves the chain by more than the poller's
     /// `MAX_REORG_DEPTH` is refused as implausible, forever, leaving Vaults pinned
-    /// to a chain the node no longer has. Publishing the fork point is what lets
-    /// them tell "we did this" from "the backend is lying". Durable because
-    /// adoption can outlive the session that performed the repair.
+    /// to a chain the node no longer has. Publishing the floor is what lets them
+    /// tell "we did this" from "the backend is lying". Durable because adoption can
+    /// outlive the session that performed the repair.
+    ///
+    /// Recorded and *published* at different times, deliberately. See
+    /// [`publish_sanctioned_rollback`].
     #[serde(default)]
     pub sanctioned_rollback: Option<SanctionedRollback>,
 }
 
-/// The fork point of a rollback we performed deliberately.
+/// The floor of a rollback we performed deliberately, and the node we performed it
+/// on.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SanctionedRollback {
     pub hash: String,
     pub height: i32,
+    /// RPC endpoint of the node this authorises, as `ip:port`.
+    ///
+    /// The floor block is public — every node following the chain has it — so it
+    /// cannot scope the exception on its own. Without this, an external `bitcoind`
+    /// a Vault happens to be pointed at would satisfy the floor check and lose its
+    /// depth guard for everything above it.
+    pub node_addr: String,
+    /// Fingerprint of that node's credentials, which an address alone cannot
+    /// supply: a socket is a location, and a different node — or the same one
+    /// rebuilt on a new datadir — can later occupy it. The managed node
+    /// authenticates by a cookie file inside its own datadir, so this moves when
+    /// the datadir does.
+    #[serde(default)]
+    pub node_credentials: String,
+    /// Whether the repair this floor belongs to has been observed to *finish*.
+    ///
+    /// The record is written before the chain is touched, so on its own it says only
+    /// "a repair was started". Arming the poller exception on that is unsafe — the
+    /// reorg may still be in flight, and a poll could adopt a chain that is about to
+    /// change again — but discarding it is worse, because nothing else would ever
+    /// authorise the finished chain. So it persists as pending and is only ever
+    /// published once something has confirmed the node is done: see
+    /// [`publish_sanctioned_rollback`], which refuses to arm a pending floor, and
+    /// [`resume_pending_repair`], which establishes the confirmation a restart lost.
+    #[serde(default)]
+    pub confirmed: bool,
+    /// Identifies the repair that wrote this floor.
+    ///
+    /// A watcher can outlive the claim it started under — the flag-clearing path
+    /// deliberately releases the node after a bounded window and keeps watching — so by
+    /// the time it has something to confirm, the record may belong to a *different*
+    /// repair that has since claimed the node and replaced it. Confirming by position
+    /// ("whatever is stored") would then mark that newer, possibly mid-rewind operation
+    /// as finished and arm an exception for it. Every confirmation therefore names the
+    /// operation it believes it is confirming, and is refused if the record has moved on.
+    #[serde(default)]
+    pub operation_id: String,
+}
+
+/// A token identifying one chain-repair operation. Long enough that two repairs never
+/// collide; it only has to be unique, not unguessable.
+fn new_operation_id() -> String {
+    use rand::Rng;
+    rand::thread_rng()
+        .sample_iter(rand::distributions::Alphanumeric)
+        .take(16)
+        .map(char::from)
+        .collect()
+}
+
+impl SanctionedRollback {
+    /// The floor of a rollback about to be performed on `bitcoind`.
+    fn at(
+        floor: &coincube_core::miniscript::bitcoin::BlockHash,
+        height: i32,
+        id: coincubed::BackendId,
+    ) -> Self {
+        Self {
+            hash: floor.to_string(),
+            height,
+            node_addr: id.addr.to_string(),
+            node_credentials: id.credentials,
+            confirmed: false,
+            operation_id: new_operation_id(),
+        }
+    }
 }
 
 /// A rewind we have started and not yet confirmed finished.
@@ -438,55 +508,480 @@ impl ManagedNodeState {
         }
     }
 
-    /// Persist the floor of a repair's rollback and tell this process's pollers
-    /// about it.
+    /// Persist (or clear) the floor of a repair's rollback. Does **not** publish it.
     ///
-    /// Returns whether it is now on disk. Callers must not begin the repair unless
-    /// it is: an in-memory-only authorisation dies with the process, and the Vault
-    /// that has to adopt the rollback may not open until a later session — at which
-    /// point the permanent refusal this exists to prevent is back, with the chain
-    /// already rewound.
+    /// Returns whether it is now on disk. Callers must not begin a repair unless it
+    /// is: an in-memory-only authorisation dies with the process, and the Vault that
+    /// has to adopt the rollback may not open until a later session — at which point
+    /// the permanent refusal this exists to prevent is back, with the chain already
+    /// rewound.
+    pub fn write_sanctioned_rollback(
+        coincube_datadir: &CoincubeDirectory,
+        floor: Option<SanctionedRollback>,
+    ) -> bool {
+        matches!(
+            Self::write_sanctioned_rollback_tracked(coincube_datadir, floor),
+            FloorWrite::Written
+        )
+    }
+
+    /// Mark the recorded floor as belonging to a repair that has finished, and hand
+    /// back the confirmed record so it can be published.
     ///
-    /// Published only once persisted, so what this process acts on and what the next
-    /// one will read cannot disagree.
-    pub fn set_sanctioned_rollback(
+    /// The only route from pending to armed. `None` if there is nothing recorded or
+    /// the write failed, in which case the floor stays pending and a later start
+    /// establishes the confirmation again — better than arming something we could not
+    /// record as settled.
+    pub fn confirm_sanctioned_rollback(
+        coincube_datadir: &CoincubeDirectory,
+        operation_id: &str,
+    ) -> Option<SanctionedRollback> {
+        let mut state = Self::try_load(coincube_datadir)
+            .inspect_err(|e| warn!("could not read managed-node state to confirm a repair: {e}"))
+            .ok()?;
+        let floor = state.sanctioned_rollback.as_mut()?;
+        // Fails closed on anything but an exact match. A record that has moved on
+        // belongs to a repair we know nothing about — very possibly one still in flight
+        // — and marking *that* finished is precisely the confusion to avoid.
+        if floor.operation_id != operation_id {
+            warn!(
+                "not confirming a chain repair: the recorded floor now belongs to a \
+                 different operation"
+            );
+            return None;
+        }
+        floor.confirmed = true;
+        let floor = floor.clone();
+        state
+            .save(coincube_datadir)
+            .inspect_err(|e| warn!("could not record the repair as finished: {e}"))
+            .ok()?;
+        Some(floor)
+    }
+
+    /// Give a record written before the node identity existed the identity of the
+    /// managed node we are actually talking to.
+    ///
+    /// Such a record names an address and nothing else, which any `bitcoind` on that
+    /// port would match, so it cannot be published as-is. Dropping it is not an
+    /// option either: nothing would then schedule another repair — a Knots → Knots
+    /// restart plans nothing — so a Vault still holding the pre-repair chain would
+    /// refuse the node's chain forever, which is the exact failure the record exists
+    /// to prevent. Migrating is the only answer that neither widens the exception
+    /// nor discards it.
+    ///
+    /// Only when the address still matches. If it does not, the record describes a
+    /// node this datadir no longer talks to and carries no authority here.
+    pub fn migrate_sanctioned_rollback(
+        coincube_datadir: &CoincubeDirectory,
+        node: &coincubed::BackendId,
+        legacy: &coincubed::BackendId,
+    ) {
+        let Ok(mut state) = Self::try_load(coincube_datadir) else {
+            return;
+        };
+        let Some(floor) = state.sanctioned_rollback.as_mut() else {
+            return;
+        };
+        if floor.node_credentials == node.credentials {
+            return;
+        }
+        // Recorded under the identity this node had before its datadir carried a
+        // marker, and provably *this* node's, because that older fingerprint is one we
+        // can still compute and it matches. Re-stamp it: the day a marker is installed
+        // — which is any managed-node start after an upgrade — every authorisation
+        // written before it would otherwise stop matching, stranding a Vault on the
+        // pre-repair chain with nothing left to schedule another repair.
+        if !floor.node_credentials.is_empty() {
+            if floor.node_credentials == legacy.credentials {
+                info!("re-stamping a repair record from before this datadir had an identity");
+                floor.node_credentials = node.credentials.clone();
+                if let Err(e) = state.save(coincube_datadir) {
+                    warn!("could not migrate the repair record: {e}");
+                }
+            }
+            return;
+        }
+        if floor.node_addr != node.addr.to_string() {
+            warn!(
+                "a repair record predating node identities names {:?}, but the managed node is \
+                 at {}; discarding it rather than applying it to a different node",
+                floor.node_addr, node.addr
+            );
+            state.sanctioned_rollback = None;
+        } else {
+            info!("adopting the managed node's identity for a repair record that predates it");
+            floor.node_credentials = node.credentials.clone();
+        }
+        if let Err(e) = state.save(coincube_datadir) {
+            warn!("could not migrate the repair record: {e}");
+        }
+    }
+
+    /// Move an unreadable sidecar aside and start from a clean one.
+    ///
+    /// Only for a repair the user deliberately asked for. Every automatic path
+    /// treats an unreadable sidecar as "a rewind may be pending" and declines,
+    /// which is right — but it would also make the manual "Re-check chain" action
+    /// impossible, leaving the user with the one instruction we give them and no
+    /// way to carry it out. Renamed rather than deleted, so the original is still
+    /// there to look at.
+    /// Replace an unreadable sidecar with a state carrying nothing but `floor`, keeping
+    /// the original as evidence.
+    ///
+    /// Crash-safe by construction, which a rename-away followed by a separate write is
+    /// not: that leaves a window in which the canonical path does not exist at all, and a
+    /// crash inside it reads to the next start as "nothing pending" — from a node that
+    /// may be parked below an invalidated block, which is the very thing the unreadable
+    /// sidecar was making it decline to plan from.
+    ///
+    /// So the evidence is taken as a *copy* while the canonical file stays where it is,
+    /// and the canonical file then changes in one atomic replacement. A crash before that
+    /// replacement leaves the original unreadable file in place and reconciliation fails
+    /// closed; a crash after it leaves a valid pending record that the next start
+    /// resumes. There is no durable moment in between.
+    ///
+    /// Returns the evidence path and the original bytes, so a repair that never reaches
+    /// the chain can put things back the same atomic way.
+    fn replace_unreadable(
         coincube_datadir: &CoincubeDirectory,
         floor: SanctionedRollback,
-    ) -> bool {
+    ) -> PendingInstall {
+        let canonical = Self::path(coincube_datadir);
+        let original = match std::fs::read(&canonical) {
+            Ok(original) => original,
+            Err(e) => return PendingInstall::NotInstalled(e),
+        };
+        // Durable before anything else changes: if this fails we have touched nothing.
+        let evidence = match write_evidence_copy(&canonical, &original) {
+            Ok(evidence) => evidence,
+            Err(e) => return PendingInstall::NotInstalled(e),
+        };
+        warn!("managed-node state at {canonical:?} is unreadable; kept a copy at {evidence:?}");
+        let operation_id = floor.operation_id.clone();
+        let replacement = Self {
+            sanctioned_rollback: Some(floor),
+            ..Self::default()
+        };
+        match replacement.save_tracked(coincube_datadir) {
+            AtomicWrite::Durable => PendingInstall::Installed { evidence, original },
+            // The canonical file already holds the pending record; only its durability is
+            // in doubt. Deleting the evidence here — on the assumption that an error means
+            // nothing happened — is exactly how a pending repair ends up with no surviving
+            // copy of what it displaced.
+            AtomicWrite::ReplacedNotDurable(e) => PendingInstall::InstalledNotDurable {
+                evidence,
+                original,
+                error: e,
+            },
+            AtomicWrite::NotReplaced(e) => {
+                // Classified as "not replaced", but check rather than assume: the cost of
+                // being wrong is deleting the evidence for a repair that is in fact
+                // installed. Whatever the canonical file says now is the answer.
+                if Self::installed_operation(coincube_datadir).as_deref() == Some(&operation_id) {
+                    return PendingInstall::InstalledNotDurable {
+                        evidence,
+                        original,
+                        error: e,
+                    };
+                }
+                let _ = remove_evidence(&evidence, canonical.parent());
+                PendingInstall::NotInstalled(e)
+            }
+        }
+    }
+
+    /// [`Self::write_sanctioned_rollback`], reporting which side of the rename a failure
+    /// fell on.
+    ///
+    /// The boolean form cannot express the case that matters: the rename lands before the
+    /// directory entry is flushed, so a failure at the last step returns "no" over a
+    /// canonical file that already holds the new floor. A caller that believes it means
+    /// "nothing was written" will not restore what it displaced — and the sidecar is then
+    /// left naming a pending repair that never started, in place of a confirmed one that
+    /// Vaults were relying on.
+    fn write_sanctioned_rollback_tracked(
+        coincube_datadir: &CoincubeDirectory,
+        floor: Option<SanctionedRollback>,
+    ) -> FloorWrite {
+        let expected = floor.as_ref().map(|floor| floor.operation_id.clone());
         let mut state = match Self::try_load(coincube_datadir) {
             Ok(state) => state,
             Err(e) => {
                 warn!("could not read managed-node state to record the rollback floor: {e}");
-                return false;
+                return FloorWrite::NotWritten(e);
             }
         };
-        state.sanctioned_rollback = Some(floor.clone());
-        if let Err(e) = state.save(coincube_datadir) {
-            warn!("could not record the repair's rollback floor: {e}");
-            return false;
+        // Everything else in the sidecar is left exactly as it was: the flavour ledger and
+        // any in-flight rewind belong to other concerns entirely.
+        state.sanctioned_rollback = floor;
+        match state.save_tracked(coincube_datadir) {
+            AtomicWrite::Durable => FloorWrite::Written,
+            AtomicWrite::ReplacedNotDurable(e) => FloorWrite::WrittenNotDurable(e),
+            AtomicWrite::NotReplaced(e) => {
+                // Verify rather than trust the classification. Believing "nothing
+                // happened" when something did is what leaves a displaced record
+                // unrestored, so the canonical file gets the casting vote.
+                if Self::installed_operation(coincube_datadir) == expected {
+                    FloorWrite::WrittenNotDurable(e)
+                } else {
+                    FloorWrite::NotWritten(e)
+                }
+            }
         }
-        publish_sanctioned_rollback(Some(&floor));
-        true
+    }
+
+    /// The operation the canonical file currently names, if it holds a readable record.
+    fn installed_operation(coincube_datadir: &CoincubeDirectory) -> Option<String> {
+        Self::try_load(coincube_datadir)
+            .ok()?
+            .sanctioned_rollback
+            .map(|floor| floor.operation_id)
+    }
+
+    /// [`Self::save`], reporting which side of the rename a failure fell on.
+    fn save_tracked(&self, coincube_datadir: &CoincubeDirectory) -> AtomicWrite {
+        let path = Self::path(coincube_datadir);
+        if let Some(parent) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                return AtomicWrite::NotReplaced(e);
+            }
+        }
+        match serde_json::to_string_pretty(self) {
+            Ok(json) => write_atomically_tracked(&path, json.as_bytes()),
+            Err(e) => AtomicWrite::NotReplaced(io::Error::other(e)),
+        }
     }
 }
 
-/// Hand the recorded fork point to coincubed, so every poller in this process can
-/// tell a rollback we caused from a backend misreporting one.
-fn publish_sanctioned_rollback(point: Option<&SanctionedRollback>) {
-    let tip =
-        point.and_then(|point| {
-            match coincube_core::miniscript::bitcoin::BlockHash::from_str(&point.hash) {
-                Ok(hash) => Some(coincubed::BlockChainTip {
-                    hash,
-                    height: point.height,
-                }),
-                Err(e) => {
-                    warn!("unreadable repair fork point {:?}: {e}", point.hash);
-                    None
-                }
+/// How far writing a rollback floor into a readable sidecar got. Same three-way
+/// distinction as [`AtomicWrite`], and for the same reason.
+#[derive(Debug)]
+enum FloorWrite {
+    /// The canonical file still holds what it held.
+    NotWritten(io::Error),
+    /// The canonical file now holds the new floor, but durability was not confirmed.
+    WrittenNotDurable(io::Error),
+    /// Written and confirmed durable.
+    Written,
+}
+
+/// How far installing a pending-repair record over an unreadable sidecar got.
+#[derive(Debug)]
+enum PendingInstall {
+    /// The canonical file still holds the original bytes, and any evidence copy taken
+    /// along the way has been removed. Nothing happened.
+    NotInstalled(io::Error),
+    /// The canonical file now holds the pending record, but we could not confirm it is
+    /// durable. The evidence is kept, and the caller must not treat this as a repair it
+    /// may act on — only as one it must be able to undo.
+    InstalledNotDurable {
+        evidence: PathBuf,
+        original: Vec<u8>,
+        error: io::Error,
+    },
+    /// Installed and confirmed durable.
+    Installed {
+        evidence: PathBuf,
+        original: Vec<u8>,
+    },
+}
+
+/// How many `.corrupt[.N]` evidence names to try before giving up. Small in tests so the
+/// exhaustion path is reachable without creating a thousand files.
+fn evidence_name_limit() -> u32 {
+    #[cfg(not(test))]
+    {
+        1_000
+    }
+    #[cfg(test)]
+    4
+}
+
+/// Write `contents` to the first free `.corrupt[.N]` beside `canonical`, and make it
+/// durable before returning.
+///
+/// The name is reserved with `create_new`, which is atomic: two repairs racing — in this
+/// process or another, since the maintenance claim is only process-wide — cannot be
+/// handed the same name, and neither can overwrite evidence the other just wrote. That
+/// also sidesteps Windows refusing a rename onto an existing destination, because nothing
+/// is renamed onto anything here.
+fn write_evidence_copy(canonical: &Path, contents: &[u8]) -> io::Result<PathBuf> {
+    use std::io::Write;
+
+    for n in 0..evidence_name_limit() {
+        let candidate = match n {
+            0 => canonical.with_extension("corrupt"),
+            n => canonical.with_extension(format!("corrupt.{n}")),
+        };
+        let mut file = match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(file) => file,
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e),
+        };
+        let written = (|| -> io::Result<()> {
+            fail_if(Failpoint::EvidenceWrite)?;
+            file.write_all(contents)?;
+            fail_if(Failpoint::EvidenceSync)?;
+            file.sync_all()?;
+            fail_if(Failpoint::EvidenceDirSync)?;
+            if let Some(parent) = canonical.parent() {
+                sync_parent_dir(parent)?;
             }
-        });
-    coincubed::set_sanctioned_rollback(tip);
+            Ok(())
+        })();
+        match written {
+            Ok(()) => return Ok(candidate),
+            Err(e) => {
+                // The name is reserved but the file is empty or half-written. Leaving it
+                // would present a partial copy as completed evidence and burn one of a
+                // finite set of names — enough repeated failures and manual repair is
+                // impossible. Close it first, since Windows will not unlink an open file.
+                drop(file);
+                if let Err(cleanup) = remove_evidence(&candidate, canonical.parent()) {
+                    // Failing closed and saying so: an incomplete file is still there, and
+                    // pretending otherwise is how it gets mistaken for real evidence.
+                    return Err(io::Error::other(format!(
+                        "could not write the managed-node evidence copy ({e}), and the \
+                         incomplete file left at {candidate:?} could not be removed \
+                         ({cleanup}); delete it by hand before retrying the repair"
+                    )));
+                }
+                return Err(e);
+            }
+        }
+    }
+    Err(io::Error::other(
+        "too many quarantined managed-node state files already",
+    ))
+}
+
+/// Remove an incomplete evidence file and make the removal itself durable, so the name
+/// is genuinely free again rather than free-until-the-next-crash.
+fn remove_evidence(candidate: &Path, parent: Option<&Path>) -> io::Result<()> {
+    fail_if(Failpoint::EvidenceCleanup)?;
+    match std::fs::remove_file(candidate) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    }
+    if let Some(parent) = parent {
+        sync_parent_dir(parent)?;
+    }
+    Ok(())
+}
+
+/// Flush a directory entry, so a file created or renamed in it survives a crash.
+///
+/// Unix only, for the same reason [`write_atomically`] gives.
+fn sync_parent_dir(dir: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    std::fs::File::open(dir)?.sync_all()?;
+    #[cfg(not(unix))]
+    let _ = dir;
+    Ok(())
+}
+
+/// Mark the repair identified by `operation_id` as finished and arm the poller
+/// exception for it.
+///
+/// The only way an exception ever goes live, so that "the chain is final" and "pollers
+/// may act on it" cannot drift apart: the durable record and the live slot are set from
+/// one place, in that order.
+///
+/// The caller must own the chain-operation claim. Anyone who has released it wants
+/// [`reclaim_confirm_and_publish`] instead.
+fn confirm_and_publish(coincube_datadir: &CoincubeDirectory, operation_id: &str) {
+    match ManagedNodeState::confirm_sanctioned_rollback(coincube_datadir, operation_id) {
+        Some(floor) => publish_sanctioned_rollback(Some(&floor)),
+        None => warn!(
+            "did not arm this repair's rollback: it could not be recorded as finished, or the \
+             record now belongs to another operation. A later start will sort it out."
+        ),
+    }
+}
+
+/// Same, for a watcher that has already given the node up.
+///
+/// Retakes the claim first. Without it, a watcher outliving its own operation can arm an
+/// exception in the middle of somebody else's: the flag-clearing path releases the node
+/// after a bounded window and keeps watching for hours, and in that time another repair
+/// can claim the node, withdraw the live authorisation and start rewinding the chain.
+/// Publishing then puts an exception back that the newer operation deliberately took
+/// away, over a chain that is mid-rewind — the exact transient the claim exists to keep
+/// pollers away from.
+///
+/// A bare guard, not a [`ChainOperation`]: this is exclusion only, with nothing to
+/// withdraw or restore. Contention means someone else owns the node, so we leave the
+/// floor pending and let a later start confirm it.
+fn reclaim_confirm_and_publish(coincube_datadir: &CoincubeDirectory, operation_id: &str) {
+    let Some(_guard) = coincubed::MaintenanceGuard::try_acquire() else {
+        warn!(
+            "another chain operation now owns the managed node, so this repair's rollback is \
+             left pending rather than authorised over an operation in progress"
+        );
+        return;
+    };
+    confirm_and_publish(coincube_datadir, operation_id);
+}
+
+/// Hand the recorded floor to coincubed, so every poller in this process can tell a
+/// rollback we caused from a backend misreporting one.
+///
+/// Publishing is deliberately *not* part of recording it. Maintenance stops pollers
+/// from starting a poll; it cannot stop one already in flight, and the depth guard
+/// is what protects those. Between `invalidateblock` and the end of the reconnect
+/// the node sits at the rewind floor on a chain that is about to change again — and
+/// an exception published then lets an in-flight poll roll a Vault back to the
+/// floor mid-repair, which is precisely what the guard was there to prevent. So the
+/// floor is persisted before the destructive call and published only once the chain
+/// has reached a confirmed terminal state, while maintenance is still held.
+fn publish_sanctioned_rollback(floor: Option<&SanctionedRollback>) {
+    let sanction = floor.and_then(|floor| {
+        // The one choke point, so no caller — including startup, which sees whatever
+        // the last session left behind — can arm an exception for a repair that was
+        // never seen to finish.
+        if !floor.confirmed {
+            return None;
+        }
+        let hash = match coincube_core::miniscript::bitcoin::BlockHash::from_str(&floor.hash) {
+            Ok(hash) => hash,
+            Err(e) => {
+                warn!("unreadable repair rollback floor {:?}: {e}", floor.hash);
+                return None;
+            }
+        };
+        let addr = match floor.node_addr.parse() {
+            Ok(addr) => addr,
+            Err(e) => {
+                warn!("unreadable repair node address {:?}: {e}", floor.node_addr);
+                return None;
+            }
+        };
+        // A record written before credentials were part of the identity cannot be
+        // scoped to a node, and an exception that matches on address alone is one
+        // any bitcoind on that port would satisfy. Drop it and let the repair be
+        // planned again rather than widen it.
+        if floor.node_credentials.is_empty() {
+            warn!("repair record predates node-identity scoping; not re-arming it");
+            return None;
+        }
+        Some(coincubed::SanctionedRollback {
+            floor: coincubed::BlockChainTip {
+                hash,
+                height: floor.height,
+            },
+            node: coincubed::BackendId {
+                addr,
+                credentials: floor.node_credentials.clone(),
+            },
+        })
+    });
+    coincubed::set_sanctioned_rollback(sanction);
 }
 
 /// Write `contents` to `path` through a sibling temp file, flushing before the
@@ -497,23 +992,103 @@ fn publish_sanctioned_rollback(point: Option<&SanctionedRollback>) {
 /// crash can lose the rename and with it a rewind record — precisely the crash this
 /// record exists to survive.
 fn write_atomically(path: &Path, contents: &[u8]) -> io::Result<()> {
+    match write_atomically_tracked(path, contents) {
+        AtomicWrite::Durable => Ok(()),
+        AtomicWrite::ReplacedNotDurable(e) | AtomicWrite::NotReplaced(e) => Err(e),
+    }
+}
+
+/// How far an atomic replacement got.
+///
+/// The distinction is not pedantry. The rename happens before the directory entry is
+/// flushed, so a failure at the last step returns an error over a destination that
+/// *already holds the new contents* — and a caller that reads "error" as "nothing
+/// happened" will clean up on a false premise. See
+/// [`ManagedNodeState::replace_unreadable`], where getting this wrong deletes the only
+/// surviving copy of the state a pending repair displaced.
+#[derive(Debug)]
+enum AtomicWrite {
+    /// The destination was not touched; it still holds whatever it held.
+    NotReplaced(io::Error),
+    /// The destination now holds the new contents, but the directory entry naming them
+    /// was not confirmed durable, so a crash could still lose it.
+    ReplacedNotDurable(io::Error),
+    /// Replaced, and confirmed durable.
+    Durable,
+}
+
+/// [`write_atomically`], reporting which side of the rename a failure fell on.
+fn write_atomically_tracked(path: &Path, contents: &[u8]) -> AtomicWrite {
     use std::io::Write;
 
     let tmp = path.with_extension("tmp");
-    {
+    let staged = (|| -> io::Result<()> {
         let mut file = std::fs::File::create(&tmp)?;
+        fail_if(Failpoint::StateWrite)?;
         file.write_all(contents)?;
-        file.sync_all()?;
+        fail_if(Failpoint::StateSync)?;
+        file.sync_all()
+    })();
+    if let Err(e) = staged {
+        // Nothing has been renamed, so the destination is untouched; drop the partial
+        // staging file rather than leave it for the next writer to trip over.
+        let _ = std::fs::remove_file(&tmp);
+        return AtomicWrite::NotReplaced(e);
     }
-    std::fs::rename(&tmp, path)?;
+    if let Err(e) = fail_if(Failpoint::StateRename).and_then(|()| std::fs::rename(&tmp, path)) {
+        let _ = std::fs::remove_file(&tmp);
+        return AtomicWrite::NotReplaced(e);
+    }
 
-    // Unix only: Windows has no equivalent (a directory can't be opened as a file
-    // without backup semantics), and NTFS metadata journalling makes the rename
-    // durable there anyway.
-    #[cfg(unix)]
-    if let Some(parent) = path.parent() {
-        std::fs::File::open(parent)?.sync_all()?;
+    // Past this line the destination has already changed. Unix only: Windows has no
+    // equivalent (a directory can't be opened as a file without backup semantics), and
+    // NTFS metadata journalling makes the rename durable there anyway.
+    let synced = (|| -> io::Result<()> {
+        fail_if(Failpoint::StateDirSync)?;
+        #[cfg(unix)]
+        if let Some(parent) = path.parent() {
+            std::fs::File::open(parent)?.sync_all()?;
+        }
+        Ok(())
+    })();
+    match synced {
+        Ok(()) => AtomicWrite::Durable,
+        Err(e) => AtomicWrite::ReplacedNotDurable(e),
     }
+}
+
+/// Filesystem steps whose failure modes are worth exercising, since none of them can be
+/// provoked from outside.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Failpoint {
+    None,
+    EvidenceWrite,
+    EvidenceSync,
+    EvidenceDirSync,
+    EvidenceCleanup,
+    StateWrite,
+    StateSync,
+    StateRename,
+    StateDirSync,
+}
+
+#[cfg(test)]
+thread_local! {
+    /// A set, not a single point: the interesting cases are compound — a write that
+    /// fails *and* a cleanup that then fails too.
+    static ARMED_FAILPOINTS: std::cell::RefCell<Vec<Failpoint>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Fail here if a test has armed this point. Compiled out entirely otherwise.
+#[inline]
+fn fail_if(point: Failpoint) -> io::Result<()> {
+    #[cfg(test)]
+    if ARMED_FAILPOINTS.with(|armed| armed.borrow().contains(&point)) {
+        return Err(io::Error::other(format!("injected failure at {point:?}")));
+    }
+    #[cfg(not(test))]
+    let _ = point;
     Ok(())
 }
 
@@ -556,17 +1131,54 @@ pub fn reconcile_after_start(
     coincube_datadir: &CoincubeDirectory,
     bitcoind: &coincubed::BitcoinD,
     config: &coincubed::config::BitcoindConfig,
+    identity: &NodeIdentity,
     network: Network,
     observed_flavor: NodeFlavor,
 ) {
+    // Nothing here may run against a provisional identity. Every branch below either
+    // records a repair, arms an authorisation, or advances the flavour ledger on the
+    // strength of one — and all three would be written against an identity that changes
+    // the moment the marker this start could not install finally lands. The node is
+    // already up and syncing by now; declining to reconcile costs a retry on the next
+    // start, which is what the durable records are for.
+    if !identity.permits_chain_repair() {
+        warn!(
+            "skipping the managed-node chain check: the node's identity is not established \
+             yet, so any repair recorded now would not be recognised later. It will be \
+             retried on the next start."
+        );
+        return;
+    }
     // Re-arm the poller exception first: a repair from an earlier session may still
     // be waiting for some Vault to adopt its rollback, and that Vault's poller can
     // start the moment we return.
-    publish_sanctioned_rollback(
-        ManagedNodeState::load(coincube_datadir)
-            .sanctioned_rollback
-            .as_ref(),
+    //
+    // But only if no rewind is outstanding. A recorded floor plus an unfinished
+    // rewind means the chain is parked mid-repair, not repaired — publishing then
+    // would authorise pollers to adopt a temporary rollback that is about to be
+    // undone. The recovery below republishes it once the chain settles.
+    // A record written before repairs were scoped to a node names only an address.
+    // Give it this node's identity while we have it, rather than let it be discarded
+    // at publish time — nothing would schedule another repair, and a Vault still on
+    // the pre-repair chain would refuse the node's chain for good.
+    ManagedNodeState::migrate_sanctioned_rollback(
+        coincube_datadir,
+        &bitcoind.backend_id(),
+        &bitcoind.legacy_backend_id(),
     );
+    let recorded = ManagedNodeState::load(coincube_datadir);
+    if recorded.rewind.is_none() {
+        match recorded.sanctioned_rollback.as_ref() {
+            // Seen to finish in an earlier session, so it is safe to arm now.
+            Some(floor) if floor.confirmed => publish_sanctioned_rollback(Some(floor)),
+            // Started and never seen to finish. Publishing it here is what would let a
+            // poller adopt a chain still mid-reorg; leaving it alone is what would
+            // strand a Vault forever. Neither: re-establish the confirmation the lost
+            // session was going to provide, and arm it on the far side of that.
+            Some(floor) => resume_pending_repair(coincube_datadir, config, identity, floor),
+            None => {}
+        }
+    }
 
     // Before anything else: if a previous run died mid-rewind, the node is parked
     // below an invalidated block and will not move until we release it. Planning
@@ -574,7 +1186,15 @@ pub fn reconcile_after_start(
     // a planner fed it draws exactly the wrong conclusion — a node parked at the
     // floor looks like "nothing left above the anchor", which records the current
     // flavour and retires the very swap the recovery is still working on.
-    if !resume_pending_rewind(coincube_datadir, bitcoind, config, observed_flavor).may_plan() {
+    if !resume_pending_rewind(
+        coincube_datadir,
+        bitcoind,
+        config,
+        identity,
+        observed_flavor,
+    )
+    .may_plan()
+    {
         return;
     }
 
@@ -627,7 +1247,7 @@ pub fn reconcile_after_start(
             // Idempotent and cheap, so advancing the record is safe even if it fails:
             // a node still following less work than it knows about is caught again by
             // the height comparison on the next start, with no reliance on the ledger.
-            if let Err(e) = execute(coincube_datadir, bitcoind, plan) {
+            if let Err(e) = clear_failure_flags(coincube_datadir, config, identity, plan) {
                 warn!("RDTS revalidation failed: {e}");
             }
             ManagedNodeState::record_run(coincube_datadir, observed_flavor);
@@ -646,6 +1266,7 @@ pub fn reconcile_after_start(
             spawn_replay(
                 coincube_datadir.clone(),
                 config.clone(),
+                identity,
                 observed_flavor,
                 floor_height,
                 target_height,
@@ -666,6 +1287,7 @@ pub fn reconcile_after_start(
 fn spawn_replay(
     coincube_datadir: CoincubeDirectory,
     config: coincubed::config::BitcoindConfig,
+    identity: &NodeIdentity,
     observed_flavor: NodeFlavor,
     floor_height: i32,
     target_height: i32,
@@ -674,15 +1296,27 @@ fn spawn_replay(
     // Vaults can attach to the one shared node in the same instant; a check followed
     // by a set would let two of them each start rewinding it. The guard's Drop
     // releases on every exit path, including a spawn that never happens.
-    let Some(guard) = coincubed::MaintenanceGuard::try_acquire() else {
-        info!("A chain replay is already running; not starting another.");
-        return;
+    let operation = match ChainOperation::claim(&coincube_datadir, identity) {
+        Ok(operation) => operation,
+        Err(ClaimRefused::Busy) => {
+            info!("A chain replay is already running; not starting another.");
+            return;
+        }
+        Err(ClaimRefused::UnstableIdentity) => {
+            warn!(
+                "not replaying the chain: the managed node's identity is not established, so \
+                 the rollback could not be authorised for the node it was performed on"
+            );
+            return;
+        }
     };
     let spawned = thread::Builder::new()
         .name("rdts-replay".to_string())
         .spawn(move || {
-            // Held for the whole replay; released when this closure returns.
-            let _guard = guard;
+            // Held for the whole replay; released when this closure returns. If this
+            // closure never runs, dropping it un-does the claim — including putting
+            // back the authorisation it displaced, since nothing was touched.
+            let mut operation = operation;
             let bitcoind = match coincubed::BitcoinD::new(&config, "rdts_replay".to_string()) {
                 Ok(bitcoind) => bitcoind,
                 Err(e) => {
@@ -690,7 +1324,13 @@ fn spawn_replay(
                     return;
                 }
             };
-            match execute_replay(&coincube_datadir, &bitcoind, floor_height, target_height) {
+            match execute_replay(
+                &mut operation,
+                &coincube_datadir,
+                &bitcoind,
+                floor_height,
+                target_height,
+            ) {
                 // Only now has the swap actually been dealt with, so only now may the
                 // ledger advance. Leaving it behind on failure is what makes the next
                 // start retry, instead of seeing Knots → Knots and skipping forever —
@@ -755,6 +1395,7 @@ pub fn resume_pending_rewind(
     coincube_datadir: &CoincubeDirectory,
     bitcoind: &coincubed::BitcoinD,
     config: &coincubed::config::BitcoindConfig,
+    identity: &NodeIdentity,
     observed_flavor: NodeFlavor,
 ) -> RecoveryState {
     // `try_load`, not `load`: an unreadable sidecar must not read as "nothing
@@ -787,10 +1428,27 @@ pub fn resume_pending_rewind(
     // record out from under it, leaving the chain half-rewound with nothing to
     // finish it. Claiming maintenance is both that check and this recovery's own
     // exclusion, in one atomic step.
-    let Some(guard) = coincubed::MaintenanceGuard::try_acquire() else {
-        info!("A chain rewind is already being worked on; leaving it to its owner.");
-        return RecoveryState::InFlight;
+    let mut operation = match ChainOperation::claim(coincube_datadir, identity) {
+        Ok(operation) => operation,
+        Err(ClaimRefused::Busy) => {
+            info!("A chain rewind is already being worked on; leaving it to its owner.");
+            return RecoveryState::InFlight;
+        }
+        Err(ClaimRefused::UnstableIdentity) => {
+            warn!(
+                "a chain rewind is outstanding but the managed node's identity is not \
+                 established; leaving the node parked rather than reconnecting it on an \
+                 authorisation no Vault would recognise"
+            );
+            return RecoveryState::Indeterminate;
+        }
     };
+    // Committed at once, unlike the paths that are about to move the chain
+    // themselves. This one inherits a chain that is *already* parked below an
+    // invalidated block, so there is no earlier authorisation worth restoring — one
+    // would describe a chain state that no longer exists, and could well match the
+    // parked one.
+    operation.commit();
 
     warn!(
         "A chain rewind from a previous run was left unfinished (floor {}, target {}). \
@@ -813,7 +1471,7 @@ pub fn resume_pending_rewind(
     let spawned = thread::Builder::new()
         .name("rdts-rewind-recovery".to_string())
         .spawn(move || {
-            let _guard = guard;
+            let _operation = operation;
             let bitcoind = match coincubed::BitcoinD::new(&config, "rdts_recovery".to_string()) {
                 Ok(bitcoind) => bitcoind,
                 Err(e) => {
@@ -821,52 +1479,55 @@ pub fn resume_pending_rewind(
                     return;
                 }
             };
-            // The rollback the interrupted rewind created is ours, so authorise the
-            // pollers to adopt it however deep it turns out to be. Before the
-            // reconsider and refusing to go on without it, for the same reason the
-            // replay does: an authorisation we cannot persist is one the Vault that
-            // needs it will never see. The rewind record stays, so a later start
-            // retries the whole recovery.
-            if !ManagedNodeState::set_sanctioned_rollback(
-                &coincube_datadir,
-                SanctionedRollback {
-                    hash: anchor.to_string(),
-                    height: rewind.floor_height,
-                },
-            ) {
+            // The rollback the interrupted rewind created is ours, so record the
+            // authorisation before the reconsider and refuse to go on without it, for
+            // the same reason the replay does: an authorisation we cannot persist is
+            // one the Vault that needs it will never see. Recorded only — publishing
+            // it now would let an in-flight poll adopt the parked chain, which is
+            // about to move again. The rewind record stays, so a later start retries.
+            let floor = SanctionedRollback::at(&anchor, rewind.floor_height, bitcoind.backend_id());
+            if !ManagedNodeState::write_sanctioned_rollback(&coincube_datadir, Some(floor.clone()))
+            {
                 warn!(
                     "could not record the rollback floor; leaving the rewind for a later \
                      start rather than reconnecting a chain no Vault would adopt"
                 );
                 return;
             }
-            if let Err(e) = bitcoind.reconsider_block_noreply(&anchor) {
-                warn!("could not finish the pending rewind: {e}");
-                return;
-            }
-            match wait_for_tip(
+            // The block the interrupted rewind invalidated, which is what identifies
+            // the branch when we come to confirm the reconnect. Unreadable means we
+            // fall back to the signals that need no branch identity, not that we
+            // guess.
+            let invalidated =
+                coincube_core::miniscript::bitcoin::BlockHash::from_str(&rewind.invalidated_hash)
+                    .inspect_err(|e| {
+                        warn!("unreadable invalidated block in the rewind record: {e}")
+                    })
+                    .ok();
+            match reconnect_and_confirm(
                 &bitcoind,
-                RECONNECT_DEADLINE,
-                |blocks| blocks >= rewind.target_height,
-                |blocks| rejected_above(&bitcoind, blocks),
+                &anchor,
+                invalidated.as_ref(),
+                rewind.floor_height,
+                rewind.target_height,
             ) {
-                // A confirmed terminal state, either back where the rewind started or
-                // stopped short because Knots rejected a block. Either way the node is
-                // whole, so the record and the flavour may retire together.
-                Ok(TipWait::Reached(_)) => {
+                // A confirmed terminal state. The chain is final, so the pollers may
+                // be let at it and the record and flavour may retire — all while
+                // maintenance is still held.
+                Ok(Some(height)) => {
+                    if height < rewind.target_height {
+                        warn!(
+                            "The recovered node settled at height {height} rather than {}.",
+                            rewind.target_height
+                        );
+                    }
+                    confirm_and_publish(&coincube_datadir, &floor.operation_id);
                     ManagedNodeState::finish_rewind(&coincube_datadir, observed_flavor);
                 }
-                Ok(TipWait::Settled(height)) => {
-                    warn!(
-                        "The recovered node settled at height {height} rather than {}.",
-                        rewind.target_height
-                    );
-                    ManagedNodeState::finish_rewind(&coincube_datadir, observed_flavor);
-                }
-                // Still reconnecting when we stopped watching, or unresponsive. The
-                // record stays, so the next start picks the recovery up rather than
-                // losing both it and the swap that caused it.
-                Ok(TipWait::Deadline) => {
+                // Still reconnecting when we stopped watching. The record stays, so
+                // the next start picks the recovery up rather than losing both it and
+                // the swap that caused it.
+                Ok(None) => {
                     warn!("the rewind recovery had not finished when we stopped watching")
                 }
                 Err(e) => warn!("the rewind recovery did not confirm: {e}"),
@@ -878,6 +1539,229 @@ pub fn resume_pending_rewind(
     RecoveryState::InFlight
 }
 
+/// Exclusive use of the managed node for an operation that moves its chain.
+///
+/// Claiming it withdraws whatever rollback authorisation is in force, and that
+/// withdrawal is the point. A completed repair leaves a live exception naming this
+/// node and a floor — and the next repair rewinds to the *same* floor on the same
+/// node, so that stale exception matches the transient rewind perfectly. Recording
+/// the new floor without publishing it is no protection while the old one is armed:
+/// an in-flight poll, which maintenance cannot stop, would adopt the temporary
+/// rollback on the strength of the previous repair's authorisation.
+///
+/// Withdrawing it is only right once the chain is actually going to move, though.
+/// Everything between claiming the node and the first mutating call can fail —
+/// opening a connection, reading the anchor, persisting the floor, spawning the
+/// worker — and on those paths the earlier repair is still exactly as valid as it
+/// was a moment ago. So this snapshots what it displaced and puts it back on drop,
+/// unless [`Self::commit`] has been called to say the chain has been touched. The
+/// alternative is a Vault that had not yet adopted the earlier repair being stranded
+/// for the rest of the session by an operation that never even started.
+pub struct ChainOperation {
+    coincube_datadir: CoincubeDirectory,
+    /// Dropped last, so the restore below still happens under maintenance.
+    _guard: coincubed::MaintenanceGuard,
+    /// The authorisation that was live when we claimed the node.
+    displaced_live: Option<coincubed::SanctionedRollback>,
+    /// What the durable record held, and whether it was even readable. `None` means
+    /// we could not read it, so we must not write anything back over it.
+    displaced_record: Option<Option<SanctionedRollback>>,
+    /// Whether we have overwritten that record and so owe it a restore.
+    record_written: bool,
+    /// Set when this operation replaced an unreadable sidecar: the evidence copy it
+    /// kept, and the original bytes, so the replacement can be undone the same atomic
+    /// way it was made.
+    replaced_unreadable: Option<(PathBuf, Vec<u8>)>,
+    committed: bool,
+}
+
+/// Whether a chain operation could be claimed right now, without keeping it.
+///
+/// Exists so the identity gate can be asserted directly. Claiming and dropping is
+/// harmless — an uncommitted [`ChainOperation`] restores everything it displaced.
+pub fn probe_chain_operation(
+    coincube_datadir: &CoincubeDirectory,
+    identity: &NodeIdentity,
+) -> Result<(), ClaimRefused> {
+    ChainOperation::claim(coincube_datadir, identity).map(|_| ())
+}
+
+/// Why a chain operation could not be started.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaimRefused {
+    /// Another chain operation already owns the node.
+    Busy,
+    /// The node's durable identity is not settled, so anything recorded now would name
+    /// an identity later clients will not agree with.
+    UnstableIdentity,
+}
+
+impl ChainOperation {
+    /// Claim the node for an operation that will move its chain.
+    ///
+    /// Takes the identity because this is the one gate every such operation passes
+    /// through — the replay, the crash recovery, and the flag-clearing repair — so
+    /// requiring it here is what makes "no repair without a settled identity" true by
+    /// construction rather than by each caller remembering to check.
+    fn claim(
+        coincube_datadir: &CoincubeDirectory,
+        identity: &NodeIdentity,
+    ) -> Result<Self, ClaimRefused> {
+        if !identity.permits_chain_repair() {
+            return Err(ClaimRefused::UnstableIdentity);
+        }
+        let guard = coincubed::MaintenanceGuard::try_acquire().ok_or(ClaimRefused::Busy)?;
+        let displaced_live = coincubed::sanctioned_rollback();
+        let displaced_record = ManagedNodeState::try_load(coincube_datadir)
+            .ok()
+            .map(|state| state.sanctioned_rollback);
+        coincubed::set_sanctioned_rollback(None);
+        Ok(Self {
+            coincube_datadir: coincube_datadir.clone(),
+            _guard: guard,
+            displaced_live,
+            displaced_record,
+            record_written: false,
+            replaced_unreadable: None,
+            committed: false,
+        })
+    }
+
+    /// Persist the floor this operation will rewind to, remembering what it displaced so
+    /// a failure before the chain is touched can put it back.
+    ///
+    /// Two shapes, because the sidecar may not be readable. An unreadable one is exactly
+    /// the state the automatic paths decline to plan from — and rightly, since it may be
+    /// hiding a rewind that left the node parked — so only a deliberate repair, which has
+    /// already claimed the node and settled its identity, gets to move past it. When it
+    /// does, the original is kept as evidence and the canonical file is replaced in one
+    /// atomic step; see [`ManagedNodeState::replace_unreadable`] for why it is never
+    /// renamed away first.
+    fn record_floor(&mut self, floor: SanctionedRollback) -> bool {
+        if ManagedNodeState::try_load(&self.coincube_datadir).is_ok() {
+            return match ManagedNodeState::write_sanctioned_rollback_tracked(
+                &self.coincube_datadir,
+                Some(floor),
+            ) {
+                FloorWrite::Written => {
+                    self.record_written = true;
+                    true
+                }
+                // Remembered but not reported as success, exactly as on the unreadable
+                // path: remembering is what makes the rollback restore the record this
+                // displaced, and refusing is what keeps the node untouched.
+                FloorWrite::WrittenNotDurable(e) => {
+                    warn!(
+                        "the rollback floor was written but could not be confirmed durable \
+                         ({e}); not touching the node"
+                    );
+                    self.record_written = true;
+                    false
+                }
+                FloorWrite::NotWritten(e) => {
+                    warn!("could not record the repair's rollback floor: {e}");
+                    false
+                }
+            };
+        }
+        match ManagedNodeState::replace_unreadable(&self.coincube_datadir, floor) {
+            PendingInstall::Installed { evidence, original } => {
+                self.replaced_unreadable = Some((evidence, original));
+                self.record_written = true;
+                true
+            }
+            // Remembered but *not* reported as success. Remembering keeps the rollback
+            // correct — the canonical file really did change, and dropping this operation
+            // has to put it back. Refusing keeps the node untouched: the caller stops
+            // before `reconsiderblock`, because intent we could not confirm durable is
+            // intent that may not survive to be resumed.
+            PendingInstall::InstalledNotDurable {
+                evidence,
+                original,
+                error,
+            } => {
+                warn!(
+                    "the pending repair was written but could not be confirmed durable \
+                     ({error}); leaving the evidence at {evidence:?} and not touching the node"
+                );
+                self.replaced_unreadable = Some((evidence, original));
+                self.record_written = true;
+                false
+            }
+            PendingInstall::NotInstalled(e) => {
+                warn!("could not record the rollback floor over an unreadable sidecar: {e}");
+                false
+            }
+        }
+    }
+
+    /// The chain is about to change (or already has), so there is no going back to
+    /// the previous authorisation.
+    fn commit(&mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for ChainOperation {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        // Nothing was changed, so the previous repair's authorisation still describes
+        // the chain accurately. Putting it back is the difference between "we
+        // declined to start" and "we stranded whoever had not adopted it yet".
+        if let Some((evidence, original)) = self.replaced_unreadable.take() {
+            // The sidecar we replaced was unreadable, so the record we wrote in its place
+            // is not better information — and leaving it reads as "nothing pending" to
+            // the next start, from a node that may be parked mid-rewind. Put the original
+            // back through the same atomic replacement, so the canonical path is never
+            // absent, and only then drop the evidence for a repair that never happened.
+            let canonical = ManagedNodeState::path(&self.coincube_datadir);
+            match write_atomically_tracked(&canonical, &original) {
+                AtomicWrite::Durable => {
+                    let _ = remove_evidence(&evidence, canonical.parent());
+                    warn!(
+                        "the repair did not start, so the unreadable managed-node state was \
+                         put back at {canonical:?}"
+                    );
+                }
+                // The original is back but not confirmed durable, so the copy stays: it is
+                // the only other record of those bytes.
+                AtomicWrite::ReplacedNotDurable(e) => warn!(
+                    "put the unreadable managed-node state back, but could not confirm it \
+                     durable ({e}); keeping the copy at {evidence:?}"
+                ),
+                AtomicWrite::NotReplaced(e) => warn!(
+                    "could not restore the unreadable managed-node state ({e}); the copy at \
+                     {evidence:?} still holds it"
+                ),
+            }
+        } else if self.record_written {
+            if let Some(displaced) = self.displaced_record.take() {
+                // Restoring is a write like any other, so it has the same ambiguity to
+                // answer for — reverting to the boolean form here would just move the
+                // problem rather than fix it.
+                match ManagedNodeState::write_sanctioned_rollback_tracked(
+                    &self.coincube_datadir,
+                    displaced,
+                ) {
+                    FloorWrite::Written => {}
+                    FloorWrite::WrittenNotDurable(e) => warn!(
+                        "put the previous repair record back, but could not confirm it \
+                         durable ({e})"
+                    ),
+                    FloorWrite::NotWritten(e) => warn!(
+                        "could not put the previous repair record back ({e}); the sidecar \
+                         still names a repair that never started, which a later start will \
+                         try to resume"
+                    ),
+                }
+            }
+        }
+        coincubed::set_sanctioned_rollback(self.displaced_live.take());
+    }
+}
+
 /// How long to let each phase of a replay run before we stop watching it.
 ///
 /// Expiry is not a failure of the *node* — it keeps working through the reconnect
@@ -886,6 +1770,13 @@ pub fn resume_pending_rewind(
 /// that point is that we stopped looking, and the record must survive to be
 /// confirmed later rather than be retired on an assumption.
 const DISCONNECT_DEADLINE: Duration = Duration::from_secs(30 * 60);
+/// Shorter than the replay's: clearing the flags leaves nothing half-done, so this
+/// bounds how long Vaults are held for an operation that is usually seconds.
+const RECONSIDER_DEADLINE: Duration = Duration::from_secs(30 * 60);
+/// How long to keep watching for completion *after* the node has been released, so a
+/// reorg that outlasts the parked window still gets its authorisation armed in this
+/// session rather than waiting for the next start.
+const CONFIRM_DEADLINE: Duration = Duration::from_secs(6 * 60 * 60);
 const RECONNECT_DEADLINE: Duration = Duration::from_secs(6 * 60 * 60);
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
 
@@ -898,6 +1789,7 @@ const POLL_INTERVAL: Duration = Duration::from_secs(2);
 /// what actually prevents that — but it keeps Vaults from flapping into a warning
 /// state during an operation the user deliberately asked for.
 pub fn execute_replay(
+    operation: &mut ChainOperation,
     coincube_datadir: &CoincubeDirectory,
     bitcoind: &coincubed::BitcoinD,
     floor_height: i32,
@@ -955,18 +1847,19 @@ pub fn execute_replay(
          {first_divergent}..{target_height} under BIP-110."
     );
 
-    // The rollback about to happen is one we chose, so let every poller adopt it
-    // however deep it is. Persisted before the disconnect and, like the rewind
+    // The rollback about to happen is one we chose, so every poller will need to be
+    // allowed to adopt it. Persisted before the disconnect and, like the rewind
     // record above, a hard precondition for it: an authorisation that only ever
     // lived in this process dies with it, and a Vault opened afterwards would refuse
     // the repaired chain permanently — with the rewind already done and no way back.
-    if !ManagedNodeState::set_sanctioned_rollback(
-        coincube_datadir,
-        SanctionedRollback {
-            hash: floor_hash.to_string(),
-            height: floor_height,
-        },
-    ) {
+    //
+    // Recorded, not published. Between the disconnect below and the end of the
+    // reconnect the node sits at the floor on a chain that is about to change again;
+    // an exception live during that window lets a poll already in flight — which
+    // maintenance cannot stop — roll a Vault back to the floor mid-repair. It is
+    // published at the bottom of this function, once the chain is final.
+    let sanction = SanctionedRollback::at(&floor_hash, floor_height, bitcoind.backend_id());
+    if !operation.record_floor(sanction.clone()) {
         // Undo the intent we just recorded: nothing destructive has happened yet, so
         // leaving a rewind record behind would send the next start looking for a
         // rewind that never started.
@@ -978,6 +1871,10 @@ pub fn execute_replay(
         );
     }
 
+    // Past this line the chain has been touched, so the authorisation this operation
+    // displaced can no longer be put back — it would describe a chain that no longer
+    // exists, and its floor is very likely this one.
+    operation.commit();
     bitcoind
         .invalidate_block_noreply(&invalidate_hash)
         .map_err(|e| format!("invalidateblock at height {first_divergent} failed: {e}"))?;
@@ -1009,29 +1906,31 @@ pub fn execute_replay(
     }
 
     info!("Rewind complete; reconnecting under BIP-110 rules.");
-    bitcoind
-        .reconsider_block_noreply(&floor_hash)
-        .map_err(|e| format!("reconsiderblock at height {floor_height} failed: {e}"))?;
-    match wait_for_tip(
+    match reconnect_and_confirm(
         bitcoind,
-        RECONNECT_DEADLINE,
-        |blocks| blocks >= target_height,
-        |blocks| rejected_above(bitcoind, blocks),
+        &floor_hash,
+        Some(&invalidate_hash),
+        floor_height,
+        target_height,
     )? {
-        TipWait::Reached(_) => Ok(()),
-        // The node says it rejected the block above its tip, so it is done and will
-        // not climb further. A real terminal state, not a failure: this is Knots
-        // refusing something Core had accepted.
-        TipWait::Settled(height) => {
-            warn!(
-                "After re-checking, the node settled at height {height} rather than \
-                 {target_height}. Blocks accepted under Core were rejected under BIP-110."
-            );
+        // The chain is final. Only now may the pollers be allowed past their depth
+        // limit, and this still happens under maintenance — the caller holds it until
+        // this function returns.
+        Some(height) => {
+            if height < target_height {
+                // A real terminal state, not a failure: Knots refused something Core
+                // had accepted.
+                warn!(
+                    "After re-checking, the node settled at height {height} rather than \
+                     {target_height}. Blocks accepted under Core were rejected under BIP-110."
+                );
+            }
+            confirm_and_publish(coincube_datadir, &sanction.operation_id);
             Ok(())
         }
         // We stopped watching mid-reconnect. The node carries on by itself, and the
         // record we leave behind lets a later start confirm and retire it.
-        TipWait::Deadline => Err(
+        None => Err(
             "the reconnect had not finished when we stopped watching; leaving the record \
              so a later start can confirm it"
                 .to_string(),
@@ -1055,8 +1954,54 @@ enum TipWait {
     Deadline,
 }
 
-/// Whether the node says it has stopped advancing because it *rejected* what comes
-/// next: a branch above the active tip that it validated and marked invalid.
+/// Reconnect from `anchor` and establish, authoritatively, where the node ends up.
+///
+/// `Ok(Some(height))` is a confirmed terminal state; `Ok(None)` means we stopped
+/// watching before reaching one and nothing may be concluded.
+///
+/// Two signals, because neither covers the whole space on its own:
+///
+/// 1. **`reconsiderblock` returning.** It re-activates the best chain before it
+///    replies, so a reply means the node is done. This is the only thing that can
+///    settle the awkward case — the node clears the flags, immediately re-rejects
+///    the same block, and leaves the block index looking precisely as our own
+///    `invalidateblock` left it. No amount of watching from outside distinguishes
+///    that from a request that never arrived. It is also exactly the case that
+///    finishes fast, so the call returns well inside the socket timeout.
+/// 2. **Watching the chain**, for reconnects that legitimately outlast the socket.
+///    Those are the ones that reconnected a great many blocks, and a node that got
+///    that far has demonstrably acted on the request — which is what makes the fork
+///    point usable as evidence in [`is_replay_branch_rejected`].
+fn reconnect_and_confirm(
+    bitcoind: &coincubed::BitcoinD,
+    anchor: &coincube_core::miniscript::bitcoin::BlockHash,
+    invalidated: Option<&coincube_core::miniscript::bitcoin::BlockHash>,
+    floor_height: i32,
+    target_height: i32,
+) -> Result<Option<i32>, String> {
+    let completed = bitcoind
+        .reconsider_block(anchor)
+        .map_err(|e| format!("reconsiderblock at height {floor_height} failed: {e}"))?;
+    if completed {
+        // The node finished within the timeout, so whatever it reports is final.
+        let status = bitcoind
+            .chain_status()
+            .map_err(|e| format!("could not read the height the node settled at: {e}"))?;
+        return Ok(Some(status.blocks));
+    }
+    match wait_for_tip(
+        bitcoind,
+        RECONNECT_DEADLINE,
+        |blocks| blocks >= target_height,
+        |blocks| replay_branch_rejected(bitcoind, blocks, floor_height, target_height, invalidated),
+    )? {
+        TipWait::Reached(height) | TipWait::Settled(height) => Ok(Some(height)),
+        TipWait::Deadline => Ok(None),
+    }
+}
+
+/// Whether the node has finished with the branch we asked it to re-check: that
+/// branch is now marked invalid, so nothing more is coming from it.
 ///
 /// The authoritative end of a reconnect, and the reason a stationary height is not
 /// allowed to stand in for one. Validating a single block can outlast any stability
@@ -1064,20 +2009,250 @@ enum TipWait {
 /// "finished" look identical — and concluding the latter retires the only record
 /// that can retry, on a node that may still be mid-reconsideration.
 ///
+/// Identified by where the invalid branch sits, not by where the active tip stopped.
+/// Those are not the same thing: having refused a block, the node is free to go and
+/// follow a *compliant* alternative for a while, which leaves the invalid branch
+/// forking well below the new tip. Keying on "forks exactly at the tip" would call
+/// that node non-terminal forever — the deadline would expire, the rewind record
+/// would survive, and every restart would replay the whole recovery.
+///
+/// Two things have to hold, and they answer different questions.
+///
+/// **Did the node act on the reconsider?** `blocks > floor_height`. Our own
+/// `invalidateblock` landed on the block just above the floor, so before the
+/// reconsider takes effect `getchaintips` already reports the original branch as
+/// invalid and forking at exactly the floor. Reading that as "re-checked and
+/// refused" would retire the recovery record with the chain still parked. What rules
+/// it out is the tip itself having climbed above the floor, which cannot happen until
+/// the node has re-activated something. Note this is the *tip*, not the fork point:
+/// the node may well reject the first block above the floor and then activate a
+/// compliant alternative that also forks at the floor, and requiring the fork to be
+/// above the floor would refuse that perfectly ordinary outcome. The case where the
+/// tip never climbs at all — refused the first block, no alternative to move to — has
+/// no signature here and is settled by [`reconnect_and_confirm`] instead.
+///
+/// **Is this the branch we replayed?** Geometry narrows it to a branch reaching at
+/// least as high as the chain did before we started and forking no deeper than the
+/// floor, and then [`descends_from`] settles it: the candidate must actually descend
+/// from the block we invalidated. Geometry alone is a coincidence away from being
+/// wrong, and an unrelated invalid branch that happened to fit would retire the
+/// record early.
+///
 /// `getchaintips` reports `invalid` only for a branch the node actually validated,
 /// which is exactly this case: the blocks were already on disk and were re-checked
 /// under the new rules. (Its other failure mode — a branch abandoned before
 /// download, reported `headers-only` — cannot arise here.)
-fn rejected_above(bitcoind: &coincubed::BitcoinD, blocks: i32) -> bool {
-    match bitcoind.chain_tips() {
-        Ok(tips) => tips
-            .iter()
-            .any(|tip| tip.status == "invalid" && tip.height > blocks),
+fn replay_branch_rejected(
+    bitcoind: &coincubed::BitcoinD,
+    blocks: i32,
+    floor_height: i32,
+    target_height: i32,
+    invalidated: Option<&coincube_core::miniscript::bitcoin::BlockHash>,
+) -> bool {
+    // Without the block we invalidated there is no way to identify the branch, so
+    // there is nothing to confirm here. `reconnect_and_confirm` still has the RPC
+    // reply and a fully restored tip to go on.
+    let Some(invalidated) = invalidated else {
+        return false;
+    };
+    let tips = match bitcoind.chain_tips() {
+        Ok(tips) => tips,
         Err(e) => {
             warn!("could not read chain tips to tell whether the reconnect finished: {e}");
+            return false;
+        }
+    };
+    let candidates: Vec<_> =
+        candidate_rejected_branches(&tips, blocks, floor_height, target_height)
+            .map(|tip| tip.hash)
+            .collect();
+    candidates
+        .iter()
+        .any(|hash| descends_from(bitcoind, hash, invalidated, floor_height + 1))
+}
+
+/// The branches that *could* be the one we replayed, on `getchaintips` geometry
+/// alone. Separated from the RPCs so every shape of output can be exercised directly;
+/// a candidate is only ever a candidate until [`descends_from`] agrees.
+fn candidate_rejected_branches(
+    tips: &[coincubed::ChainTipEntry],
+    blocks: i32,
+    floor_height: i32,
+    target_height: i32,
+) -> impl Iterator<Item = &coincubed::ChainTipEntry> {
+    // The node has not acted on the reconsider yet, so any invalid branch on offer is
+    // the one our own `invalidateblock` created.
+    let acted = blocks > floor_height;
+    tips.iter().filter(move |tip| {
+        acted
+            && tip.status == "invalid"
+            && tip.height >= target_height
+            && tip.height.saturating_sub(tip.branch_len) >= floor_height
+    })
+}
+
+/// Whether the branch tipped by `tip` descends from `ancestor`, which sits at
+/// `ancestor_height`.
+///
+/// Walks the branch's headers back to that height and compares. Fails closed: a walk
+/// we cannot finish leaves the terminal state unconfirmed rather than assuming it,
+/// which costs a retry at worst.
+///
+/// Only reached once a candidate has passed the geometric filter and the tip has sat
+/// still for minutes, so paying one `getblockheader` per block of the branch is
+/// affordable — and it is the only way to turn "a branch that looks like ours" into
+/// "our branch".
+fn descends_from(
+    bitcoind: &coincubed::BitcoinD,
+    tip: &coincube_core::miniscript::bitcoin::BlockHash,
+    ancestor: &coincube_core::miniscript::bitcoin::BlockHash,
+    ancestor_height: i32,
+) -> bool {
+    /// Ceiling on the walk, so a misreported branch cannot spin us forever.
+    const MAX_STEPS: usize = 50_000;
+
+    let mut cursor = *tip;
+    for _ in 0..MAX_STEPS {
+        if cursor == *ancestor {
+            return true;
+        }
+        let Some(header) = bitcoind.get_block_stats(cursor) else {
+            return false;
+        };
+        // Walked past where the ancestor would be without meeting it.
+        if header.height <= ancestor_height {
+            return false;
+        }
+        let Some(previous) = header.previous_blockhash else {
+            return false;
+        };
+        cursor = previous;
+    }
+    warn!("gave up walking a rejected branch back to the block we invalidated");
+    false
+}
+
+/// Watch until the node has demonstrably finished re-activating its chain, or until
+/// `deadline`. `true` only on a positive confirmation.
+fn watch_reorg(bitcoind: &coincubed::BitcoinD, baseline_work: &str, deadline: Duration) -> bool {
+    match wait_for_tip(
+        bitcoind,
+        deadline,
+        |_| false,
+        |_| reorg_completed(bitcoind, baseline_work),
+    ) {
+        Ok(TipWait::Settled(height)) => {
+            info!("The node settled at height {height} after clearing the flags.");
+            true
+        }
+        Ok(_) => false,
+        Err(e) => {
+            warn!("could not watch the reorg after clearing the flags: {e}");
             false
         }
     }
+}
+
+/// Re-establish the confirmation a session that died mid-repair was going to provide.
+///
+/// A pending floor on disk means a `reconsiderblock` was issued and never seen to
+/// finish. `reconsiderblock` is idempotent and disconnects nothing, so the honest way
+/// to find out where the node ended up is to ask again and watch — which is what
+/// [`clear_failure_flags`] does, so this simply is that, with the anchor taken from the
+/// record instead of from a fresh plan.
+///
+/// Only ever a flag-clearing repair, by construction: a replay that got as far as
+/// writing a floor also wrote a rewind record, and its caller only reaches here when
+/// there is none. A replay's floor is therefore either confirmed or still guarded by
+/// that record. Re-issuing at a replay floor would be harmless anyway — it is the same
+/// idempotent call the recovery path makes.
+///
+/// Best-effort and off the startup path: the floor stays pending if this fails, and the
+/// next start tries again.
+fn resume_pending_repair(
+    coincube_datadir: &CoincubeDirectory,
+    config: &coincubed::config::BitcoindConfig,
+    identity: &NodeIdentity,
+    floor: &SanctionedRollback,
+) {
+    info!(
+        "A chain repair from a previous run was never confirmed finished (floor {}). \
+         Re-checking before authorising Vaults to adopt its rollback.",
+        floor.height
+    );
+    if let Err(e) = clear_failure_flags(
+        coincube_datadir,
+        config,
+        identity,
+        RevalidationPlan::ClearFailureFlags {
+            anchor_height: floor.height,
+        },
+    ) {
+        warn!("could not resume the unconfirmed chain repair: {e}");
+    }
+}
+
+/// The work in the chain the node is currently on.
+fn active_chainwork(bitcoind: &coincubed::BitcoinD) -> Option<String> {
+    let status = bitcoind.chain_status().ok()?;
+    bitcoind.block_chainwork(&status.best_block_hash?)
+}
+
+/// Whether clearing the flags has demonstrably finished: the node has moved to a
+/// chain carrying more work than it had before we asked, and has stopped moving.
+///
+/// The progress half is not decoration. [`following_best_known`] on its own is
+/// satisfied by the state this operation exists to change — a stranded node is on the
+/// only branch it has not rejected, so nothing it knows of outweighs it, and the
+/// predicate reads as "finished" before the `reconsiderblock` has had any effect at
+/// all. Requiring the work to have *increased* past what we measured beforehand is
+/// what distinguishes a completed reorg from an untouched one.
+fn reorg_completed(bitcoind: &coincubed::BitcoinD, baseline_work: &str) -> bool {
+    match active_chainwork(bitcoind) {
+        // No more work than before we asked: still the state we wanted changed.
+        Some(work) if work.as_str() <= baseline_work => false,
+        Some(_) => following_best_known(bitcoind),
+        None => false,
+    }
+}
+
+/// Whether the node is following the branch carrying the most work of any it knows
+/// of and has not rejected.
+///
+/// Necessary for a `reconsiderblock` to be finished, but not sufficient on its own —
+/// see [`reorg_completed`], which is what callers should ask.
+///
+/// On work, not height — the distinction that is merely academic elsewhere in this
+/// module is load-bearing here. A branch can be shorter and still carry more work,
+/// and a height comparison would call the node finished while such a branch is
+/// pending, releasing maintenance and publishing the authorisation mid-reorg.
+/// `getchaintips` does not report work, so each candidate costs a `getblockheader`;
+/// this is only asked once the tip has sat still for minutes, so that is cheap.
+///
+/// A candidate we cannot weigh keeps us waiting rather than concluding.
+fn following_best_known(bitcoind: &coincubed::BitcoinD) -> bool {
+    let tips = match bitcoind.chain_tips() {
+        Ok(tips) => tips,
+        Err(e) => {
+            warn!("could not read chain tips to tell whether the reorg finished: {e}");
+            return false;
+        }
+    };
+    let Some(active) = tips.iter().find(|tip| tip.is_active()) else {
+        warn!("the node reported no active chain tip");
+        return false;
+    };
+    let Some(active_work) = bitcoind.block_chainwork(&active.hash) else {
+        return false;
+    };
+    !tips
+        .iter()
+        .filter(|tip| !tip.is_active() && tip.status != "invalid")
+        .any(|tip| {
+            bitcoind
+                .block_chainwork(&tip.hash)
+                .is_none_or(|work| work > active_work)
+        })
 }
 
 /// Poll the node's height until `done`, until `settled` confirms it has stopped for
@@ -1143,54 +2318,180 @@ fn wait_for_tip(
     Ok(TipWait::Deadline)
 }
 
-/// Issue the `reconsiderblock` for `plan`, if it calls for one.
+/// Clear the inherited block-index rejections from the RDTS anchor, so the node can
+/// reorg onto the most-work chain it would have followed natively.
 ///
-/// Fire-and-forget: re-activating the chain can reconnect many blocks and far
-/// exceed the RPC socket timeout. Progress is observed out of band, from the
-/// node's `getblockchaininfo` and its debug log.
-pub fn execute(
+/// Claims the node for the duration, exactly like a replay does. Not a formality:
+/// `reconsiderblock(anchor)` clears the `BLOCK_FAILED_*` marks on the anchor's
+/// descendants, and a replay's `invalidateblock` mark is one of them — so firing
+/// this while a replay is running releases the chain the replay is holding down and
+/// leaves it reconnecting against a rewind that is no longer in force.
+///
+/// Returns once the request is away; the reorg itself is watched on a background
+/// thread which holds the claim until the node settles. The `reconsiderblock` has to
+/// be fire-and-forget because re-activating a chain can reconnect many blocks and far
+/// outlast the RPC socket timeout.
+///
+/// `Ok(Some(anchor_height))` when the request was issued.
+pub fn clear_failure_flags(
     coincube_datadir: &CoincubeDirectory,
-    bitcoind: &coincubed::BitcoinD,
+    config: &coincubed::config::BitcoindConfig,
+    identity: &NodeIdentity,
     plan: RevalidationPlan,
 ) -> Result<Option<i32>, String> {
     let RevalidationPlan::ClearFailureFlags { anchor_height } = plan else {
         return Ok(None);
     };
+    let mut operation = match ChainOperation::claim(coincube_datadir, identity) {
+        Ok(operation) => operation,
+        Err(ClaimRefused::Busy) => {
+            return Err(
+                "The managed node is already being repaired; wait for that to finish before \
+                 starting another."
+                    .to_string(),
+            )
+        }
+        Err(ClaimRefused::UnstableIdentity) => {
+            return Err(
+                "Could not establish the managed node's identity, so a repair cannot be \
+                 recorded against it yet. The node is otherwise fine — try again in a moment, \
+                 or restart it."
+                    .to_string(),
+            )
+        }
+    };
+    // Every non-mutating step first — connect, resolve the anchor — so that by the time
+    // the sidecar changes at all, the only thing left that can fail is the write itself.
+    // Its own connection, since the watching outlives this call.
+    let bitcoind = coincubed::BitcoinD::new(config, "rdts_clear_flags".to_string())
+        .map_err(|e| format!("Could not reach the managed node: {e}"))?;
     let anchor = bitcoind
         .get_block_hash(anchor_height)
         .ok_or_else(|| format!("no block at the RDTS anchor height {anchor_height}"))?;
+
     // Clearing the flags can reorg the node onto a branch that forks anywhere above
     // the anchor, which is far deeper than the poller will follow on its own
-    // authority. The anchor bounds how far back that can reach, so publish it:
+    // authority. The anchor bounds how far back that can reach, so authorise it:
     // without this every Vault refuses the repaired chain from here on. As in the
     // replay, an authorisation we cannot persist is one a later session will not
     // have, so it gates the repair rather than merely being logged.
-    if !ManagedNodeState::set_sanctioned_rollback(
-        coincube_datadir,
-        SanctionedRollback {
-            hash: anchor.to_string(),
-            height: anchor_height,
-        },
-    ) {
+    let sanction = SanctionedRollback::at(&anchor, anchor_height, bitcoind.backend_id());
+    if !operation.record_floor(sanction.clone()) {
         return Err(
             "could not record the rollback floor, so Vaults could not adopt the repaired \
              chain; refusing to proceed"
                 .to_string(),
         );
     }
-    info!(
-        "Clearing inherited block-index rejections from the RDTS anchor \
-         (height {anchor_height}, {anchor}) so this node can follow the most-work chain."
-    );
-    bitcoind
-        .reconsider_block_noreply(&anchor)
-        .map_err(|e| format!("reconsiderblock at height {anchor_height} failed: {e}"))?;
+
+    let worker_datadir = coincube_datadir.clone();
+    // The worker issues the `reconsiderblock` itself, and is spawned before anything
+    // touches the node. Mutating first and spawning second leaves a failed spawn
+    // holding nothing: the request is away, the claim is dropped, no authorisation is
+    // published, and a deep reorg lands on Vaults that will refuse it for the rest of
+    // the session — while this function reports success. Nothing here has changed the
+    // chain yet, so a spawn that fails simply un-does the claim.
+    let spawned = thread::Builder::new()
+        .name("rdts-clear-flags".to_string())
+        .spawn(move || {
+            // From here the chain is ours to change, so the displaced authorisation
+            // cannot be restored.
+            operation.commit();
+            let _operation = operation;
+            info!(
+                "Clearing inherited block-index rejections from the RDTS anchor \
+                 (height {anchor_height}, {anchor}) so this node can follow the most-work chain."
+            );
+            // Reorging onto a better branch disconnects the current one back to the
+            // fork point before connecting the replacement, so there is a window in
+            // which the node's tip is at neither. Unlike a replay's rewind that
+            // intermediate tip *is* on the path to the final answer rather than one
+            // about to be undone — but holding the claim until it settles means no
+            // poller has to reason about that, and the authorisation only goes live
+            // once there is nothing left in flight.
+            //
+            // Measured before the request, so "the node moved to something better"
+            // can be told from "the node has not started".
+            let baseline = active_chainwork(&bitcoind);
+            // The waiting variant, so a reorg that completes inside the socket timeout
+            // — the common case, since clearing flags usually reconnects little or
+            // nothing — is confirmed outright instead of watched for minutes.
+            let coincube_datadir = worker_datadir;
+            let quick = match bitcoind.reconsider_block(&anchor) {
+                Ok(replied) => replied,
+                Err(e) => {
+                    warn!("reconsiderblock at height {anchor_height} failed: {e}");
+                    return;
+                }
+            };
+            if quick {
+                info!("The node finished re-activating its best known chain.");
+                confirm_and_publish(&coincube_datadir, &sanction.operation_id);
+                return;
+            }
+            let Some(baseline) = baseline else {
+                warn!(
+                    "could not measure the node's chain work before clearing the flags, so \
+                     completion cannot be confirmed here; a later start will"
+                );
+                return;
+            };
+            if watch_reorg(&bitcoind, &baseline, RECONSIDER_DEADLINE) {
+                confirm_and_publish(&coincube_datadir, &sanction.operation_id);
+                return;
+            }
+
+            // Not finished inside the window every Vault is parked for. Let them go —
+            // nothing is half-done on this path, so a node still working is just a node
+            // catching up — but keep watching, because the authorisation still has to
+            // be armed when it does finish. Without this the floor would sit pending
+            // until the next start even though the reorg completed minutes later, and
+            // every poll in between would refuse the repaired chain.
+            drop(_operation);
+            info!("Still re-activating; released the node and watching for completion.");
+            if watch_reorg(&bitcoind, &baseline, CONFIRM_DEADLINE) {
+                reclaim_confirm_and_publish(&coincube_datadir, &sanction.operation_id);
+            } else {
+                warn!(
+                    "the node had not confirmably finished re-activating its chain when we \
+                     stopped watching; leaving the recorded rollback floor pending for a \
+                     later start to confirm rather than authorising one now"
+                );
+            }
+        });
+    if let Err(e) = spawned {
+        return Err(format!(
+            "could not start the thread that performs the repair, so nothing was changed: {e}"
+        ));
+    }
     Ok(Some(anchor_height))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Serialises the tests that drive the process-wide sanctioned-rollback slot.
+    /// Run in parallel they would each observe the others' arming and disarming.
+    static SANCTION_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Takes that lock and leaves the slot disarmed on the way in and out, so a
+    /// failing assertion cannot leak an exception into the rest of the suite.
+    struct SanctionSlot(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
+
+    impl SanctionSlot {
+        fn claim() -> Self {
+            let guard = SANCTION_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            coincubed::set_sanctioned_rollback(None);
+            Self(guard)
+        }
+    }
+
+    impl Drop for SanctionSlot {
+        fn drop(&mut self) {
+            coincubed::set_sanctioned_rollback(None);
+        }
+    }
 
     fn facts(network: Network, from: NodeFlavor, to: NodeFlavor) -> ChainFacts {
         ChainFacts {
@@ -1541,9 +2842,36 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    // The fork point of a repair has to outlive the session that performed it: the
-    // Vault that must adopt the rollback may not even be open yet, and without the
-    // record its poller refuses the repaired chain as an implausible reorg forever.
+    /// A floor for a repair that has been seen to finish, i.e. one that may be armed.
+    fn a_floor() -> SanctionedRollback {
+        SanctionedRollback {
+            confirmed: true,
+            ..a_pending_floor()
+        }
+    }
+
+    /// The same floor as it is first written: recorded, but not yet seen to finish.
+    fn a_pending_floor() -> SanctionedRollback {
+        SanctionedRollback {
+            hash: "00".repeat(31) + "2a",
+            height: RDTS_ANCHOR_MAINNET,
+            node_addr: "127.0.0.1:8332".to_string(),
+            node_credentials: coincubed::BackendId::fingerprint("cookie:/managed/.cookie"),
+            confirmed: false,
+            operation_id: "operation-A".to_string(),
+        }
+    }
+
+    fn a_node_id() -> coincubed::BackendId {
+        coincubed::BackendId {
+            addr: "127.0.0.1:8332".parse().unwrap(),
+            credentials: coincubed::BackendId::fingerprint("cookie:/managed/.cookie"),
+        }
+    }
+
+    // The floor of a repair has to outlive the session that performed it: the Vault
+    // that must adopt the rollback may not even be open yet, and without the record
+    // its poller refuses the repaired chain as an implausible reorg forever.
     #[test]
     fn a_repairs_rollback_floor_is_persisted_and_published() {
         let dir = std::env::temp_dir().join(format!(
@@ -1553,14 +2881,12 @@ mod tests {
         ));
         let _ = std::fs::remove_dir_all(&dir);
         let datadir = CoincubeDirectory::new(dir.clone());
+        let _slot = SanctionSlot::claim();
 
-        let floor = SanctionedRollback {
-            hash: "00".repeat(31) + "2a",
-            height: RDTS_ANCHOR_MAINNET,
-        };
-        assert!(ManagedNodeState::set_sanctioned_rollback(
+        let floor = a_floor();
+        assert!(ManagedNodeState::write_sanctioned_rollback(
             &datadir,
-            floor.clone()
+            Some(floor.clone())
         ));
 
         // Durable...
@@ -1568,14 +2894,20 @@ mod tests {
             ManagedNodeState::load(&datadir).sanctioned_rollback,
             Some(floor.clone())
         );
-        // ...and live, so this session's pollers can already act on it.
+        // ...but NOT yet live. Recording happens before the chain is touched; a
+        // poll already in flight must not be able to adopt the transient rewind.
+        assert!(coincubed::sanctioned_rollback().is_none());
+
+        // Publishing is the separate, later step, once the chain is final.
+        publish_sanctioned_rollback(Some(&floor));
         let published = coincubed::sanctioned_rollback().expect("published");
-        assert_eq!(published.height, RDTS_ANCHOR_MAINNET);
-        assert_eq!(published.hash.to_string(), floor.hash);
+        assert_eq!(published.floor.height, RDTS_ANCHOR_MAINNET);
+        assert_eq!(published.floor.hash.to_string(), floor.hash);
+        assert_eq!(published.node.addr.to_string(), floor.node_addr);
+        assert_eq!(published.node.credentials, floor.node_credentials);
 
         // Republishing from a fresh load is what re-arms it on the next start.
         coincubed::set_sanctioned_rollback(None);
-        assert!(coincubed::sanctioned_rollback().is_none());
         publish_sanctioned_rollback(
             ManagedNodeState::load(&datadir)
                 .sanctioned_rollback
@@ -1583,10 +2915,25 @@ mod tests {
         );
         assert!(coincubed::sanctioned_rollback().is_some());
 
-        // An unreadable hash disarms rather than authorising something arbitrary.
+        // An unreadable hash, or an unreadable node address, disarms rather than
+        // authorising something arbitrary.
         publish_sanctioned_rollback(Some(&SanctionedRollback {
             hash: "not a block hash".to_string(),
-            height: RDTS_ANCHOR_MAINNET,
+            ..a_floor()
+        }));
+        assert!(coincubed::sanctioned_rollback().is_none());
+        publish_sanctioned_rollback(Some(&SanctionedRollback {
+            node_addr: "not an address".to_string(),
+            ..a_floor()
+        }));
+        assert!(coincubed::sanctioned_rollback().is_none());
+
+        // A record from before the identity was scoped to credentials matches on
+        // address alone, which any bitcoind on that port would satisfy. Dropped, not
+        // widened.
+        publish_sanctioned_rollback(Some(&SanctionedRollback {
+            node_credentials: String::new(),
+            ..a_floor()
         }));
         assert!(coincubed::sanctioned_rollback().is_none());
 
@@ -1595,9 +2942,9 @@ mod tests {
         // this, and an authorisation this process alone can see is exactly the state
         // that strands the next one.
         std::fs::write(ManagedNodeState::path(&datadir), b"{ not json").unwrap();
-        assert!(!ManagedNodeState::set_sanctioned_rollback(
+        assert!(!ManagedNodeState::write_sanctioned_rollback(
             &datadir,
-            floor.clone()
+            Some(floor.clone())
         ));
         assert!(coincubed::sanctioned_rollback().is_none());
 
@@ -1612,6 +2959,1227 @@ mod tests {
         assert!(RecoveryState::Idle.may_plan());
         assert!(!RecoveryState::InFlight.may_plan());
         assert!(!RecoveryState::Indeterminate.may_plan());
+    }
+
+    // A recorded floor alongside an unfinished rewind describes a chain parked
+    // mid-repair, not a repaired one. Re-arming the exception at startup on the
+    // strength of the record alone would authorise pollers to adopt a rollback that
+    // is about to be undone by the reconnect.
+    #[test]
+    fn a_saved_floor_is_not_re_armed_while_a_rewind_is_outstanding() {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-rearm-test-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let datadir = CoincubeDirectory::new(dir.clone());
+        let _slot = SanctionSlot::claim();
+
+        assert!(ManagedNodeState::write_sanctioned_rollback(
+            &datadir,
+            Some(a_floor())
+        ));
+        assert!(ManagedNodeState::set_rewind(
+            &datadir,
+            Some(RewindInFlight {
+                invalidated_hash: "00".repeat(32),
+                floor_height: RDTS_ANCHOR_MAINNET,
+                target_height: RDTS_ANCHOR_MAINNET + 5_000,
+            })
+        ));
+
+        // This is the gate `reconcile_after_start` applies.
+        let recorded = ManagedNodeState::load(&datadir);
+        assert!(recorded.rewind.is_some());
+        if recorded.rewind.is_none() {
+            publish_sanctioned_rollback(recorded.sanctioned_rollback.as_ref());
+        }
+        assert!(coincubed::sanctioned_rollback().is_none());
+
+        // Once the rewind retires, the same record does re-arm.
+        assert!(ManagedNodeState::finish_rewind(&datadir, NodeFlavor::Knots));
+        let recorded = ManagedNodeState::load(&datadir);
+        if recorded.rewind.is_none() {
+            publish_sanctioned_rollback(recorded.sanctioned_rollback.as_ref());
+        }
+        assert!(coincubed::sanctioned_rollback().is_some());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn a_temp_datadir(name: &str) -> (std::path::PathBuf, CoincubeDirectory) {
+        let dir = std::env::temp_dir().join(format!(
+            "coincube-{name}-test-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        (dir.clone(), CoincubeDirectory::new(dir))
+    }
+
+    // The second-cycle case. A completed repair leaves a live exception naming this
+    // node and this floor; the next replay rewinds to the same floor on the same
+    // node, so that stale exception fits the transient rewind exactly. Recording the
+    // new floor without publishing it protects nothing while the old one is armed —
+    // claiming the node has to empty the slot.
+    #[test]
+    fn claiming_the_node_withdraws_a_previous_repairs_authorisation() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir) = a_temp_datadir("claim");
+
+        // A repair completed earlier in this process left its authorisation live.
+        publish_sanctioned_rollback(Some(&a_floor()));
+        assert!(coincubed::sanctioned_rollback().is_some());
+
+        // Claiming the node for the next one takes it away again, before any
+        // `invalidateblock` has had the chance to park the chain at that floor.
+        let mut operation =
+            ChainOperation::claim(&datadir, &NodeIdentity::Stable).expect("uncontended");
+        assert!(coincubed::sanctioned_rollback().is_none());
+
+        // And it really is exclusive: a second claim finds the node taken.
+        assert!(matches!(
+            ChainOperation::claim(&datadir, &NodeIdentity::Stable),
+            Err(ClaimRefused::Busy)
+        ));
+
+        // Committed, so dropping it leaves the slot empty — the chain has moved and
+        // the old authorisation no longer describes anything.
+        operation.commit();
+        drop(operation);
+        assert!(coincubed::sanctioned_rollback().is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Withdrawing the previous authorisation is only right once the chain is actually
+    // going to move. Everything between claiming the node and the first mutating call
+    // can fail — connecting, reading the anchor, persisting the floor, spawning the
+    // worker — and on those paths the earlier repair is still exactly as valid as it
+    // was. Leaving it withdrawn strands a Vault that had not adopted it yet, for the
+    // rest of the session, over an operation that never started.
+    #[test]
+    fn an_abandoned_claim_restores_what_it_displaced() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir) = a_temp_datadir("abandoned-claim");
+
+        let earlier = a_floor();
+        assert!(ManagedNodeState::write_sanctioned_rollback(
+            &datadir,
+            Some(earlier.clone())
+        ));
+        publish_sanctioned_rollback(Some(&earlier));
+
+        // A repair claims the node, records its own floor over the earlier one, and
+        // then gives up before touching the chain.
+        {
+            let mut operation =
+                ChainOperation::claim(&datadir, &NodeIdentity::Stable).expect("uncontended");
+            assert!(coincubed::sanctioned_rollback().is_none());
+            let next = SanctionedRollback {
+                height: RDTS_ANCHOR_MAINNET + 4_000,
+                ..a_floor()
+            };
+            assert!(operation.record_floor(next.clone()));
+            assert_eq!(
+                ManagedNodeState::load(&datadir).sanctioned_rollback,
+                Some(next)
+            );
+        }
+
+        // Both the live exception and the durable record are back as they were.
+        assert_eq!(
+            coincubed::sanctioned_rollback().map(|s| s.floor.height),
+            Some(earlier.height)
+        );
+        assert_eq!(
+            ManagedNodeState::load(&datadir).sanctioned_rollback,
+            Some(earlier)
+        );
+        // And the node is free for the next attempt.
+        assert!(ChainOperation::claim(&datadir, &NodeIdentity::Stable).is_ok());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // A floor is written before the chain is touched, so on its own it only says a
+    // repair was *started*. Arming it on a restart would let a poller adopt a chain
+    // that may still be mid-reorg — the record has to distinguish pending from
+    // confirmed, and publication has to refuse the former wherever it comes from.
+    #[test]
+    fn a_pending_repair_is_never_armed() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir) = a_temp_datadir("pending");
+
+        // What `clear_failure_flags` leaves on disk before the reorg is confirmed.
+        assert!(ManagedNodeState::write_sanctioned_rollback(
+            &datadir,
+            Some(a_pending_floor())
+        ));
+
+        // The startup gate: a pending floor is not confirmed, so it is not armed.
+        let recorded = ManagedNodeState::load(&datadir);
+        let floor = recorded.sanctioned_rollback.as_ref().expect("recorded");
+        assert!(!floor.confirmed);
+        publish_sanctioned_rollback(Some(floor));
+        assert!(
+            coincubed::sanctioned_rollback().is_none(),
+            "a repair that was never seen to finish must not authorise anything"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ...and the other half: a repair that finishes later — after the window every
+    // Vault was parked for, or in a later session entirely — still has to become
+    // armable, or the Vaults that needed it refuse the repaired chain forever.
+    #[test]
+    fn a_repair_confirmed_after_the_deadline_becomes_armable() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir) = a_temp_datadir("late-confirm");
+
+        assert!(ManagedNodeState::write_sanctioned_rollback(
+            &datadir,
+            Some(a_pending_floor())
+        ));
+        publish_sanctioned_rollback(
+            ManagedNodeState::load(&datadir)
+                .sanctioned_rollback
+                .as_ref(),
+        );
+        assert!(coincubed::sanctioned_rollback().is_none());
+
+        // The reorg is observed to finish. This is the single route from pending to
+        // armed, and it both records the fact and hands back what to publish.
+        let confirmed = ManagedNodeState::confirm_sanctioned_rollback(
+            &datadir,
+            &a_pending_floor().operation_id,
+        )
+        .expect("confirmed");
+        assert!(confirmed.confirmed);
+        publish_sanctioned_rollback(Some(&confirmed));
+        assert!(coincubed::sanctioned_rollback().is_some());
+
+        // Durably confirmed, so a later start arms it without re-confirming.
+        coincubed::set_sanctioned_rollback(None);
+        let reloaded = ManagedNodeState::load(&datadir);
+        assert!(reloaded.sanctioned_rollback.as_ref().unwrap().confirmed);
+        publish_sanctioned_rollback(reloaded.sanctioned_rollback.as_ref());
+        assert!(coincubed::sanctioned_rollback().is_some());
+
+        // Confirming with nothing recorded is not an error, just nothing to do.
+        assert!(ManagedNodeState::write_sanctioned_rollback(&datadir, None));
+        assert!(ManagedNodeState::confirm_sanctioned_rollback(&datadir, "operation-A").is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // A `BitcoinD` caches the identity it derives at construction, so one built while the
+    // datadir's marker is merely *late* reports something that changes the moment the
+    // marker lands. A repair recorded in that window names an identity no later client
+    // agrees with. The claim is the single gate every chain operation passes through, so
+    // requiring a settled identity there is what makes "no repair without one" hold by
+    // construction rather than by each caller remembering.
+    #[test]
+    fn an_unsettled_identity_permits_no_chain_operation() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir) = a_temp_datadir("unstable-identity");
+        let config = coincubed::config::BitcoindConfig {
+            rpc_auth: coincubed::config::BitcoindRpcAuth::CookieFile(dir.join(".cookie")),
+            addr: "127.0.0.1:8332".parse().unwrap(),
+        };
+
+        assert!(matches!(
+            ChainOperation::claim(&datadir, &NodeIdentity::Unstable),
+            Err(ClaimRefused::UnstableIdentity)
+        ));
+
+        // The manual repair refuses too, and refuses *before* contacting the node or
+        // writing anything — this test has no node to contact, which is the proof.
+        let refusal = clear_failure_flags(
+            &datadir,
+            &config,
+            &NodeIdentity::Unstable,
+            RevalidationPlan::ClearFailureFlags {
+                anchor_height: RDTS_ANCHOR_MAINNET,
+            },
+        )
+        .expect_err("must refuse");
+        assert!(
+            refusal.contains("identity"),
+            "the refusal should say why: {}",
+            refusal
+        );
+        assert_eq!(
+            ManagedNodeState::load(&datadir).sanctioned_rollback,
+            None,
+            "a refused repair must leave no half-recorded floor behind"
+        );
+
+        // A plan that calls for no repair is still a no-op rather than a failure, so an
+        // unsettled identity does not turn ordinary starts into errors.
+        assert_eq!(
+            clear_failure_flags(
+                &datadir,
+                &config,
+                &NodeIdentity::Unstable,
+                RevalidationPlan::Skip(SkipReason::NothingToClear)
+            ),
+            Ok(None)
+        );
+
+        // And the gate is not simply always-closed: once the identity is settled the same
+        // claim succeeds.
+        assert!(ChainOperation::claim(&datadir, &NodeIdentity::Stable).is_ok());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The flag-clearing path releases the node after a bounded window and keeps watching
+    // for hours. In that time another repair can claim the node, withdraw the live
+    // authorisation and start rewinding the chain — so when the old watcher finally has
+    // something to confirm, the record it finds may not be its own. Confirming by
+    // position would mark the newer, possibly mid-rewind operation as finished and arm an
+    // exception over exactly the transient the claim exists to keep pollers away from.
+    #[test]
+    fn a_stale_watcher_cannot_confirm_a_newer_repair() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir) = a_temp_datadir("stale-watcher");
+
+        // Repair A records its floor and, in the real thing, later drops its claim and
+        // carries on watching.
+        let a = a_pending_floor();
+        assert!(ManagedNodeState::write_sanctioned_rollback(
+            &datadir,
+            Some(a.clone())
+        ));
+
+        // Repair B claims the node, withdrawing the live authorisation, and replaces the
+        // durable floor with its own.
+        let mut b_operation =
+            ChainOperation::claim(&datadir, &NodeIdentity::Stable).expect("uncontended");
+        let b = SanctionedRollback {
+            operation_id: "operation-B".to_string(),
+            height: RDTS_ANCHOR_MAINNET + 2_000,
+            ..a_pending_floor()
+        };
+        assert!(b_operation.record_floor(b.clone()));
+        b_operation.commit();
+        assert!(coincubed::sanctioned_rollback().is_none());
+
+        // A's watcher fires. It cannot even take the claim, because B owns the node.
+        reclaim_confirm_and_publish(&datadir, &a.operation_id);
+        assert!(
+            coincubed::sanctioned_rollback().is_none(),
+            "a stale watcher armed an exception while another operation held the node"
+        );
+        // B is untouched: still pending, still B's.
+        let stored = ManagedNodeState::load(&datadir)
+            .sanctioned_rollback
+            .expect("kept");
+        assert!(!stored.confirmed, "B was marked finished by A's watcher");
+        assert_eq!(stored.operation_id, b.operation_id);
+
+        // Now B finishes and gives the node up. A's watcher fires again — it can take
+        // the claim this time, so only the operation id stands between it and arming
+        // something that is not its own.
+        drop(b_operation);
+        reclaim_confirm_and_publish(&datadir, &a.operation_id);
+        assert!(
+            coincubed::sanctioned_rollback().is_none(),
+            "a stale watcher confirmed a record belonging to another operation"
+        );
+        let stored = ManagedNodeState::load(&datadir)
+            .sanctioned_rollback
+            .expect("kept");
+        assert!(!stored.confirmed);
+        assert_eq!(stored.operation_id, b.operation_id);
+
+        // And B confirming its own record still works, so the id check has not simply
+        // wedged confirmation.
+        reclaim_confirm_and_publish(&datadir, &b.operation_id);
+        assert_eq!(
+            coincubed::sanctioned_rollback().map(|s| s.floor.height),
+            Some(b.height)
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The day a datadir gains an instance marker, every authorisation recorded before
+    // it changes fingerprint. Left alone they would all stop matching at once, and
+    // nothing schedules another repair — so an authorisation provably written by this
+    // same node under the older scheme is re-stamped instead.
+    #[test]
+    fn a_path_only_authorisation_survives_the_marker_being_introduced() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir) = a_temp_datadir("restamp");
+
+        // The identity before and after the datadir was stamped.
+        let legacy = a_node_id();
+        let stamped = coincubed::BackendId {
+            addr: legacy.addr,
+            credentials: coincubed::BackendId::fingerprint(
+                "cookie:/managed/.cookie|instance:abc123",
+            ),
+        };
+        assert_ne!(legacy.credentials, stamped.credentials);
+
+        // Recorded under the old scheme, and confirmed, so the only thing standing
+        // between it and being armed is the identity.
+        assert!(ManagedNodeState::write_sanctioned_rollback(
+            &datadir,
+            Some(a_floor())
+        ));
+        ManagedNodeState::migrate_sanctioned_rollback(&datadir, &stamped, &legacy);
+        let migrated = ManagedNodeState::load(&datadir)
+            .sanctioned_rollback
+            .expect("kept");
+        assert_eq!(migrated.node_credentials, stamped.credentials);
+        // Still confirmed: re-stamping the identity must not reset what we knew about
+        // the repair's completion.
+        assert!(migrated.confirmed);
+
+        // A record matching neither the current nor the previous fingerprint is not
+        // ours to re-stamp, and is left exactly as it is.
+        let foreign = SanctionedRollback {
+            node_credentials: coincubed::BackendId::fingerprint("cookie:/elsewhere/.cookie"),
+            ..a_floor()
+        };
+        assert!(ManagedNodeState::write_sanctioned_rollback(
+            &datadir,
+            Some(foreign.clone())
+        ));
+        ManagedNodeState::migrate_sanctioned_rollback(&datadir, &stamped, &legacy);
+        assert_eq!(
+            ManagedNodeState::load(&datadir).sanctioned_rollback,
+            Some(foreign)
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // A record written before repairs were scoped to a node names only an address,
+    // which any bitcoind on that port would match. It cannot be published as-is — but
+    // discarding it is worse: nothing would schedule another repair (a Knots → Knots
+    // restart plans nothing), so a Vault still holding the pre-repair chain would
+    // refuse the node's chain for good. Migration is the only answer that neither
+    // widens the exception nor throws it away.
+    #[test]
+    fn a_legacy_record_is_migrated_rather_than_dropped() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir) = a_temp_datadir("migrate");
+
+        let legacy = SanctionedRollback {
+            node_credentials: String::new(),
+            ..a_floor()
+        };
+        assert!(ManagedNodeState::write_sanctioned_rollback(
+            &datadir,
+            Some(legacy.clone())
+        ));
+        // As it stands it authorises nothing, which is why it must not be left alone.
+        publish_sanctioned_rollback(Some(&legacy));
+        assert!(coincubed::sanctioned_rollback().is_none());
+
+        // The managed node we are actually talking to lends it an identity.
+        let node = a_node_id();
+        ManagedNodeState::migrate_sanctioned_rollback(&datadir, &node, &node);
+        let migrated = ManagedNodeState::load(&datadir)
+            .sanctioned_rollback
+            .expect("kept");
+        assert_eq!(migrated.node_credentials, node.credentials);
+        assert_eq!(migrated.height, legacy.height);
+        publish_sanctioned_rollback(Some(&migrated));
+        assert_eq!(
+            coincubed::sanctioned_rollback().map(|s| s.node),
+            Some(node.clone())
+        );
+
+        // A record naming a different endpoint carries no authority for this node, so
+        // that one really is dropped — and dropped from disk, so it stops being
+        // reconsidered on every start.
+        assert!(ManagedNodeState::write_sanctioned_rollback(
+            &datadir,
+            Some(SanctionedRollback {
+                node_addr: "127.0.0.1:18332".to_string(),
+                node_credentials: String::new(),
+                ..a_floor()
+            })
+        ));
+        ManagedNodeState::migrate_sanctioned_rollback(&datadir, &node, &node);
+        assert_eq!(ManagedNodeState::load(&datadir).sanctioned_rollback, None);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The manual "Re-check chain" action is what we tell the user to reach for when the
+    // state file cannot be read, so it has to be able to get past one — and the way it
+    // does so has to be crash-safe at every step. The canonical path must never be
+    // durably absent: a crash while it is missing reads as "nothing pending" to the next
+    // start, from a node that may be parked below an invalidated block.
+    #[test]
+    fn replacing_an_unreadable_state_file_is_crash_safe_at_every_stage() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir) = a_temp_datadir("crash-safe-replace");
+        let canonical = ManagedNodeState::path(&datadir);
+        let unreadable = b"{ not json".as_slice();
+        std::fs::create_dir_all(canonical.parent().unwrap()).unwrap();
+        std::fs::write(&canonical, unreadable).unwrap();
+
+        // Stage 1 — evidence is taken as a copy, so the canonical file is untouched.
+        // A crash here leaves the original in place and reconciliation fails closed.
+        let evidence = write_evidence_copy(&canonical, unreadable).expect("evidence");
+        assert_eq!(std::fs::read(&canonical).unwrap(), unreadable);
+        assert_eq!(std::fs::read(&evidence).unwrap(), unreadable);
+        assert!(ManagedNodeState::try_load(&datadir).is_err());
+        std::fs::remove_file(&evidence).unwrap();
+
+        // Stage 2 — the whole transition. Before it, the canonical file is the original;
+        // after it, a valid pending record. There is no step in between at which the
+        // canonical path does not exist.
+        let (evidence, original) =
+            match ManagedNodeState::replace_unreadable(&datadir, a_pending_floor()) {
+                PendingInstall::Installed { evidence, original } => (evidence, original),
+                other => panic!("expected a durable install, got {:?}", other),
+            };
+        assert_eq!(original, unreadable);
+        assert_eq!(std::fs::read(&evidence).unwrap(), unreadable);
+        assert!(canonical.exists(), "the canonical path went missing");
+        let loaded = ManagedNodeState::load(&datadir);
+        assert_eq!(loaded.sanctioned_rollback, Some(a_pending_floor()));
+        assert!(
+            !loaded.sanctioned_rollback.unwrap().confirmed,
+            "the installed record must be pending, so a later start resumes it"
+        );
+
+        // Stage 3 — undoing it goes back the same way, and takes the evidence for a
+        // repair that never happened with it.
+        write_atomically(&canonical, &original).unwrap();
+        std::fs::remove_file(&evidence).unwrap();
+        assert_eq!(std::fs::read(&canonical).unwrap(), unreadable);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Arms a failpoint for the current thread and disarms it on drop, so a failing
+    /// assertion cannot leak an injected failure into the rest of the test.
+    struct Injected;
+
+    impl Injected {
+        fn at(point: Failpoint) -> Self {
+            Self::all(&[point])
+        }
+
+        fn all(points: &[Failpoint]) -> Self {
+            ARMED_FAILPOINTS.with(|armed| *armed.borrow_mut() = points.to_vec());
+            Self
+        }
+    }
+
+    impl Drop for Injected {
+        fn drop(&mut self) {
+            ARMED_FAILPOINTS.with(|armed| armed.borrow_mut().clear());
+        }
+    }
+
+    /// A datadir holding an unreadable canonical sidecar, plus those bytes.
+    fn an_unreadable_sidecar(name: &str) -> (std::path::PathBuf, CoincubeDirectory, Vec<u8>) {
+        let (dir, datadir) = a_temp_datadir(name);
+        let canonical = ManagedNodeState::path(&datadir);
+        std::fs::create_dir_all(canonical.parent().unwrap()).unwrap();
+        let unreadable = b"{ not json".to_vec();
+        std::fs::write(&canonical, &unreadable).unwrap();
+        (dir, datadir, unreadable)
+    }
+
+    // Every way the evidence copy can fail after its name has been reserved. The name is
+    // finite and shared, so an empty or half-written file left behind is worse than the
+    // failure itself: it reads as completed evidence and burns one of the names, and
+    // enough of them make manual repair impossible.
+    #[test]
+    fn a_failed_evidence_copy_leaves_no_partial_artifact() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir, unreadable) = an_unreadable_sidecar("evidence-failpoints");
+        let canonical = ManagedNodeState::path(&datadir);
+        let first = canonical.with_extension("corrupt");
+
+        for point in [
+            Failpoint::EvidenceWrite,
+            Failpoint::EvidenceSync,
+            Failpoint::EvidenceDirSync,
+        ] {
+            let armed = Injected::at(point);
+            let outcome = ManagedNodeState::replace_unreadable(&datadir, a_pending_floor());
+            drop(armed);
+
+            assert!(
+                matches!(outcome, PendingInstall::NotInstalled(_)),
+                "{:?} should stop before the canonical file changes, got {:?}",
+                point,
+                outcome
+            );
+            // The reserved name is free again, not holding a partial file...
+            assert!(
+                !first.exists(),
+                "{:?} left a partial evidence file behind",
+                point
+            );
+            assert_eq!(corrupt_evidence(&datadir), Vec::<std::path::PathBuf>::new());
+            // ...and the canonical state is byte-identical and still fail-closed.
+            assert_eq!(std::fs::read(&canonical).unwrap(), unreadable);
+            assert!(ManagedNodeState::try_load(&datadir).is_err());
+        }
+
+        // Cleanup failing is reported rather than hidden: presenting a partial file as a
+        // completed quarantine copy is the one outcome that must not happen quietly.
+        {
+            let _armed = Injected::all(&[Failpoint::EvidenceWrite, Failpoint::EvidenceCleanup]);
+            let error = match write_evidence_copy(&canonical, &unreadable) {
+                Err(e) => e.to_string(),
+                Ok(path) => panic!("expected cleanup to fail, got evidence at {:?}", path),
+            };
+            assert!(
+                error.contains("could not be removed"),
+                "the cleanup failure should be explicit: {}",
+                error
+            );
+        }
+        // That one really is still there, which is why it was reported.
+        assert!(first.exists());
+        std::fs::remove_file(&first).unwrap();
+
+        // And once the filesystem behaves, the same name is allocated and the repair goes
+        // through — the failures burned nothing.
+        let (evidence, _) = match ManagedNodeState::replace_unreadable(&datadir, a_pending_floor())
+        {
+            PendingInstall::Installed { evidence, original } => (evidence, original),
+            other => panic!("expected a healthy retry to install, got {:?}", other),
+        };
+        assert_eq!(evidence, first);
+        assert_eq!(std::fs::read(&evidence).unwrap(), unreadable);
+        assert_eq!(
+            ManagedNodeState::load(&datadir).sanctioned_rollback,
+            Some(a_pending_floor())
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The readable-sidecar path had the same post-rename blind spot as the unreadable one:
+    // a directory-fsync failure reports "not written" over a canonical file that already
+    // holds the new floor. Believing that meant the displaced record was never put back —
+    // so a confirmed authorisation Vaults were relying on got replaced by a pending repair
+    // that never started, which the next start would then resume.
+    #[test]
+    fn an_undurable_floor_write_still_restores_what_it_displaced() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir) = a_temp_datadir("undurable-readable");
+
+        // 1. A readable sidecar holding a confirmed repair, alongside state that has
+        //    nothing to do with repairs and must survive untouched.
+        let previous = a_floor();
+        assert!(previous.confirmed);
+        ManagedNodeState::record_run(&datadir, NodeFlavor::Knots);
+        let rewind = RewindInFlight {
+            invalidated_hash: "11".repeat(32),
+            floor_height: RDTS_ANCHOR_MAINNET,
+            target_height: RDTS_ANCHOR_MAINNET + 7,
+        };
+        assert!(ManagedNodeState::set_rewind(&datadir, Some(rewind.clone())));
+        assert!(ManagedNodeState::write_sanctioned_rollback(
+            &datadir,
+            Some(previous.clone())
+        ));
+
+        // 2. It is armed, which is the state a Vault's poller is relying on.
+        publish_sanctioned_rollback(Some(&previous));
+        assert!(coincubed::sanctioned_rollback().is_some());
+
+        // 3. A new operation claims the node, withdrawing that authorisation.
+        let mut operation =
+            ChainOperation::claim(&datadir, &NodeIdentity::Stable).expect("uncontended");
+        assert!(coincubed::sanctioned_rollback().is_none());
+
+        // 4 & 5. Its floor lands but cannot be confirmed durable, so it is refused — the
+        //        caller stops before `reconsiderblock`.
+        let pending = SanctionedRollback {
+            operation_id: "operation-late".to_string(),
+            height: RDTS_ANCHOR_MAINNET + 900,
+            ..a_pending_floor()
+        };
+        let armed = Injected::at(Failpoint::StateDirSync);
+        let recorded = operation.record_floor(pending.clone());
+        drop(armed);
+        assert!(!recorded, "an undurable write must not report success");
+
+        // 6. And yet the canonical file really does name the new pending floor — which is
+        //    exactly why "not written" cannot be taken at face value.
+        assert_eq!(
+            ManagedNodeState::load(&datadir).sanctioned_rollback,
+            Some(pending.clone())
+        );
+
+        // 7. Abandoned without ever reaching the chain.
+        drop(operation);
+
+        // 8, 9, 10. The previous confirmed record is back on disk, the previous
+        //           authorisation is armed again, and the restoration is durable rather
+        //           than only true for this process.
+        let reloaded = ManagedNodeState::load(&datadir);
+        assert_eq!(reloaded.sanctioned_rollback, Some(previous.clone()));
+        assert_eq!(
+            coincubed::sanctioned_rollback().map(|s| s.floor.height),
+            Some(previous.height)
+        );
+        // Unrelated state came through untouched.
+        assert_eq!(reloaded.rewind, Some(rewind));
+        assert_eq!(reloaded.last_run_flavor, Some(NodeFlavor::Knots));
+
+        // 11. The abandoned operation is neither armed nor resumable: what is on disk is
+        //     the old confirmed floor, so startup arms it rather than resuming anything.
+        let stored = reloaded.sanctioned_rollback.unwrap();
+        assert_ne!(stored.operation_id, pending.operation_id);
+        assert!(stored.confirmed, "startup would resume a pending floor");
+        assert!(
+            ManagedNodeState::confirm_sanctioned_rollback(&datadir, &pending.operation_id)
+                .is_none(),
+            "the abandoned operation must not be confirmable"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // What the restoration itself can run into. None of it can leave the caller believing
+    // something happened that did not, or the reverse.
+    #[test]
+    fn floor_restoration_reports_which_side_of_the_rename_it_failed_on() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir) = a_temp_datadir("restore-failures");
+        let previous = a_floor();
+        let pending = SanctionedRollback {
+            operation_id: "operation-new".to_string(),
+            ..a_pending_floor()
+        };
+
+        // A write that never lands is reported as such, and the canonical file agrees:
+        // the read-back still names the *old* operation, so it is not mistaken for a
+        // replacement that merely lacked its fsync.
+        assert!(ManagedNodeState::write_sanctioned_rollback(
+            &datadir,
+            Some(previous.clone())
+        ));
+        let armed = Injected::at(Failpoint::StateRename);
+        let outcome =
+            ManagedNodeState::write_sanctioned_rollback_tracked(&datadir, Some(pending.clone()));
+        drop(armed);
+        assert!(
+            matches!(outcome, FloorWrite::NotWritten(_)),
+            "a read-back naming the old operation means nothing was replaced, got {:?}",
+            outcome
+        );
+        assert_eq!(
+            ManagedNodeState::load(&datadir).sanctioned_rollback,
+            Some(previous.clone())
+        );
+
+        // Failing *before* the restoration rename leaves the new floor in place, and says
+        // so — the sidecar names a repair that never started, and a later start resumes it
+        // rather than silently doing nothing.
+        {
+            let mut operation =
+                ChainOperation::claim(&datadir, &NodeIdentity::Stable).expect("uncontended");
+            assert!(operation.record_floor(pending.clone()));
+            let _armed = Injected::at(Failpoint::StateRename);
+            drop(operation);
+        }
+        assert_eq!(
+            ManagedNodeState::load(&datadir).sanctioned_rollback,
+            Some(pending.clone()),
+            "a restoration that never landed must not look like it did"
+        );
+
+        // Failing *after* the restoration rename but before its fsync still restores: the
+        // canonical file holds the previous record, durability alone is unconfirmed.
+        assert!(ManagedNodeState::write_sanctioned_rollback(
+            &datadir,
+            Some(previous.clone())
+        ));
+        {
+            let mut operation =
+                ChainOperation::claim(&datadir, &NodeIdentity::Stable).expect("uncontended");
+            assert!(operation.record_floor(pending.clone()));
+            let _armed = Injected::at(Failpoint::StateDirSync);
+            drop(operation);
+        }
+        assert_eq!(
+            ManagedNodeState::load(&datadir).sanctioned_rollback,
+            Some(previous),
+            "the previous record should be back even when its fsync failed"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The rename lands before the directory entry is flushed, so a failure at the last
+    // step returns an error over a canonical file that already holds the pending record.
+    // Reading that as "nothing happened" deletes the evidence for a repair that startup
+    // will go on to resume — and leaves the operation unable to roll itself back.
+    #[test]
+    fn a_post_replacement_failure_is_not_mistaken_for_nothing_happening() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir, unreadable) = an_unreadable_sidecar("post-replacement");
+        let canonical = ManagedNodeState::path(&datadir);
+
+        // Fail after the rename but before durability is confirmed.
+        let armed = Injected::at(Failpoint::StateDirSync);
+        let outcome = ManagedNodeState::replace_unreadable(&datadir, a_pending_floor());
+        drop(armed);
+
+        let (evidence, original) = match outcome {
+            PendingInstall::InstalledNotDurable {
+                evidence, original, ..
+            } => (evidence, original),
+            other => panic!(
+                "expected an installed-but-undurable outcome, got {:?}",
+                other
+            ),
+        };
+        // The outcome and the filesystem agree: the record really is installed...
+        assert_eq!(
+            ManagedNodeState::load(&datadir).sanctioned_rollback,
+            Some(a_pending_floor())
+        );
+        // ...and the evidence is still there, because it is now the only copy of what the
+        // repair displaced.
+        assert!(evidence.exists(), "the evidence copy was deleted");
+        assert_eq!(std::fs::read(&evidence).unwrap(), unreadable);
+        assert_eq!(original, unreadable);
+
+        // Restore for the next part of the test.
+        write_atomically(&canonical, &unreadable).unwrap();
+        std::fs::remove_file(&evidence).unwrap();
+
+        // Through the operation: the same failure is remembered, so the rollback stays
+        // correct — but reported as failure, so the caller never reaches the RPC. An
+        // intent we could not confirm durable is one that may not survive to be resumed.
+        {
+            let mut operation =
+                ChainOperation::claim(&datadir, &NodeIdentity::Stable).expect("uncontended");
+            let armed = Injected::at(Failpoint::StateDirSync);
+            let recorded = operation.record_floor(a_pending_floor());
+            drop(armed);
+            assert!(!recorded, "an undurable write must not report success");
+            assert_eq!(
+                ManagedNodeState::load(&datadir).sanctioned_rollback,
+                Some(a_pending_floor()),
+                "the canonical file should reflect what actually happened"
+            );
+            // No commit, so dropping rolls it back — which only works because the
+            // operation remembered the replacement despite reporting failure.
+        }
+        assert!(canonical.exists(), "the canonical path went missing");
+        assert_eq!(std::fs::read(&canonical).unwrap(), unreadable);
+        assert!(ManagedNodeState::try_load(&datadir).is_err());
+        assert_eq!(corrupt_evidence(&datadir), Vec::<std::path::PathBuf>::new());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The failures on the other side of the rename, where the canonical file genuinely is
+    // untouched. Outcome and filesystem have to agree here too, in the opposite direction.
+    #[test]
+    fn a_pre_replacement_failure_leaves_the_canonical_state_untouched() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir, unreadable) = an_unreadable_sidecar("pre-replacement");
+        let canonical = ManagedNodeState::path(&datadir);
+
+        for point in [
+            Failpoint::StateWrite,
+            Failpoint::StateSync,
+            Failpoint::StateRename,
+        ] {
+            let armed = Injected::at(point);
+            let outcome = ManagedNodeState::replace_unreadable(&datadir, a_pending_floor());
+            drop(armed);
+
+            assert!(
+                matches!(outcome, PendingInstall::NotInstalled(_)),
+                "{:?} should report that nothing was replaced, got {:?}",
+                point,
+                outcome
+            );
+            assert_eq!(std::fs::read(&canonical).unwrap(), unreadable);
+            assert!(ManagedNodeState::try_load(&datadir).is_err());
+            // Nothing was installed, so the evidence for it is gone too...
+            assert_eq!(corrupt_evidence(&datadir), Vec::<std::path::PathBuf>::new());
+            // ...and no staging file is left for the next writer to trip over.
+            assert!(!canonical.with_extension("tmp").exists());
+        }
+
+        // And through the operation, which is what gates the mutating RPC.
+        let mut operation =
+            ChainOperation::claim(&datadir, &NodeIdentity::Stable).expect("uncontended");
+        let armed = Injected::at(Failpoint::StateRename);
+        assert!(!operation.record_floor(a_pending_floor()));
+        drop(armed);
+        drop(operation);
+        assert_eq!(std::fs::read(&canonical).unwrap(), unreadable);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Evidence names are reserved with `create_new`, so two repairs racing — here, or in
+    // another process, since the maintenance claim is only process-wide — cannot be
+    // handed the same name or overwrite each other's evidence.
+    #[test]
+    fn evidence_names_are_allocated_without_collision() {
+        let (dir, datadir) = a_temp_datadir("evidence-names");
+        let canonical = ManagedNodeState::path(&datadir);
+        std::fs::create_dir_all(canonical.parent().unwrap()).unwrap();
+
+        let racers = evidence_name_limit() as usize;
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(racers));
+        let claimed: Vec<PathBuf> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..racers)
+                .map(|n| {
+                    let barrier = barrier.clone();
+                    let canonical = canonical.clone();
+                    scope.spawn(move || {
+                        let body = format!("racer-{n}");
+                        barrier.wait();
+                        let path = write_evidence_copy(&canonical, body.as_bytes())
+                            .expect("evidence name");
+                        // Each racer's own bytes, not another's.
+                        assert_eq!(std::fs::read_to_string(&path).unwrap(), body);
+                        path
+                    })
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+        let distinct: std::collections::HashSet<_> = claimed.iter().collect();
+        assert_eq!(
+            distinct.len(),
+            racers,
+            "two racers were handed the same name"
+        );
+
+        // Exhausting the names is an error, not an overwrite — and it happens before
+        // anything else is touched.
+        assert!(write_evidence_copy(&canonical, b"one too many").is_err());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // A repair that cannot keep its evidence must not replace the canonical file either,
+    // and must not go on to touch the node.
+    #[test]
+    fn evidence_that_cannot_be_written_leaves_everything_alone() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir) = a_temp_datadir("evidence-fails");
+        let canonical = ManagedNodeState::path(&datadir);
+        let unreadable = b"{ not json".as_slice();
+        std::fs::create_dir_all(canonical.parent().unwrap()).unwrap();
+        std::fs::write(&canonical, unreadable).unwrap();
+
+        // Every evidence name is taken, so the copy cannot be made.
+        for n in 0..evidence_name_limit() {
+            let taken = match n {
+                0 => canonical.with_extension("corrupt"),
+                n => canonical.with_extension(format!("corrupt.{n}")),
+            };
+            std::fs::write(&taken, b"someone else's evidence").unwrap();
+        }
+
+        assert!(matches!(
+            ManagedNodeState::replace_unreadable(&datadir, a_pending_floor()),
+            PendingInstall::NotInstalled(_)
+        ));
+        assert_eq!(
+            std::fs::read(&canonical).unwrap(),
+            unreadable,
+            "the canonical file was replaced despite the evidence failing"
+        );
+        // And the same through the operation, which is what gates the mutating RPC: a
+        // floor it could not record means `clear_failure_flags` returns before spawning
+        // the worker that issues `reconsiderblock`.
+        let mut operation =
+            ChainOperation::claim(&datadir, &NodeIdentity::Stable).expect("uncontended");
+        assert!(!operation.record_floor(a_pending_floor()));
+        drop(operation);
+        assert_eq!(std::fs::read(&canonical).unwrap(), unreadable);
+        assert!(ManagedNodeState::try_load(&datadir).is_err());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A config pointing at a datadir with no cookie file, so `BitcoinD::new` fails on
+    /// A config pointing at a datadir with no cookie file, so `BitcoinD::new` fails on
+    /// the spot — a preflight failure *after* the claim, with no node and no network.
+    fn an_unreachable_config(dir: &std::path::Path) -> coincubed::config::BitcoindConfig {
+        coincubed::config::BitcoindConfig {
+            rpc_auth: coincubed::config::BitcoindRpcAuth::CookieFile(dir.join(".cookie")),
+            addr: "127.0.0.1:1".parse().unwrap(),
+        }
+    }
+
+    fn corrupt_evidence(datadir: &CoincubeDirectory) -> Vec<std::path::PathBuf> {
+        let canonical = ManagedNodeState::path(datadir);
+        (0..8)
+            .map(|n| match n {
+                0 => canonical.with_extension("corrupt"),
+                n => canonical.with_extension(format!("corrupt.{n}")),
+            })
+            .filter(|p| p.exists())
+            .collect()
+    }
+
+    // Quarantining the unreadable sidecar is only safe if the repair then happens. Moving
+    // it and *then* refusing turns a state the next start correctly reads as "something
+    // may be pending, do not plan" into "nothing pending" — and it may then plan from a
+    // node parked below an invalidated block, which is the failure the record exists to
+    // prevent. So it must not be moved before the repair is committed to, and must come
+    // back if the repair falls over on the way.
+    #[test]
+    fn a_refused_repair_leaves_the_recovery_state_where_it_was() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir) = a_temp_datadir("quarantine-rollback");
+        let config = an_unreachable_config(&dir);
+        let unreadable = b"{ not json".as_slice();
+
+        let plan = RevalidationPlan::ClearFailureFlags {
+            anchor_height: RDTS_ANCHOR_MAINNET,
+        };
+        let write_unreadable = || {
+            std::fs::create_dir_all(ManagedNodeState::path(&datadir).parent().unwrap()).unwrap();
+            std::fs::write(ManagedNodeState::path(&datadir), unreadable).unwrap();
+        };
+
+        // 1. Refused for an unsettled identity. Nothing is moved, because the refusal
+        //    happens before the claim — let alone before any RPC.
+        write_unreadable();
+        assert!(clear_failure_flags(&datadir, &config, &NodeIdentity::Unstable, plan).is_err());
+        assert!(ManagedNodeState::try_load(&datadir).is_err());
+        assert_eq!(corrupt_evidence(&datadir), Vec::<std::path::PathBuf>::new());
+
+        // 2. Refused because another chain operation owns the node. Same again.
+        let busy = ChainOperation::claim(&datadir, &NodeIdentity::Stable).expect("uncontended");
+        assert!(clear_failure_flags(&datadir, &config, &NodeIdentity::Stable, plan).is_err());
+        assert!(ManagedNodeState::try_load(&datadir).is_err());
+        assert_eq!(corrupt_evidence(&datadir), Vec::<std::path::PathBuf>::new());
+        drop(busy);
+
+        // 3. Claimed, quarantined, and *then* the node turns out to be unreachable —
+        //    the case the ordering alone cannot rule out. The move is undone, so the
+        //    next start still sees an unreadable sidecar and declines to plan.
+        let refusal = clear_failure_flags(&datadir, &config, &NodeIdentity::Stable, plan)
+            .expect_err("unreachable node");
+        assert!(
+            refusal.contains("Could not reach"),
+            "expected a connection failure, got: {}",
+            refusal
+        );
+        assert!(
+            ManagedNodeState::try_load(&datadir).is_err(),
+            "the unreadable recovery state was not put back"
+        );
+        assert_eq!(
+            std::fs::read(ManagedNodeState::path(&datadir)).unwrap(),
+            unreadable,
+            "the restored file is not the one that was moved"
+        );
+        assert_eq!(
+            corrupt_evidence(&datadir),
+            Vec::<std::path::PathBuf>::new(),
+            "a repair that never started left a quarantine artifact behind"
+        );
+        // And the node is free again, so a later attempt is not blocked by the failed one.
+        assert!(ChainOperation::claim(&datadir, &NodeIdentity::Stable).is_ok());
+
+        // 4. The one case the preflight-first ordering cannot rule out: the sidecar has
+        //    already been replaced, and the operation is then abandoned without ever
+        //    reaching the chain. The original comes back through the same atomic
+        //    replacement — so the canonical path is never absent — and the evidence for a
+        //    repair that did not happen goes with it.
+        let canonical = ManagedNodeState::path(&datadir);
+        {
+            let mut operation =
+                ChainOperation::claim(&datadir, &NodeIdentity::Stable).expect("uncontended");
+            assert!(operation.record_floor(a_pending_floor()));
+            // Mid-transition the canonical file holds a valid pending record, not nothing.
+            assert_eq!(
+                ManagedNodeState::load(&datadir).sanctioned_rollback,
+                Some(a_pending_floor())
+            );
+            assert_eq!(corrupt_evidence(&datadir).len(), 1);
+            // ...and no `commit`, so dropping it here rolls the whole thing back.
+        }
+        assert!(canonical.exists(), "the canonical path went missing");
+        assert_eq!(
+            std::fs::read(&canonical).unwrap(),
+            unreadable,
+            "the original unreadable state was not restored byte-for-byte"
+        );
+        assert!(ManagedNodeState::try_load(&datadir).is_err());
+        assert_eq!(
+            corrupt_evidence(&datadir),
+            Vec::<std::path::PathBuf>::new(),
+            "evidence was kept for a repair that never started"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The other half: a repair that *does* reach the chain keeps its quarantine, and each
+    // one keeps its own evidence file rather than overwriting the last.
+    #[test]
+    fn a_committed_repair_keeps_its_quarantine_evidence() {
+        let _slot = SanctionSlot::claim();
+        let (dir, datadir) = a_temp_datadir("quarantine-commit");
+
+        for expected in ["corrupt", "corrupt.1"] {
+            std::fs::create_dir_all(ManagedNodeState::path(&datadir).parent().unwrap()).unwrap();
+            std::fs::write(ManagedNodeState::path(&datadir), b"{ not json").unwrap();
+
+            let mut operation =
+                ChainOperation::claim(&datadir, &NodeIdentity::Stable).expect("uncontended");
+            assert!(operation.record_floor(a_pending_floor()));
+            // Past this point the chain has been touched, so the evidence stays where it
+            // was put — there is no state to go back to.
+            operation.commit();
+            drop(operation);
+
+            assert!(
+                ManagedNodeState::path(&datadir)
+                    .with_extension(expected)
+                    .exists(),
+                "expected evidence at .{}",
+                expected
+            );
+            // The canonical path holds a valid pending record, so a crash right here
+            // leaves the next start something to resume rather than nothing at all.
+            let loaded = ManagedNodeState::load(&datadir);
+            assert_eq!(loaded.sanctioned_rollback, Some(a_pending_floor()));
+        }
+        assert_eq!(corrupt_evidence(&datadir).len(), 2);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn branch(height: i32, branch_len: i32, status: &str) -> coincubed::ChainTipEntry {
+        use coincube_core::miniscript::bitcoin::{self, hashes::Hash};
+        coincubed::ChainTipEntry {
+            height,
+            hash: bitcoin::BlockHash::from_byte_array([height as u8; 32]),
+            branch_len,
+            status: status.to_string(),
+        }
+    }
+
+    fn candidates(
+        tips: &[coincubed::ChainTipEntry],
+        blocks: i32,
+        floor: i32,
+        target: i32,
+    ) -> usize {
+        candidate_rejected_branches(tips, blocks, floor, target).count()
+    }
+
+    // Which branches can be the one we replayed, on `getchaintips` geometry. The
+    // shapes that matter are the two the earlier rules each got wrong, plus the one
+    // that must never pass.
+    #[test]
+    fn a_rejected_replay_branch_is_recognised_wherever_the_node_settled() {
+        const FLOOR: i32 = 961_631;
+        const TARGET: i32 = 970_000;
+
+        // Refused at 966,000, so the Core branch forks at 965,999 and reaches the
+        // original tip. The node stopped right there.
+        let rejected = branch(TARGET, TARGET - 965_999, "invalid");
+        assert_eq!(
+            candidates(
+                &[branch(965_999, 0, "active"), rejected.clone()],
+                965_999,
+                FLOOR,
+                TARGET
+            ),
+            1
+        );
+
+        // Same rejection, but the node then followed a compliant alternative up to
+        // 966,010. Still ours — keying on "forks at the tip" refused this.
+        assert_eq!(
+            candidates(
+                &[branch(966_010, 0, "active"), rejected.clone()],
+                966_010,
+                FLOOR,
+                TARGET
+            ),
+            1
+        );
+
+        // Refused the first block above the floor, then activated a compliant
+        // alternative that forks at the floor too and climbed well past it. The
+        // invalid branch still forks *at* the floor, so requiring the fork to be
+        // strictly above it refused this outcome as well — for the whole six hours,
+        // keeping the rewind record alive and replaying the recovery on every restart.
+        // What proves the node acted is its tip having climbed, not the fork point.
+        let refused_at_floor = branch(TARGET, TARGET - FLOOR, "invalid");
+        assert_eq!(
+            candidates(
+                &[branch(965_000, 0, "active"), refused_at_floor.clone()],
+                965_000,
+                FLOOR,
+                TARGET
+            ),
+            1
+        );
+
+        // The same branch geometry while the tip is still *at* the floor is exactly
+        // what our own `invalidateblock` leaves behind, and must never pass: reading it
+        // as "re-checked and refused" would retire the recovery record with the chain
+        // still parked below the invalidated block.
+        assert_eq!(
+            candidates(&[refused_at_floor], FLOOR, FLOOR, TARGET),
+            0,
+            "a parked chain must not look finished"
+        );
+
+        // An invalid branch that never reaches the height the chain started from is
+        // not the one we replayed.
+        assert_eq!(
+            candidates(&[branch(963_000, 100, "invalid")], 965_999, FLOOR, TARGET),
+            0
+        );
+
+        // Nor is one forking below the floor we rewound to.
+        assert_eq!(
+            candidates(
+                &[branch(TARGET, TARGET - (FLOOR - 1), "invalid")],
+                965_999,
+                FLOOR,
+                TARGET
+            ),
+            0
+        );
+
+        // A branch the node merely has headers for proves nothing: it never validated
+        // it, so it cannot be why the chain stopped.
+        assert_eq!(
+            candidates(
+                &[branch(TARGET, TARGET - 965_999, "headers-only")],
+                965_999,
+                FLOOR,
+                TARGET
+            ),
+            0
+        );
+
+        // And nothing is a candidate while the tip is still below the floor — the
+        // disconnect has not even been undone yet.
+        assert_eq!(candidates(&[rejected], FLOOR - 10, FLOOR, TARGET), 0);
     }
 
     fn tip(height: i32, status: &str) -> coincubed::ChainTipEntry {

--- a/coincubed/src/bitcoin/d/mod.rs
+++ b/coincubed/src/bitcoin/d/mod.rs
@@ -38,6 +38,23 @@ use serde_json::Value as Json;
 // If bitcoind takes more than 3 minutes to answer one of our queries, fail.
 const RPC_SOCKET_TIMEOUT: u64 = 180;
 
+/// Name of the marker a managed node's datadir carries to identify *this* instance of
+/// it, written next to the cookie file. See [`BitcoinD::backend_id`].
+pub const NODE_INSTANCE_FILE: &str = ".coincube_node_instance";
+
+/// Length of a node-instance identity, in characters.
+pub const NODE_INSTANCE_LEN: usize = 32;
+
+/// Whether `value` is a complete, well-formed node identity.
+///
+/// Reader and writer have to agree on this exactly. A marker that is accepted while
+/// half-written yields an identity that differs from the one the finished file gives,
+/// and a repair recorded against the first would stop matching once the second is
+/// what everybody reads.
+pub fn valid_node_instance(value: &str) -> bool {
+    value.len() == NODE_INSTANCE_LEN && value.bytes().all(|b| b.is_ascii_alphanumeric())
+}
+
 // Number of retries the client is allowed to do in case of timeout or i/o error
 // while communicating with the bitcoin daemon.
 // A retry happens every 1 second, this makes us give up after one minute.
@@ -620,6 +637,19 @@ impl BitcoinD {
         self.make_request(ClientKind::Node, method, params)
     }
 
+    /// A node call whose timeout is meaningful, so it must not be retried.
+    ///
+    /// The retry path treats a timed-out request as transient and sends it again.
+    /// For a call we deliberately let run to the socket timeout — to learn whether
+    /// the node finished within it — that turns one bounded wait into several.
+    fn make_fallible_node_request_noretry(
+        &self,
+        method: &str,
+        params: Option<&serde_json::value::RawValue>,
+    ) -> Result<Json, BitcoindError> {
+        self.make_request_inner(ClientKind::Node, method, params, false)
+    }
+
     fn make_node_request(
         &self,
         method: &str,
@@ -644,6 +674,88 @@ impl BitcoinD {
         params: Option<&serde_json::value::RawValue>,
     ) -> Result<Json, BitcoindError> {
         self.make_request(ClientKind::Watchonly, method, params)
+    }
+
+    /// Which node these clients were built against: the RPC endpoint, plus a
+    /// fingerprint of everything else that distinguishes nodes sharing one.
+    ///
+    /// The instance marker, where the node has one, is what makes this an identity
+    /// rather than a description of our configuration. A cookie path separates two
+    /// *different* datadirs, but a datadir rebuilt at the same path keeps the same
+    /// path — and, for a user/password backend, two nodes on one endpoint with the
+    /// same username are indistinguishable. The marker lives inside the datadir, so
+    /// it goes when the datadir goes and the replacement gets a fresh one.
+    pub fn backend_id(&self) -> super::BackendId {
+        Self::backend_id_for(&self.config)
+    }
+
+    /// The identity a client built from `config` reports, derived fresh every time.
+    ///
+    /// Deliberately not cached. A client built while the datadir's marker was still on
+    /// its way would otherwise keep the markerless identity for the rest of its life —
+    /// and a repair authorised later, once the marker landed, would name the marker-based
+    /// identity that this long-lived client never agrees with. The poller would then go
+    /// on refusing the very rollback the repair performed, until the Vault was restarted.
+    ///
+    /// The cost is one small read, and only on the paths that ask: a poller consults this
+    /// when it has both detected a reorg and found an authorisation armed.
+    pub fn backend_id_for(config: &config::BitcoindConfig) -> super::BackendId {
+        Self::backend_id_from(
+            config,
+            Self::read_node_instance(&config.rpc_auth).as_deref(),
+        )
+    }
+
+    /// The identity this node had before datadir instance markers existed.
+    ///
+    /// Equal to [`Self::backend_id`] on a node with no marker. Exists so an
+    /// authorisation recorded under the old scheme can be recognised as this node's and
+    /// re-stamped, rather than silently stop matching the day a marker is introduced.
+    pub fn legacy_backend_id(&self) -> super::BackendId {
+        Self::legacy_backend_id_for(&self.config)
+    }
+
+    /// [`Self::legacy_backend_id`] for a config without a client.
+    pub fn legacy_backend_id_for(config: &config::BitcoindConfig) -> super::BackendId {
+        Self::backend_id_from(config, None)
+    }
+
+    fn backend_id_from(
+        config: &config::BitcoindConfig,
+        instance: Option<&str>,
+    ) -> super::BackendId {
+        let descriptor = match &config.rpc_auth {
+            config::BitcoindRpcAuth::CookieFile(path) => {
+                format!("cookie:{}", path.to_string_lossy())
+            }
+            config::BitcoindRpcAuth::UserPass(user, _) => format!("user:{user}"),
+        };
+        let descriptor = match instance {
+            Some(instance) => format!("{descriptor}|instance:{instance}"),
+            None => descriptor,
+        };
+        super::BackendId {
+            addr: config.addr,
+            credentials: super::BackendId::fingerprint(&descriptor),
+        }
+    }
+
+    /// Read the instance marker a managed node's datadir carries, if any.
+    ///
+    /// Sits beside the cookie file, i.e. inside the node's own datadir, which is what
+    /// ties it to this instance of it rather than to our configuration. Absent for an
+    /// external node, for a user/password backend, and for managed datadirs created
+    /// before the marker existed — in all of which cases identity falls back to the
+    /// endpoint and credentials alone, exactly as before.
+    fn read_node_instance(auth: &config::BitcoindRpcAuth) -> Option<String> {
+        let config::BitcoindRpcAuth::CookieFile(cookie_path) = auth else {
+            return None;
+        };
+        let marker = cookie_path.parent()?.join(NODE_INSTANCE_FILE);
+        let instance = fs::read_to_string(marker).ok()?.trim().to_string();
+        // Validated, not merely non-empty. A partially written marker must never
+        // become an identity of its own — see [`valid_node_instance`].
+        valid_node_instance(&instance).then_some(instance)
     }
 
     fn get_bitcoind_version(&self) -> u64 {
@@ -1420,6 +1532,52 @@ impl BitcoinD {
         self.make_noreply_node_request("reconsiderblock", params!(Json::String(hash.to_string())))
     }
 
+    /// Same as [`Self::reconsider_block_noreply`], but wait to see whether the node
+    /// finishes within [`RPC_SOCKET_TIMEOUT`].
+    ///
+    /// `reconsiderblock` re-activates the best chain before it replies, so a reply
+    /// means the node is *done* — which is the one authoritative completion signal
+    /// available for this operation. Watching the chain from outside cannot supply
+    /// it: a node that clears the flags and immediately re-rejects the same block
+    /// leaves the block index looking exactly as it did before the call, so an
+    /// observer cannot tell "already re-checked and refused" from "our request never
+    /// arrived".
+    ///
+    /// `Ok(false)` when the call timed out instead. That is not a failure — a
+    /// reconnect spanning many blocks legitimately outlasts the socket, and the node
+    /// carries on regardless — it only means completion has to be established some
+    /// other way.
+    pub fn reconsider_block(&self, hash: &bitcoin::BlockHash) -> Result<bool, BitcoindError> {
+        match self.make_fallible_node_request_noretry(
+            "reconsiderblock",
+            params!(Json::String(hash.to_string())),
+        ) {
+            Ok(_) => Ok(true),
+            Err(e) if e.is_timeout() => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Total work in the chain ending at `hash`, as bitcoind reports it: 64 lowercase
+    /// hex digits, zero-padded, so two of them compare correctly as strings.
+    ///
+    /// Height is not a stand-in for this. A longer branch can carry less work than a
+    /// shorter one, and "is the node on the best chain it knows of" is a question
+    /// about work.
+    pub fn block_chainwork(&self, hash: &bitcoin::BlockHash) -> Option<String> {
+        let work = self
+            .make_fallible_node_request("getblockheader", params!(Json::String(hash.to_string())))
+            .ok()?
+            .get("chainwork")
+            .and_then(Json::as_str)?
+            .to_lowercase();
+        if work.len() > 64 || !work.chars().all(|c| c.is_ascii_hexdigit()) {
+            log::warn!("Unreadable 'chainwork' in 'getblockheader' response: {work:?}");
+            return None;
+        }
+        Some(format!("{work:0>64}"))
+    }
+
     // Make sure the bitcoind has enough blocks to rescan up to this timestamp.
     fn check_prune_height(&self, timestamp: u32) -> Result<(), BitcoindError> {
         let chain_info = self.block_chain_info();
@@ -2046,6 +2204,77 @@ mod tests {
         assert!(!status("locked_in", false).has_failed());
         assert!(!status("active", true).has_failed());
         assert!(status("failed", false).has_failed());
+    }
+
+    // A client built while the datadir's marker was still on its way must not keep the
+    // markerless identity once it lands. If it did, a repair authorised afterwards would
+    // name an identity that long-lived client never agrees with, and its poller would go
+    // on refusing the very rollback the repair performed until the Vault was restarted.
+    // So the identity is derived from the config every time it is asked for, which is
+    // what this checks — `backend_id` is a one-line delegation to it.
+    #[test]
+    fn the_backend_identity_follows_a_marker_that_arrives_later() {
+        let dir = std::env::temp_dir().join(format!(
+            "coincubed-backend-id-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let config = config::BitcoindConfig {
+            rpc_auth: config::BitcoindRpcAuth::CookieFile(dir.join(".cookie")),
+            addr: "127.0.0.1:8332".parse().unwrap(),
+        };
+
+        // Before the marker exists — the state a client constructed during a failed
+        // establishment sees — identity is the markerless one.
+        let before = BitcoinD::backend_id_for(&config);
+        assert_eq!(before, BitcoinD::legacy_backend_id_for(&config));
+
+        // The marker lands later in the same process.
+        std::fs::write(
+            dir.join(NODE_INSTANCE_FILE),
+            "aB3xY7zQ1mN5pR9tK2vW4sD6gH8jL0cF",
+        )
+        .unwrap();
+
+        // The same config now reports the marker-based identity, without anything being
+        // rebuilt: a repair authorised under it is one an existing client can match.
+        let after = BitcoinD::backend_id_for(&config);
+        assert_ne!(after, before, "the identity did not follow the marker");
+        assert_ne!(after, BitcoinD::legacy_backend_id_for(&config));
+        // The pre-marker identity is still computable, which is what lets an
+        // authorisation recorded under it be recognised and re-stamped.
+        assert_eq!(BitcoinD::legacy_backend_id_for(&config), before);
+
+        // A marker that is present but malformed is not an identity of its own: it reads
+        // as "no marker yet", so a client cannot settle on a value the finished file will
+        // contradict.
+        std::fs::write(dir.join(NODE_INSTANCE_FILE), "partial").unwrap();
+        assert_eq!(BitcoinD::backend_id_for(&config), before);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Reader and writer of the datadir instance marker have to agree on this exactly.
+    // Anything the reader accepts while it is half-written becomes an identity of its
+    // own, and a repair recorded against it stops matching once the complete marker is
+    // what everybody sees.
+    #[test]
+    fn only_a_complete_node_instance_is_accepted() {
+        assert!(valid_node_instance(&"a".repeat(NODE_INSTANCE_LEN)));
+        assert!(valid_node_instance("aB3xY7zQ1mN5pR9tK2vW4sD6gH8jL0cF"));
+
+        // Empty, truncated, over-long, or carrying anything the generator never emits.
+        assert!(!valid_node_instance(""));
+        assert!(!valid_node_instance(&"a".repeat(NODE_INSTANCE_LEN - 1)));
+        assert!(!valid_node_instance(&"a".repeat(NODE_INSTANCE_LEN + 1)));
+        assert!(!valid_node_instance(&format!(
+            "{}!",
+            "a".repeat(NODE_INSTANCE_LEN - 1)
+        )));
+        // Multi-byte characters must not pass a length check done in bytes.
+        assert!(!valid_node_instance(&"é".repeat(NODE_INSTANCE_LEN / 2)));
     }
 
     // Bitcoin Knots 29.x shares Core's numeric `getnetworkinfo.version` scheme:

--- a/coincubed/src/bitcoin/mod.rs
+++ b/coincubed/src/bitcoin/mod.rs
@@ -11,7 +11,7 @@ use crate::bitcoin::d::{BitcoindError, CachedTxGetter, LSBlockEntry};
 use coincube_core::descriptors;
 pub use d::{MempoolEntry, MempoolEntryFees, SyncProgress};
 
-use std::{collections::HashMap, fmt, sync};
+use std::{collections::HashMap, fmt, net, sync};
 
 use miniscript::bitcoin::{self, address, bip32::ChildNumber};
 
@@ -215,23 +215,67 @@ impl Drop for MaintenanceGuard {
 /// block the poller will find — so pinning the exception to the floor would refuse
 /// every realistic outcome and authorise only the one where nothing replayed.
 ///
-/// The hash is still carried, and still checked: the poller confirms the backend's
-/// chain actually contains this block before honouring the floor, so a sanction
-/// left over from a different chain or a different datadir authorises nothing.
-static SANCTIONED_ROLLBACK: sync::Mutex<Option<BlockChainTip>> = sync::Mutex::new(None);
+/// The floor's hash is still carried and still checked, but it cannot carry the
+/// scoping on its own: the blocks a repair names are public, and every healthy node
+/// on the same chain contains them. So the exception is addressed to a specific
+/// node — see [`SanctionedRollback::node`].
+static SANCTIONED_ROLLBACK: sync::Mutex<Option<SanctionedRollback>> = sync::Mutex::new(None);
 
-/// Authorise (or withdraw) over-deep rollbacks reaching no deeper than `floor`.
-pub fn set_sanctioned_rollback(floor: Option<BlockChainTip>) {
-    *SANCTIONED_ROLLBACK
-        .lock()
-        .expect("sanctioned rollback lock poisoned") = floor;
+/// Which `bitcoind` a backend talks to.
+///
+/// The socket alone is a *location*, not an identity: a different node, or the same
+/// node rebuilt on a different datadir, can later occupy the same address. So the
+/// credential descriptor comes along with it — for the managed node that is the path
+/// to a cookie file living inside the node's own datadir, which moves when the
+/// datadir does. Fingerprinted rather than carried verbatim, because this ends up
+/// written to a state file on disk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendId {
+    /// Where it listens.
+    pub addr: net::SocketAddr,
+    /// Hex SHA-256 of the credential descriptor — the cookie file's path, or the
+    /// RPC username. Never the password.
+    pub credentials: String,
 }
 
-/// The floor the poller is currently allowed to roll back to past its depth limit.
-pub fn sanctioned_rollback() -> Option<BlockChainTip> {
+impl BackendId {
+    /// Fingerprint a credential descriptor. Hashed so that neither a filesystem
+    /// layout nor a username is written to disk verbatim.
+    pub fn fingerprint(descriptor: &str) -> String {
+        use miniscript::bitcoin::hashes::{sha256, Hash};
+        sha256::Hash::hash(descriptor.as_bytes()).to_string()
+    }
+}
+
+/// An over-deep rollback the poller may apply, and the node it applies to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SanctionedRollback {
+    /// Deepest block a repair-induced rollback may reach. See
+    /// [`SANCTIONED_ROLLBACK`] for why this is a floor and not a fork point.
+    pub floor: BlockChainTip,
+    /// The node the repair was performed on.
+    ///
+    /// Load-bearing, because this slot is process-wide and the floor block is
+    /// public. Without it, a Vault pointed at an entirely different `bitcoind` —
+    /// an external one the user configured, which never underwent the repair —
+    /// would find the floor in its own chain, satisfy the exception, and lose the
+    /// depth guard for every rollback above it.
+    pub node: BackendId,
+}
+
+/// Authorise (or withdraw) over-deep rollbacks on one node.
+pub fn set_sanctioned_rollback(sanction: Option<SanctionedRollback>) {
     *SANCTIONED_ROLLBACK
         .lock()
+        .expect("sanctioned rollback lock poisoned") = sanction;
+}
+
+/// The rollback the poller is currently allowed to apply past its depth limit.
+pub fn sanctioned_rollback() -> Option<SanctionedRollback> {
+    SANCTIONED_ROLLBACK
+        .lock()
         .expect("sanctioned rollback lock poisoned")
+        .clone()
 }
 
 /// Our Bitcoin backend.
@@ -244,6 +288,15 @@ pub trait BitcoinInterface: Send {
     /// pauses too — conservative, and bounded by the rewind's duration.
     fn is_bitcoind(&self) -> bool {
         false
+    }
+
+    /// Which `bitcoind` this backend talks to, when it talks to one at all.
+    ///
+    /// Used to scope a sanctioned rollback to the node a repair was actually
+    /// performed on: the blocks a repair names are public, so a chain-level check
+    /// cannot tell the managed node from any other node following the same chain.
+    fn backend_id(&self) -> Option<BackendId> {
+        None
     }
 
     fn genesis_block_timestamp(&self) -> u32;
@@ -364,6 +417,10 @@ pub trait BitcoinInterface: Send {
 impl BitcoinInterface for d::BitcoinD {
     fn is_bitcoind(&self) -> bool {
         true
+    }
+
+    fn backend_id(&self) -> Option<BackendId> {
+        Some(self.backend_id())
     }
 
     fn genesis_block_timestamp(&self) -> u32 {
@@ -988,6 +1045,10 @@ impl BitcoinInterface for esplora::Esplora {
 impl BitcoinInterface for sync::Arc<sync::Mutex<dyn BitcoinInterface + 'static>> {
     fn is_bitcoind(&self) -> bool {
         self.lock().unwrap().is_bitcoind()
+    }
+
+    fn backend_id(&self) -> Option<BackendId> {
+        self.lock().unwrap().backend_id()
     }
 
     fn genesis_block_timestamp(&self) -> u32 {

--- a/coincubed/src/bitcoin/poller/looper.rs
+++ b/coincubed/src/bitcoin/poller/looper.rs
@@ -274,17 +274,23 @@ fn new_tip(bit: &impl BitcoinInterface, current_tip: &BlockChainTip) -> TipUpdat
         // misreporting, so they are both walked for and applied past the limit —
         // otherwise the repaired node and our state stay permanently divorced. See
         // `crate::bitcoin::sanctioned_rollback`.
-        let sanctioned =
-            crate::bitcoin::sanctioned_rollback().filter(|floor| floor.height < current_tip.height);
+        // Addressed to one node, and this backend has to be it. The floor block is
+        // public — every node on the chain has it — so without matching the node an
+        // exception raised for the managed node would also disarm the guard for an
+        // external `bitcoind` that never underwent the repair.
+        let sanctioned = crate::bitcoin::sanctioned_rollback().filter(|sanction| {
+            sanction.floor.height < current_tip.height
+                && bit.backend_id().as_ref() == Some(&sanction.node)
+        });
         // Bounded at one past the limit: any fork we would accept is found inside it, and
         // anything deeper is refused without walking the rest of the way. Unbounded, a
         // backend claiming a 10k-block reorg would cost us 10k sequential round-trips before
         // we rejected the answer. A sanctioned rollback raises the bound just far enough to
         // reach its floor, and no further.
-        let max_depth = match sanctioned {
-            Some(floor) => current_tip
+        let max_depth = match &sanctioned {
+            Some(sanction) => current_tip
                 .height
-                .saturating_sub(floor.height)
+                .saturating_sub(sanction.floor.height)
                 .max(MAX_REORG_DEPTH),
             None => MAX_REORG_DEPTH,
         };
@@ -292,14 +298,14 @@ fn new_tip(bit: &impl BitcoinInterface, current_tip: &BlockChainTip) -> TipUpdat
             AncestorSearch::Found(common_ancestor) => {
                 let depth = current_tip.height.saturating_sub(common_ancestor.height);
                 if depth > MAX_REORG_DEPTH {
-                    // Two conditions, and the second is what keeps this from being a
-                    // blanket depth increase: the fork must be at or above the floor we
-                    // rewound to, *and* the backend's chain must actually contain that
-                    // floor block. A sanction left over from another chain, another
-                    // datadir, or a node that never underwent the repair authorises
-                    // nothing.
-                    let authorised = sanctioned.is_some_and(|floor| {
-                        common_ancestor.height >= floor.height && bit.is_in_chain(&floor)
+                    // Having already established this is the node the repair was
+                    // performed on: the fork must be at or above the floor it rewound
+                    // to, and that floor block must still be in the node's chain — a
+                    // sanction surviving a datadir replaced under the same RPC port
+                    // authorises nothing.
+                    let authorised = sanctioned.as_ref().is_some_and(|sanction| {
+                        common_ancestor.height >= sanction.floor.height
+                            && bit.is_in_chain(&sanction.floor)
                     });
                     if !authorised {
                         return TipUpdate::ImplausibleReorg { min_depth: depth };
@@ -669,9 +675,21 @@ mod tests {
     struct Sanction(#[allow(dead_code)] sync::MutexGuard<'static, ()>);
 
     impl Sanction {
-        fn arm(point: BlockChainTip) -> Self {
+        /// Armed for the node `DummyBitcoind` reports itself as.
+        fn arm(floor: BlockChainTip) -> Self {
+            Self::arm_for(
+                floor,
+                crate::testutils::DUMMY_RPC_ADDR,
+                crate::testutils::DUMMY_CREDENTIALS,
+            )
+        }
+
+        fn arm_for(floor: BlockChainTip, addr: &str, credentials: &str) -> Self {
             let guard = SANCTION_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-            crate::bitcoin::set_sanctioned_rollback(Some(point));
+            crate::bitcoin::set_sanctioned_rollback(Some(crate::bitcoin::SanctionedRollback {
+                floor,
+                node: crate::testutils::dummy_backend_id(addr, credentials),
+            }));
             Self(guard)
         }
 
@@ -763,7 +781,7 @@ mod tests {
         drop(_armed);
 
         // Right depth, but this backend's chain never contained the block we rewound
-        // to — a sanction left over from another chain or another datadir.
+        // to — a datadir replaced under the same RPC port.
         let mut bit = forked_backend(&our_tip, 10_000);
         bit.also_in_chain = vec![tip(10_000, 0xee)];
         let _armed = Sanction::arm(floor);
@@ -771,6 +789,61 @@ mod tests {
             TipUpdate::ImplausibleReorg { .. } => {}
             other => panic!(
                 "expected a sanction from another chain to authorise nothing, got {:?}",
+                other
+            ),
+        }
+    }
+
+    // The floor block is public: every node on the chain has it, so a chain-level
+    // check cannot tell the repaired node from any other. Without the endpoint in the
+    // exception, a Vault pointed at an external `bitcoind` that never underwent the
+    // repair would lose its depth guard for everything above the floor.
+    #[test]
+    fn a_sanction_authorises_nothing_on_another_node() {
+        let our_tip = tip(20_000, 0xaa);
+        let floor = tip(10_000, 0xcc);
+        // Same chain, same floor block, different node.
+        let bit = repaired_backend(&our_tip, 10_000, floor);
+
+        let _armed = Sanction::arm_for(
+            floor,
+            "127.0.0.1:18332",
+            crate::testutils::DUMMY_CREDENTIALS,
+        );
+        match new_tip(&bit, &our_tip) {
+            TipUpdate::ImplausibleReorg { .. } => {}
+            other => panic!(
+                "expected a sanction for another node to authorise nothing, got {:?}",
+                other
+            ),
+        }
+        drop(_armed);
+
+        // Same address, different credentials — the shape a datadir replaced under
+        // the same port takes, since the cookie file lives inside the datadir.
+        let bit = repaired_backend(&our_tip, 10_000, floor);
+        let _armed = Sanction::arm_for(
+            floor,
+            crate::testutils::DUMMY_RPC_ADDR,
+            "cookie:/somewhere/else/.cookie",
+        );
+        match new_tip(&bit, &our_tip) {
+            TipUpdate::ImplausibleReorg { .. } => {}
+            other => panic!(
+                "expected a sanction for another datadir to authorise nothing, got {:?}",
+                other
+            ),
+        }
+        drop(_armed);
+
+        // And a backend that is not a bitcoind at all has no identity to match.
+        let mut bit = repaired_backend(&our_tip, 10_000, floor);
+        bit.backend_id = None;
+        let _armed = Sanction::arm(floor);
+        match new_tip(&bit, &our_tip) {
+            TipUpdate::ImplausibleReorg { .. } => {}
+            other => panic!(
+                "expected an unidentifiable backend to authorise nothing, got {:?}",
                 other
             ),
         }

--- a/coincubed/src/lib.rs
+++ b/coincubed/src/lib.rs
@@ -16,13 +16,13 @@ pub use miniscript;
 
 pub use crate::bitcoin::{
     d::{
-        BitcoinD, BitcoindError, ChainStatus, ChainTipEntry, DeploymentStatus, PruneState,
-        WalletError,
+        valid_node_instance, BitcoinD, BitcoindError, ChainStatus, ChainTipEntry, DeploymentStatus,
+        PruneState, WalletError, NODE_INSTANCE_FILE, NODE_INSTANCE_LEN,
     },
     electrum::{Electrum, ElectrumError},
     esplora::{Esplora, EsploraError},
     managed_node_maintenance, sanctioned_rollback, set_managed_node_maintenance,
-    set_sanctioned_rollback, BlockChainTip, MaintenanceGuard,
+    set_sanctioned_rollback, BackendId, BlockChainTip, MaintenanceGuard, SanctionedRollback,
 };
 
 use crate::jsonrpc::server;

--- a/coincubed/src/testutils.rs
+++ b/coincubed/src/testutils.rs
@@ -1,6 +1,7 @@
 use crate::{
     bitcoin::{
-        AncestorSearch, BitcoinInterface, Block, BlockChainTip, MempoolEntry, SyncProgress, UTxO,
+        AncestorSearch, BackendId, BitcoinInterface, Block, BlockChainTip, MempoolEntry,
+        SyncProgress, UTxO,
     },
     config::{BitcoinConfig, Config},
     database::{
@@ -36,6 +37,22 @@ pub struct DummyBitcoind {
     /// Blocks this backend's chain contains regardless of [`Self::in_chain`], so a
     /// forked backend can still be asked about a block deeper than the fork point.
     pub also_in_chain: Vec<BlockChainTip>,
+    /// Which node this backend claims to be, for scoping a sanctioned rollback.
+    pub backend_id: Option<BackendId>,
+}
+
+/// The endpoint [`DummyBitcoind`] reports by default.
+pub const DUMMY_RPC_ADDR: &str = "127.0.0.1:8332";
+
+/// The credential descriptor [`DummyBitcoind`] reports by default.
+pub const DUMMY_CREDENTIALS: &str = "cookie:/dummy/.cookie";
+
+/// The identity [`DummyBitcoind`] reports by default.
+pub fn dummy_backend_id(addr: &str, credentials: &str) -> BackendId {
+    BackendId {
+        addr: addr.parse().expect("valid socket address"),
+        credentials: BackendId::fingerprint(credentials),
+    }
 }
 
 impl DummyBitcoind {
@@ -50,6 +67,7 @@ impl DummyBitcoind {
             in_chain: true,
             ancestor: None,
             also_in_chain: Vec::new(),
+            backend_id: Some(dummy_backend_id(DUMMY_RPC_ADDR, DUMMY_CREDENTIALS)),
         }
     }
 }
@@ -77,6 +95,10 @@ impl BitcoinInterface for DummyBitcoind {
 
     fn is_in_chain(&self, tip: &BlockChainTip) -> bool {
         self.in_chain || self.also_in_chain.contains(tip)
+    }
+
+    fn backend_id(&self) -> Option<BackendId> {
+        self.backend_id.clone()
     }
 
     fn sync_wallet(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes core managed-bitcoind chain reconciliation, durable repair authorisation, and poller exceptions; mistakes could strand Vaults on the wrong chain or authorize rollbacks on the wrong node.
> 
> **Overview**
> **Hardens RDTS/BIP-110 chain repair** so rollback authorisations apply only to the managed node that performed the repair, repairs cannot race replays or each other, and pollers are not armed until a repair is actually finished.
> 
> **Managed node identity:** Adds a datadir-local instance marker (installed atomically under an advisory lock) so `BackendId` survives datadir wipes at the RPC endpoint. `establish_node_identity` runs before the first `BitcoinD` connection; **`NodeIdentity::Unstable`** blocks recording or starting any chain repair until identity is settled.
> 
> **Rollback records and publication:** `SanctionedRollback` now carries **node address/credentials**, a **pending vs `confirmed`** flag, and an **`operation_id`**. Floors are **written before** touching the chain but **published to coincubed only after confirmation**—avoiding in-flight polls adopting a mid-reorg chain. Startup migrates legacy path-only records instead of dropping them.
> 
> **`ChainOperation`:** Single gate for replays, flag clearing, and recovery—claims maintenance, **withdraws** any live sanctioned rollback, snapshots durable state, and **restores on drop** unless `commit()` after the chain moves. Manual **chain repair** routes through `clear_failure_flags` (not inline RPC), which refuses if another operation is busy or identity is unstable; UI docs warn about concurrent replay.
> 
> **Durability:** Tracked atomic writes, crash-safe replacement of unreadable sidecars with `.corrupt` evidence copies, background workers with work-based reorg completion and late confirmation via `reclaim_confirm_and_publish`. Large new test suite (concurrency, failpoints, identity timeout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e28789486c318601845905ae7fcd3b2a7881cbcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->